### PR TITLE
Enable rust-2024-compatibility lint rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 resolver = "2"
 members = [
-    "rust/foxglove",
-    "rust/foxglove-proto-gen",
-    "rust/examples/*",
-    "rust/examples-unstable/*",
-    "python/foxglove-sdk",
+  "rust/foxglove",
+  "rust/foxglove-proto-gen",
+  "rust/examples/*",
+  "rust/examples-unstable/*",
+  "python/foxglove-sdk",
 ]
 
 [workspace.dependencies]
@@ -20,3 +20,6 @@ tokio = { version = "1.40", features = ["macros", "rt-multi-thread", "signal", "
 tokio-tungstenite = "0.26"
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { version = "0.1", features = ["log"] }
+
+[workspace.lints.rust]
+rust-2024-compatibility = "warn"

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 name = "foxglove_py"
 crate-type = ["cdylib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes.workspace = true
 env_logger = "0.11.5"

--- a/rust/examples-unstable/client-publish/Cargo.toml
+++ b/rust/examples-unstable/client-publish/Cargo.toml
@@ -3,6 +3,9 @@ name = "example-client-publish"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 foxglove = { path = "../../foxglove", features = ["unstable"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/rust/examples-unstable/ws-stream-mcap/Cargo.toml
+++ b/rust/examples-unstable/ws-stream-mcap/Cargo.toml
@@ -3,6 +3,9 @@ name = "example-ws-stream-mcap"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0"
 bytes = "1.9"

--- a/rust/examples/mcap/Cargo.toml
+++ b/rust/examples/mcap/Cargo.toml
@@ -3,6 +3,9 @@ name = "example-mcap"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 foxglove = { path = "../../foxglove" }
 clap = { version = "4.5", features = ["derive"] }

--- a/rust/examples/param-server/Cargo.toml
+++ b/rust/examples/param-server/Cargo.toml
@@ -3,6 +3,9 @@ name = "example-param-server"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 foxglove = { path = "../../foxglove", features = ["unstable"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/rust/examples/ws-server-blocking/Cargo.toml
+++ b/rust/examples/ws-server-blocking/Cargo.toml
@@ -3,6 +3,9 @@ name = "example-ws-server-blocking"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 foxglove = { path = "../../foxglove" }
 clap = { version = "4.5", features = ["derive"] }

--- a/rust/examples/ws-server/Cargo.toml
+++ b/rust/examples/ws-server/Cargo.toml
@@ -3,6 +3,9 @@ name = "example-ws-server"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 foxglove = { path = "../../foxglove" }
 tokio = { version = "1.0", features = ["full"] }

--- a/rust/examples/ws-services/Cargo.toml
+++ b/rust/examples/ws-services/Cargo.toml
@@ -2,6 +2,9 @@
 name = "example-ws-services"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0"
 bytes = "1.9"

--- a/rust/foxglove-proto-gen/Cargo.toml
+++ b/rust/foxglove-proto-gen/Cargo.toml
@@ -3,6 +3,9 @@ name = "foxglove-proto-gen"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.95"
 prost.workspace = true

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -11,6 +11,9 @@ default = []
 chrono = ["dep:chrono"]
 unstable = []
 
+[lints]
+workspace = true
+
 [dependencies]
 arc-swap = "1.7.1"
 base64 = "0.22.1"


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Enables lint rules to ease compatibility with the 2024 edition. A lot of these might require some manual inspection to decide what we want to do about them.