### PR TITLE
C/C++: add basic channel wrapper and log method

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,7 @@ BasedOnStyle: Google
 
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortLambdasOnASingleLine: Empty
+AlignAfterOpenBracket: BlockIndent
 AccessModifierOffset: -2
 TabWidth: 2
 ContinuationIndentWidth: 2

--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -12,5 +12,23 @@ header = """
  */
 """
 
+usize_is_size_t = true
+
+after_includes = """
+
+#ifndef FOXGLOVE_NONNULL
+#if defined(__clang__) || defined(__GNUC__)
+#define FOXGLOVE_NONNULL __attribute__((nonnull))
+#else
+#define FOXGLOVE_NONNULL
+#endif
+#endif
+"""
+
+[ptr]
+non_null_attribute = "FOXGLOVE_NONNULL"
+
 [export.rename]
-"FoxgloveWebSocketServer" = "foxglove_websocket_server"
+FoxgloveWebSocketServer = "foxglove_websocket_server"
+FoxgloveChannel = "foxglove_channel"
+FoxgloveSchema = "foxglove_schema"

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -72,7 +72,9 @@ void foxglove_server_stop(struct foxglove_websocket_server *server);
  * Create a new channel. The channel must later be freed with `foxglove_channel_free`.
  *
  * # Safety
