### PR TITLE
rust: Demote &Arc<Channel> to &Channel

### DIFF
--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -2,9 +2,9 @@ use crate::log_sink_set::LogSinkSet;
 use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
-use std::{collections::BTreeMap, sync::Arc};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 pub struct ChannelId(u64);
@@ -122,12 +122,12 @@ impl Channel {
     }
 
     /// Logs a message.
-    pub fn log(self: &Arc<Self>, msg: &[u8]) {
+    pub fn log(&self, msg: &[u8]) {
         self.log_with_meta(msg, PartialMetadata::default());
     }
 
     /// Logs a message with additional metadata.
-    pub fn log_with_meta(self: &Arc<Self>, msg: &[u8], opts: PartialMetadata) {
+    pub fn log_with_meta(&self, msg: &[u8], opts: PartialMetadata) {
         // Bail out early if there are no sinks (logging is disabled).
         if self.sinks.is_empty() {
             return;
@@ -274,7 +274,7 @@ mod test {
 
         let recorded = recording_sink.recorded.lock();
         assert_eq!(recorded.len(), 1);
-        assert_eq!(&recorded[0].channel, &channel);
+        assert_eq!(recorded[0].channel_id, channel.id());
         assert_eq!(recorded[0].msg, msg.to_vec());
         assert_eq!(recorded[0].metadata.sequence, 1);
         assert_eq!(

--- a/rust/foxglove/src/log_context.rs
+++ b/rust/foxglove/src/log_context.rs
@@ -230,7 +230,7 @@ mod tests {
         assert_eq!(recorded1.len(), 1);
         assert_eq!(recorded2.len(), 1);
 
-        assert_eq!(&recorded1[0].channel, &channel);
+        assert_eq!(recorded1[0].channel_id, channel.id());
         assert_eq!(recorded1[0].msg, msg.to_vec());
         let metadata1 = &recorded1[0].metadata;
         assert!(metadata1.log_time >= now);
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(metadata1.log_time, metadata1.publish_time);
         assert!(metadata1.sequence > 0);
 
-        assert_eq!(&recorded2[0].channel, &channel);
+        assert_eq!(recorded2[0].channel_id, channel.id());
         assert_eq!(recorded2[0].msg, msg.to_vec());
         let metadata2 = &recorded2[0].metadata;
         assert!(metadata2.log_time >= now);
@@ -274,7 +274,7 @@ mod tests {
 
         let recorded = recording_sink.recorded.lock();
         assert_eq!(recorded.len(), 1);
-        assert_eq!(&recorded[0].channel, &channel);
+        assert_eq!(recorded[0].channel_id, channel.id());
         assert_eq!(recorded[0].msg, msg.to_vec());
         let metadata = &recorded[0].metadata;
         assert_eq!(metadata.sequence, opts.sequence.unwrap());

--- a/rust/foxglove/src/log_sink.rs
+++ b/rust/foxglove/src/log_sink.rs
@@ -10,12 +10,7 @@ use std::sync::Arc;
 pub trait LogSink: Send + Sync {
     /// log writes the message for the channel to the sink.
     /// metadata contains optional message metadata that may be used by some sink implementations.
-    fn log(
-        &self,
-        channel: &Arc<Channel>,
-        msg: &[u8],
-        metadata: &Metadata,
-    ) -> Result<(), FoxgloveError>;
+    fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError>;
 
     /// add_channel is called when a new channel is associated with this Sink.
     /// Sinks can track channels seen, and do new channel related things the first

--- a/rust/foxglove/src/mcap_writer/mcap_sink.rs
+++ b/rust/foxglove/src/mcap_writer/mcap_sink.rs
@@ -27,7 +27,7 @@ impl<W: Write + Seek> WriterState<W> {
 
     fn log(
         &mut self,
-        channel: &Arc<Channel>,
+        channel: &Channel,
         msg: &[u8],
         metadata: &Metadata,
     ) -> Result<(), FoxgloveError> {
@@ -95,12 +95,7 @@ impl<W: Write + Seek> McapSink<W> {
 }
 
 impl<W: Write + Seek + Send> LogSink for McapSink<W> {
-    fn log(
-        &self,
-        channel: &Arc<Channel>,
-        msg: &[u8],
-        metadata: &Metadata,
-    ) -> Result<(), FoxgloveError> {
+    fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {
         _ = metadata;
         let mut guard = self.0.lock();
         let writer = guard.as_mut().ok_or(FoxgloveError::SinkClosed)?;

--- a/rust/foxglove/src/testutil/log_sink.rs
+++ b/rust/foxglove/src/testutil/log_sink.rs
@@ -1,14 +1,14 @@
+use crate::channel::ChannelId;
 use crate::log_sink::LogSink;
 use crate::{Channel, FoxgloveError, Metadata};
 use parking_lot::Mutex;
-use std::sync::Arc;
 
 pub struct MockSink;
 
 impl LogSink for MockSink {
     fn log(
         &self,
-        _channel: &Arc<Channel>,
+        _channel: &Channel,
         _msg: &[u8],
         _metadata: &Metadata,
     ) -> Result<(), FoxgloveError> {
@@ -17,7 +17,7 @@ impl LogSink for MockSink {
 }
 
 pub struct LogCall {
-    pub channel: Arc<Channel>,
+    pub channel_id: ChannelId,
     pub msg: Vec<u8>,
     pub metadata: Metadata,
 }
@@ -35,15 +35,10 @@ impl RecordingSink {
 }
 
 impl LogSink for RecordingSink {
-    fn log(
-        &self,
-        channel: &Arc<Channel>,
-        msg: &[u8],
-        metadata: &Metadata,
-    ) -> Result<(), FoxgloveError> {
+    fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {
         let mut recorded = self.recorded.lock();
         recorded.push(LogCall {
-            channel: channel.clone(),
+            channel_id: channel.id(),
             msg: msg.to_vec(),
             metadata: *metadata,
         });
@@ -65,7 +60,7 @@ impl std::fmt::Display for StrError {
 impl LogSink for ErrorSink {
     fn log(
         &self,
-        _channel: &Arc<Channel>,
+        _channel: &Channel,
         _msg: &[u8],
         _metadata: &Metadata,
     ) -> Result<(), FoxgloveError> {

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -1637,12 +1637,7 @@ fn send_lossy(
 }
 
 impl LogSink for Server {
-    fn log(
-        &self,
-        channel: &Arc<Channel>,
-        msg: &[u8],
-        metadata: &Metadata,
-    ) -> Result<(), FoxgloveError> {
+    fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {
         let clients = self.clients.get();
         for client in clients.iter() {
             let subscriptions = client.subscriptions.lock();


### PR DESCRIPTION
I think we can relax `&Arc<Channel>` to just `&Channel` in `LogSink::log`.