### PR TITLE
python: Add a server listener that handles client message callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
+ "tracing",
  "walkdir",
 ]
 

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tokio-tungstenite.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 [build-dependencies]
 walkdir = "2.5.0"

--- a/python/foxglove-sdk/python/examples/live_visualization.py
+++ b/python/foxglove-sdk/python/examples/live_visualization.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import math
 import struct
 import foxglove
@@ -57,8 +58,8 @@ class ExampleListener(foxglove.ServerListener):
         channel: foxglove.ClientChannelView,
         data: bytes,
     ) -> None:
-        print(f"Message from client {client.id} on channel {channel.topic}")
-        print(f"Data: {data!r}")
+        logging.info(f"Message from client {client.id} on channel {channel.topic}")
+        logging.info(f"Data: {data!r}")
 
 
 def main() -> None:

--- a/python/foxglove-sdk/python/examples/live_visualization.py
+++ b/python/foxglove-sdk/python/examples/live_visualization.py
@@ -45,12 +45,18 @@ plot_schema = {
 
 
 class ExampleListener(foxglove.ServerListener):
+    """
+    This listener demonstrates receiving messages from the client.
+    You can send messages from Foxglove app in the publish panel:
+    https://docs.foxglove.dev/docs/visualization/panels/publish
+    """
+
     def on_message_data(
         self,
         client: foxglove.Client,
         channel: foxglove.ClientChannelView,
         data: bytes,
-    ):
+    ) -> None:
         print(f"Message from client {client.id} on channel {channel.topic}")
         print(f"Data: {data!r}")
 
@@ -61,6 +67,7 @@ def main() -> None:
     server = foxglove.start_server(
         server_listener=ExampleListener(),
         capabilities=[Capability.ClientPublish],
+        supported_encodings=["json"],
     )
 
     # Log messages having well-known Foxglove schemas using the appropriate channel type.

--- a/python/foxglove-sdk/python/examples/live_visualization.py
+++ b/python/foxglove-sdk/python/examples/live_visualization.py
@@ -7,7 +7,7 @@ import time
 
 from examples.geometry import euler_to_quaternion
 
-from foxglove import SchemaDefinition
+from foxglove import Capability, SchemaDefinition
 from foxglove.channels import (
     FrameTransformsChannel,
     PointCloudChannel,
@@ -44,10 +44,24 @@ plot_schema = {
 }
 
 
+class ExampleListener(foxglove.ServerListener):
+    def on_message_data(
+        self,
+        client: foxglove.Client,
+        channel: foxglove.ClientChannelView,
+        data: bytes,
+    ):
+        print(f"Message from client {client.id} on channel {channel.topic}")
+        print(f"Data: {data!r}")
+
+
 def main() -> None:
     foxglove.verbose_on()
 
-    server = foxglove.start_server()
+    server = foxglove.start_server(
+        server_listener=ExampleListener(),
+        capabilities=[Capability.ClientPublish],
+    )
 
     # Log messages having well-known Foxglove schemas using the appropriate channel type.
     box_chan = SceneUpdateChannel("/boxes")
@@ -101,8 +115,6 @@ def main() -> None:
                     ]
                 )
             )
