### PR TITLE
python: add close method to channels

### DIFF
--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -69,6 +69,7 @@ class BaseChannel:
         log_time: Optional[int] = None,
         sequence: Optional[int] = None,
     ) -> None: ...
+    def close(self) -> None: ...
 
 class Capability(Enum):
     """

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
@@ -41,6 +41,7 @@ class CameraCalibrationChannel:
         cls,
         topic: str,
     ) -> "CameraCalibrationChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "CameraCalibration",
@@ -58,6 +59,7 @@ class CircleAnnotationChannel:
         cls,
         topic: str,
     ) -> "CircleAnnotationChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "CircleAnnotation",
@@ -75,6 +77,7 @@ class ColorChannel:
         cls,
         topic: str,
     ) -> "ColorChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Color",
@@ -92,6 +95,7 @@ class CompressedImageChannel:
         cls,
         topic: str,
     ) -> "CompressedImageChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "CompressedImage",
@@ -109,6 +113,7 @@ class CompressedVideoChannel:
         cls,
         topic: str,
     ) -> "CompressedVideoChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "CompressedVideo",
@@ -126,6 +131,7 @@ class FrameTransformChannel:
         cls,
         topic: str,
     ) -> "FrameTransformChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "FrameTransform",
@@ -143,6 +149,7 @@ class FrameTransformsChannel:
         cls,
         topic: str,
     ) -> "FrameTransformsChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "FrameTransforms",
@@ -160,6 +167,7 @@ class GeoJsonChannel:
         cls,
         topic: str,
     ) -> "GeoJsonChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "GeoJson",
@@ -177,6 +185,7 @@ class GridChannel:
         cls,
         topic: str,
     ) -> "GridChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Grid",
@@ -194,6 +203,7 @@ class ImageAnnotationsChannel:
         cls,
         topic: str,
     ) -> "ImageAnnotationsChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "ImageAnnotations",
@@ -211,6 +221,7 @@ class KeyValuePairChannel:
         cls,
         topic: str,
     ) -> "KeyValuePairChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "KeyValuePair",
@@ -228,6 +239,7 @@ class LaserScanChannel:
         cls,
         topic: str,
     ) -> "LaserScanChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "LaserScan",
@@ -245,6 +257,7 @@ class LocationFixChannel:
         cls,
         topic: str,
     ) -> "LocationFixChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "LocationFix",
@@ -262,6 +275,7 @@ class LogChannel:
         cls,
         topic: str,
     ) -> "LogChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Log",
@@ -279,6 +293,7 @@ class PackedElementFieldChannel:
         cls,
         topic: str,
     ) -> "PackedElementFieldChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "PackedElementField",
@@ -296,6 +311,7 @@ class Point2Channel:
         cls,
         topic: str,
     ) -> "Point2Channel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Point2",
@@ -313,6 +329,7 @@ class Point3Channel:
         cls,
         topic: str,
     ) -> "Point3Channel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Point3",
@@ -330,6 +347,7 @@ class PointCloudChannel:
         cls,
         topic: str,
     ) -> "PointCloudChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "PointCloud",
@@ -347,6 +365,7 @@ class PointsAnnotationChannel:
         cls,
         topic: str,
     ) -> "PointsAnnotationChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "PointsAnnotation",
@@ -364,6 +383,7 @@ class PoseChannel:
         cls,
         topic: str,
     ) -> "PoseChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Pose",
@@ -381,6 +401,7 @@ class PoseInFrameChannel:
         cls,
         topic: str,
     ) -> "PoseInFrameChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "PoseInFrame",
@@ -398,6 +419,7 @@ class PosesInFrameChannel:
         cls,
         topic: str,
     ) -> "PosesInFrameChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "PosesInFrame",
@@ -415,6 +437,7 @@ class QuaternionChannel:
         cls,
         topic: str,
     ) -> "QuaternionChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Quaternion",
@@ -432,6 +455,7 @@ class RawImageChannel:
         cls,
         topic: str,
     ) -> "RawImageChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "RawImage",
@@ -449,6 +473,7 @@ class SceneEntityChannel:
         cls,
         topic: str,
     ) -> "SceneEntityChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "SceneEntity",
@@ -466,6 +491,7 @@ class SceneEntityDeletionChannel:
         cls,
         topic: str,
     ) -> "SceneEntityDeletionChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "SceneEntityDeletion",
@@ -483,6 +509,7 @@ class SceneUpdateChannel:
         cls,
         topic: str,
     ) -> "SceneUpdateChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "SceneUpdate",
@@ -500,6 +527,7 @@ class TextAnnotationChannel:
         cls,
         topic: str,
     ) -> "TextAnnotationChannel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "TextAnnotation",
@@ -517,6 +545,7 @@ class Vector2Channel:
         cls,
         topic: str,
     ) -> "Vector2Channel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Vector2",
@@ -534,6 +563,7 @@ class Vector3Channel:
         cls,
         topic: str,
     ) -> "Vector3Channel": ...
+    def close(self) -> None: ...
     def log(
         self,
         message: "Vector3",

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -98,6 +98,15 @@ class Channel:
 
         raise ValueError(f"Unsupported message type: {type(msg)}")
 
+    def close(self) -> None:
+        """
+        Close the channel.
+
+        You do not need to call this unless you explicitly want to remove advertisements from live
+        visualization clients. Destroying all references to the channel will also close it.
+        """
+        self.base.close()
+
 
 _channels_by_topic: Dict[str, Channel] = {}
 

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -99,7 +99,7 @@ impl CameraCalibrationChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed CameraCalibrationChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CameraCalibrationChannel");
         }
     }
 
@@ -164,7 +164,7 @@ impl CircleAnnotationChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed CircleAnnotationChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CircleAnnotationChannel");
         }
     }
 
@@ -229,7 +229,7 @@ impl ColorChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed ColorChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed ColorChannel");
         }
     }
 
@@ -294,7 +294,7 @@ impl CompressedImageChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed CompressedImageChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CompressedImageChannel");
         }
     }
 
@@ -359,7 +359,7 @@ impl CompressedVideoChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed CompressedVideoChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CompressedVideoChannel");
         }
     }
 
@@ -424,7 +424,7 @@ impl FrameTransformChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed FrameTransformChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed FrameTransformChannel");
         }
     }
 
@@ -489,7 +489,7 @@ impl FrameTransformsChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed FrameTransformsChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed FrameTransformsChannel");
         }
     }
 
@@ -554,7 +554,7 @@ impl GeoJsonChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed GeoJsonChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed GeoJsonChannel");
         }
     }
 
@@ -619,7 +619,7 @@ impl GridChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed GridChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed GridChannel");
         }
     }
 
@@ -684,7 +684,7 @@ impl ImageAnnotationsChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed ImageAnnotationsChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed ImageAnnotationsChannel");
         }
     }
 
@@ -749,7 +749,7 @@ impl KeyValuePairChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed KeyValuePairChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed KeyValuePairChannel");
         }
     }
 
@@ -814,7 +814,7 @@ impl LaserScanChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed LaserScanChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed LaserScanChannel");
         }
     }
 
@@ -879,7 +879,7 @@ impl LocationFixChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed LocationFixChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed LocationFixChannel");
         }
     }
 
@@ -944,7 +944,7 @@ impl LogChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed LogChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed LogChannel");
         }
     }
 
@@ -1009,7 +1009,7 @@ impl SceneEntityDeletionChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed SceneEntityDeletionChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed SceneEntityDeletionChannel");
         }
     }
 
@@ -1074,7 +1074,7 @@ impl SceneEntityChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed SceneEntityChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed SceneEntityChannel");
         }
     }
 
@@ -1139,7 +1139,7 @@ impl SceneUpdateChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed SceneUpdateChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed SceneUpdateChannel");
         }
     }
 
@@ -1204,7 +1204,7 @@ impl PackedElementFieldChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed PackedElementFieldChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PackedElementFieldChannel");
         }
     }
 
@@ -1269,7 +1269,7 @@ impl Point2Channel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed Point2Channel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Point2Channel");
         }
     }
 
@@ -1334,7 +1334,7 @@ impl Point3Channel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed Point3Channel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Point3Channel");
         }
     }
 
@@ -1399,7 +1399,7 @@ impl PointCloudChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed PointCloudChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PointCloudChannel");
         }
     }
 
@@ -1464,7 +1464,7 @@ impl PointsAnnotationChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed PointsAnnotationChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PointsAnnotationChannel");
         }
     }
 
@@ -1529,7 +1529,7 @@ impl PoseChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed PoseChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PoseChannel");
         }
     }
 
@@ -1594,7 +1594,7 @@ impl PoseInFrameChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed PoseInFrameChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PoseInFrameChannel");
         }
     }
 
@@ -1659,7 +1659,7 @@ impl PosesInFrameChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed PosesInFrameChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PosesInFrameChannel");
         }
     }
 
@@ -1724,7 +1724,7 @@ impl QuaternionChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed QuaternionChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed QuaternionChannel");
         }
     }
 
@@ -1789,7 +1789,7 @@ impl RawImageChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed RawImageChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed RawImageChannel");
         }
     }
 
@@ -1854,7 +1854,7 @@ impl TextAnnotationChannel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed TextAnnotationChannel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed TextAnnotationChannel");
         }
     }
 
@@ -1919,7 +1919,7 @@ impl Vector2Channel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed Vector2Channel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Vector2Channel");
         }
     }
 
@@ -1984,7 +1984,7 @@ impl Vector3Channel {
         if let Some(channel) = &self.0 {
             channel.log_with_meta(&msg.0, metadata);
         } else {
-            tracing::debug!("Cannot log() on a closed Vector3Channel");
+            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Vector3Channel");
         }
     }
 

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -49,7 +49,7 @@ pub fn register_submodule(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 /// A channel for logging :py:class:`foxglove.schemas.CameraCalibration` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CameraCalibrationChannel(TypedChannel<foxglove::schemas::CameraCalibration>);
+struct CameraCalibrationChannel(Option<TypedChannel<foxglove::schemas::CameraCalibration>>);
 
 #[pymethods]
 impl CameraCalibrationChannel {
@@ -59,7 +59,17 @@ impl CameraCalibrationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.CameraCalibration` message to the channel.
@@ -86,17 +96,25 @@ impl CameraCalibrationChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed CameraCalibrationChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("CameraCalibrationChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("CameraCalibrationChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "CameraCalibrationChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.CircleAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CircleAnnotationChannel(TypedChannel<foxglove::schemas::CircleAnnotation>);
+struct CircleAnnotationChannel(Option<TypedChannel<foxglove::schemas::CircleAnnotation>>);
 
 #[pymethods]
 impl CircleAnnotationChannel {
@@ -106,7 +124,17 @@ impl CircleAnnotationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.CircleAnnotation` message to the channel.
@@ -133,17 +161,25 @@ impl CircleAnnotationChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed CircleAnnotationChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("CircleAnnotationChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("CircleAnnotationChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "CircleAnnotationChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Color` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ColorChannel(TypedChannel<foxglove::schemas::Color>);
+struct ColorChannel(Option<TypedChannel<foxglove::schemas::Color>>);
 
 #[pymethods]
 impl ColorChannel {
@@ -153,7 +189,17 @@ impl ColorChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Color` message to the channel.
@@ -180,17 +226,25 @@ impl ColorChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed ColorChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("ColorChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("ColorChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "ColorChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.CompressedImage` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CompressedImageChannel(TypedChannel<foxglove::schemas::CompressedImage>);
+struct CompressedImageChannel(Option<TypedChannel<foxglove::schemas::CompressedImage>>);
 
 #[pymethods]
 impl CompressedImageChannel {
@@ -200,7 +254,17 @@ impl CompressedImageChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.CompressedImage` message to the channel.
@@ -227,17 +291,25 @@ impl CompressedImageChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed CompressedImageChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("CompressedImageChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("CompressedImageChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "CompressedImageChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.CompressedVideo` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CompressedVideoChannel(TypedChannel<foxglove::schemas::CompressedVideo>);
+struct CompressedVideoChannel(Option<TypedChannel<foxglove::schemas::CompressedVideo>>);
 
 #[pymethods]
 impl CompressedVideoChannel {
@@ -247,7 +319,17 @@ impl CompressedVideoChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.CompressedVideo` message to the channel.
@@ -274,17 +356,25 @@ impl CompressedVideoChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed CompressedVideoChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("CompressedVideoChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("CompressedVideoChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "CompressedVideoChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.FrameTransform` messages.
 #[pyclass(module = "foxglove.channels")]
-struct FrameTransformChannel(TypedChannel<foxglove::schemas::FrameTransform>);
+struct FrameTransformChannel(Option<TypedChannel<foxglove::schemas::FrameTransform>>);
 
 #[pymethods]
 impl FrameTransformChannel {
@@ -294,7 +384,17 @@ impl FrameTransformChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.FrameTransform` message to the channel.
@@ -321,17 +421,25 @@ impl FrameTransformChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed FrameTransformChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("FrameTransformChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("FrameTransformChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "FrameTransformChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.FrameTransforms` messages.
 #[pyclass(module = "foxglove.channels")]
-struct FrameTransformsChannel(TypedChannel<foxglove::schemas::FrameTransforms>);
+struct FrameTransformsChannel(Option<TypedChannel<foxglove::schemas::FrameTransforms>>);
 
 #[pymethods]
 impl FrameTransformsChannel {
@@ -341,7 +449,17 @@ impl FrameTransformsChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.FrameTransforms` message to the channel.
@@ -368,17 +486,25 @@ impl FrameTransformsChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed FrameTransformsChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("FrameTransformsChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("FrameTransformsChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "FrameTransformsChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.GeoJson` messages.
 #[pyclass(module = "foxglove.channels")]
-struct GeoJsonChannel(TypedChannel<foxglove::schemas::GeoJson>);
+struct GeoJsonChannel(Option<TypedChannel<foxglove::schemas::GeoJson>>);
 
 #[pymethods]
 impl GeoJsonChannel {
@@ -388,7 +514,17 @@ impl GeoJsonChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.GeoJson` message to the channel.
@@ -415,17 +551,25 @@ impl GeoJsonChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed GeoJsonChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("GeoJsonChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("GeoJsonChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "GeoJsonChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Grid` messages.
 #[pyclass(module = "foxglove.channels")]
-struct GridChannel(TypedChannel<foxglove::schemas::Grid>);
+struct GridChannel(Option<TypedChannel<foxglove::schemas::Grid>>);
 
 #[pymethods]
 impl GridChannel {
@@ -435,7 +579,17 @@ impl GridChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Grid` message to the channel.
@@ -462,17 +616,25 @@ impl GridChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed GridChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("GridChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("GridChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "GridChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.ImageAnnotations` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ImageAnnotationsChannel(TypedChannel<foxglove::schemas::ImageAnnotations>);
+struct ImageAnnotationsChannel(Option<TypedChannel<foxglove::schemas::ImageAnnotations>>);
 
 #[pymethods]
 impl ImageAnnotationsChannel {
@@ -482,7 +644,17 @@ impl ImageAnnotationsChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.ImageAnnotations` message to the channel.
@@ -509,17 +681,25 @@ impl ImageAnnotationsChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed ImageAnnotationsChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("ImageAnnotationsChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("ImageAnnotationsChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "ImageAnnotationsChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.KeyValuePair` messages.
 #[pyclass(module = "foxglove.channels")]
-struct KeyValuePairChannel(TypedChannel<foxglove::schemas::KeyValuePair>);
+struct KeyValuePairChannel(Option<TypedChannel<foxglove::schemas::KeyValuePair>>);
 
 #[pymethods]
 impl KeyValuePairChannel {
@@ -529,7 +709,17 @@ impl KeyValuePairChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.KeyValuePair` message to the channel.
@@ -556,17 +746,25 @@ impl KeyValuePairChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed KeyValuePairChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("KeyValuePairChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("KeyValuePairChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "KeyValuePairChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.LaserScan` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LaserScanChannel(TypedChannel<foxglove::schemas::LaserScan>);
+struct LaserScanChannel(Option<TypedChannel<foxglove::schemas::LaserScan>>);
 
 #[pymethods]
 impl LaserScanChannel {
@@ -576,7 +774,17 @@ impl LaserScanChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.LaserScan` message to the channel.
@@ -603,17 +811,25 @@ impl LaserScanChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed LaserScanChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("LaserScanChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("LaserScanChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "LaserScanChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.LocationFix` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LocationFixChannel(TypedChannel<foxglove::schemas::LocationFix>);
+struct LocationFixChannel(Option<TypedChannel<foxglove::schemas::LocationFix>>);
 
 #[pymethods]
 impl LocationFixChannel {
@@ -623,7 +839,17 @@ impl LocationFixChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.LocationFix` message to the channel.
@@ -650,17 +876,25 @@ impl LocationFixChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed LocationFixChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("LocationFixChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("LocationFixChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "LocationFixChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Log` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LogChannel(TypedChannel<foxglove::schemas::Log>);
+struct LogChannel(Option<TypedChannel<foxglove::schemas::Log>>);
 
 #[pymethods]
 impl LogChannel {
@@ -670,7 +904,17 @@ impl LogChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Log` message to the channel.
@@ -697,17 +941,25 @@ impl LogChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed LogChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("LogChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("LogChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "LogChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneEntityDeletion` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneEntityDeletionChannel(TypedChannel<foxglove::schemas::SceneEntityDeletion>);
+struct SceneEntityDeletionChannel(Option<TypedChannel<foxglove::schemas::SceneEntityDeletion>>);
 
 #[pymethods]
 impl SceneEntityDeletionChannel {
@@ -717,7 +969,17 @@ impl SceneEntityDeletionChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneEntityDeletion` message to the channel.
@@ -744,17 +1006,25 @@ impl SceneEntityDeletionChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed SceneEntityDeletionChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("SceneEntityDeletionChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("SceneEntityDeletionChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "SceneEntityDeletionChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneEntity` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneEntityChannel(TypedChannel<foxglove::schemas::SceneEntity>);
+struct SceneEntityChannel(Option<TypedChannel<foxglove::schemas::SceneEntity>>);
 
 #[pymethods]
 impl SceneEntityChannel {
@@ -764,7 +1034,17 @@ impl SceneEntityChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneEntity` message to the channel.
@@ -791,17 +1071,25 @@ impl SceneEntityChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed SceneEntityChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("SceneEntityChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("SceneEntityChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "SceneEntityChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneUpdate` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneUpdateChannel(TypedChannel<foxglove::schemas::SceneUpdate>);
+struct SceneUpdateChannel(Option<TypedChannel<foxglove::schemas::SceneUpdate>>);
 
 #[pymethods]
 impl SceneUpdateChannel {
@@ -811,7 +1099,17 @@ impl SceneUpdateChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneUpdate` message to the channel.
@@ -838,17 +1136,25 @@ impl SceneUpdateChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed SceneUpdateChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("SceneUpdateChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("SceneUpdateChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "SceneUpdateChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PackedElementField` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PackedElementFieldChannel(TypedChannel<foxglove::schemas::PackedElementField>);
+struct PackedElementFieldChannel(Option<TypedChannel<foxglove::schemas::PackedElementField>>);
 
 #[pymethods]
 impl PackedElementFieldChannel {
@@ -858,7 +1164,17 @@ impl PackedElementFieldChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.PackedElementField` message to the channel.
@@ -885,17 +1201,25 @@ impl PackedElementFieldChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed PackedElementFieldChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("PackedElementFieldChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("PackedElementFieldChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "PackedElementFieldChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Point2` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Point2Channel(TypedChannel<foxglove::schemas::Point2>);
+struct Point2Channel(Option<TypedChannel<foxglove::schemas::Point2>>);
 
 #[pymethods]
 impl Point2Channel {
@@ -905,7 +1229,17 @@ impl Point2Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Point2` message to the channel.
@@ -932,17 +1266,25 @@ impl Point2Channel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed Point2Channel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("Point2Channel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("Point2Channel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "Point2Channel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Point3` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Point3Channel(TypedChannel<foxglove::schemas::Point3>);
+struct Point3Channel(Option<TypedChannel<foxglove::schemas::Point3>>);
 
 #[pymethods]
 impl Point3Channel {
@@ -952,7 +1294,17 @@ impl Point3Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Point3` message to the channel.
@@ -979,17 +1331,25 @@ impl Point3Channel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed Point3Channel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("Point3Channel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("Point3Channel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "Point3Channel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PointCloud` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PointCloudChannel(TypedChannel<foxglove::schemas::PointCloud>);
+struct PointCloudChannel(Option<TypedChannel<foxglove::schemas::PointCloud>>);
 
 #[pymethods]
 impl PointCloudChannel {
@@ -999,7 +1359,17 @@ impl PointCloudChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.PointCloud` message to the channel.
@@ -1026,17 +1396,25 @@ impl PointCloudChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed PointCloudChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("PointCloudChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("PointCloudChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "PointCloudChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PointsAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PointsAnnotationChannel(TypedChannel<foxglove::schemas::PointsAnnotation>);
+struct PointsAnnotationChannel(Option<TypedChannel<foxglove::schemas::PointsAnnotation>>);
 
 #[pymethods]
 impl PointsAnnotationChannel {
@@ -1046,7 +1424,17 @@ impl PointsAnnotationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.PointsAnnotation` message to the channel.
@@ -1073,17 +1461,25 @@ impl PointsAnnotationChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed PointsAnnotationChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("PointsAnnotationChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("PointsAnnotationChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "PointsAnnotationChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Pose` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PoseChannel(TypedChannel<foxglove::schemas::Pose>);
+struct PoseChannel(Option<TypedChannel<foxglove::schemas::Pose>>);
 
 #[pymethods]
 impl PoseChannel {
@@ -1093,7 +1489,17 @@ impl PoseChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Pose` message to the channel.
@@ -1120,17 +1526,25 @@ impl PoseChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed PoseChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("PoseChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("PoseChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "PoseChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PoseInFrame` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PoseInFrameChannel(TypedChannel<foxglove::schemas::PoseInFrame>);
+struct PoseInFrameChannel(Option<TypedChannel<foxglove::schemas::PoseInFrame>>);
 
 #[pymethods]
 impl PoseInFrameChannel {
@@ -1140,7 +1554,17 @@ impl PoseInFrameChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.PoseInFrame` message to the channel.
@@ -1167,17 +1591,25 @@ impl PoseInFrameChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed PoseInFrameChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("PoseInFrameChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("PoseInFrameChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "PoseInFrameChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PosesInFrame` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PosesInFrameChannel(TypedChannel<foxglove::schemas::PosesInFrame>);
+struct PosesInFrameChannel(Option<TypedChannel<foxglove::schemas::PosesInFrame>>);
 
 #[pymethods]
 impl PosesInFrameChannel {
@@ -1187,7 +1619,17 @@ impl PosesInFrameChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.PosesInFrame` message to the channel.
@@ -1214,17 +1656,25 @@ impl PosesInFrameChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed PosesInFrameChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("PosesInFrameChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("PosesInFrameChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "PosesInFrameChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Quaternion` messages.
 #[pyclass(module = "foxglove.channels")]
-struct QuaternionChannel(TypedChannel<foxglove::schemas::Quaternion>);
+struct QuaternionChannel(Option<TypedChannel<foxglove::schemas::Quaternion>>);
 
 #[pymethods]
 impl QuaternionChannel {
@@ -1234,7 +1684,17 @@ impl QuaternionChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Quaternion` message to the channel.
@@ -1261,17 +1721,25 @@ impl QuaternionChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed QuaternionChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("QuaternionChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("QuaternionChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "QuaternionChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.RawImage` messages.
 #[pyclass(module = "foxglove.channels")]
-struct RawImageChannel(TypedChannel<foxglove::schemas::RawImage>);
+struct RawImageChannel(Option<TypedChannel<foxglove::schemas::RawImage>>);
 
 #[pymethods]
 impl RawImageChannel {
@@ -1281,7 +1749,17 @@ impl RawImageChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.RawImage` message to the channel.
@@ -1308,17 +1786,25 @@ impl RawImageChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed RawImageChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("RawImageChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("RawImageChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "RawImageChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.TextAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct TextAnnotationChannel(TypedChannel<foxglove::schemas::TextAnnotation>);
+struct TextAnnotationChannel(Option<TypedChannel<foxglove::schemas::TextAnnotation>>);
 
 #[pymethods]
 impl TextAnnotationChannel {
@@ -1328,7 +1814,17 @@ impl TextAnnotationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.TextAnnotation` message to the channel.
@@ -1355,17 +1851,25 @@ impl TextAnnotationChannel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed TextAnnotationChannel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("TextAnnotationChannel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("TextAnnotationChannel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "TextAnnotationChannel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Vector2` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Vector2Channel(TypedChannel<foxglove::schemas::Vector2>);
+struct Vector2Channel(Option<TypedChannel<foxglove::schemas::Vector2>>);
 
 #[pymethods]
 impl Vector2Channel {
@@ -1375,7 +1879,17 @@ impl Vector2Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Vector2` message to the channel.
@@ -1402,17 +1916,25 @@ impl Vector2Channel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed Vector2Channel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("Vector2Channel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("Vector2Channel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "Vector2Channel (closed)".to_string()
+        }
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Vector3` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Vector3Channel(TypedChannel<foxglove::schemas::Vector3>);
+struct Vector3Channel(Option<TypedChannel<foxglove::schemas::Vector3>>);
 
 #[pymethods]
 impl Vector3Channel {
@@ -1422,7 +1944,17 @@ impl Vector3Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:`log` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:`foxglove.schemas.Vector3` message to the channel.
@@ -1449,10 +1981,18 @@ impl Vector3Channel {
             publish_time,
             sequence,
         };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+            channel.log_with_meta(&msg.0, metadata);
+        } else {
+            tracing::debug!("Cannot log() on a closed Vector3Channel");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("Vector3Channel(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("Vector3Channel(topic='{}')", channel.topic()).to_string()
+        } else {
+            "Vector3Channel (closed)".to_string()
+        }
     }
 }

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -145,6 +145,16 @@ impl Channel {
 
         self.sinks.for_each(|sink| sink.log(self, msg, &metadata));
     }
+
+    /// Close the channel.
+    /// Note the channel is closed automatically when dropped.
+    pub fn close(&self) {
+        self.sinks.for_each(|sink| {
+            sink.remove_channel(self);
+            Ok(())
+        });
+        self.sinks.clear();
+    }
 }
 
 #[cfg(test)]

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -145,16 +145,6 @@ impl Channel {
 
         self.sinks.for_each(|sink| sink.log(self, msg, &metadata));
     }
-
-    /// Close the channel.
-    /// Note the channel is closed automatically when dropped.
-    pub fn close(&self) {
-        self.sinks.for_each(|sink| {
-            sink.remove_channel(self);
-            Ok(())
-        });
-        self.sinks.clear();
-    }
 }
 
 #[cfg(test)]

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -627,7 +627,7 @@ export function generateChannelClasses(messageSchemas: FoxgloveMessageSchema[]):
     return `
 /// A channel for logging :py:class:\`foxglove.schemas.${schemaClass}\` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ${channelClass}(TypedChannel<foxglove::schemas::${schemaClass}>);
+struct ${channelClass}(Option<TypedChannel<foxglove::schemas::${schemaClass}>>);
 
 #[pymethods]
 impl ${channelClass} {
@@ -637,7 +637,17 @@ impl ${channelClass} {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(base))
+        Ok(Self(Some(base)))
+    }
+
+    /// Close the channel.
+    ///
+    /// You do not need to call this unless you explicitly want to remove advertisements from live
+    /// visualization clients. Destroying all references to the channel will also close it.
+    ///
+    /// It is an error to call :py:meth:\`log\` after closing the channel.
+    fn close(&mut self) {
+        self.0 = None;
     }
 
     /// Log a :py:class:\`foxglove.schemas.${schemaClass}\` message to the channel.
@@ -660,11 +670,19 @@ impl ${channelClass} {
         sequence: Option<u32>,
     ) {
         let metadata = PartialMetadata{ log_time, publish_time, sequence };
-        self.0.log_with_meta(&msg.0, metadata);
+        if let Some(channel) = &self.0 {
+          channel.log_with_meta(&msg.0, metadata);
+        } else {
+          tracing::debug!("Cannot log() on a closed ${channelClass}");
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("${channelClass}(topic='{}')", self.0.topic()).to_string()
+        if let Some(channel) = &self.0 {
+            format!("${channelClass}(topic='{}')", channel.topic()).to_string()
+        } else {
+            "${channelClass} (closed)".to_string()
+        }
     }
 }
 `;
@@ -698,6 +716,7 @@ export function generatePyChannelStub(messageSchemas: FoxgloveMessageSchema[]): 
         `        cls,`,
         `        topic: str,`,
         `    ) -> "${channelClass}": ...\n`,
+        `    def close(self) -> None: ...`,
         `    def log(`,
         `        self,`,
         `        message: "${schemaClass}",`,

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -673,7 +673,7 @@ impl ${channelClass} {
         if let Some(channel) = &self.0 {
           channel.log_with_meta(&msg.0, metadata);
         } else {
-          tracing::debug!("Cannot log() on a closed ${channelClass}");
+          tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed ${channelClass}");
         }
     }
 


### PR DESCRIPTION
Allow python implementations to explicitly close their channels, in order to stop advertisements to the app.

For both typed channels and BaseChannel, each python class stores the reference to the underlying channel as an option, and sets it to None when closed. Calling `log` after this results in debug logging, but does not raise an error.

I have not added this to any examples; I think this is a niche requirement which is not typically needed.