### PR TITLE
rust: Add missing docs, expand FoxgloveError

### DIFF
--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -44,6 +44,7 @@ pub struct Schema {
 }
 
 impl Schema {
+    /// Returns a new schema.
     pub fn new(
         name: impl Into<String>,
         encoding: impl Into<String>,
@@ -90,27 +91,32 @@ pub struct Channel {
 }
 
 impl Channel {
+    /// Returns the channel ID.
     pub fn id(&self) -> ChannelId {
         self.id
     }
 
+    /// Returns the channel topic.
     pub fn topic(&self) -> &str {
         &self.topic
     }
 
+    /// Returns the channel schema.
     pub fn schema(&self) -> Option<&Schema> {
         self.schema.as_ref()
     }
 
+    /// Atomically increments and returns the next message sequence number.
     pub fn next_sequence(&self) -> u32 {
         self.message_sequence.fetch_add(1, Relaxed)
     }
 
+    /// Logs a message.
     pub fn log(self: &Arc<Self>, msg: &[u8]) {
-        self.log_with_meta(msg, PartialMetadata::new());
+        self.log_with_meta(msg, PartialMetadata::default());
     }
 
-    // Log a message to all sinks. Logs a warning for any errors.
+    /// Logs a message with additional metadata.
     pub fn log_with_meta(self: &Arc<Self>, msg: &[u8], opts: PartialMetadata) {
         // Bail out early if there are no sinks (logging is disabled).
         if self.sinks.is_empty() {
@@ -131,7 +137,7 @@ impl Channel {
     }
 }
 
-// For tests
+#[cfg(test)]
 impl PartialEq for Channel {
     fn eq(&self, other: &Self) -> bool {
         self.topic == other.topic
@@ -142,6 +148,7 @@ impl PartialEq for Channel {
     }
 }
 
+#[cfg(test)]
 impl Eq for Channel {}
 
 impl std::fmt::Debug for Channel {

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -17,6 +17,7 @@ pub struct ChannelBuilder<'a> {
 }
 
 impl<'a> ChannelBuilder<'a> {
+    /// Creates a new channel builder for the specified topic.
     pub fn new<T: Into<String>>(topic: T) -> Self {
         Self {
             topic: topic.into(),
@@ -74,7 +75,7 @@ impl<'a> ChannelBuilder<'a> {
             topic: self.topic,
             message_encoding: self
                 .message_encoding
-                .ok_or_else(|| FoxgloveError::Fatal("Message encoding is required".to_string()))?,
+                .ok_or_else(|| FoxgloveError::MessageEncodingRequired)?,
             schema: self.schema,
             metadata: self.metadata,
         });

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -12,6 +12,7 @@ const STACK_BUFFER_SIZE: usize = 128 * 1024;
 /// Implementing this trait for your type `T` enables the use of [`TypedChannel<T>`],
 /// which offers a type-checked `log` method.
 pub trait Encode {
+    /// The error type returned by methods in this trait.
     type Error: std::error::Error;
 
     /// Returns the schema for your data.
@@ -84,7 +85,7 @@ impl<T: Encode> TypedChannel<T> {
 
     /// Encodes the message and logs it on the channel.
     pub fn log(&self, msg: &T) {
-        self.log_with_meta(msg, PartialMetadata::new());
+        self.log_with_meta(msg, PartialMetadata::default());
     }
 
     /// Encodes the message and logs it on the channel with additional metadata.

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -154,6 +154,8 @@
 //!
 //! [tokio]: https://docs.rs/tokio/latest/tokio/
 
+#![warn(missing_docs)]
+
 use thiserror::Error;
 
 mod channel;
@@ -197,9 +199,24 @@ pub use websocket_server::{WebSocketServer, WebSocketServerHandle};
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum FoxgloveError {
-    /// A unspecified unrecoverable error.
-    #[error("Fatal error: {0}")]
-    Fatal(String),
+    /// An unspecified error.
+    #[error("{0}")]
+    Unspecified(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// The sink dropped a message because it is closed.
+    #[error("Sink closed")]
+    SinkClosed,
+    /// A schema is required.
+    #[error("Schema is required")]
+    SchemaRequired,
+    /// A message encoding is required.
+    #[error("Message encoding is required")]
+    MessageEncodingRequired,
+    /// The server was already started.
+    #[error("Server already started")]
+    ServerAlreadyStarted,
+    /// Failed to bind to the specified host and port.
+    #[error("Failed to bind port: {0}")]
+    Bind(std::io::Error),
     /// A channel for the same topic has already been registered.
     #[error("Channel for topic {0} already exists in registry")]
     DuplicateChannel(String),

--- a/rust/foxglove/src/mcap_writer/mcap_sink.rs
+++ b/rust/foxglove/src/mcap_writer/mcap_sink.rs
@@ -103,10 +103,7 @@ impl<W: Write + Seek + Send> LogSink for McapSink<W> {
     ) -> Result<(), FoxgloveError> {
         _ = metadata;
         let mut guard = self.0.lock();
-        let writer = guard
-            .as_mut()
-            .ok_or(FoxgloveError::Fatal("File writer is closed".to_string()))?;
-
+        let writer = guard.as_mut().ok_or(FoxgloveError::SinkClosed)?;
         writer.log(channel, msg, metadata)
     }
 }

--- a/rust/foxglove/src/metadata.rs
+++ b/rust/foxglove/src/metadata.rs
@@ -38,13 +38,3 @@ pub struct Metadata {
     /// If omitted, log time is used.
     pub publish_time: u64,
 }
-
-impl PartialMetadata {
-    pub const fn new() -> Self {
-        Self {
-            sequence: None,
-            log_time: None,
-            publish_time: None,
-        }
-    }
-}

--- a/rust/foxglove/src/tests.rs
+++ b/rust/foxglove/src/tests.rs
@@ -1,4 +1,28 @@
+use std::{error::Error, fmt::Display};
+
+use crate::FoxgloveError;
+
 mod logging;
 mod websocket;
 #[cfg(feature = "unstable")]
 mod websocket_unstable;
+
+#[derive(Debug, thiserror::Error)]
+struct SourceError(&'static str);
+impl Display for SourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[test]
+fn test_unspecified_error_downcast() {
+    let src_err = SourceError("oh no");
+    let fg_err = FoxgloveError::Unspecified(src_err.into());
+    assert_eq!(format!("{fg_err}"), "oh no");
+    assert!(fg_err
+        .source()
+        .unwrap()
+        .downcast_ref::<SourceError>()
+        .is_some());
+}

--- a/rust/foxglove/src/testutil/log_sink.rs
+++ b/rust/foxglove/src/testutil/log_sink.rs
@@ -53,6 +53,15 @@ impl LogSink for RecordingSink {
 
 pub struct ErrorSink;
 
+#[derive(Debug, thiserror::Error)]
+struct StrError(&'static str);
+
+impl std::fmt::Display for StrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
 impl LogSink for ErrorSink {
     fn log(
         &self,
@@ -60,6 +69,8 @@ impl LogSink for ErrorSink {
         _msg: &[u8],
         _metadata: &Metadata,
     ) -> Result<(), FoxgloveError> {
-        Err(FoxgloveError::Fatal("ErrorSink always fails".to_string()))
+        Err(FoxgloveError::Unspecified(Box::new(StrError(
+            "ErrorSink always fails",
+        ))))
     }
 }

--- a/rust/foxglove/src/websocket/protocol/client.rs
+++ b/rust/foxglove/src/websocket/protocol/client.rs
@@ -6,10 +6,12 @@ use serde::{Deserialize, Serialize};
 
 type Error = Box<dyn std::error::Error>;
 
+/// A client channel ID.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 pub struct ClientChannelId(u32);
 
 impl ClientChannelId {
+    /// Creates a new client channel ID.
     pub fn new(id: u32) -> Self {
         Self(id)
     }


### PR DESCRIPTION
- Add the last missing docs, and slap on a `#![warn(missing_docs)]` attribute.
- Remove the mostly-useless `PartialMetadata::new()`.
- Expand the `FoxgloveError` somewhat:
  - Rename `Fatal` as `Unspecified` and retain the source error for downcasting.
  - Add variants for things that don't benefit from being opaque.