### PR TITLE
Optimize serialization of byte buffers in Python SDK

### DIFF
--- a/python/foxglove-sdk/python/examples/live_visualization.py
+++ b/python/foxglove-sdk/python/examples/live_visualization.py
@@ -1,15 +1,26 @@
+import math
+import struct
 import foxglove
 import numpy as np
 import time
 
 from examples.geometry import euler_to_quaternion
-from foxglove.channels import SceneUpdateChannel, FrameTransformChannel
+from foxglove.channels import (
+    FrameTransformsChannel,
+    PointCloudChannel,
+    SceneUpdateChannel,
+)
 from foxglove.schemas import (
     Color,
     CubePrimitive,
     Duration,
     FrameTransform,
+    FrameTransforms,
+    PackedElementField,
+    PackedElementFieldNumericType,
+    PointCloud,
     Pose,
+    Quaternion,
     RawImage,
     SceneEntity,
     SceneUpdate,
@@ -32,7 +43,8 @@ def main() -> None:
 
     # Log messages having well-known Foxglove schemas using the appropriate channel type.
     box_chan = SceneUpdateChannel("/boxes")
-    tf_chan = FrameTransformChannel("/tf")
+    tf_chan = FrameTransformsChannel("/tf")
+    point_chan = PointCloudChannel("/pointcloud")
 
     # Log arbitrary messages
     sin_chan = foxglove.Channel(
@@ -51,13 +63,26 @@ def main() -> None:
             }
 
             tf_chan.log(
-                FrameTransform(
-                    parent_frame_id="world",
-                    child_frame_id="box",
-                    rotation=euler_to_quaternion(roll=1, pitch=0, yaw=counter * 0.1),
+                FrameTransforms(
+                    transforms=[
+                        FrameTransform(
+                            parent_frame_id="world",
+                            child_frame_id="box",
+                            rotation=euler_to_quaternion(
+                                roll=1, pitch=0, yaw=counter * 0.1
+                            ),
+                        ),
+                        FrameTransform(
+                            parent_frame_id="world",
+                            child_frame_id="points",
+                            translation=Vector3(x=-10, y=-10, z=0),
+                        ),
+                    ]
                 )
             )
+
             sin_chan.log(json_msg)
+
             box_chan.log(
                 SceneUpdate(
                     entities=[
@@ -82,6 +107,8 @@ def main() -> None:
                 )
             )
 
+            point_chan.log(make_point_cloud())
+
             # Or use high-level log API without needing to manage explicit Channels.
             foxglove.log(
                 "/high-level",
@@ -98,6 +125,42 @@ def main() -> None:
 
     except KeyboardInterrupt:
         server.stop()
+
+
+def make_point_cloud() -> PointCloud:
+    """
+    https://foxglove.dev/blog/visualizing-point-clouds-with-custom-colors
+    """
+    point_struct = struct.Struct("<fffBBBB")
+    f32 = PackedElementFieldNumericType.Float32
+    u32 = PackedElementFieldNumericType.Uint32
+
+    t = time.time()
+    points = [(x + math.cos(t + y / 5), y, 0) for x in range(20) for y in range(20)]
+    buffer = bytearray(point_struct.size * len(points))
+    for i, point in enumerate(points):
+        x, y, z = point
+        r = int(255 * (0.5 + 0.5 * x / 20))
+        g = int(255 * y / 20)
+        b = int(255 * (0.5 + 0.5 * math.sin(t)))
+        a = int(255 * (0.5 + 0.5 * ((x / 20) * (y / 20))))
+        point_struct.pack_into(buffer, i * point_struct.size, x, y, z, b, g, r, a)
+
+    return PointCloud(
+        frame_id="points",
+        pose=Pose(
+            position=Vector3(x=0, y=0, z=0),
+            orientation=Quaternion(x=0, y=0, z=0, w=1),
+        ),
+        point_stride=16,  # 4 fields * 4 bytes
+        fields=[
+            PackedElementField(name="x", offset=0, type=f32),
+            PackedElementField(name="y", offset=4, type=f32),
+            PackedElementField(name="z", offset=8, type=f32),
+            PackedElementField(name="rgba", offset=12, type=u32),
+        ],
+        data=bytes(buffer),
+    )
 
 
 if __name__ == "__main__":

--- a/python/foxglove-sdk/src/generated/schemas.rs
+++ b/python/foxglove-sdk/src/generated/schemas.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::enum_variant_names)]
 #![allow(non_snake_case)]
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PyBytes};
 
 /// An enumeration indicating how input points should be interpreted to create lines
 #[pyclass(eq, eq_int, module = "foxglove.schemas")]
@@ -306,12 +306,17 @@ pub(crate) struct CompressedImage(pub(crate) foxglove::schemas::CompressedImage)
 #[pymethods]
 impl CompressedImage {
     #[new]
-    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), data=vec![], format="".to_string()) )]
-    fn new(timestamp: Option<Timestamp>, frame_id: String, data: Vec<u8>, format: String) -> Self {
+    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), data=None, format="".to_string()) )]
+    fn new(
+        timestamp: Option<Timestamp>,
+        frame_id: String,
+        data: Option<Bound<'_, PyBytes>>,
+        format: String,
+    ) -> Self {
         Self(foxglove::schemas::CompressedImage {
             timestamp: timestamp.map(Into::into),
             frame_id,
-            data,
+            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
             format,
         })
     }
