### PR TITLE
python: rename new_mcap_file() to open_file()

### DIFF
--- a/python/foxglove-sdk/python/docs/index.rst
+++ b/python/foxglove-sdk/python/docs/index.rst
@@ -26,7 +26,7 @@ Overview
 To record messages, you need at least one sink and at least one channel.
 
 A "sink" is a destination for logged messages — either an MCAP file or a live visualization server.
-Use :python:`record_file` or :python:`with new_mcap_file("")` to register a new MCAP sink. Use
+Use :python:`record_file` or :python:`with open_file("")` to register a new MCAP sink. Use
 :python:`start_server` to create a new live visualization server.
 
 A "channel" gives a way to log related messages which have the same schema. Each channel is

--- a/python/foxglove-sdk/python/examples/write_log.py
+++ b/python/foxglove-sdk/python/examples/write_log.py
@@ -12,7 +12,7 @@ args = parser.parse_args()
 
 def main() -> None:
     # Create a new mcap file at the given path for recording
-    with foxglove.new_mcap_file(args.path):
+    with foxglove.open_file(args.path):
         channel = LogChannel("/hello")
 
         for i in range(10):

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -114,7 +114,7 @@ def verbose_off() -> None:
 
 
 @contextmanager
-def new_mcap_file(fname: str) -> Iterator[None]:
+def open_file(fname: str) -> Iterator[None]:
     """
     Create an MCAP file at the given path for recording.
 
@@ -135,7 +135,7 @@ __all__ = [
     "ServerListener",
     "WebSocketServer",
     "log",
-    "new_mcap_file",
+    "open_file",
     "record_file",
     "start_server",
     "verbose_off",

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Protocol, Tuple
 class MCAPWriter:
     """
     A writer for logging messages to an MCAP file. Obtain an instance by calling `record_file`, or
-    the context-managed `new_mcap_file`.
+    the context-managed `open_file`.
 
     If you're using `record_file`, you must maintain a reference to the returned writer until you
     are done logging. The writer will be closed automatically when it is garbage collected, but you

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -23,7 +23,7 @@ struct BaseChannel(Arc<Channel>);
 ///  A writer for logging messages to an MCAP file.
 ///
 /// Obtain an instance by calling :py:func:`record_file`, or the context-managed
-/// :py:func:`new_mcap_file`.
+/// :py:func:`open_file`.
 ///
 /// If you're using :py:func:`record_file`, you must maintain a reference to the returned writer
 /// until you are done logging. The writer will be closed automatically when it is garbage
@@ -46,7 +46,7 @@ impl PyMcapWriter {
     ///
     /// You may call this to explicitly close the writer. Note that the writer will be automatically
     /// closed for you when it is garbage collected, or when using the context-managed
-    /// :py:func:`new_mcap_file`.
+    /// :py:func:`open_file`.
     fn close(&mut self) -> PyResult<()> {
         if let Some(writer) = self.0.take() {
             writer.close().map_err(PyFoxgloveError::from)?;


### PR DESCRIPTION
The existing name for this method feels clunky - longer than it needs to be, since we have no plans to support other file types.

Proposing to rename to `open_file` for consistency with python stdlib