### PR TITLE
Mitigate flaky test

### DIFF
--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -1432,7 +1432,7 @@ async fn test_slow_client() {
     let mut ws_client = connect_client(addr).await;
 
     // Publish more status messages than the client can handle
-    for i in 0..10 {
+    for i in 0..50 {
         let status = Status::new(StatusLevel::Error, format!("msg{}", i));
         server.publish_status(status);
     }


### PR DESCRIPTION
This should mitigate a flaky test related to message queue size, by putting more messages on the channel (example: https://github.com/foxglove/foxglove-sdk/actions/runs/13598790792/job/38021236440). Prior to this, it failed about 50% of the time locally for me.