### PR TITLE
rust: Bump SDK version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foxglove"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxglove"
-version = "0.1.0"
+version = "0.1.1"
 description = "Foxglove SDK"
 edition = "2021"
 repository = "https://github.com/foxglove/foxglove-sdk"


### PR DESCRIPTION
### Changelog
- Expanded documentation.
- Expanded `FoxgloveError` variants.
- Reworked unstable examples to use higher-level interfaces.
- Reduced visibility of internal websocket symbols.
- Renamed `TypedMessage` trait to `Encode`.