### PR TITLE
python: Add conversions for Duration and Timestamp

### DIFF
--- a/python/foxglove-sdk-examples/live-visualization/main.py
+++ b/python/foxglove-sdk-examples/live-visualization/main.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import math
@@ -27,6 +28,7 @@ from foxglove.schemas import (
     RawImage,
     SceneEntity,
     SceneUpdate,
+    Timestamp,
     Vector3,
 )
 
@@ -162,7 +164,8 @@ def main() -> None:
                         SceneEntity(
                             frame_id="box",
                             id="box_1",
-                            lifetime=Duration(sec=10),
+                            timestamp=Timestamp.from_datetime(datetime.datetime.now()),
+                            lifetime=Duration.from_secs(1.2345),
                             cubes=[
                                 CubePrimitive(
                                     pose=Pose(

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
@@ -48,7 +48,7 @@ class Timestamp:
         nsec: Optional[int] = None,
     ) -> "Timestamp": ...
     @staticmethod
-    def from_timestamp(timestamp: float) -> "Timestamp":
+    def from_epoch_secs(timestamp: float) -> "Timestamp":
         """
         Creates a :py:class:`Timestamp` from an epoch timestamp, such as is
         returned by :py:func:`time.time` or

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
@@ -6,6 +6,9 @@ class Duration:
     A duration in seconds and nanoseconds
     """
 
+    sec: int
+    nsec: int
+
     def __new__(
         cls,
         sec: int,
@@ -41,6 +44,9 @@ class Timestamp:
     """
     A timestamp in seconds and nanoseconds
     """
+
+    sec: int
+    nsec: int
 
     def __new__(
         cls,

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
@@ -1,3 +1,4 @@
+import datetime
 from typing import Optional
 
 class Duration:
@@ -10,6 +11,31 @@ class Duration:
         sec: int,
         nsec: Optional[int] = None,
     ) -> "Duration": ...
+    @staticmethod
+    def from_secs(secs: float) -> "Duration":
+        """
+        Creates a :py:class:`Duration` from seconds.
+
+        Raises `OverflowError` if the duration cannot be represented.
+
+        :param secs: Seconds
+        :type secs: float
+        :rtype: :py:class:`Duration`
+        """
+        ...
+
+    @staticmethod
+    def from_timedelta(td: datetime.timedelta) -> "Duration":
+        """
+        Creates a :py:class:`Duration` from a timedelta.
+
+        Raises `OverflowError` if the duration cannot be represented.
+
+        :param td: Timedelta
+        :type td: :py:class:`datetime.timedelta`
+        :rtype: :py:class:`Duration`
+        """
+        ...
 
 class Timestamp:
     """
@@ -21,3 +47,32 @@ class Timestamp:
         sec: int,
         nsec: Optional[int] = None,
     ) -> "Timestamp": ...
+    @staticmethod
+    def from_timestamp(timestamp: float) -> "Timestamp":
+        """
+        Creates a :py:class:`Timestamp` from an epoch timestamp, such as is
+        returned by :py:func:`time.time` or
+        :py:func:`datetime.datetime.timestamp`.
+
+        Raises `OverflowError` if the timestamp cannot be represented.
+
+        :param timestamp: Seconds since epoch
+        :type timestamp: float
+        :rtype: :py:class:`Timestamp`
+        """
+        ...
+
+    @staticmethod
+    def from_datetime(dt: datetime.datetime) -> "Timestamp":
+        """
+        Creates a UNIX epoch :py:class:`Timestamp` from a datetime object.
+
+        Naive datetime objects are presumed to be in the local timezone.
+
+        Raises `OverflowError` if the timestamp cannot be represented.
+
+        :param dt: Datetime
+        :type dt: :py:class:`datetime.datetime`
+        :rtype: :py:class:`Timestamp`
+        """
+        ...

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
@@ -6,14 +6,15 @@ class Duration:
     A duration in seconds and nanoseconds
     """
 
-    sec: int
-    nsec: int
-
     def __new__(
         cls,
         sec: int,
         nsec: Optional[int] = None,
     ) -> "Duration": ...
+    @property
+    def sec(self) -> int: ...
+    @property
+    def nsec(self) -> int: ...
     @staticmethod
     def from_secs(secs: float) -> "Duration":
         """
@@ -45,14 +46,15 @@ class Timestamp:
     A timestamp in seconds and nanoseconds
     """
 
-    sec: int
-    nsec: int
-
     def __new__(
         cls,
         sec: int,
         nsec: Optional[int] = None,
     ) -> "Timestamp": ...
+    @property
+    def sec(self) -> int: ...
+    @property
+    def nsec(self) -> int: ...
     @staticmethod
     def from_epoch_secs(timestamp: float) -> "Timestamp":
         """

--- a/python/foxglove-sdk/python/foxglove/tests/test_time.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_time.py
@@ -5,7 +5,7 @@ from foxglove.schemas import Duration, Timestamp
 
 
 class TestTime(unittest.TestCase):
-    def test_duration_from_secs(self):
+    def test_duration_from_secs(self) -> None:
         self.assertEqual(Duration.from_secs(1.123), Duration(sec=1, nsec=123_000_000))
         self.assertEqual(Duration.from_secs(-0.123), Duration(sec=-1, nsec=877_000_000))
         self.assertEqual(Duration.from_secs(-1.123), Duration(sec=-2, nsec=877_000_000))
@@ -16,7 +16,7 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(OverflowError):
             Duration.from_secs(1e42)
 
-    def test_duration_from_timedelta(self):
+    def test_duration_from_timedelta(self) -> None:
         td = datetime.timedelta(seconds=1, milliseconds=123)
         self.assertEqual(Duration.from_timedelta(td), Duration(sec=1, nsec=123_000_000))
 
@@ -38,7 +38,7 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(OverflowError):
             Duration.from_timedelta(datetime.timedelta.max)
 
-    def test_timestamp_from_timestamp(self):
+    def test_timestamp_from_timestamp(self) -> None:
         self.assertEqual(
             Timestamp.from_timestamp(1.123), Timestamp(sec=1, nsec=123_000_000)
         )
@@ -49,7 +49,7 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(OverflowError):
             Timestamp.from_timestamp(1e42)
 
-    def test_timestamp_from_datetime(self):
+    def test_timestamp_from_datetime(self) -> None:
         utc = datetime.timezone.utc
         dt = datetime.datetime(1970, 1, 1, tzinfo=utc)
         self.assertEqual(Timestamp.from_datetime(dt), Timestamp(sec=0))

--- a/python/foxglove-sdk/python/foxglove/tests/test_time.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_time.py
@@ -38,16 +38,16 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(OverflowError):
             Duration.from_timedelta(datetime.timedelta.max)
 
-    def test_timestamp_from_timestamp(self) -> None:
+    def test_timestamp_from_epoch_secs(self) -> None:
         self.assertEqual(
-            Timestamp.from_timestamp(1.123), Timestamp(sec=1, nsec=123_000_000)
+            Timestamp.from_epoch_secs(1.123), Timestamp(sec=1, nsec=123_000_000)
         )
 
         with self.assertRaises(OverflowError):
-            Timestamp.from_timestamp(-1.0)
+            Timestamp.from_epoch_secs(-1.0)
 
         with self.assertRaises(OverflowError):
-            Timestamp.from_timestamp(1e42)
+            Timestamp.from_epoch_secs(1e42)
 
     def test_timestamp_from_datetime(self) -> None:
         utc = datetime.timezone.utc

--- a/python/foxglove-sdk/python/foxglove/tests/test_time.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_time.py
@@ -24,9 +24,18 @@ class TestTime(unittest.TestCase):
         )
 
         # argument conversions
-        Duration(sec=-(2**31))
-        Duration(sec=0, nsec=2**32 - 1)
-        Duration(sec=2**31 - 1, nsec=999_999_999)
+        d = Duration(sec=-(2**31))
+        self.assertEqual(d.sec, -(2**31))
+        self.assertEqual(d.nsec, 0)
+
+        d = Duration(sec=0, nsec=2**32 - 1)
+        self.assertEqual(d.sec, 4)
+        self.assertEqual(d.nsec, 294_967_295)
+
+        d = Duration(sec=2**31 - 1, nsec=999_999_999)
+        self.assertEqual(d.sec, 2**31 - 1)
+        self.assertEqual(d.nsec, 999_999_999)
+
         with self.assertRaises(OverflowError):
             Duration(sec=-(2**31) - 1)
         with self.assertRaises(OverflowError):
@@ -89,9 +98,18 @@ class TestTime(unittest.TestCase):
         )
 
         # argument conversions
-        Timestamp(sec=0)
-        Timestamp(sec=0, nsec=2**32 - 1)
-        Timestamp(sec=2**32 - 1, nsec=999_999_999)
+        t = Timestamp(sec=0)
+        self.assertEqual(t.sec, 0)
+        self.assertEqual(t.nsec, 0)
+
+        t = Timestamp(sec=0, nsec=2**32 - 1)
+        self.assertEqual(t.sec, 4)
+        self.assertEqual(t.nsec, 294_967_295)
+
+        t = Timestamp(sec=2**32 - 1, nsec=999_999_999)
+        self.assertEqual(t.sec, 2**32 - 1)
+        self.assertEqual(t.nsec, 999_999_999)
+
         with self.assertRaises(OverflowError):
             Timestamp(sec=-1)
         with self.assertRaises(OverflowError):

--- a/python/foxglove-sdk/python/foxglove/tests/test_time.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_time.py
@@ -1,0 +1,74 @@
+import datetime
+import unittest
+
+from foxglove.schemas import Duration, Timestamp
+
+
+class TestTime(unittest.TestCase):
+    def test_duration_from_secs(self):
+        self.assertEqual(Duration.from_secs(1.123), Duration(sec=1, nsec=123_000_000))
+        self.assertEqual(Duration.from_secs(-0.123), Duration(sec=-1, nsec=877_000_000))
+        self.assertEqual(Duration.from_secs(-1.123), Duration(sec=-2, nsec=877_000_000))
+
+        with self.assertRaises(OverflowError):
+            Duration.from_secs(-1e42)
+
+        with self.assertRaises(OverflowError):
+            Duration.from_secs(1e42)
+
+    def test_duration_from_timedelta(self):
+        td = datetime.timedelta(seconds=1, milliseconds=123)
+        self.assertEqual(Duration.from_timedelta(td), Duration(sec=1, nsec=123_000_000))
+
+        # no loss of precision
+        td = datetime.timedelta(days=9876, microseconds=123_456)
+        self.assertEqual(
+            Duration.from_timedelta(td), Duration(sec=853_286_400, nsec=123_456_000)
+        )
+
+        # timedeltas are normalized
+        td = datetime.timedelta(seconds=8 * 24 * 3600, milliseconds=99_111)
+        self.assertEqual(
+            Duration.from_timedelta(td), Duration(sec=691_299, nsec=111_000_000)
+        )
+
+        with self.assertRaises(OverflowError):
+            Duration.from_timedelta(datetime.timedelta.min)
+
+        with self.assertRaises(OverflowError):
+            Duration.from_timedelta(datetime.timedelta.max)
+
+    def test_timestamp_from_timestamp(self):
+        self.assertEqual(
+            Timestamp.from_timestamp(1.123), Timestamp(sec=1, nsec=123_000_000)
+        )
+
+        with self.assertRaises(OverflowError):
+            Timestamp.from_timestamp(-1.0)
+
+        with self.assertRaises(OverflowError):
+            Timestamp.from_timestamp(1e42)
+
+    def test_timestamp_from_datetime(self):
+        utc = datetime.timezone.utc
+        dt = datetime.datetime(1970, 1, 1, tzinfo=utc)
+        self.assertEqual(Timestamp.from_datetime(dt), Timestamp(sec=0))
+
+        # no loss of precision
+        dt = datetime.datetime(2025, 1, 1, microsecond=42, tzinfo=utc)
+        self.assertEqual(
+            Timestamp.from_datetime(dt), Timestamp(sec=1_735_689_600, nsec=42_000)
+        )
+
+        # alternative timezone
+        local_tz = datetime.timezone(datetime.timedelta(hours=-1))
+        dt = datetime.datetime(1970, 1, 1, 0, 0, 1, 123_000, tzinfo=local_tz)
+        self.assertEqual(
+            Timestamp.from_datetime(dt), Timestamp(sec=3601, nsec=123_000_000)
+        )
+
+        with self.assertRaises(OverflowError):
+            Timestamp.from_datetime(datetime.datetime(1969, 12, 31, tzinfo=utc))
+
+        with self.assertRaises(OverflowError):
+            Timestamp.from_datetime(datetime.datetime(2106, 2, 8, tzinfo=utc))

--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -35,8 +35,8 @@ impl Timestamp {
     /// :rtype: :py:class:`Timestamp`
     #[staticmethod]
     #[pyo3(signature = (timestamp))]
-    fn from_timestamp(timestamp: f64) -> PyResult<Self> {
-        foxglove::schemas::Timestamp::try_from_timestamp_secs_f64(timestamp)
+    fn from_epoch_secs(timestamp: f64) -> PyResult<Self> {
+        foxglove::schemas::Timestamp::try_from_epoch_secs_f64(timestamp)
             .map(Self)
             .map_err(|_| PyOverflowError::new_err("timestamp out of range"))
     }

--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -10,7 +10,7 @@ use pyo3::types::{timezone_utc, PyDateTime};
 /// :param nsec: The number of nanoseconds since the :py:attr:\`sec\` value.
 #[pyclass(module = "foxglove.schemas", eq)]
 #[derive(Clone, PartialEq, Eq)]
-pub struct Timestamp(pub(crate) foxglove::schemas::Timestamp);
+pub struct Timestamp(foxglove::schemas::Timestamp);
 
 #[pymethods]
 impl Timestamp {
@@ -23,7 +23,7 @@ impl Timestamp {
     }
 
     fn __repr__(&self) -> String {
-        format!("Timestamp(sec={}, nsec={})", self.0.sec(), self.0.nsec()).to_string()
+        format!("Timestamp(sec={}, nsec={})", self.sec(), self.nsec()).to_string()
     }
 
     /// The number of seconds in the timestamp.
@@ -110,7 +110,7 @@ impl From<Timestamp> for foxglove::schemas::Timestamp {
 /// :param nsec: The number of nanoseconds in the positive direction.
 #[pyclass(module = "foxglove.schemas", eq)]
 #[derive(Clone, PartialEq, Eq)]
-pub struct Duration(pub(crate) foxglove::schemas::Duration);
+pub struct Duration(foxglove::schemas::Duration);
 
 #[pymethods]
 impl Duration {
@@ -123,7 +123,7 @@ impl Duration {
     }
 
     fn __repr__(&self) -> String {
-        format!("Duration(sec={}, nsec={})", self.0.sec(), self.0.nsec()).to_string()
+        format!("Duration(sec={}, nsec={})", self.sec(), self.nsec()).to_string()
     }
 
     /// The number of seconds in the duration.

--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -72,6 +72,9 @@ impl Timestamp {
             dt = dt.call_method0(py, "astimezone")?.extract(py)?;
         }
         let utc = timezone_utc(py);
+
+        // We're not simply using `datetime.total_seconds()`, because the conversion to floating
+        // point loses preceision and is not round-trippable.
         let epoch = PyDateTime::new(py, 1970, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
         let td = dt.call_method1(py, "__sub__", (epoch,))?;
 

--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -1,13 +1,15 @@
 //! Wrappers for well-known types.
 
+use pyo3::exceptions::PyOverflowError;
 use pyo3::prelude::*;
+use pyo3::types::{timezone_utc, PyDateTime};
 
 /// A timestamp in seconds and nanoseconds
 ///
 /// :param sec: The number of seconds since a user-defined epoch.
 /// :param nsec: The number of nanoseconds since the :py:attr:\`sec\` value.
-#[pyclass(module = "foxglove.schemas")]
-#[derive(Clone)]
+#[pyclass(module = "foxglove.schemas", eq)]
+#[derive(Clone, PartialEq)]
 pub struct Timestamp(pub(crate) foxglove::schemas::Timestamp);
 
 #[pymethods]
@@ -22,6 +24,65 @@ impl Timestamp {
     fn __repr__(&self) -> String {
         format!("Timestamp(sec={}, nsec={})", self.0.sec, self.0.nsec).to_string()
     }
+
+    /// Creates a :py:class:`Timestamp` from an epoch timestamp, such as is returned by
+    /// :py:func:`time.time` or :py:func:`datetime.datetime.timestamp`.
+    ///
+    /// Raises `OverflowError` if the timestamp cannot be represented.
+    ///
+    /// :param timestamp: Seconds since epoch
+    /// :type timestamp: float
+    /// :rtype: :py:class:`Timestamp`
+    #[staticmethod]
+    #[pyo3(signature = (timestamp))]
+    fn from_timestamp(timestamp: f64) -> PyResult<Self> {
+        foxglove::schemas::Timestamp::try_from_timestamp_secs_f64(timestamp)
+            .map(Self)
+            .map_err(|_| PyOverflowError::new_err("timestamp out of range"))
+    }
+
+    /// Creates a UNIX epoch :py:class:`Timestamp` from a datetime object.
+    ///
+    /// Naive datetime objects are presumed to be in the local timezone.
+    ///
+    /// Raises `OverflowError` if the timestamp cannot be represented.
+    ///
+    /// :param dt: Datetime
+    /// :type dt: :py:class:`datetime.datetime`
+    /// :rtype: :py:class:`Timestamp`
+    #[staticmethod]
+    #[pyo3(signature = (dt))]
+    fn from_datetime(py: Python, mut dt: Py<PyDateTime>) -> PyResult<Self> {
+        // If this is a naive datetime, presume the local timezone.
+        let tzinfo: Py<PyAny> = dt.getattr(py, "tzinfo")?;
+        if tzinfo.is_none(py) {
+            dt = dt.call_method0(py, "astimezone")?.extract(py)?;
+        }
+        let utc = timezone_utc(py);
+        let epoch = PyDateTime::new(py, 1970, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
+        let td = dt.call_method1(py, "__sub__", (epoch,))?;
+
+        // Timedelta objects are normalized:
+        //
+        // - 0 <= microseconds < 1000000
+        // - 0 <= seconds < 3600*24 (the number of seconds in one day)
+        // - -999999999 <= days <= 999999999
+        //
+        // It is safe to multiply microseconds by 1000.
+        let days: i32 = td.getattr(py, "days")?.extract(py)?;
+        let seconds: u32 = td.getattr(py, "seconds")?.extract(py)?;
+        let microseconds: u32 = td.getattr(py, "microseconds")?.extract(py)?;
+        if days < 0 {
+            return Err(PyOverflowError::new_err("timestamp out of range"));
+        }
+        let Some(sec) = (days as u32)
+            .checked_mul(24 * 3600)
+            .and_then(|s| s.checked_add(seconds))
+        else {
+            return Err(PyOverflowError::new_err("timestamp out of range"));
+        };
+        Ok(Self::new(sec, Some(microseconds * 1000)))
+    }
 }
 
 impl From<Timestamp> for foxglove::schemas::Timestamp {
@@ -34,8 +95,8 @@ impl From<Timestamp> for foxglove::schemas::Timestamp {
 ///
 /// :param sec: The number of seconds in the duration.
 /// :param nsec: The number of nanoseconds in the positive direction.
-#[pyclass(module = "foxglove.schemas")]
-#[derive(Clone)]
+#[pyclass(module = "foxglove.schemas", eq)]
+#[derive(Clone, PartialEq)]
 pub struct Duration(pub(crate) foxglove::schemas::Duration);
 
 #[pymethods]
@@ -49,6 +110,50 @@ impl Duration {
 
     fn __repr__(&self) -> String {
         format!("Duration(sec={}, nsec={})", self.0.sec, self.0.nsec).to_string()
+    }
+
+    /// Creates a :py:class:`Duration` from seconds.
+    ///
+    /// Raises `OverflowError` if the duration cannot be represented.
+    ///
+    /// :param secs: Seconds
+    /// :type secs: float
+    /// :rtype: :py:class:`Duration`
+    #[staticmethod]
+    #[pyo3(signature = (secs))]
+    fn from_secs(secs: f64) -> PyResult<Self> {
+        foxglove::schemas::Duration::try_from_secs_f64(secs)
+            .map(Self)
+            .map_err(|_| PyOverflowError::new_err("duration out of range"))
+    }
+
+    /// Creates a :py:class:`Duration` from a timedelta.
+    ///
+    /// Raises `OverflowError` if the duration cannot be represented.
+    ///
+    /// :param td: Timedelta
+    /// :type td: :py:class:`datetime.timedelta`
+    /// :rtype: :py:class:`Duration`
+    #[staticmethod]
+    #[pyo3(signature = (td))]
+    fn from_timedelta(py: Python, td: Py<PyAny>) -> PyResult<Self> {
+        // Timedelta objects are normalized:
+        //
+        // - 0 <= microseconds < 1000000
+        // - 0 <= seconds < 3600*24 (the number of seconds in one day)
+        // - -999999999 <= days <= 999999999
+        //
+        // It is safe to read seconds as i32, and multiply microseconds by 1000.
+        let microseconds: u32 = td.getattr(py, "microseconds")?.extract(py)?;
+        let seconds: i32 = td.getattr(py, "seconds")?.extract(py)?;
+        let days: i32 = td.getattr(py, "days")?.extract(py)?;
+        let Some(sec) = days
+            .checked_mul(3600 * 24)
+            .and_then(|s| s.checked_add(seconds))
+        else {
+            return Err(PyOverflowError::new_err("duration out of range"));
+        };
+        Ok(Self::new(sec, Some(microseconds * 1000)))
     }
 }
 

--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -9,7 +9,7 @@ use pyo3::types::{timezone_utc, PyDateTime};
 /// :param sec: The number of seconds since a user-defined epoch.
 /// :param nsec: The number of nanoseconds since the :py:attr:\`sec\` value.
 #[pyclass(module = "foxglove.schemas", eq)]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Timestamp(pub(crate) foxglove::schemas::Timestamp);
 
 #[pymethods]
@@ -109,7 +109,7 @@ impl From<Timestamp> for foxglove::schemas::Timestamp {
 /// :param sec: The number of seconds in the duration.
 /// :param nsec: The number of nanoseconds in the positive direction.
 #[pyclass(module = "foxglove.schemas", eq)]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Duration(pub(crate) foxglove::schemas::Duration);
 
 #[pymethods]

--- a/rust/examples/ws-server/src/main.rs
+++ b/rust/examples/ws-server/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 
+use foxglove::convert::SaturatingInto;
 use foxglove::schemas::{
     Color, CubePrimitive, FrameTransform, Pose, Quaternion, SceneEntity, SceneUpdate, Vector3,
 };
@@ -48,7 +49,7 @@ fn log(counter: u32) {
         entities: vec![SceneEntity {
             frame_id: "box".to_string(),
             id: "box_1".to_string(),
-            lifetime: Some(foxglove::schemas::Duration { sec: 10, nsec: 0 }),
+            lifetime: Some(Duration::from_millis(10_100).saturating_into()),
             cubes: vec![CubePrimitive {
                 pose: Some(Pose {
                     position: Some(Vector3 {

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -280,9 +280,9 @@ impl Timestamp {
         self.into()
     }
 
-    /// Creates a `Timestamp` from `f64` timestamp seconds, or fails if the value is
+    /// Creates a `Timestamp` from seconds since epoch as an `f64`, or fails if the value is
     /// unrepresentable.
-    pub fn try_from_timestamp_secs_f64(secs: f64) -> Result<Self, RangeError> {
+    pub fn try_from_epoch_secs_f64(secs: f64) -> Result<Self, RangeError> {
         if secs < 0.0 {
             Err(RangeError::LowerBound)
         } else if secs > u32::MAX as f64 {
@@ -300,9 +300,9 @@ impl Timestamp {
         }
     }
 
-    /// Saturating `Timestamp` from `f64` timestamp seconds.
-    pub fn saturating_from_timestamp_secs_f64(secs: f64) -> Self {
-        match Self::try_from_timestamp_secs_f64(secs) {
+    /// Saturating `Timestamp` from seconds since epoch as an `f64`.
+    pub fn saturating_from_epoch_secs_f64(secs: f64) -> Self {
+        match Self::try_from_epoch_secs_f64(secs) {
             Ok(d) => d,
             Err(RangeError::LowerBound) => Timestamp::MIN,
             Err(RangeError::UpperBound) => Timestamp::MAX,

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -14,15 +14,49 @@ mod chrono;
 #[cfg(test)]
 mod tests;
 
-/// Converts time integer types and normalizes excessive nanoseconds into seconds.
-fn normalize(sec: impl Into<i64>, mut nsec: u32) -> (i64, i32) {
+/// The result type for [`normalize_nsec`].
+#[derive(Debug, PartialEq, Eq)]
+enum NormalizeResult {
+    /// Nanoseconds already within range.
+    Ok(u32),
+    /// Nanoseconds overflowed into seconds. Result is `(sec, nsec)`.
+    Overflow(u32, u32),
+}
+
+/// Normalizes nsec to be on within range `[0, 1_000_000_000)`.
+fn normalize_nsec(nsec: u32) -> NormalizeResult {
     if nsec < 1_000_000_000 {
-        (sec.into(), i32::try_from(nsec).unwrap())
+        NormalizeResult::Ok(nsec)
     } else {
-        // We're upconverting seconds from u32/i32, so there's no risk of overflow here.
-        let div = nsec / 1_000_000_000;
-        nsec %= 1_000_000_000;
-        (sec.into() + i64::from(div), i32::try_from(nsec).unwrap())
+        let sec = nsec / 1_000_000_000;
+        NormalizeResult::Overflow(sec, nsec % 1_000_000_000)
+    }
+}
+
+impl NormalizeResult {
+    /// Carries the result into an i32 representation of seconds.
+    ///
+    /// Returns None if the result overflows seconds.
+    fn carry_i32(self, sec: i32) -> Option<(i32, u32)> {
+        match self {
+            Self::Ok(nsec) => Some((sec, nsec)),
+            Self::Overflow(extra_sec, nsec) => {
+                let Ok(extra_sec) = i32::try_from(extra_sec) else {
+                    unreachable!("expected {extra_sec} to be within [0, 4]")
+                };
+                sec.checked_add(extra_sec).map(|sec| (sec, nsec))
+            }
+        }
+    }
+
+    /// Carries the result into a u32 representation of seconds.
+    ///
+    /// Returns None if the result overflows seconds.
+    fn carry_u32(self, sec: u32) -> Option<(u32, u32)> {
+        match self {
+            Self::Ok(nsec) => Some((sec, nsec)),
+            Self::Overflow(extra_sec, nsec) => sec.checked_add(extra_sec).map(|sec| (sec, nsec)),
+        }
     }
 }
 
@@ -37,17 +71,11 @@ fn normalize(sec: impl Into<i64>, mut nsec: u32) -> (i64, i32) {
 /// use foxglove::schemas::Duration;
 ///
 /// // A duration of 2.718... seconds.
-/// let duration = Duration {
-///     sec: 2,
-///     nsec: 718_281_828,
-/// };
+/// let duration = Duration::new(2, 718_281_828);
 ///
 /// // A duration of -3.14... seconds. Note that nanoseconds are always in the positive
 /// // direction.
-/// let duration = Duration {
-///     sec: -4,
-///     nsec: 858_407_346,
-/// };
+/// let duration = Duration::new(-4, 858_407_346);
 /// ```
 ///
 /// Various conversions are implemented. These conversions may fail with [`RangeError`], because
@@ -56,24 +84,12 @@ fn normalize(sec: impl Into<i64>, mut nsec: u32) -> (i64, i32) {
 /// ```
 /// # use foxglove::schemas::Duration;
 /// let duration: Duration = std::time::Duration::from_micros(577_215).try_into().unwrap();
-/// assert_eq!(
-///     duration,
-///     Duration {
-///         sec: 0,
-///         nsec: 577_215_000
-///     }
-/// );
+/// assert_eq!(duration, Duration::new(0, 577_215_000));
 ///
 /// #[cfg(feature = "chrono")]
 /// {
 ///     let duration: Duration = chrono::TimeDelta::microseconds(1_414_213).try_into().unwrap();
-///     assert_eq!(
-///         duration,
-///         Duration {
-///             sec: 1,
-///             nsec: 414_213_000
-///         }
-///     );
+///     assert_eq!(duration, Duration::new(1, 414_213_000));
 /// }
 /// ```
 ///
@@ -87,12 +103,12 @@ fn normalize(sec: impl Into<i64>, mut nsec: u32) -> (i64, i32) {
 /// let duration: Duration = std::time::Duration::from_secs(u64::MAX).saturating_into();
 /// assert_eq!(duration, Duration::MAX);
 /// ```
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Duration {
     /// Seconds offset.
-    pub sec: i32,
+    sec: i32,
     /// Nanoseconds offset in the positive direction.
-    pub nsec: u32,
+    nsec: u32,
 }
 
 impl Duration {
@@ -112,18 +128,42 @@ impl Duration {
         self.into()
     }
 
+    /// Creates a new normalized duration.
+    ///
+    /// Returns `None` if the result is out of range. This can only happen if `nsec` is greater
+    /// than `999_999_999`.
+    pub fn new_checked(sec: i32, nsec: u32) -> Option<Self> {
+        if let Some((sec, nsec)) = normalize_nsec(nsec).carry_i32(sec) {
+            Some(Self { sec, nsec })
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new normalized duration.
+    ///
+    /// Panics if the result is out of range. This can only happen if `nsec` is greater than
+    /// `999_999_999`.
+    pub fn new(sec: i32, nsec: u32) -> Self {
+        Self::new_checked(sec, nsec).unwrap()
+    }
+
+    /// Returns the number of seconds in the duration.
+    pub fn sec(&self) -> i32 {
+        self.sec
+    }
+
+    /// Returns the number of fractional seconds in the duration, as nanoseconds.
+    pub fn nsec(&self) -> u32 {
+        self.nsec
+    }
+
     /// Creates a `Duration` from `f64` seconds, or fails if the value is unrepresentable.
     pub fn try_from_secs_f64(secs: f64) -> Result<Self, RangeError> {
         if secs < i32::MIN as f64 {
             Err(RangeError::LowerBound)
-        } else if secs > i32::MAX as f64 {
-            if secs < (i32::MAX as f64 + 1.0) {
-                let sec = i32::MAX;
-                let nsec = ((secs - sec as f64) * 1e9) as u32;
-                Ok(Self { sec, nsec })
-            } else {
-                Err(RangeError::UpperBound)
-            }
+        } else if secs >= i32::MAX as f64 + 1.0 {
+            Err(RangeError::UpperBound)
         } else {
             let mut sec = secs as i32;
             let mut nsec = ((secs - sec as f64) * 1e9) as i32;
@@ -131,12 +171,12 @@ impl Duration {
                 sec -= 1;
                 nsec += 1_000_000_000;
             }
-            Ok(Self {
+            Ok(Self::new(
                 sec,
-                nsec: u32::try_from(nsec).unwrap_or_else(|e| {
-                    panic!("expected {nsec} to be within [0, 1_000_000_000): {e}")
+                u32::try_from(nsec).unwrap_or_else(|e| {
+                    unreachable!("expected {nsec} to be within [0, 1_000_000_000): {e}")
                 }),
-            })
+            ))
         }
     }
 
@@ -152,8 +192,12 @@ impl Duration {
 
 impl From<Duration> for prost_types::Duration {
     fn from(v: Duration) -> Self {
-        let (seconds, nanos) = normalize(v.sec, v.nsec);
-        Self { seconds, nanos }
+        Self {
+            seconds: i64::from(v.sec),
+            nanos: i32::try_from(v.nsec).unwrap_or_else(|e| {
+                unreachable!("expected {} to be within [0, 1_000_000_000): {e}", v.nsec)
+            }),
+        }
     }
 }
 
@@ -221,10 +265,7 @@ where
 /// ```
 /// use foxglove::schemas::Timestamp;
 ///
-/// let timestamp = Timestamp {
-///     sec: 1_548_054_420,
-///     nsec: 76_657_283,
-/// };
+/// let timestamp = Timestamp::new(1_548_054_420, 76_657_283);
 /// ```
 ///
 /// Various conversions are implemented, which presume the choice of the unix epoch as the
@@ -258,12 +299,12 @@ where
 ///     .saturating_into();
 /// assert_eq!(timestamp, Timestamp::MIN);
 /// ```
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Timestamp {
     /// Seconds since epoch.
-    pub sec: u32,
+    sec: u32,
     /// Additional nanoseconds since epoch.
-    pub nsec: u32,
+    nsec: u32,
 }
 
 impl Timestamp {
@@ -280,23 +321,47 @@ impl Timestamp {
         self.into()
     }
 
+    /// Creates a new normalized timestamp.
+    ///
+    /// Returns `None` if the result is out of range. This can only happen if `nsec` is greater
+    /// than `999_999_999`.
+    pub fn new_checked(sec: u32, nsec: u32) -> Option<Self> {
+        if let Some((sec, nsec)) = normalize_nsec(nsec).carry_u32(sec) {
+            Some(Self { sec, nsec })
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new normalized timestamp.
+    ///
+    /// Panics if the result is out of range. This can only happen if `nsec` is greater than
+    /// `999_999_999`.
+    pub fn new(sec: u32, nsec: u32) -> Self {
+        Self::new_checked(sec, nsec).unwrap()
+    }
+
+    /// Returns the number of seconds in the timestamp.
+    pub fn sec(&self) -> u32 {
+        self.sec
+    }
+
+    /// Returns the number of fractional seconds in the timestamp, as nanoseconds.
+    pub fn nsec(&self) -> u32 {
+        self.nsec
+    }
+
     /// Creates a `Timestamp` from seconds since epoch as an `f64`, or fails if the value is
     /// unrepresentable.
     pub fn try_from_epoch_secs_f64(secs: f64) -> Result<Self, RangeError> {
         if secs < 0.0 {
             Err(RangeError::LowerBound)
-        } else if secs > u32::MAX as f64 {
-            if secs < (u32::MAX as f64 + 1.0) {
-                let sec = u32::MAX;
-                let nsec = ((secs - sec as f64) * 1e9) as u32;
-                Ok(Self { sec, nsec })
-            } else {
-                Err(RangeError::UpperBound)
-            }
+        } else if secs >= u32::MAX as f64 + 1.0 {
+            Err(RangeError::UpperBound)
         } else {
             let sec = secs as u32;
             let nsec = ((secs - sec as f64) * 1e9) as u32;
-            Ok(Self { sec, nsec })
+            Ok(Self::new(sec, nsec))
         }
     }
 
@@ -312,8 +377,12 @@ impl Timestamp {
 
 impl From<Timestamp> for prost_types::Timestamp {
     fn from(v: Timestamp) -> Self {
-        let (seconds, nanos) = normalize(v.sec, v.nsec);
-        Self { seconds, nanos }
+        Self {
+            seconds: i64::from(v.sec),
+            nanos: i32::try_from(v.nsec).unwrap_or_else(|e| {
+                unreachable!("expected {} to be within [0, 1_000_000_000): {e}", v.nsec)
+            }),
+        }
     }
 }
 
@@ -360,7 +429,7 @@ impl TryFrom<std::time::SystemTime> for Timestamp {
             return Err(RangeError::UpperBound);
         };
         let nsec = duration.subsec_nanos();
-        Ok(Self { sec, nsec })
+        Ok(Self::new(sec, nsec))
     }
 }
 

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -125,20 +125,18 @@ impl Duration {
                 Err(RangeError::UpperBound)
             }
         } else {
-            let sec = secs as i32;
-            let nsec = ((secs - sec as f64) * 1e9) as i32;
+            let mut sec = secs as i32;
+            let mut nsec = ((secs - sec as f64) * 1e9) as i32;
             if nsec < 0 {
-                assert!(sec <= 0);
-                Ok(Self {
-                    sec: sec - 1,
-                    nsec: u32::try_from(nsec + 1_000_000_000).expect("positive"),
-                })
-            } else {
-                Ok(Self {
-                    sec,
-                    nsec: u32::try_from(nsec).expect("positive"),
-                })
+                sec -= 1;
+                nsec += 1_000_000_000;
             }
+            Ok(Self {
+                sec,
+                nsec: u32::try_from(nsec).unwrap_or_else(|e| {
+                    panic!("expected {nsec} to be within [0, 1_000_000_000): {e}")
+                }),
+            })
         }
     }
 

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -4,7 +4,7 @@
 //! Timestamp in protobuf, even though we schematize those types differently. This module provides
 //! an infallible translation from the foxglove schema to the underlying protobuf representation.
 //!
-//! This module lives outside crate::schemas, because everything under the schemas/ direcory is
+//! This module lives outside `crate::schemas`, because everything under the schemas/ direcory is
 //! generated.
 
 use crate::convert::{RangeError, SaturatingFrom};
@@ -158,13 +158,13 @@ impl Duration {
 
     /// Creates a `Duration` from `f64` seconds, or fails if the value is unrepresentable.
     pub fn try_from_secs_f64(secs: f64) -> Result<Self, RangeError> {
-        if secs < i32::MIN as f64 {
+        if secs < f64::from(i32::MIN) {
             Err(RangeError::LowerBound)
-        } else if secs >= i32::MAX as f64 + 1.0 {
+        } else if secs >= f64::from(i32::MAX) + 1.0 {
             Err(RangeError::UpperBound)
         } else {
             let mut sec = secs as i32;
-            let mut nsec = ((secs - sec as f64) * 1e9) as i32;
+            let mut nsec = ((secs - f64::from(sec)) * 1e9) as i32;
             if nsec < 0 {
                 sec -= 1;
                 nsec += 1_000_000_000;
@@ -352,11 +352,11 @@ impl Timestamp {
     pub fn try_from_epoch_secs_f64(secs: f64) -> Result<Self, RangeError> {
         if secs < 0.0 {
             Err(RangeError::LowerBound)
-        } else if secs >= u32::MAX as f64 + 1.0 {
+        } else if secs >= f64::from(u32::MAX) + 1.0 {
             Err(RangeError::UpperBound)
         } else {
             let sec = secs as u32;
-            let nsec = ((secs - sec as f64) * 1e9) as u32;
+            let nsec = ((secs - f64::from(sec)) * 1e9) as u32;
             Ok(Self::new(sec, nsec))
         }
     }

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -133,11 +133,9 @@ impl Duration {
     /// Returns `None` if the result is out of range. This can only happen if `nsec` is greater
     /// than `999_999_999`.
     pub fn new_checked(sec: i32, nsec: u32) -> Option<Self> {
-        if let Some((sec, nsec)) = normalize_nsec(nsec).carry_i32(sec) {
-            Some(Self { sec, nsec })
-        } else {
-            None
-        }
+        normalize_nsec(nsec)
+            .carry_i32(sec)
+            .map(|(sec, nsec)| Self { sec, nsec })
     }
 
     /// Creates a new normalized duration.
@@ -326,11 +324,9 @@ impl Timestamp {
     /// Returns `None` if the result is out of range. This can only happen if `nsec` is greater
     /// than `999_999_999`.
     pub fn new_checked(sec: u32, nsec: u32) -> Option<Self> {
-        if let Some((sec, nsec)) = normalize_nsec(nsec).carry_u32(sec) {
-            Some(Self { sec, nsec })
-        } else {
-            None
-        }
+        normalize_nsec(nsec)
+            .carry_u32(sec)
+            .map(|(sec, nsec)| Self { sec, nsec })
     }
 
     /// Creates a new normalized timestamp.

--- a/rust/foxglove/src/schemas_wkt/chrono.rs
+++ b/rust/foxglove/src/schemas_wkt/chrono.rs
@@ -27,7 +27,7 @@ impl TryFrom<chrono::TimeDelta> for Duration {
             sec -= 1;
             u32::try_from(subsec_nanos + 1_000_000_000).expect("positive")
         };
-        Ok(Self { sec, nsec })
+        Ok(Self::new(sec, nsec))
     }
 }
 
@@ -44,7 +44,7 @@ impl TryFrom<chrono::DateTime<chrono::Utc>> for Timestamp {
             });
         };
         let nsec = time.timestamp_subsec_nanos();
-        Ok(Self { sec, nsec })
+        Ok(Self::new(sec, nsec))
     }
 }
 

--- a/rust/foxglove/src/schemas_wkt/tests.rs
+++ b/rust/foxglove/src/schemas_wkt/tests.rs
@@ -1,22 +1,74 @@
 use assert_matches::assert_matches;
 
-use super::{normalize, Duration, Timestamp};
+use super::{normalize_nsec, Duration, NormalizeResult, Timestamp};
 use crate::convert::{RangeError, SaturatingFrom};
 
 #[test]
-fn test_normalize() {
-    assert_eq!(normalize(0, 0), (0, 0));
-    assert_eq!(normalize(0, 999_999_999), (0, 999_999_999));
-    assert_eq!(normalize(0, 1_000_000_000), (1, 0));
-    assert_eq!(normalize(0, 2_999_999_999), (2, 999_999_999));
-    assert_eq!(normalize(-1, 1_111_111_111), (0, 111_111_111));
-    assert_eq!(normalize(i32::MIN, 1_000_000_001), (i32::MIN as i64 + 1, 1));
-    assert_eq!(normalize(i32::MAX, 1_000_000_001), (i32::MAX as i64 + 1, 1));
-    assert_eq!(normalize(u32::MAX, 1_000_000_001), (u32::MAX as i64 + 1, 1));
+fn test_normalize_nsec() {
+    // no overflow
+    assert_eq!(normalize_nsec(0), NormalizeResult::Ok(0));
     assert_eq!(
-        normalize(u32::MAX, u32::MAX),
-        (u32::MAX as i64 + 4, 294_967_295)
+        normalize_nsec(999_999_999),
+        NormalizeResult::Ok(999_999_999)
     );
+
+    // overflow
+    assert_eq!(
+        normalize_nsec(1_000_000_000),
+        NormalizeResult::Overflow(1, 0)
+    );
+    assert_eq!(
+        normalize_nsec(2_999_999_999),
+        NormalizeResult::Overflow(2, 999_999_999)
+    );
+    assert_eq!(
+        normalize_nsec(u32::MAX),
+        NormalizeResult::Overflow(4, 294_967_295)
+    );
+
+    // no carry
+    assert_eq!(normalize_nsec(1).carry_u32(1), Some((1, 1)));
+    assert_eq!(normalize_nsec(1).carry_i32(-1), Some((-1, 1)));
+
+    // carry
+    assert_eq!(normalize_nsec(1_000_000_001).carry_u32(1), Some((2, 1)));
+    assert_eq!(normalize_nsec(1_000_000_001).carry_i32(-1), Some((0, 1)));
+
+    // out of range
+    assert_eq!(normalize_nsec(1_000_000_001).carry_i32(i32::MAX), None);
+    assert_eq!(normalize_nsec(1_000_000_001).carry_u32(u32::MAX), None);
+}
+
+#[test]
+fn test_duration_normalization() {
+    assert_eq!(
+        Duration::new(0, 1_111_222_333),
+        Duration {
+            sec: 1,
+            nsec: 111_222_333,
+        }
+    );
+    assert_eq!(
+        Duration::new(0, u32::MAX),
+        Duration {
+            sec: 4,
+            nsec: 294_967_295,
+        }
+    );
+    assert_eq!(
+        Duration::new(-2, 1_000_000_001),
+        Duration { sec: -1, nsec: 1 }
+    );
+    assert_eq!(
+        Duration::new(i32::MIN, 1_000_000_001),
+        Duration {
+            sec: i32::MIN + 1,
+            nsec: 1
+        }
+    );
+
+    // overflow
+    assert!(Duration::new_checked(i32::MAX, 1_000_000_000).is_none());
 }
 
 #[test]
@@ -117,6 +169,25 @@ fn test_duration_from_std_duration() {
     let orig = std::time::Duration::from_secs(i32::MAX as u64 + 1);
     assert_matches!(Duration::try_from(orig), Err(RangeError::UpperBound));
     assert_eq!(Duration::saturating_from(orig), Duration::MAX);
+}
+
+#[test]
+fn test_timestamp_normalization() {
+    assert_eq!(
+        Timestamp::new(0, 1_111_222_333),
+        Timestamp {
+            sec: 1,
+            nsec: 111_222_333
+        }
+    );
+    assert_eq!(
+        Timestamp::new(0, u32::MAX),
+        Timestamp {
+            sec: 4,
+            nsec: 294_967_295
+        }
+    );
+    assert!(Timestamp::new_checked(u32::MAX, 1_000_000_000).is_none());
 }
 
 #[test]

--- a/rust/foxglove/src/schemas_wkt/tests.rs
+++ b/rust/foxglove/src/schemas_wkt/tests.rs
@@ -120,9 +120,9 @@ fn test_duration_from_std_duration() {
 }
 
 #[test]
-fn test_timestamp_from_secs_f64() {
+fn test_timestamp_from_epoch_secs_f64() {
     assert_eq!(
-        Timestamp::try_from_timestamp_secs_f64(1.618_033_989).unwrap(),
+        Timestamp::try_from_epoch_secs_f64(1.618_033_989).unwrap(),
         Timestamp {
             sec: 1,
             nsec: 618_033_989
@@ -131,13 +131,13 @@ fn test_timestamp_from_secs_f64() {
 
     // min
     assert_eq!(
-        Timestamp::try_from_timestamp_secs_f64(0.0).unwrap(),
+        Timestamp::try_from_epoch_secs_f64(0.0).unwrap(),
         Timestamp::MIN,
     );
 
     // nearly max
     assert_eq!(
-        Timestamp::try_from_timestamp_secs_f64(u32::MAX as f64).unwrap(),
+        Timestamp::try_from_epoch_secs_f64(u32::MAX as f64).unwrap(),
         Timestamp {
             sec: u32::MAX,
             nsec: 0
@@ -146,27 +146,27 @@ fn test_timestamp_from_secs_f64() {
 
     // fractional seconds beyond u32::MAX seconds are supported, but precision is limited.
     assert_matches!(
-        Timestamp::try_from_timestamp_secs_f64(u32::MAX as f64 + 0.1),
+        Timestamp::try_from_epoch_secs_f64(u32::MAX as f64 + 0.1),
         Ok(_)
     );
 
     // too past
     assert_matches!(
-        Timestamp::try_from_timestamp_secs_f64(-0.1),
+        Timestamp::try_from_epoch_secs_f64(-0.1),
         Err(RangeError::LowerBound)
     );
     assert_eq!(
-        Timestamp::saturating_from_timestamp_secs_f64(-0.1),
+        Timestamp::saturating_from_epoch_secs_f64(-0.1),
         Timestamp::MIN
     );
 
     // too future
     assert_matches!(
-        Timestamp::try_from_timestamp_secs_f64(u32::MAX as f64 + 1.),
+        Timestamp::try_from_epoch_secs_f64(u32::MAX as f64 + 1.),
         Err(RangeError::UpperBound)
     );
     assert_eq!(
-        Timestamp::saturating_from_timestamp_secs_f64(u32::MAX as f64 + 1.),
+        Timestamp::saturating_from_epoch_secs_f64(u32::MAX as f64 + 1.),
         Timestamp::MAX
     );
 }

--- a/rust/foxglove/src/schemas_wkt/tests.rs
+++ b/rust/foxglove/src/schemas_wkt/tests.rs
@@ -100,13 +100,13 @@ fn test_duration_from_secs_f64() {
 
     // min
     assert_eq!(
-        Duration::try_from_secs_f64(i32::MIN as f64).unwrap(),
+        Duration::try_from_secs_f64(i32::MIN.into()).unwrap(),
         Duration::MIN,
     );
 
     // nearly max
     assert_eq!(
-        Duration::try_from_secs_f64(i32::MAX as f64).unwrap(),
+        Duration::try_from_secs_f64(i32::MAX.into()).unwrap(),
         Duration {
             sec: i32::MAX,
             nsec: 0
@@ -114,25 +114,28 @@ fn test_duration_from_secs_f64() {
     );
 
     // fractional seconds beyond i32::MAX seconds are supported, but precision is limited.
-    assert_matches!(Duration::try_from_secs_f64(i32::MAX as f64 + 0.1), Ok(_));
+    assert_matches!(
+        Duration::try_from_secs_f64(f64::from(i32::MAX) + 0.1),
+        Ok(_)
+    );
 
     // out of range negative
     assert_matches!(
-        Duration::try_from_secs_f64(i32::MIN as f64 - 0.1),
+        Duration::try_from_secs_f64(f64::from(i32::MIN) - 0.1),
         Err(RangeError::LowerBound)
     );
     assert_eq!(
-        Duration::saturating_from_secs_f64(i32::MIN as f64 - 0.1),
+        Duration::saturating_from_secs_f64(f64::from(i32::MIN) - 0.1),
         Duration::MIN
     );
 
     // out of range positive
     assert_matches!(
-        Duration::try_from_secs_f64(i32::MAX as f64 + 1.),
+        Duration::try_from_secs_f64(f64::from(i32::MAX) + 1.),
         Err(RangeError::UpperBound)
     );
     assert_eq!(
-        Duration::saturating_from_secs_f64(i32::MAX as f64 + 1.),
+        Duration::saturating_from_secs_f64(f64::from(i32::MAX) + 1.),
         Duration::MAX
     );
 }
@@ -208,7 +211,7 @@ fn test_timestamp_from_epoch_secs_f64() {
 
     // nearly max
     assert_eq!(
-        Timestamp::try_from_epoch_secs_f64(u32::MAX as f64).unwrap(),
+        Timestamp::try_from_epoch_secs_f64(u32::MAX.into()).unwrap(),
         Timestamp {
             sec: u32::MAX,
             nsec: 0
@@ -217,7 +220,7 @@ fn test_timestamp_from_epoch_secs_f64() {
 
     // fractional seconds beyond u32::MAX seconds are supported, but precision is limited.
     assert_matches!(
-        Timestamp::try_from_epoch_secs_f64(u32::MAX as f64 + 0.1),
+        Timestamp::try_from_epoch_secs_f64(f64::from(u32::MAX) + 0.1),
         Ok(_)
     );
 
@@ -233,11 +236,11 @@ fn test_timestamp_from_epoch_secs_f64() {
 
     // too future
     assert_matches!(
-        Timestamp::try_from_epoch_secs_f64(u32::MAX as f64 + 1.),
+        Timestamp::try_from_epoch_secs_f64(f64::from(u32::MAX) + 1.),
         Err(RangeError::UpperBound)
     );
     assert_eq!(
-        Timestamp::saturating_from_epoch_secs_f64(u32::MAX as f64 + 1.),
+        Timestamp::saturating_from_epoch_secs_f64(f64::from(u32::MAX) + 1.),
         Timestamp::MAX
     );
 }
@@ -252,7 +255,7 @@ fn test_timestamp_from_system_time() {
     // max
     let orig = std::time::UNIX_EPOCH
         .checked_add(std::time::Duration::from_nanos(
-            u32::MAX as u64 * 1_000_000_000 + 999_999_999,
+            u64::from(u32::MAX) * 1_000_000_000 + 999_999_999,
         ))
         .unwrap();
     let ts = Timestamp::try_from(orig).unwrap();
@@ -273,7 +276,7 @@ fn test_timestamp_from_system_time() {
 
     // too future
     let orig = std::time::UNIX_EPOCH
-        .checked_add(std::time::Duration::from_secs(u32::MAX as u64 + 1))
+        .checked_add(std::time::Duration::from_secs(u64::from(u32::MAX) + 1))
         .unwrap();
     assert_matches!(Timestamp::try_from(orig), Err(RangeError::UpperBound));
     assert_eq!(Timestamp::saturating_from(orig), Timestamp::MAX);


### PR DESCRIPTION
This change adds the following conversions into Duration and Timestamp for python:

- `Duration.from_secs(secs: float)`
- `Duration.from_timedelta(td: datetime.timedelta)`
- `Timestamp.from_epoch_secs(timestamp: float)`
- `Timestamp.from_datetime(dt: datetime.datetime)`