### PR TITLE
rust: Use CamelCase for FoxgloveError variants

### DIFF
--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -226,13 +226,13 @@ pub enum FoxgloveError {
     DuplicateChannel(String),
     /// An I/O error.
     #[error(transparent)]
-    IOError(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
     /// An error related to MCAP encoding.
     #[error("MCAP error: {0}")]
-    MCAPError(#[from] mcap::McapError),
+    McapError(#[from] mcap::McapError),
     /// An error related to JSON encoding.
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
     #[error(transparent)]
-    JSONError(#[from] serde_json::Error),
+    JsonError(#[from] serde_json::Error),
 }

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -213,7 +213,7 @@ pub fn parameters_json(
 ) -> Result<String, FoxgloveError> {
     serde_json::to_value(&ServerMessage::ParameterValues { parameters, id })
         .map(|value| value.to_string())
-        .map_err(FoxgloveError::JSONError)
+        .map_err(FoxgloveError::JsonError)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We had a couple variants that were not conforming to UpperCamelCase as defined by the [naming guidelines](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case).