-
-            sin_chan.log(json_msg)
 
             box_chan.log(
                 SceneUpdate(

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -7,17 +7,20 @@ schemas.
 
 import atexit
 from contextlib import contextmanager
-from typing import Iterator, Union
+from typing import Iterator, List, Optional, Protocol, Union
 from ._foxglove_py import (
+    ClientChannelView,
+    Client,
     MCAPWriter,
     WebSocketServer,
     record_file,
     enable_logging,
     disable_logging,
-    start_server,
     shutdown,
     Capability,
 )
+
+from ._foxglove_py import start_server as _start_server
 
 
 from .channel import Channel, log, SchemaDefinition
@@ -29,6 +32,36 @@ logging.basicConfig(
 )
 
 atexit.register(shutdown)
+
+
+class ServerListener(Protocol):
+    """
+    A mechanism to register callbacks for handling client message events.
+    """
+
+    def on_message_data(
+        self, client: Client, channel: ClientChannelView, data: bytes
+    ) -> None:
+        pass
+
+
+def start_server(
+    name: Optional[str] = None,
+    host: Optional[str] = "127.0.0.1",
+    port: Optional[int] = 8765,
+    capabilities: Optional[List[Capability]] = None,
+    server_listener: Optional[ServerListener] = None,
+) -> WebSocketServer:
+    """
+    Start a websocket server for live visualization.
+    """
+    return _start_server(
+        name=name,
+        host=host,
+        port=port,
+        capabilities=capabilities,
+        server_listener=server_listener,
+    )
 
 
 def _log_level_from_int(level: int) -> str:
@@ -83,6 +116,7 @@ __all__ = [
     "Channel",
     "MCAPWriter",
     "SchemaDefinition",
+    "ServerListener",
     "WebSocketServer",
     "log",
     "new_mcap_file",

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -42,6 +42,13 @@ class ServerListener(Protocol):
     def on_message_data(
         self, client: Client, channel: ClientChannelView, data: bytes
     ) -> None:
+        """
+        Called by the server when a message is received from a client.
+
+        :param client: The client (id) that sent the message.
+        :param channel: The channel (id, topic) that the message was sent on.
+        :param data: The message data.
+        """
         pass
 
 
@@ -51,9 +58,17 @@ def start_server(
     port: Optional[int] = 8765,
     capabilities: Optional[List[Capability]] = None,
     server_listener: Optional[ServerListener] = None,
+    supported_encodings: Optional[List[str]] = None,
 ) -> WebSocketServer:
     """
     Start a websocket server for live visualization.
+
+    :param name: The name of the server.
+    :param host: The host to bind to.
+    :param port: The port to bind to.
+    :param capabilities: A list of capabilities to advertise to clients.
+    :param server_listener: A Python object that implements the :py:class:`ServerListener` protocol.
+    :param supported_encodings: A list of encodings to advertise to clients.
     """
     return _start_server(
         name=name,
@@ -61,6 +76,7 @@ def start_server(
         port=port,
         capabilities=capabilities,
         server_listener=server_listener,
+        supported_encodings=supported_encodings,
     )
 
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Protocol, Tuple
 
 class MCAPWriter:
     """
@@ -79,12 +79,29 @@ class Capability(Enum):
     """
 
     Time = ...
+    ClientPublish = ...
+
+class Client:
+    """
+    A client that is connected to a running websocket server.
+    """
+
+    id = ...
+
+class ClientChannelView:
+    """
+    Information about a client channel.
+    """
+
+    id = ...
+    topic = ...
 
 def start_server(
     name: Optional[str] = None,
     host: Optional[str] = "127.0.0.1",
     port: Optional[int] = 8765,
     capabilities: Optional[List[Capability]] = None,
+    server_listener: Any = None,
 ) -> WebSocketServer:
     """
     Start a websocket server for live visualization.

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -102,6 +102,7 @@ def start_server(
     port: Optional[int] = 8765,
     capabilities: Optional[List[Capability]] = None,
     server_listener: Any = None,
+    supported_encodings: Optional[List[str]] = None,
 ) -> WebSocketServer:
     """
     Start a websocket server for live visualization.

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::sync::Arc;
 use websocket_server::{
-    start_server, PyCapability, PyClient, PyClientChannelView, PyServerListener, PyWebSocketServer,
+    start_server, PyCapability, PyClient, PyClientChannelView, PyWebSocketServer,
 };
 
 mod errors;
@@ -208,7 +208,6 @@ fn _foxglove_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Websocket server classes
     m.add_class::<PyWebSocketServer>()?;
-    m.add_class::<PyServerListener>()?;
     m.add_class::<PyCapability>()?;
     m.add_class::<PyClient>()?;
     m.add_class::<PyClientChannelView>()?;

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -1,8 +1,7 @@
 use errors::PyFoxgloveError;
-use foxglove::{
-    Channel, ChannelBuilder, LogContext, McapWriter, McapWriterHandle, Schema, WebSocketServer,
-    WebSocketServerBlockingHandle,
-};
+use foxglove::{Channel, ChannelBuilder, LogContext, McapWriter, McapWriterHandle, Schema};
+use generated::channels;
+use generated::schemas;
 use log::LevelFilter;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -10,72 +9,14 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::BufWriter;
 use std::sync::Arc;
-use std::time;
+use websocket_server::{start_server, Capability, PyWebSocketServer};
 
 mod errors;
 mod generated;
-
-use generated::channels;
-use generated::schemas;
+mod websocket_server;
 
 #[pyclass]
 struct BaseChannel(Arc<Channel>);
-
-/// A live visualization server. Obtain an instance by calling :py:func:`start_server`.
-#[pyclass(name = "WebSocketServer")]
-struct PyWebSocketServer(Option<WebSocketServerBlockingHandle>);
-
-#[pymethods]
-impl PyWebSocketServer {
-    fn stop(&mut self, py: Python<'_>) {
-        if let Some(server) = self.0.take() {
-            py.allow_threads(|| server.stop())
-        }
-    }
-
-    /// Sets a new session ID and notifies all clients, causing them to reset their state.
-    /// If no session ID is provided, generates a new one based on the current timestamp.
-    #[pyo3(signature = (session_id=None))]
-    fn clear_session(&self, session_id: Option<String>) -> PyResult<()> {
-        if let Some(server) = &self.0 {
-            server.clear_session(session_id);
-        }
-        Ok(())
-    }
-
-    fn broadcast_time(&self, timestamp_nanos: u64) -> PyResult<()> {
-        if let Some(server) = &self.0 {
-            server.broadcast_time(timestamp_nanos);
-        }
-        Ok(())
-    }
-}
-
-/// A capability that the websocket server advertises to its clients.
-#[pyclass(eq, eq_int)]
-#[derive(Clone, PartialEq)]
-enum Capability {
-    /// Allow clients to advertise channels to send data messages to the server.
-    // ClientPublish,
-    /// Allow clients to get & set parameters.
-    // Parameters,
-    /// Inform clients about the latest server time.
-    ///
-    /// This allows accelerated, slowed, or stepped control over the progress of time. If the
-    /// server publishes time data, then timestamps of published messages must originate from the
-    /// same time source.
-    Time,
-}
-
-impl From<Capability> for foxglove::websocket::Capability {
-    fn from(value: Capability) -> Self {
-        match value {
-            // Capability::ClientPublish => foxglove::websocket::Capability::ClientPublish,
-            // Capability::Parameters => foxglove::websocket::Capability::Parameters,
-            Capability::Time => foxglove::websocket::Capability::Time,
-        }
-    }
-}
 
 ///  A writer for logging messages to an MCAP file.
 ///
@@ -214,48 +155,6 @@ fn record_file(path: &str) -> PyResult<PyMcapWriter> {
     Ok(PyMcapWriter(Some(handle)))
 }
 
-/// Start a new Foxglove WebSocket server.
-///
-/// :param name: The name of the server.
-/// :param host: The host to bind to.
-/// :param port: The port to bind to.
-///
-/// To connect to this server: open Foxglove, choose "Open a new connection", and select Foxglove
-/// WebSocket. The default connection string matches the defaults used by the SDK.
-#[pyfunction]
-#[pyo3(signature = (*, name = None, host="127.0.0.1", port=8765, capabilities=None))]
-fn start_server(
-    py: Python<'_>,
-    name: Option<String>,
-    host: &str,
-    port: u16,
-    capabilities: Option<Vec<Capability>>,
-) -> PyResult<PyWebSocketServer> {
-    let session_id = time::SystemTime::now()
-        .duration_since(time::UNIX_EPOCH)
-        .expect("Failed to create session ID; invalid system time")
-        .as_millis()
-        .to_string();
-
-    let mut server = WebSocketServer::new()
-        .session_id(session_id)
-        .bind(host, port);
-
-    if let Some(capabilities) = capabilities {
-        server = server.capabilities(capabilities.into_iter().map(Capability::into));
-    }
-
-    if let Some(name) = name {
-        server = server.name(name);
-    }
-
-    let handle = py
-        .allow_threads(|| server.start_blocking())
-        .map_err(PyFoxgloveError::from)?;
-
-    Ok(PyWebSocketServer(Some(handle)))
-}
-
 #[pyfunction]
 fn get_channel_for_topic(topic: &str) -> PyResult<Option<BaseChannel>> {
     let channel = LogContext::global().get_channel_by_topic(topic);
@@ -303,9 +202,9 @@ fn _foxglove_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_channel_for_topic, m)?)?;
     m.add_class::<BaseChannel>()?;
     m.add_class::<PyWebSocketServer>()?;
+    m.add_class::<Capability>()?;
     m.add_class::<PyMcapWriter>()?;
     m.add_class::<PartialMetadata>()?;
-    m.add_class::<Capability>()?;
 
     // Register the schema & channel modules
     // A declarative submodule is created in generated/schemas_module.rs, but this is currently

--- a/python/foxglove-sdk/src/websocket_server.rs
+++ b/python/foxglove-sdk/src/websocket_server.rs
@@ -5,7 +5,7 @@ use foxglove::{
 };
 use pyo3::{
     prelude::*,
-    types::{PyBytes, PyDict, PyString},
+    types::{PyBytes, PyString},
 };
 use std::sync::Arc;
 use std::time;
@@ -61,14 +61,11 @@ impl ServerListener for PyServerListener {
                 topic: PyString::new(py, channel.topic()).into(),
             };
 
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("client", client_info)?;
-            kwargs.set_item("channel", channel_view)?;
-            kwargs.set_item("data", PyBytes::new(py, payload))?;
-
+            // client, channel, data
+            let args = (client_info, channel_view, PyBytes::new(py, payload));
             self.listener
                 .bind(py)
-                .call_method("on_message_data", (), Some(&kwargs))?;
+                .call_method("on_message_data", args, None)?;
 
             Ok(())
         });

--- a/python/foxglove-sdk/src/websocket_server.rs
+++ b/python/foxglove-sdk/src/websocket_server.rs
@@ -5,7 +5,7 @@ use foxglove::{
 };
 use pyo3::{
     prelude::*,
-    types::{PyBytes, PyDict},
+    types::{PyBytes, PyDict, PyString},
 };
 use std::sync::Arc;
 use std::time;
@@ -37,7 +37,7 @@ pub struct PyClientChannelView {
     #[pyo3(get)]
     id: u32,
     #[pyo3(get)]
-    topic: String,
+    topic: Py<PyString>,
 }
 
 /// Implementations of ServerListener which call the python methods. foxglove/__init__.py defines
@@ -55,12 +55,12 @@ impl ServerListener for PyServerListener {
             id: client.id().into(),
         };
 
-        let channel_view = PyClientChannelView {
-            id: channel.id().into(),
-            topic: channel.topic().to_string(),
-        };
-
         let result: PyResult<()> = Python::with_gil(|py| {
+            let channel_view = PyClientChannelView {
+                id: channel.id().into(),
+                topic: PyString::new(py, channel.topic()).into(),
+            };
+
             let kwargs = PyDict::new(py);
             kwargs.set_item("client", client_info)?;
             kwargs.set_item("channel", channel_view)?;

--- a/python/foxglove-sdk/src/websocket_server.rs
+++ b/python/foxglove-sdk/src/websocket_server.rs
@@ -84,11 +84,14 @@ impl ServerListener for PyServerListener {
 /// :param host: The host to bind to.
 /// :param port: The port to bind to.
 /// :param capabilities: A list of capabilities to advertise to clients.
+/// :param server_listener: A Python object that implements the :py:class:`ServerListener` protocol.
+/// :param supported_encodings: A list of encodings to advertise to clients.
+///    Foxglove currently supports "json", "ros1", and "cdr" for client-side publishing.
 ///
 /// To connect to this server: open Foxglove, choose "Open a new connection", and select Foxglove
 /// WebSocket. The default connection string matches the defaults used by the SDK.
 #[pyfunction]
-#[pyo3(signature = (*, name = None, host="127.0.0.1", port=8765, capabilities=None, server_listener=None))]
+#[pyo3(signature = (*, name = None, host="127.0.0.1", port=8765, capabilities=None, server_listener=None, supported_encodings=None))]
 pub fn start_server(
     py: Python<'_>,
     name: Option<String>,
@@ -96,6 +99,7 @@ pub fn start_server(
     port: u16,
     capabilities: Option<Vec<PyCapability>>,
     server_listener: Option<Py<PyAny>>,
+    supported_encodings: Option<Vec<String>>,
 ) -> PyResult<PyWebSocketServer> {
     let session_id = time::SystemTime::now()
         .duration_since(time::UNIX_EPOCH)
@@ -118,6 +122,10 @@ pub fn start_server(
 
     if let Some(capabilities) = capabilities {
         server = server.capabilities(capabilities.into_iter().map(PyCapability::into));
+    }
+
+    if let Some(supported_encodings) = supported_encodings {
+        server = server.supported_encodings(supported_encodings);
     }
 
     let handle = py

--- a/python/foxglove-sdk/src/websocket_server.rs
+++ b/python/foxglove-sdk/src/websocket_server.rs
@@ -1,7 +1,82 @@
 use crate::errors::PyFoxgloveError;
-use foxglove::{WebSocketServer, WebSocketServerBlockingHandle};
-use pyo3::prelude::*;
+use foxglove::{
+    websocket::{Client, ClientChannelView, ServerListener},
+    WebSocketServer, WebSocketServerBlockingHandle,
+};
+use pyo3::{
+    prelude::*,
+    types::{PyBytes, PyDict},
+};
+use std::sync::Arc;
 use std::time;
+
+/// A mechanism to register callbacks for handling client message events.
+/// The wrapped Python object must have (optionally) defined methods like:
+///   on_message_data(self, client_id: int, topic: str, payload: bytes)
+///   on_subscribe(self, client_id: int, topic: str)
+///   on_unsubscribe(self, client_id: int, topic: str)
+///   on_client_advertise(self, client_id: int, topic: str)
+///   on_client_unadvertise(self, client_id: int, topic: str)
+#[pyclass(name = "ServerListener", module = "foxglove")]
+pub struct PyServerListener {
+    listener: Py<PyAny>,
+}
+
+#[pymethods]
+impl PyServerListener {
+    #[new]
+    fn new(listener: Py<PyAny>) -> Self {
+        PyServerListener { listener }
+    }
+}
+
+/// A client connected to a running websocket server.
+#[pyclass(name = "Client", module = "foxglove")]
+pub struct PyClient {
+    #[pyo3(get)]
+    id: u32,
+}
+
+/// Information about a client channel.
+#[pyclass(name = "ClientChannelView", module = "foxglove")]
+pub struct PyClientChannelView {
+    #[pyo3(get)]
+    id: u32,
+    #[pyo3(get)]
+    topic: String,
+}
+
+// Implement the ServerListener trait for PyServerListener, bridging callback calls to Python.
+impl ServerListener for PyServerListener {
+    fn on_message_data(&self, client: Client, channel: ClientChannelView, payload: &[u8]) {
+        let client_info = PyClient {
+            id: client.id().into(),
+        };
+
+        let channel_view = PyClientChannelView {
+            id: channel.id().into(),
+            topic: channel.topic().to_string(),
+        };
+
+        let result: PyResult<()> = Python::with_gil(|py| {
+            // foxglove/__init__.py defines the `ServerListener` protocol
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("client", client_info)?;
+            kwargs.set_item("channel", channel_view)?;
+            kwargs.set_item("data", PyBytes::new(py, payload))?;
+
+            self.listener
+                .bind(py)
+                .call_method("on_message_data", (), Some(&kwargs))?;
+
+            Ok(())
+        });
+
+        if let Err(err) = result {
+            tracing::error!("Callback failed: {}", err.to_string());
+        }
+    }
+}
 
 /// Start a new Foxglove WebSocket server.
 ///
@@ -13,13 +88,14 @@ use std::time;
 /// To connect to this server: open Foxglove, choose "Open a new connection", and select Foxglove
 /// WebSocket. The default connection string matches the defaults used by the SDK.
 #[pyfunction]
-#[pyo3(signature = (name = None, host="127.0.0.1", port=8765, capabilities=None))]
+#[pyo3(signature = (name = None, host="127.0.0.1", port=8765, capabilities=None, server_listener=None))]
 pub fn start_server(
     py: Python<'_>,
     name: Option<String>,
     host: &str,
     port: u16,
-    capabilities: Option<Vec<Capability>>,
+    capabilities: Option<Vec<PyCapability>>,
+    server_listener: Option<Py<PyAny>>,
 ) -> PyResult<PyWebSocketServer> {
     let session_id = time::SystemTime::now()
         .duration_since(time::UNIX_EPOCH)
@@ -31,22 +107,28 @@ pub fn start_server(
         .session_id(session_id)
         .bind(host, port);
 
+    if let Some(py_obj) = server_listener {
+        let listener = PyServerListener::new(py_obj);
+        server = server.listener(Arc::new(listener));
+    }
+
     if let Some(name) = name {
         server = server.name(name);
     }
 
     if let Some(capabilities) = capabilities {
-        server = server.capabilities(capabilities.into_iter().map(Capability::into));
+        server = server.capabilities(capabilities.into_iter().map(PyCapability::into));
     }
 
     let handle = py
         .allow_threads(|| server.start_blocking())
         .map_err(PyFoxgloveError::from)?;
+
     Ok(PyWebSocketServer(Some(handle)))
 }
 
 /// A live visualization server. Obtain an instance by calling :py:func:`start_server`.
-#[pyclass(name = "WebSocketServer")]
+#[pyclass(name = "WebSocketServer", module = "foxglove")]
 pub struct PyWebSocketServer(pub Option<WebSocketServerBlockingHandle>);
 
 #[pymethods]
@@ -76,11 +158,11 @@ impl PyWebSocketServer {
 }
 
 /// A capability that the websocket server advertises to its clients.
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, name = "Capability")]
 #[derive(Clone, PartialEq)]
-pub enum Capability {
+pub enum PyCapability {
     /// Allow clients to advertise channels to send data messages to the server.
-    // ClientPublish,
+    ClientPublish,
     /// Allow clients to get & set parameters.
     // Parameters,
     /// Inform clients about the latest server time.
@@ -91,12 +173,12 @@ pub enum Capability {
     Time,
 }
 
-impl From<Capability> for foxglove::websocket::Capability {
-    fn from(value: Capability) -> Self {
+impl From<PyCapability> for foxglove::websocket::Capability {
+    fn from(value: PyCapability) -> Self {
         match value {
-            // Capability::ClientPublish => foxglove::websocket::Capability::ClientPublish,
-            // Capability::Parameters => foxglove::websocket::Capability::Parameters,
-            Capability::Time => foxglove::websocket::Capability::Time,
+            PyCapability::ClientPublish => foxglove::websocket::Capability::ClientPublish,
+            // PyCapability::Parameters => foxglove::websocket::Capability::Parameters,
+            PyCapability::Time => foxglove::websocket::Capability::Time,
         }
     }
 }

--- a/python/foxglove-sdk/src/websocket_server.rs
+++ b/python/foxglove-sdk/src/websocket_server.rs
@@ -88,7 +88,7 @@ impl ServerListener for PyServerListener {
 /// To connect to this server: open Foxglove, choose "Open a new connection", and select Foxglove
 /// WebSocket. The default connection string matches the defaults used by the SDK.
 #[pyfunction]
-#[pyo3(signature = (name = None, host="127.0.0.1", port=8765, capabilities=None, server_listener=None))]
+#[pyo3(signature = (*, name = None, host="127.0.0.1", port=8765, capabilities=None, server_listener=None))]
 pub fn start_server(
     py: Python<'_>,
     name: Option<String>,

--- a/python/foxglove-sdk/src/websocket_server.rs
+++ b/python/foxglove-sdk/src/websocket_server.rs
@@ -1,0 +1,102 @@
+use crate::errors::PyFoxgloveError;
+use foxglove::{WebSocketServer, WebSocketServerBlockingHandle};
+use pyo3::prelude::*;
+use std::time;
+
+/// Start a new Foxglove WebSocket server.
+///
+/// :param name: The name of the server.
+/// :param host: The host to bind to.
+/// :param port: The port to bind to.
+/// :param capabilities: A list of capabilities to advertise to clients.
+///
+/// To connect to this server: open Foxglove, choose "Open a new connection", and select Foxglove
+/// WebSocket. The default connection string matches the defaults used by the SDK.
+#[pyfunction]
+#[pyo3(signature = (name = None, host="127.0.0.1", port=8765, capabilities=None))]
+pub fn start_server(
+    py: Python<'_>,
+    name: Option<String>,
+    host: &str,
+    port: u16,
+    capabilities: Option<Vec<Capability>>,
+) -> PyResult<PyWebSocketServer> {
+    let session_id = time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .expect("Failed to create session ID; invalid system time")
+        .as_millis()
+        .to_string();
+
+    let mut server = WebSocketServer::new()
+        .session_id(session_id)
+        .bind(host, port);
+
+    if let Some(name) = name {
+        server = server.name(name);
+    }
+
+    if let Some(capabilities) = capabilities {
+        server = server.capabilities(capabilities.into_iter().map(Capability::into));
+    }
+
+    let handle = py
+        .allow_threads(|| server.start_blocking())
+        .map_err(PyFoxgloveError::from)?;
+    Ok(PyWebSocketServer(Some(handle)))
+}
+
+/// A live visualization server. Obtain an instance by calling :py:func:`start_server`.
+#[pyclass(name = "WebSocketServer")]
+pub struct PyWebSocketServer(pub Option<WebSocketServerBlockingHandle>);
+
+#[pymethods]
+impl PyWebSocketServer {
+    pub fn stop(&mut self, py: Python<'_>) {
+        if let Some(server) = self.0.take() {
+            py.allow_threads(|| server.stop())
+        }
+    }
+
+    /// Sets a new session ID and notifies all clients, causing them to reset their state.
+    /// If no session ID is provided, generates a new one based on the current timestamp.
+    #[pyo3(signature = (session_id=None))]
+    pub fn clear_session(&self, session_id: Option<String>) -> PyResult<()> {
+        if let Some(server) = &self.0 {
+            server.clear_session(session_id);
+        }
+        Ok(())
+    }
+
+    pub fn broadcast_time(&self, timestamp_nanos: u64) -> PyResult<()> {
+        if let Some(server) = &self.0 {
+            server.broadcast_time(timestamp_nanos);
+        }
+        Ok(())
+    }
+}
+
+/// A capability that the websocket server advertises to its clients.
+#[pyclass(eq, eq_int)]
+#[derive(Clone, PartialEq)]
+pub enum Capability {
+    /// Allow clients to advertise channels to send data messages to the server.
+    // ClientPublish,
+    /// Allow clients to get & set parameters.
+    // Parameters,
+    /// Inform clients about the latest server time.
+    ///
+    /// This allows accelerated, slowed, or stepped control over the progress of time. If the
+    /// server publishes time data, then timestamps of published messages must originate from the
+    /// same time source.
+    Time,
+}
+
+impl From<Capability> for foxglove::websocket::Capability {
+    fn from(value: Capability) -> Self {
+        match value {
+            // Capability::ClientPublish => foxglove::websocket::Capability::ClientPublish,
+            // Capability::Parameters => foxglove::websocket::Capability::Parameters,
+            Capability::Time => foxglove::websocket::Capability::Time,
+        }
+    }
+}

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -45,6 +45,12 @@ use service::{CallId, Service, ServiceId};
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct ClientId(u32);
 
+impl From<ClientId> for u32 {
+    fn from(client: ClientId) -> Self {
+        client.0
+    }
+}
+
 /// A connected client session with the websocket server.
 #[derive(Debug)]
 pub struct Client<'a>(&'a ConnectedClient);


### PR DESCRIPTION
This adds a server listener interface to the Python SDK.

This is implemented as a Protocol in python; pyo3 does not support extending a Python class. To provide reasonable typing on `start_server`, that's now a wrapping function in the public package, to avoid the stub interface referencing the external type.

Since the ws-related code is starting to grow in python, I've moved related classes and functions into `websocket_server.rs` (from lib.rs). The exports are still in the top-level `foxglove` package for now.

To support the message data callback, this also adds support for the `ClientPublish` capability and `supported_encodings`.

I updated the existing live_visualization example to exercise this.