### PR TITLE
rust: inline definitions for derived schemas

### DIFF
--- a/rust/examples/ws-server/src/main.rs
+++ b/rust/examples/ws-server/src/main.rs
@@ -9,7 +9,15 @@ use serde::Serialize;
 use std::time::Duration;
 
 #[derive(Debug, Serialize, JsonSchema)]
+enum MessageLevel {
+    Debug,
+    #[allow(dead_code)]
+    Info,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
 struct Message {
+    level: MessageLevel,
     msg: String,
     count: u32,
 }
@@ -31,6 +39,7 @@ async fn log_forever(fps: u8) {
 
 fn log(counter: u32) {
     MSG_CHANNEL.log(&Message {
+        level: MessageLevel::Debug,
         msg: "Hello, world!".to_string(),
         count: counter,
     });

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -1,6 +1,6 @@
 use crate::{Channel, ChannelBuilder, FoxgloveError, PartialMetadata, Schema};
 use bytes::BufMut;
-use schemars::{schema_for, JsonSchema};
+use schemars::{gen::SchemaSettings, JsonSchema};
 use serde::Serialize;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -37,13 +37,21 @@ pub trait Encode {
     }
 }
 
-/// Automatically implements [`Encode`] for any type that implements [`Serialize`] and [`JsonSchema`](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html).
-/// See the JsonSchema Trait and schema_for! macro from the [schemars crate](https://docs.rs/schemars/latest/schemars/) for more information.
+/// Automatically implements [`Encode`] for any type that implements [`Serialize`] and
+/// [`JsonSchema`](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html). See the
+/// JsonSchema Trait and SchemaGenerator from the [schemars
+/// crate](https://docs.rs/schemars/latest/schemars/) for more information.
+/// Definitions are inlined since Foxglove does not support external references.
 impl<T: Serialize + JsonSchema> Encode for T {
     type Error = serde_json::Error;
 
     fn get_schema() -> Option<Schema> {
-        let json_schema = schema_for!(T);
+        let settings = SchemaSettings::draft07().with(|option| {
+            option.inline_subschemas = true;
+        });
+        let generator = settings.into_generator();
+        let json_schema = generator.into_root_schema_for::<T>();
+
         Some(Schema::new(
             std::any::type_name::<T>().to_string(),
             "jsonschema".to_string(),
@@ -170,6 +178,7 @@ mod test {
     use crate::Schema;
     use prost::bytes::BufMut;
     use serde::Serialize;
+    use serde_json::{json, Value};
     use tracing_test::traced_test;
 
     #[derive(Debug, Serialize)]
@@ -219,5 +228,28 @@ mod test {
 
         channel.log(&message);
         assert!(!logs_contain("error logging message"));
+    }
+
+    #[test]
+    fn test_derived_schema_inlines_enums() {
+        #[derive(Serialize, JsonSchema)]
+        #[allow(dead_code)]
+        enum Foo {
+            A,
+        }
+
+        #[derive(Serialize, JsonSchema)]
+        struct Bar {
+            foo: Foo,
+        }
+
+        let schema = Bar::get_schema();
+        assert!(schema.is_some());
+
+        let schema = schema.unwrap();
+        assert_eq!(schema.encoding, "jsonschema");
+
+        let json: Value = serde_json::from_slice(&schema.data).expect("failed to parse schema");
+        assert_eq!(json["properties"]["foo"]["enum"], json!(["A"]));
     }
 }


### PR DESCRIPTION
This updates the auto-generated JSON schema for custom types to inline definitions, rather than including `$ref`s. Current versions of Foxglove do not support the latter.

This specifies the `draft07` version of JSONSchema, which is currently the default in schemars.

I added an enum to the example to confirm that this works (does not produce a 'problem') in the app.