### PR TITLE
Merge release tags with --ff when available

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -23,7 +23,7 @@ jobs:
           git config user.name "Foxglove"
           git config user.email "support@foxglove.dev"
           git checkout -b main --track origin/main
-          git merge --no-ff "${{ env.SDK_TAG }}"
+          git merge "${{ env.SDK_TAG }}"
           git push origin main
 
       - name: Delete old release branch


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
When merging release tags, there is no need for `--no-ff`. The thing we want to avoid is a squash merge (which would alter the commit we tagged). But if there have been no new commits to main since the release is tagged, then `--ff` is fine.

By removing `--no-ff`, git will automatically create either a fast-forward merge or a merge commit, as needed.