@@ -336,12 +341,17 @@ pub(crate) struct CompressedVideo(pub(crate) foxglove::schemas::CompressedVideo)
 #[pymethods]
 impl CompressedVideo {
     #[new]
-    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), data=vec![], format="".to_string()) )]
-    fn new(timestamp: Option<Timestamp>, frame_id: String, data: Vec<u8>, format: String) -> Self {
+    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), data=None, format="".to_string()) )]
+    fn new(
+        timestamp: Option<Timestamp>,
+        frame_id: String,
+        data: Option<Bound<'_, PyBytes>>,
+        format: String,
+    ) -> Self {
         Self(foxglove::schemas::CompressedVideo {
             timestamp: timestamp.map(Into::into),
             frame_id,
-            data,
+            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
             format,
         })
     }
@@ -523,7 +533,7 @@ pub(crate) struct Grid(pub(crate) foxglove::schemas::Grid);
 #[pymethods]
 impl Grid {
     #[new]
-    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), pose=None, column_count=0, cell_size=None, row_stride=0, cell_stride=0, fields=vec![], data=vec![]) )]
+    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), pose=None, column_count=0, cell_size=None, row_stride=0, cell_stride=0, fields=vec![], data=None) )]
     fn new(
         timestamp: Option<Timestamp>,
         frame_id: String,
@@ -533,7 +543,7 @@ impl Grid {
         row_stride: u32,
         cell_stride: u32,
         fields: Vec<PackedElementField>,
-        data: Vec<u8>,
+        data: Option<Bound<'_, PyBytes>>,
     ) -> Self {
         Self(foxglove::schemas::Grid {
             timestamp: timestamp.map(Into::into),
@@ -544,7 +554,7 @@ impl Grid {
             row_stride,
             cell_stride,
             fields: fields.into_iter().map(|x| x.into()).collect(),
-            data,
+            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {
@@ -942,7 +952,7 @@ pub(crate) struct ModelPrimitive(pub(crate) foxglove::schemas::ModelPrimitive);
 #[pymethods]
 impl ModelPrimitive {
     #[new]
-    #[pyo3(signature = (*, pose=None, scale=None, color=None, override_color=false, url="".to_string(), media_type="".to_string(), data=vec![]) )]
+    #[pyo3(signature = (*, pose=None, scale=None, color=None, override_color=false, url="".to_string(), media_type="".to_string(), data=None) )]
     fn new(
         pose: Option<Pose>,
         scale: Option<Vector3>,
@@ -950,7 +960,7 @@ impl ModelPrimitive {
         override_color: bool,
         url: String,
         media_type: String,
-        data: Vec<u8>,
+        data: Option<Bound<'_, PyBytes>>,
     ) -> Self {
         Self(foxglove::schemas::ModelPrimitive {
             pose: pose.map(Into::into),
@@ -959,7 +969,7 @@ impl ModelPrimitive {
             override_color,
             url,
             media_type,
-            data,
+            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {
@@ -1065,14 +1075,14 @@ pub(crate) struct PointCloud(pub(crate) foxglove::schemas::PointCloud);
 #[pymethods]
 impl PointCloud {
     #[new]
-    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), pose=None, point_stride=0, fields=vec![], data=vec![]) )]
+    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), pose=None, point_stride=0, fields=vec![], data=None) )]
     fn new(
         timestamp: Option<Timestamp>,
         frame_id: String,
         pose: Option<Pose>,
         point_stride: u32,
         fields: Vec<PackedElementField>,
-        data: Vec<u8>,
+        data: Option<Bound<'_, PyBytes>>,
     ) -> Self {
         Self(foxglove::schemas::PointCloud {
             timestamp: timestamp.map(Into::into),
@@ -1080,7 +1090,7 @@ impl PointCloud {
             pose: pose.map(Into::into),
             point_stride,
             fields: fields.into_iter().map(|x| x.into()).collect(),
-            data,
+            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {
@@ -1267,7 +1277,7 @@ pub(crate) struct RawImage(pub(crate) foxglove::schemas::RawImage);
 #[pymethods]
 impl RawImage {
     #[new]
-    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), width=0, height=0, encoding="".to_string(), step=0, data=vec![]) )]
+    #[pyo3(signature = (*, timestamp=None, frame_id="".to_string(), width=0, height=0, encoding="".to_string(), step=0, data=None) )]
     fn new(
         timestamp: Option<Timestamp>,
         frame_id: String,
@@ -1275,7 +1285,7 @@ impl RawImage {
         height: u32,
         encoding: String,
         step: u32,
-        data: Vec<u8>,
+        data: Option<Bound<'_, PyBytes>>,
     ) -> Self {
         Self(foxglove::schemas::RawImage {
             timestamp: timestamp.map(Into::into),
@@ -1284,7 +1294,7 @@ impl RawImage {
             height,
             encoding,
             step,
-            data,
+            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {

--- a/typescript/schemas/src/internal/generatePyclass.test.ts
+++ b/typescript/schemas/src/internal/generatePyclass.test.ts
@@ -9,7 +9,7 @@ describe("generatePyclass", () => {
         #![allow(clippy::too_many_arguments)]
         #![allow(clippy::enum_variant_names)]
         #![allow(non_snake_case)]
-        use pyo3::prelude::*;
+        use pyo3::{prelude::*, types::PyBytes};
 
         "
         `);
@@ -38,26 +38,26 @@ describe("generatePyclass", () => {
         #[pymethods]
         impl ExampleMessage {
             #[new]
-            #[pyo3(signature = (*, field_duration=None, field_time=None, field_boolean=false, field_bytes=vec![], field_float64=0.0, field_uint32=0, field_string="".to_string(), field_duration_array=vec![], field_time_array=vec![], field_boolean_array=vec![], field_bytes_array=vec![], field_float64_array=vec![], field_uint32_array=vec![], field_string_array=vec![], field_duration_fixed_array=vec![], field_time_fixed_array=vec![], field_boolean_fixed_array=vec![], field_bytes_fixed_array=vec![], field_float64_fixed_array=vec![], field_uint32_fixed_array=vec![], field_string_fixed_array=vec![], field_enum=ExampleMessageExampleEnum::A, field_enum_array=vec![], field_nested=None, field_nested_array=vec![]) )]
+            #[pyo3(signature = (*, field_duration=None, field_time=None, field_boolean=false, field_bytes=None, field_float64=0.0, field_uint32=0, field_string="".to_string(), field_duration_array=vec![], field_time_array=vec![], field_boolean_array=vec![], field_bytes_array=None, field_float64_array=vec![], field_uint32_array=vec![], field_string_array=vec![], field_duration_fixed_array=vec![], field_time_fixed_array=vec![], field_boolean_fixed_array=vec![], field_bytes_fixed_array=None, field_float64_fixed_array=vec![], field_uint32_fixed_array=vec![], field_string_fixed_array=vec![], field_enum=ExampleMessageExampleEnum::A, field_enum_array=vec![], field_nested=None, field_nested_array=vec![]) )]
             fn new(
                 field_duration: Option<Duration>,
                 field_time: Option<Timestamp>,
                 field_boolean: bool,
-                field_bytes: Vec<u8>,
+                field_bytes: Option<Bound<'_, PyBytes>>,
                 field_float64: f64,
                 field_uint32: u32,
                 field_string: String,
                 field_duration_array: Vec<Option<Duration>>,
                 field_time_array: Vec<Option<Timestamp>>,
                 field_boolean_array: Vec<bool>,
-                field_bytes_array: Vec<Vec<u8>>,
+                field_bytes_array: Option<Bound<'_, PyBytes>>,
                 field_float64_array: Vec<f64>,
                 field_uint32_array: Vec<u32>,
                 field_string_array: Vec<String>,
                 field_duration_fixed_array: Vec<Option<Duration>>,
                 field_time_fixed_array: Vec<Option<Timestamp>>,
                 field_boolean_fixed_array: Vec<bool>,
-                field_bytes_fixed_array: Vec<Vec<u8>>,
+                field_bytes_fixed_array: Option<Bound<'_, PyBytes>>,
                 field_float64_fixed_array: Vec<f64>,
                 field_uint32_fixed_array: Vec<u32>,
                 field_string_fixed_array: Vec<String>,
@@ -70,21 +70,21 @@ describe("generatePyclass", () => {
                     field_duration: field_duration.map(Into::into),
                     field_time: field_time.map(Into::into),
                     field_boolean,
-                    field_bytes,
+                    field_bytes: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
                     field_float64,
                     field_uint32,
                     field_string,
                     field_duration_array: field_duration_array.map(Into::into),
                     field_time_array: field_time_array.map(Into::into),
                     field_boolean_array,
-                    field_bytes_array,
+                    field_bytes_array: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
                     field_float64_array,
                     field_uint32_array,
                     field_string_array,
                     field_duration_fixed_array: field_duration_fixed_array.map(Into::into),
                     field_time_fixed_array: field_time_fixed_array.map(Into::into),
                     field_boolean_fixed_array,
-                    field_bytes_fixed_array,
+                    field_bytes_fixed_array: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
                     field_float64_fixed_array,
                     field_uint32_fixed_array,
                     field_string_fixed_array,


### PR DESCRIPTION
This PR modifies the generated schema structs to improve the serialization of byte arrays. When a struct `Vec` field is constructed, pyo3 will iterate the vec and copy each element. This change updates the `Vec<u8>` fields to accept a python-native type, from which we copy the bytes at once. This doesn't require changing the protobuf interface in the Rust SDK. There may be further optimizations we can make, but this is pretty low-hanging fruit.

This also adds a point cloud channel to the live viz example, taken from the linked blog post.

Earlier profiling showed that this approach (similar code) gave a speedup of ~2. Writing 1000-pt point clouds in a tight loop to an mcap file increases the publishing throughput 2-3x:


<table>
<tr><th>Before</th>
</tr>
<tr><td>

```sh
duration:  1.333925s
start:     2025-02-14T08:57:23.15778-05:00 (1739541443.157780000)
end:       2025-02-14T08:57:24.491705-05:00 (1739541444.491705000)
compression:
	zstd: [21/21 chunks] [15.37 MiB/1.85 MiB (87.94%)] [1.39 MiB/sec]
channels:
	(1) /pointcloud  1001 msgs (750.42 Hz)   : foxglove.PointCloud [protobuf]
channels: 1
```

</td>
</tr>
<tr><th>After</th></tr>
<tr>
<td>

```
duration:  462.919ms
start:     2025-02-14T08:56:45.933291-05:00 (1739541405.933291000)
end:       2025-02-14T08:56:46.39621-05:00 (1739541406.396210000)
compression:
	zstd: [21/21 chunks] [15.37 MiB/1.52 MiB (90.09%)] [3.29 MiB/sec]
channels:
	(1) /pointcloud  1001 msgs (2162.37 Hz)   : foxglove.PointCloud [protobuf]
```

</td></tr>
</table>