### PR TITLE
fix doc building to only build for releases

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,18 +42,6 @@ jobs:
       - run: poetry run mypy .
       - run: poetry run python -m unittest
         working-directory: python/foxglove-sdk/python
-      - name: Sphinx build
-        run: |
-          poetry run sphinx-build --fail-on-warning ./python/docs _build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: startsWith(github.ref, 'refs/tags/sdk/v')
-        with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: python/foxglove-sdk/_build/
-          destination_dir: python/
-          force_orphan: true
 
   schemas:
     runs-on: ubuntu-latest
@@ -275,6 +263,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    needs: [lint-and-test-sdk]
     permissions:
       contents: write
     defaults:


### PR DESCRIPTION
### Changelog

None

### Docs
None

### Description
Fix python docs building to run only after Python release.
