### PR TITLE
Add rust to generate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc -b",
     "bump-sdk-version": "ts-node ./scripts/bumpSdkVersion.ts",
-    "clean": "ts-node ./scripts/updateGeneratedFiles.ts --clean",
+    "clean": "ts-node ./scripts/generate.ts --clean",
     "generate": "ts-node ./scripts/generate.ts",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "lint": "eslint --report-unused-disable-directives --fix .",


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Extended `yarn generate` script to call `cargo run --bin foxglove-proto-gen`, required to generate the rust code.

The rust generation code cannot be directly ported to typescript because it relies on a rust library (prost) to generate its protobuf implementation.

The only remaining codegen that does not live in `yarn generate` is for python; this will become obsolete once https://github.com/foxglove/foxglove-sdk/pull/201 lands.