### PR TITLE
rust: Don't expose websocket service IDs

### DIFF
--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -40,7 +40,7 @@ mod tests;
 #[cfg(all(test, feature = "unstable"))]
 mod unstable_tests;
 
-use service::{CallId, Service, ServiceId};
+use service::{CallId, Service, ServiceId, ServiceMap};
 
 /// A capability that a websocket server can support.
 #[derive(Debug, Serialize, Eq, PartialEq, Hash, Clone, Copy)]
@@ -186,7 +186,7 @@ pub(crate) struct Server {
     /// Token for cancelling all tasks
     cancellation_token: CancellationToken,
     /// Registered services.
-    services: parking_lot::RwLock<HashMap<ServiceId, Arc<Service>>>,
+    services: parking_lot::RwLock<ServiceMap>,
 }
 
 /// Provides a mechanism for registering callbacks for handling client message events.
@@ -874,12 +874,7 @@ impl Server {
             capabilities,
             supported_encodings,
             cancellation_token: CancellationToken::new(),
-            services: parking_lot::RwLock::new(
-                opts.services
-                    .into_values()
-                    .map(|s| (s.id(), Arc::new(s)))
-                    .collect(),
-            ),
+            services: parking_lot::RwLock::new(ServiceMap::from_iter(opts.services.into_values())),
         }
     }
 
