### PR TITLE
rust: Improve service handler wrappers

### DIFF
--- a/rust/examples/ws-services/src/client.rs
+++ b/rust/examples/ws-services/src/client.rs
@@ -41,7 +41,12 @@ pub async fn main(config: Config) -> Result<()> {
     for id in 0..50 {
         let client = client.clone();
         sleepers.spawn(async move {
-            if let Err(e) = client.call_sleep().await {
+            let result = if id % 2 == 0 {
+                client.call_sleep().await
+            } else {
+                client.call_blocking().await
+            };
+            if let Err(e) = result {
                 error!("{id} failed to sleep: {e}");
             } else {
                 info!("{id} is awake");
@@ -150,6 +155,13 @@ impl Client {
         self.service_call("/sleep", "raw", Bytes::new())
             .await
             .context("failed to call /sleep")?;
+        Ok(())
+    }
+
+    async fn call_blocking(&self) -> Result<()> {
+        self.service_call("/blocking", "raw", Bytes::new())
+            .await
+            .context("failed to call /blocking")?;
         Ok(())
     }
 

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -558,7 +558,7 @@ mod tests {
         let s1_schema = ServiceSchema::new("std_srvs/Empty");
         let s1 = Service::builder("foo", s1_schema)
             .with_id(ServiceId::new(1))
-            .sync_handler_fn(|_| Err("not implemented"));
+            .handler_fn(|_| Err("not implemented"));
 
         let s2_schema = ServiceSchema::new("std_srvs/SetBool")
             .with_request(
@@ -575,7 +575,7 @@ mod tests {
             );
         let s2 = Service::builder("set_bool", s2_schema)
             .with_id(ServiceId::new(2))
-            .sync_handler_fn(|_| Err("not implemented"));
+            .handler_fn(|_| Err("not implemented"));
 
         let adv = advertise_services(&[s1, s2]);
         assert_eq!(

--- a/rust/foxglove/src/websocket/service.rs
+++ b/rust/foxglove/src/websocket/service.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::future::Future;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -15,8 +16,8 @@ mod schema;
 mod semaphore;
 #[cfg(test)]
 mod tests;
+use handler::{AsyncHandlerFn, BlockingHandlerFn, HandlerFn};
 pub use handler::{Handler, SyncHandler};
-use handler::{HandlerFn, SyncHandlerFn};
 pub use request::Request;
 pub use response::Responder;
 pub(crate) use schema::MessageSchema;
@@ -109,23 +110,40 @@ impl ServiceBuilder {
 
     /// Configures a handler function and returns the constructed [`Service`].
     ///
-    /// Refer to [`Handler::call`] for a description of the `call` function.
-    pub fn handler_fn<F>(self, call: F) -> Service
-    where
-        F: Fn(Request, Responder) + Send + Sync + 'static,
-    {
-        self.handler(HandlerFn(call))
-    }
-
-    /// Configures a synchronous handler function and returns the constructed [`Service`].
-    ///
     /// Refer to [`SyncHandler::call`] for a description of the `call` function.
-    pub fn sync_handler_fn<F, E>(self, call: F) -> Service
+    pub fn handler_fn<F, E>(self, call: F) -> Service
     where
         F: Fn(Request) -> Result<Bytes, E> + Send + Sync + 'static,
         E: Display + 'static,
     {
-        self.handler(SyncHandlerFn(call))
+        self.handler(HandlerFn(call))
+    }
+
+    /// Configures a blocking handler function and returns the constructed [`Service`].
+    ///
+    /// The handler is invoked on a blocking thread with [`tokio::task::spawn_blocking`].
+    ///
+    /// Refer to [`SyncHandler::call`] for a description of the `call` function.
+    pub fn blocking_handler_fn<F, E>(self, call: F) -> Service
+    where
+        F: Fn(Request) -> Result<Bytes, E> + Send + Sync + 'static,
+        E: Display + 'static,
+    {
+        self.handler(BlockingHandlerFn(Arc::new(call)))
+    }
+
+    /// Configures an async handler function and returns the constructed [`Service`].
+    ///
+    /// The handler is invoked as a new async task with [`tokio::spawn`].
+    ///
+    /// Refer to [`SyncHandler::call`] for a description of the `call` function.
+    pub fn async_handler_fn<F, Fut, E>(self, call: F) -> Service
+    where
+        F: Fn(Request) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Bytes, E>> + Send + 'static,
+        E: Display + Send + 'static,
+    {
+        self.handler(AsyncHandlerFn(Arc::new(call)))
     }
 }
 

--- a/rust/foxglove/src/websocket/service/tests.rs
+++ b/rust/foxglove/src/websocket/service/tests.rs
@@ -1,15 +1,9 @@
-use bytes::Bytes;
-
-use super::{Request, Service, ServiceId, ServiceMap, ServiceSchema};
-
-fn handler(_: Request) -> Result<Bytes, &'static str> {
-    Err("")
-}
+use super::{Service, ServiceId, ServiceMap, ServiceSchema};
 
 fn make_service(name: &str, id: u32) -> Service {
     Service::builder(name, ServiceSchema::new("schema"))
         .with_id(ServiceId::new(id))
-        .sync_handler_fn(handler)
+        .handler_fn(|_| Err(""))
 }
 
 #[test]

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use futures_util::{FutureExt, SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -548,7 +548,7 @@ async fn test_error_status_message() {
 async fn test_service_registration_not_supported() {
     // Can't register services if we don't declare support.
     let server = create_server(ServerOptions::default());
-    let svc = Service::builder("/s", ServiceSchema::new("")).sync_handler_fn(|_| Err(""));
+    let svc = Service::builder("/s", ServiceSchema::new("")).handler_fn(|_| Err(""));
     assert_matches!(
         server.add_services(vec![svc]),
         Err(FoxgloveError::ServicesNotSupported)
@@ -562,7 +562,7 @@ async fn test_service_registration_missing_request_encoding() {
         capabilities: Some(HashSet::from([Capability::Services])),
         ..Default::default()
     });
-    let svc = Service::builder("/s", ServiceSchema::new("")).sync_handler_fn(|_| Err(""));
+    let svc = Service::builder("/s", ServiceSchema::new("")).handler_fn(|_| Err(""));
     assert_matches!(
         server.add_services(vec![svc]),
         Err(FoxgloveError::MissingRequestEncoding(_))
@@ -572,7 +572,7 @@ async fn test_service_registration_missing_request_encoding() {
 #[tokio::test]
 async fn test_service_registration_duplicate_name() {
     // Can't register a service with no encoding unless we declare global encodings.
-    let sa1 = Service::builder("/a", ServiceSchema::new("")).sync_handler_fn(|_| Err(""));
+    let sa1 = Service::builder("/a", ServiceSchema::new("")).handler_fn(|_| Err(""));
     let server = create_server(ServerOptions {
         capabilities: Some(HashSet::from([Capability::Services])),
         services: HashMap::from([(sa1.name().to_string(), sa1)]),
@@ -580,14 +580,14 @@ async fn test_service_registration_duplicate_name() {
         ..Default::default()
     });
 
-    let sa2 = Service::builder("/a", ServiceSchema::new("")).sync_handler_fn(|_| Err(""));
+    let sa2 = Service::builder("/a", ServiceSchema::new("")).handler_fn(|_| Err(""));
     assert_matches!(
         server.add_services(vec![sa2]),
         Err(FoxgloveError::DuplicateService(_))
     );
 
-    let sb1 = Service::builder("/b", ServiceSchema::new("")).sync_handler_fn(|_| Err(""));
-    let sb2 = Service::builder("/b", ServiceSchema::new("")).sync_handler_fn(|_| Err(""));
+    let sb1 = Service::builder("/b", ServiceSchema::new("")).handler_fn(|_| Err(""));
+    let sb2 = Service::builder("/b", ServiceSchema::new("")).handler_fn(|_| Err(""));
     assert_matches!(
         server.add_services(vec![sb1, sb2]),
         Err(FoxgloveError::DuplicateService(_))
@@ -1070,15 +1070,14 @@ async fn test_get_parameters() {
 async fn test_services() {
     let ok_svc = Service::builder("/ok", ServiceSchema::new("plain"))
         .with_id(ServiceId::new(1))
-        .handler_fn(|req, resp| {
+        .handler_fn(|req| -> Result<Bytes, String> {
             assert_eq!(req.service_name(), "/ok");
             assert_eq!(req.call_id(), CallId::new(99));
             let payload = req.into_payload();
             let mut response = BytesMut::with_capacity(payload.len());
             response.put(payload);
             response.reverse();
-            // Respond async, for kicks.
-            tokio::spawn(async move { resp.respond(Ok(response.freeze())) });
+            Ok(response.freeze())
         });
 
     let server = create_server(ServerOptions {
@@ -1151,7 +1150,7 @@ async fn test_services() {
     // Register a new service.
     let err_svc = Service::builder("/err", ServiceSchema::new("plain"))
         .with_id(ServiceId::new(2))
-        .sync_handler_fn(|_| Err("oh noes"));
+        .handler_fn(|_| Err("oh noes"));
     server
         .add_services(vec![err_svc])
         .expect("Failed to add service");


### PR DESCRIPTION
Borrow some good ideas for wrapping callbacks from @eloff's asset handler work in #229.

In particular, I love the idea of handling the `tokio::spawn` and `tokio::task::spawn_blocking` on our side, because it handles the 99% case beautifully. Folks that want even finer control can always implement `Handler` themselves.

Changes here:
- Remove `handler_fn` (which took `(Request, Responder)` as arguments).
- Rename `sync_handler_fn` as `handler_fn`.
- Add `blocking_handler_fn` and `async_handler_fn` for blocking and async function handlers.
- Remove some useless `'static` bounds.