### PR TITLE
Downgrade some logging to debug

### DIFF
--- a/rust/foxglove/src/runtime.rs
+++ b/rust/foxglove/src/runtime.rs
@@ -11,7 +11,7 @@ struct Runtime {
 }
 impl Runtime {
     fn new() -> Self {
-        tracing::info!("Creating tokio runtime");
+        tracing::debug!("Creating tokio runtime");
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -452,7 +452,7 @@ impl ConnectedClient {
                 }
             }
 
-            tracing::info!(
+            tracing::debug!(
                 "Client {} subscribed to channel {} with subscription id {}",
                 self.addr,
                 subscription.channel_id,
@@ -575,6 +575,8 @@ impl Server {
             }
         });
 
+        tracing::info!("Started server on {}", bound_addr);
+
         Ok(bound_addr)
     }
 
@@ -618,7 +620,7 @@ impl Server {
         let clients = self.clients.get();
         for client in clients.iter() {
             if client.send_control_msg(Message::text(message.clone())) {
-                tracing::info!(
+                tracing::debug!(
                     "Advertised channel {} with id {} to client {}",
                     channel.topic,
                     channel.id,
@@ -635,7 +637,7 @@ impl Server {
         let clients = self.clients.get();
         for client in clients.iter() {
             if client.send_control_msg(Message::text(message.clone())) {
-                tracing::info!(
+                tracing::debug!(
                     "Unadvertised channel with id {} to client {}",
                     channel_id,
                     client.addr
@@ -831,7 +833,7 @@ impl Server {
         // Run send and receive loops concurrently, and wait for receive to complete
         tokio::select! {
             _ = receive_messages => {
-                tracing::info!("Receive messages task completed");
+                tracing::debug!("Receive messages task completed");
             }
             _ = send_control_messages => {
                 tracing::error!("Send control messages task completed");
@@ -860,7 +862,7 @@ impl Server {
         }
 
         tracing::info!(
-            "Registered client {} advertising {} channels",
+            "Registered client {}; advertising {} channels",
             client.addr,
             channels.len()
         );
@@ -880,7 +882,7 @@ impl Server {
                 break;
             }
 
-            tracing::info!(
+            tracing::debug!(
                 "Advertised channel {} with id {} to client {}",
                 channel.topic,
                 channel.id,


### PR DESCRIPTION
This reduces default logging noise by changing advertisements & subscriptions to `debug`.

I added a more general "server started" info log, and made the tokio runtime messaging debug. I think we could consider not logging anything about "tokio" from the core SDK, but it also seems OK at debug level.