@@ -1287,17 +1282,17 @@ impl Server {
         let msg = Message::text(protocol::server::advertise_services(&new_services));
 
         {
-            // Ensure that the new service names are not already registered.
+            // Ensure that the new services are not already registered.
             let mut services = self.services.write();
-            for service in services.values() {
-                if new_names.contains_key(service.name()) {
+            for service in &new_services {
+                if services.contains_name(service.name()) || services.contains_id(service.id()) {
                     return Err(FoxgloveError::DuplicateService(service.name().to_string()));
                 }
             }
 
             // Update the service map.
             for service in new_services {
-                services.insert(service.id(), Arc::new(service));
+                services.insert(service);
             }
         }
 
@@ -1319,14 +1314,15 @@ impl Server {
     /// Removes services, and unadvertises them to all clients.
     ///
     /// Unrecognized service IDs are silently ignored.
-    pub fn remove_services(&self, ids: &[ServiceId]) {
+    pub fn remove_services(&self, names: impl IntoIterator<Item = impl AsRef<str>>) {
         // Remove services from the map.
-        let mut old_services = HashMap::with_capacity(ids.len());
+        let names = names.into_iter();
+        let mut old_services = HashMap::with_capacity(names.size_hint().0);
         {
             let mut services = self.services.write();
-            for id in ids {
-                if let Some(service) = services.remove(id) {
-                    old_services.insert(*id, service.name().to_string());
+            for name in names {
+                if let Some(service) = services.remove_by_name(name) {
+                    old_services.insert(service.id(), service.name().to_string());
                 }
             }
         }
@@ -1353,7 +1349,7 @@ impl Server {
 
     // Looks up a service by ID.
     fn get_service(&self, id: ServiceId) -> Option<Arc<Service>> {
-        self.services.read().get(&id).cloned()
+        self.services.read().get_by_id(id)
     }
 }
 

--- a/rust/foxglove/src/websocket/service.rs
+++ b/rust/foxglove/src/websocket/service.rs
@@ -217,16 +217,6 @@ impl ServiceMap {
         assert!(prev.is_none());
     }
 
-    /// Returns true if the map contains a service with the provided name.
-    pub fn contains_name(&mut self, name: impl AsRef<str>) -> bool {
-        self.name.contains_key(name.as_ref())
-    }
-
-    /// Returns true if the map contains a service with the provided ID.
-    pub fn contains_id(&mut self, id: ServiceId) -> bool {
-        self.id.contains_key(&id)
-    }
-
     /// Removes a service by name.
     pub fn remove_by_name(&mut self, name: impl AsRef<str>) -> Option<Arc<Service>> {
         if let Some(id) = self.name.remove(name.as_ref()) {
@@ -234,6 +224,16 @@ impl ServiceMap {
         } else {
             None
         }
+    }
+
+    /// Returns true if the map contains a service with the provided name.
+    pub fn contains_name(&self, name: impl AsRef<str>) -> bool {
+        self.name.contains_key(name.as_ref())
+    }
+
+    /// Returns true if the map contains a service with the provided ID.
+    pub fn contains_id(&self, id: ServiceId) -> bool {
+        self.id.contains_key(&id)
     }
 
     /// Returns an iterator over services.

--- a/rust/foxglove/src/websocket/service.rs
+++ b/rust/foxglove/src/websocket/service.rs
@@ -1,5 +1,6 @@
 //! Websocket services.
 
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -14,6 +15,8 @@ mod request;
 mod response;
 mod schema;
 mod semaphore;
+#[cfg(test)]
+mod tests;
 pub use handler::{Handler, SyncHandler};
 use handler::{HandlerFn, SyncHandlerFn};
 pub use request::Request;
@@ -24,7 +27,7 @@ pub(crate) use semaphore::Semaphore;
 
 /// A service ID, which uniquely identifies a service hosted by the server.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
-pub struct ServiceId(u32);
+pub(crate) struct ServiceId(u32);
 
 impl ServiceId {
     /// Creates a new service ID.
@@ -81,6 +84,7 @@ impl ServiceBuilder {
     fn new(name: impl Into<String>, schema: ServiceSchema) -> Self {
         static ID: AtomicU32 = AtomicU32::new(1);
         let id = ID.fetch_add(1, Ordering::Relaxed);
+        assert_ne!(id, 0);
         Self {
             id: ServiceId::new(id),
             name: name.into(),
@@ -153,7 +157,7 @@ impl Service {
     }
 
     /// Returns the service's ID.
-    pub fn id(&self) -> ServiceId {
+    pub(crate) fn id(&self) -> ServiceId {
         self.id
     }
 
@@ -180,5 +184,67 @@ impl Service {
     /// Invokes the service call implementation.
     pub(crate) fn call(&self, client: Client<'_>, request: Request, responder: Responder) {
         self.handler.call(client, request, responder);
+    }
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct ServiceMap {
+    id: HashMap<ServiceId, Arc<Service>>,
+    name: HashMap<String, ServiceId>,
+}
+
+impl ServiceMap {
+    /// Constructs a service map from an iterable of services.
+    ///
+    /// Panics if service IDs and names are not unique.
+    pub fn from_iter(services: impl IntoIterator<Item = Service>) -> Self {
+        let iter = services.into_iter();
+        let size = iter.size_hint().0;
+        let id = HashMap::with_capacity(size);
+        let name = HashMap::with_capacity(size);
+        let mut map = Self { id, name };
+        for service in iter {
+            map.insert(service);
+        }
+        map
+    }
+
+    /// Inserts a service into the map.
+    ///
+    /// Panics if the service ID or name is not unique.
+    pub fn insert(&mut self, service: Service) {
+        let prev = self.name.insert(service.name().to_string(), service.id());
+        assert!(prev.is_none());
+        let prev = self.id.insert(service.id(), Arc::new(service));
+        assert!(prev.is_none());
+    }
+
+    /// Returns true if the map contains a service with the provided name.
+    pub fn contains_name(&mut self, name: impl AsRef<str>) -> bool {
+        self.name.contains_key(name.as_ref())
+    }
+
+    /// Returns true if the map contains a service with the provided ID.
+    pub fn contains_id(&mut self, id: ServiceId) -> bool {
+        self.id.contains_key(&id)
+    }
+
+    /// Removes a service by name.
+    pub fn remove_by_name(&mut self, name: impl AsRef<str>) -> Option<Arc<Service>> {
+        if let Some(id) = self.name.remove(name.as_ref()) {
+            self.id.remove(&id)
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over services.
+    pub fn values(&self) -> impl Iterator<Item = &Arc<Service>> {
+        self.id.values()
+    }
+
+    /// Looks up a service by ID.
+    pub fn get_by_id(&self, id: ServiceId) -> Option<Arc<Service>> {
+        self.id.get(&id).cloned()
     }
 }

--- a/rust/foxglove/src/websocket/service/request.rs
+++ b/rust/foxglove/src/websocket/service/request.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 
-use super::{CallId, Service, ServiceId};
+use super::{CallId, Service};
 
 /// A service call request.
 #[derive(Debug, Clone)]
@@ -29,11 +29,6 @@ impl Request {
             encoding,
             payload,
         }
-    }
-
-    /// The service ID.
-    pub fn service_id(&self) -> ServiceId {
-        self.service.id()
     }
 
     /// The service name.

--- a/rust/foxglove/src/websocket/service/tests.rs
+++ b/rust/foxglove/src/websocket/service/tests.rs
@@ -1,0 +1,51 @@
+use bytes::Bytes;
+
+use crate::websocket::Client;
+
+use super::{Request, Service, ServiceId, ServiceMap, ServiceSchema};
+
+fn handler(_: Client, _: Request) -> Result<Bytes, &'static str> {
+    Err("")
+}
+
+fn make_service(name: &str, id: u32) -> Service {
+    Service::builder(name, ServiceSchema::new("schema"))
+        .with_id(ServiceId::new(id))
+        .sync_handler_fn(handler)
+}
+
+#[test]
+fn test_service_map() {
+    let s1 = make_service("s1", 1);
+    let s2 = make_service("s2", 2);
+    let s3 = make_service("s3", 3);
+
+    // init
+    let mut map = ServiceMap::default();
+    assert_eq!(map.values().count(), 0);
+    assert!(!map.contains_name("s1"));
+    assert!(!map.contains_id(ServiceId::new(1)));
+    assert!(map.get_by_id(ServiceId::new(1)).is_none());
+
+    // insert
+    map.insert(s1);
+    assert_eq!(map.values().count(), 1);
+    assert!(map.contains_name("s1"));
+    assert!(map.contains_id(ServiceId::new(1)));
+    assert!(map.get_by_id(ServiceId::new(1)).is_some());
+    assert!(!map.contains_name("s2"));
+    assert!(!map.contains_id(ServiceId::new(2)));
+
+    // remove
+    assert!(map.remove_by_name("s1").is_some());
+    assert!(!map.contains_name("s1"));
+    assert!(!map.contains_id(ServiceId::new(1)));
+
+    // insert multiple
+    map.insert(s2);
+    map.insert(s3);
+    assert_eq!(map.values().count(), 2);
+    assert!(map.get_by_id(ServiceId::new(1)).is_none());
+    assert!(map.get_by_id(ServiceId::new(2)).is_some());
+    assert!(map.get_by_id(ServiceId::new(3)).is_some());
+}

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -1071,7 +1071,6 @@ async fn test_services() {
     let ok_svc = Service::builder("/ok", ServiceSchema::new("plain"))
         .with_id(ServiceId::new(1))
         .handler_fn(|_, req, resp| {
-            assert_eq!(req.service_id(), ServiceId::new(1));
             assert_eq!(req.service_name(), "/ok");
             assert_eq!(req.call_id(), CallId::new(99));
             let payload = req.into_payload();
@@ -1227,7 +1226,7 @@ async fn test_services() {
     drop(client2);
 
     // Unregister services.
-    server.remove_services(&[ServiceId::new(1)]);
+    server.remove_services(["/ok"]);
     let msg = client1
         .next()
         .await

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::websocket::service::{Service, ServiceId};
+use crate::websocket::service::Service;
 use crate::websocket::{create_server, Capability, Parameter, Server, ServerOptions, Status};
 use crate::{get_runtime_handle, FoxgloveError, LogContext, LogSink};
 use tokio::runtime::Handle;
@@ -191,8 +191,8 @@ impl WebSocketServerHandle {
     }
 
     /// Removes services that were previously advertised.
-    pub fn remove_services(&self, ids: impl IntoIterator<Item = ServiceId>) {
-        self.0.remove_services(&ids.into_iter().collect::<Vec<_>>());
+    pub fn remove_services(&self, names: impl IntoIterator<Item = impl AsRef<str>>) {
+        self.0.remove_services(names);
     }
 
     /// Publishes the current server timestamp to all clients.
@@ -250,7 +250,7 @@ impl WebSocketServerBlockingHandle {
     /// [`remove_services`][WebSocketServerBlockingHandle::remove_services].
     ///
     /// This method will fail if the server was not configured with [`Capability::Services`].
-    pub async fn add_services(
+    pub fn add_services(
         &self,
         services: impl IntoIterator<Item = Service>,
     ) -> Result<(), FoxgloveError> {
@@ -258,8 +258,8 @@ impl WebSocketServerBlockingHandle {
     }
 
     /// Removes services that were previously advertised.
-    pub async fn remove_services(&self, ids: impl IntoIterator<Item = ServiceId>) {
-        self.0.remove_services(ids);
+    pub fn remove_services(&self, names: impl IntoIterator<Item = impl AsRef<str>>) {
+        self.0.remove_services(names);
     }
 
     /// Publishes the current server timestamp to all clients.


### PR DESCRIPTION
Websocket service IDs are an implementation detail to accommodate `ws-protocol`. It's not something that our users need to be aware of. Service names need to be unique, and so that should be the handle by which a service is identified or removed. I realized this as I was trying to implement the python plumbing for `remove_services`.

Now we need two maps for indexing services: one by name, one by ID. They need to be synchronized, so I introduced a new `ServiceMap` struct.