### PR TITLE
rust: Remove errant async for broadcast_time

### DIFF
--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -191,7 +191,7 @@ impl WebSocketServerBlockingHandle {
     /// Publishes the current server timestamp to all clients.
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
-    pub async fn broadcast_time(&self, timestamp_nanos: u64) {
+    pub fn broadcast_time(&self, timestamp_nanos: u64) {
         self.0
             .runtime()
             .block_on(self.0.broadcast_time(timestamp_nanos))


### PR DESCRIPTION
I accidentally put an async method on the `WebSocketServerBlockingHandle`. Don't do that.