### PR TITLE
rust: Remove version numbers from example crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "example-client-publish"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "example-mcap"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "clap",
  "ctrlc",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "example-param-server"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "example-ws-server"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "example-ws-server-blocking"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "clap",
  "ctrlc",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "example-ws-stream-mcap"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rust/examples-unstable/client-publish/Cargo.toml
+++ b/rust/examples-unstable/client-publish/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-client-publish"
-version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/rust/examples-unstable/param-server/Cargo.toml
+++ b/rust/examples-unstable/param-server/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-param-server"
-version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/rust/examples-unstable/ws-stream-mcap/Cargo.toml
+++ b/rust/examples-unstable/ws-stream-mcap/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-ws-stream-mcap"
-version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/rust/examples/mcap/Cargo.toml
+++ b/rust/examples/mcap/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-mcap"
-version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/rust/examples/ws-server-blocking/Cargo.toml
+++ b/rust/examples/ws-server-blocking/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-ws-server-blocking"
-version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/rust/examples/ws-server/Cargo.toml
+++ b/rust/examples/ws-server/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-ws-server"
-version = "0.2.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
No need to semver the rust example crates, we do not intend to publish them. Having a version number adds potential confusion for the release script (since they were out of sync with the core package).