- * `topic` and `message_encoding` must be null-terminated strings with valid UTF8.
+ * `topic` and `message_encoding` must be null-terminated strings with valid UTF8. `schema` is an
+ * optional pointer to a schema. The schema and the data it points to need only remain alive for
+ * the duration of this function call (they will be copied).
  */
 struct foxglove_channel *foxglove_channel_create(const char *topic,
                                                  const char *message_encoding,

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -85,7 +85,9 @@ pub extern "C" fn foxglove_server_stop(server: Option<&mut FoxgloveWebSocketServ
 /// Create a new channel. The channel must later be freed with `foxglove_channel_free`.
 ///
 /// # Safety
-/// `topic` and `message_encoding` must be null-terminated strings with valid UTF8.
+/// `topic` and `message_encoding` must be null-terminated strings with valid UTF8. `schema` is an
+/// optional pointer to a schema. The schema and the data it points to need only remain alive for
+/// the duration of this function call (they will be copied).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn foxglove_channel_create(
     topic: *const c_char,

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -3,8 +3,18 @@
 #![warn(unsafe_attr_outside_unsafe)]
 
 use std::ffi::{c_char, CStr};
+use std::sync::Arc;
 
 pub struct FoxgloveWebSocketServer(Option<foxglove::WebSocketServerBlockingHandle>);
+pub struct FoxgloveChannel(Arc<foxglove::Channel>);
+
+#[repr(C)]
+pub struct FoxgloveSchema {
+    pub name: *const c_char,
+    pub encoding: *const c_char,
+    pub data: *const u8,
+    pub data_len: usize,
+}
 
 /// Create and start a server. The server must later be freed with `foxglove_server_free`.
 ///
@@ -19,25 +29,19 @@ pub unsafe extern "C" fn foxglove_server_start(
     host: *const c_char,
     port: u16,
 ) -> *mut FoxgloveWebSocketServer {
+    let name = unsafe { CStr::from_ptr(name) }
+        .to_str()
+        .expect("name is invalid");
+    let host = unsafe { CStr::from_ptr(host) }
+        .to_str()
+        .expect("host is invalid");
     Box::into_raw(Box::new(FoxgloveWebSocketServer(Some(
         foxglove::WebSocketServer::new()
-            .name(unsafe { CStr::from_ptr(name) }.to_str().unwrap())
-            .bind(unsafe { CStr::from_ptr(host) }.to_str().unwrap(), port)
+            .name(name)
+            .bind(host, port)
             .start_blocking()
             .expect("Server failed to start"),
     ))))
-}
-
-/// Get the port on which the server is listening.
-#[unsafe(no_mangle)]
-pub extern "C" fn foxglove_server_get_port(server: Option<&FoxgloveWebSocketServer>) -> u16 {
-    let Some(server) = server else {
-        panic!("Expected a non-null server");
-    };
-    let Some(ref handle) = server.0 else {
-        panic!("Server already stopped");
-    };
-    handle.port()
 }
 
 /// Free a server created via `foxglove_server_start`.
@@ -54,6 +58,18 @@ pub extern "C" fn foxglove_server_free(server: Option<&mut FoxgloveWebSocketServ
     drop(unsafe { Box::from_raw(server) });
 }
 
+/// Get the port on which the server is listening.
+#[unsafe(no_mangle)]
+pub extern "C" fn foxglove_server_get_port(server: Option<&FoxgloveWebSocketServer>) -> u16 {
+    let Some(server) = server else {
+        panic!("Expected a non-null server");
+    };
+    let Some(ref handle) = server.0 else {
+        panic!("Server already stopped");
+    };
+    handle.port()
+}
+
 /// Stop and shut down a server.
 #[unsafe(no_mangle)]
 pub extern "C" fn foxglove_server_stop(server: Option<&mut FoxgloveWebSocketServer>) {
@@ -64,4 +80,78 @@ pub extern "C" fn foxglove_server_stop(server: Option<&mut FoxgloveWebSocketServ
         panic!("Server already stopped");
     };
     handle.stop();
+}
+
+/// Create a new channel. The channel must later be freed with `foxglove_channel_free`.
+///
+/// # Safety
+/// `topic` and `message_encoding` must be null-terminated strings with valid UTF8.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn foxglove_channel_create(
+    topic: *const c_char,
+    message_encoding: *const c_char,
+    schema: *const FoxgloveSchema,
+) -> *mut FoxgloveChannel {
+    let topic = unsafe { CStr::from_ptr(topic) }
+        .to_str()
+        .expect("topic is invalid");
+    let message_encoding = unsafe { CStr::from_ptr(message_encoding) }
+        .to_str()
+        .expect("message_encoding is invalid");
+    let schema = unsafe {
+        schema.as_ref().map(|schema| {
+            let name = CStr::from_ptr(schema.name)
+                .to_str()
+                .expect("schema name is invalid");
+            let encoding = CStr::from_ptr(schema.encoding)
+                .to_str()
+                .expect("schema encoding is invalid");
+            let data = std::slice::from_raw_parts(schema.data, schema.data_len);
+            foxglove::Schema::new(name, encoding, data)
+        })
+    };
+    Box::into_raw(Box::new(FoxgloveChannel(
+        foxglove::ChannelBuilder::new(topic)
+            .message_encoding(message_encoding)
+            .schema(schema)
+            .build()
+            .expect("Failed to create channel"),
+    )))
+}
+
+/// Free a channel created via `foxglove_channel_create`.
+#[unsafe(no_mangle)]
+pub extern "C" fn foxglove_channel_free(channel: Option<&mut FoxgloveChannel>) {
+    let Some(channel) = channel else {
+        return;
+    };
+    drop(unsafe { Box::from_raw(channel) });
+}
+
+/// Log a message on a channel.
+///
+/// # Safety
+/// `data` must be non-null, and the range `[data, data + data_len)` must contain initialized data
+/// contained within a single allocated object.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn foxglove_channel_log(
+    channel: Option<&mut FoxgloveChannel>,
+    data: *const u8,
+    data_len: usize,
+    log_time: u64,
+    publish_time: u64,
+    sequence: u32,
+) {
+    let channel = channel.expect("channel is required");
+    if data.is_null() {
+        panic!("data is required");
+    }
+    channel.0.log_with_meta(
+        unsafe { std::slice::from_raw_parts(data, data_len) },
+        foxglove::PartialMetadata {
+            log_time: Some(log_time),
+            publish_time: Some(publish_time),
+            sequence: Some(sequence),
+        },
+    );
 }

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -14,7 +14,7 @@ struct Schema {
   size_t dataLen;
 };
 
