### PR TITLE
Update MCAP handling in Python SDK

### DIFF
--- a/python/foxglove-sdk/python/docs/index.rst
+++ b/python/foxglove-sdk/python/docs/index.rst
@@ -26,8 +26,8 @@ Overview
 To record messages, you need at least one sink and at least one channel.
 
 A "sink" is a destination for logged messages — either an MCAP file or a live visualization server.
-Use :python:`record_file` to register a new MCAP sink. Use :python:`start_server` to create a new
-live visualization server.
+Use :python:`record_file` or :python:`with new_mcap_file("")` to register a new MCAP sink. Use
+:python:`start_server` to create a new live visualization server.
 
 A "channel" gives a way to log related messages which have the same schema. Each channel is
 instantiated with a unique topic name.

--- a/python/foxglove-sdk/python/examples/write_log.py
+++ b/python/foxglove-sdk/python/examples/write_log.py
@@ -1,9 +1,37 @@
 import argparse
+import inspect
 import foxglove
+
+from foxglove.channels import LogChannel
+from foxglove.schemas import Log, LogLevel
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--path", type=str, default="output.mcap")
 args = parser.parse_args()
 
-# Open a new mcap file for recording
-foxglove.record_file(args.path)
+
+def main():
+    # Create a new mcap file at the given path for recording
+    writer = foxglove.record_file(args.path)
+
+    channel = LogChannel("/hello")
+
+    for i in range(10):
+        frame = inspect.currentframe()
+        frameinfo = inspect.getframeinfo(frame) if frame else None
+
+        channel.log(
+            Log(
+                level=LogLevel.Info,
+                name="SDK example",
+                file=frameinfo.filename if frameinfo else None,
+                line=frameinfo.lineno if frameinfo else None,
+                message=f"message {i}",
+            )
+        )
+
+    writer.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/foxglove-sdk/python/examples/write_log.py
+++ b/python/foxglove-sdk/python/examples/write_log.py
@@ -10,27 +10,24 @@ parser.add_argument("--path", type=str, default="output.mcap")
 args = parser.parse_args()
 
 
-def main():
+def main() -> None:
     # Create a new mcap file at the given path for recording
-    writer = foxglove.record_file(args.path)
+    with foxglove.new_mcap_file(args.path):
+        channel = LogChannel("/hello")
 
-    channel = LogChannel("/hello")
+        for i in range(10):
+            frame = inspect.currentframe()
+            frameinfo = inspect.getframeinfo(frame) if frame else None
 
-    for i in range(10):
-        frame = inspect.currentframe()
-        frameinfo = inspect.getframeinfo(frame) if frame else None
-
-        channel.log(
-            Log(
-                level=LogLevel.Info,
-                name="SDK example",
-                file=frameinfo.filename if frameinfo else None,
-                line=frameinfo.lineno if frameinfo else None,
-                message=f"message {i}",
+            channel.log(
+                Log(
+                    level=LogLevel.Info,
+                    name="SDK example",
+                    file=frameinfo.filename if frameinfo else None,
+                    line=frameinfo.lineno if frameinfo else None,
+                    message=f"message {i}",
+                )
             )
-        )
-
-    writer.close()
 
 
 if __name__ == "__main__":

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -1,5 +1,6 @@
 import atexit
-from typing import Union
+from contextlib import contextmanager
+from typing import Iterator, Union
 from ._foxglove_py import (
     record_file,
     enable_logging,
@@ -52,6 +53,19 @@ def verbose_off() -> None:
     """
     logging.debug("SDK logging disabled")
     disable_logging()
+
+
+@contextmanager
+def new_mcap_file(fname: str) -> Iterator[None]:
+    """
+    Create an MCAP file at the given path for recording.
+    This is the context-managed equivalent of `record_file`.
+    """
+    writer = record_file(fname)
+    try:
+        yield
+    finally:
+        writer.close()
 
 
 __all__ = [

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -58,6 +58,21 @@ class PartialMetadata:
         """
         ...
 
+class MCAPWriter:
+    """
+    A writer for logging messages to an MCAP file. Obtain an instance by calling ``record_file``.
+
+    You must maintain a reference to the writer object until you are done logging. The writer will
+    be closed automatically when it is garbage collected, but you may also ``close()`` it
+    explicitly.
+    """
+
+    def close(self) -> None:
+        """
+        Close the writer explicitly.
+        """
+        ...
+
 def start_server(
     name: Optional[str] = None,
     host: Optional[str] = "127.0.0.1",
@@ -86,7 +101,7 @@ def shutdown() -> None:
     """
     ...
 
-def record_file(path: str) -> None:
+def record_file(path: str) -> MCAPWriter:
     """
     Create a new MCAP file at ``path`` for logging.
     """

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -1,8 +1,21 @@
 from typing import List, Optional, Tuple
 
 class MCAPWriter:
+    """
+    A writer for logging messages to an MCAP file. Obtain an instance by calling `record_file`, or
+    the context-managed `new_mcap_file`.
+
+    If you're using `record_file`, you must maintain a reference to the returned writer until you
+    are done logging. The writer will be closed automatically when it is garbage collected, but you
+    may also `close()` it explicitly.
+    """
+
     def __new__(cls) -> "MCAPWriter": ...
-    def close(self) -> None: ...
+    def close(self) -> None:
+        """
+        Close the writer explicitly.
+        """
+        ...
 
 class WebSocketServer:
     """
@@ -55,21 +68,6 @@ class PartialMetadata:
             current time is used.
         :param publish_time: The publish_time is the time at which the message was published. e.g.
             the timestamp at which the sensor reading was taken. If omitted, log time is used.
-        """
-        ...
-
-class MCAPWriter:
-    """
-    A writer for logging messages to an MCAP file. Obtain an instance by calling ``record_file``.
-
-    You must maintain a reference to the writer object until you are done logging. The writer will
-    be closed automatically when it is garbage collected, but you may also ``close()`` it
-    explicitly.
-    """
-
-    def close(self) -> None:
-        """
-        Close the writer explicitly.
         """
         ...
 

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -43,7 +43,7 @@ impl PyWebSocketServer {
     }
 }
 
-#[pyclass]
+#[pyclass(name = "MCAPWriter")]
 struct PyMcapWriter(Option<McapWriterHandle<BufWriter<File>>>);
 
 impl Drop for PyMcapWriter {
@@ -55,6 +55,7 @@ impl Drop for PyMcapWriter {
     }
 }
 
+#[pymethods]
 impl PyMcapWriter {
     fn close(&mut self) -> PyResult<()> {
         if let Some(writer) = self.0.take() {


### PR DESCRIPTION
This fixes the implementation of `PyMcapWriter` to agree with the declared interface. Notably, it exposes the `close` method and documents the auto-closing behavior if a reference to the writer is not held.

To make this easier to work with, this also adds a context-managed function `new_mcap_file`, which frees the user from needing to maintain a reference to the writer. I included 'mcap' in the name since (a) we've decided to expose that name in the Rust SDK, and (b) it makes clear with the output format will be, since we're asking the user to supply a file name.

This also updates the example to produce a basic MCAP file.