-class Channel {
+class Channel final {
 public:
   Channel(std::string topic, std::string messageEncoding, std::optional<Schema> schema);
 

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -1,0 +1,29 @@
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+struct foxglove_channel;
+
+namespace foxglove {
+
+struct Schema {
+  std::string_view name;
+  std::string_view encoding;
+  const std::byte* data;
+  size_t dataLen;
+};
+
+class Channel {
+public:
+  Channel(std::string topic, std::string messageEncoding, std::optional<Schema> schema);
+
+  void log(
+    const std::byte* data, size_t dataLen, uint64_t logTime, uint64_t publishTime, uint32_t sequence
+  );
+
+private:
+  std::unique_ptr<foxglove_channel, void (*)(foxglove_channel*)> _impl;
+};
+
+}  // namespace foxglove

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -12,7 +12,7 @@ struct WebSocketServerOptions {
   uint16_t port;
 };
 
-class WebSocketServer {
+class WebSocketServer final {
 public:
   explicit WebSocketServer(WebSocketServerOptions options);
 

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -14,7 +14,7 @@ struct WebSocketServerOptions {
 
 class WebSocketServer {
 public:
-  WebSocketServer(WebSocketServerOptions options);
+  explicit WebSocketServer(WebSocketServerOptions options);
 
   // Get the port on which the server is listening.
   uint16_t port() const;

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -1,0 +1,29 @@
+#include <foxglove-c/foxglove-c.h>
+#include <foxglove/channel.hpp>
+
+namespace foxglove {
+
+Channel::Channel(std::string topic, std::string messageEncoding, std::optional<Schema> schema)
+    : _impl(
+        foxglove_channel_create(
+          topic.c_str(), messageEncoding.c_str(),
+          schema ? &((const foxglove_schema&)(foxglove_schema){
+                     schema->name.data(),
+                     schema->encoding.data(),
+                     reinterpret_cast<const uint8_t*>(schema->data),
+                     schema->dataLen,
+                   })
+                 : nullptr
+        ),
+        foxglove_channel_free
+      ) {}
+
+void Channel::log(
+  const std::byte* data, size_t dataLen, uint64_t logTime, uint64_t publishTime, uint32_t sequence
+) {
+  foxglove_channel_log(
+    _impl.get(), reinterpret_cast<const uint8_t*>(data), dataLen, logTime, publishTime, sequence
+  );
+}
+
+}  // namespace foxglove

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -4,8 +4,10 @@
 namespace foxglove {
 
 WebSocketServer::WebSocketServer(WebSocketServerOptions options)
-    : _impl(foxglove_server_start(options.name.c_str(), options.host.c_str(), options.port),
-            foxglove_server_free) {}
+    : _impl(
+        foxglove_server_start(options.name.c_str(), options.host.c_str(), options.port),
+        foxglove_server_free
+      ) {}
 
 void WebSocketServer::stop() {
   foxglove_server_stop(_impl.get());

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -1,3 +1,4 @@
+#include <foxglove/channel.hpp>
 #include <foxglove/server.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -10,4 +11,17 @@ TEST_CASE("Start and stop server") {
   foxglove::WebSocketServer server{options};
   REQUIRE(server.port() != 0);
   server.stop();
+}
+
+TEST_CASE("Log a message") {
+  foxglove::WebSocketServerOptions options;
+  options.name = "unit-test";
+  options.host = "127.0.0.1";
+  options.port = 0;
+  foxglove::WebSocketServer server{options};
+  REQUIRE(server.port() != 0);
+
+  foxglove::Channel channel{"example", "json", std::nullopt};
+  const uint8_t data[] = {1, 2, 3};
+  channel.log(reinterpret_cast<const std::byte*>(data), sizeof(data), 1, 2, 3);
 }


### PR DESCRIPTION
### Changelog
C/C++ added Channel type.

### Docs

None

### Description
At least the basics of creating a schema+channel and logging messages seem to be working.

Some sadnesses/open areas to explore:
- Not sure if we want Schema to be its own ref-counted/unique_ptr'd entity, or just a plain ol' options struct. Right now I have a C++ options struct using C++ types (`std::string_view`) and a C options struct using C types (`const char*`). The conversion between these is super awkward. And the ownership/lifetime requirements of the string_views/pointers is not very clear (would need to just write it in comments).
- I want to mark some pointers as non-nullable on the C header side, but still check them for null in Rust to be safe. cbindgen will mark them as nonnull if they are `&T`, `&mut T`, or `NonNull<T>`. However, reading a bit into how the Rust side treats those types, I'm not sure that checking them for null is really possible (the compiler might be allowed to assume they are not?)  It seems like `Option<NonNull<T>>` might work, but that's kinda nuts when you think about it (could it be working by accident?)
- It feels silly and inefficient to wrap `Box` around a type that is already internally an `Arc`. Not sure there is any way around this though.
- I really would prefer `std::span` (C++20) over this ptr+length nonsense 😭 
- Need to tackle error handling across all these functions at some point – probably all will need to return some error by out-param? or return an error code?