### PR TITLE
rust: Use Bytes instead of Vec<u8> in protobufs

### DIFF
--- a/python/foxglove-sdk/src/generated/schemas.rs
+++ b/python/foxglove-sdk/src/generated/schemas.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(non_snake_case)]
 use crate::schemas_wkt::{Duration, Timestamp};
+use bytes::Bytes;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
@@ -299,7 +300,9 @@ impl CompressedImage {
         Self(foxglove::schemas::CompressedImage {
             timestamp: timestamp.map(Into::into),
             frame_id,
-            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+            data: data
+                .map(|x| Bytes::copy_from_slice(x.as_bytes()))
+                .unwrap_or_default(),
             format,
         })
     }
@@ -341,7 +344,9 @@ impl CompressedVideo {
         Self(foxglove::schemas::CompressedVideo {
             timestamp: timestamp.map(Into::into),
             frame_id,
-            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+            data: data
+                .map(|x| Bytes::copy_from_slice(x.as_bytes()))
+                .unwrap_or_default(),
             format,
         })
     }
@@ -586,7 +591,9 @@ impl Grid {
             row_stride,
             cell_stride,
             fields: fields.into_iter().map(|x| x.into()).collect(),
-            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+            data: data
+                .map(|x| Bytes::copy_from_slice(x.as_bytes()))
+                .unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {
@@ -1090,7 +1097,9 @@ impl ModelPrimitive {
             override_color,
             url,
             media_type,
-            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+            data: data
+                .map(|x| Bytes::copy_from_slice(x.as_bytes()))
+                .unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {
@@ -1237,7 +1246,9 @@ impl PointCloud {
             pose: pose.map(Into::into),
             point_stride,
             fields: fields.into_iter().map(|x| x.into()).collect(),
-            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+            data: data
+                .map(|x| Bytes::copy_from_slice(x.as_bytes()))
+                .unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {
@@ -1485,7 +1496,9 @@ impl RawImage {
             height,
             encoding,
             step,
-            data: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+            data: data
+                .map(|x| Bytes::copy_from_slice(x.as_bytes()))
+                .unwrap_or_default(),
         })
     }
     fn __repr__(&self) -> String {

--- a/rust/foxglove-proto-gen/src/lib.rs
+++ b/rust/foxglove-proto-gen/src/lib.rs
@@ -202,6 +202,7 @@ pub fn generate_protos(proto_path: &Path, out_dir: &Path) -> anyhow::Result<()> 
     config.extern_path(".google.protobuf.Duration", "crate::schemas::Duration");
     config.extern_path(".google.protobuf.Timestamp", "crate::schemas::Timestamp");
     config.out_dir(out_dir);
+    config.bytes(["."]);
 
     let mut fds = config
         .load_fds(&proto_files, &[proto_path])

--- a/rust/foxglove/src/schemas/foxglove.rs
+++ b/rust/foxglove/src/schemas/foxglove.rs
@@ -145,8 +145,8 @@ pub struct CompressedImage {
     #[prost(string, tag = "4")]
     pub frame_id: ::prost::alloc::string::String,
     /// Compressed image data
-    #[prost(bytes = "vec", tag = "2")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub data: ::prost::bytes::Bytes,
     /// Image format
     ///
     /// Supported values: image media types supported by Chrome, such as `webp`, `jpeg`, `png`
@@ -187,8 +187,8 @@ pub struct CompressedVideo {
     ///    - Use the "Low overhead bitstream format" (section 5.2)
     ///    - Each CompressedVideo message should contain enough OBUs to decode exactly one video frame
     ///    - Each message containing a key frame must also include a Sequence Header OBU
-    #[prost(bytes = "vec", tag = "3")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "3")]
+    pub data: ::prost::bytes::Bytes,
     /// Video format.
     ///
     /// Supported values: `h264`, `h265`, `vp9`, `av1`.
@@ -290,8 +290,8 @@ pub struct Grid {
     #[prost(message, repeated, tag = "8")]
     pub fields: ::prost::alloc::vec::Vec<PackedElementField>,
     /// Grid cell data, interpreted using `fields`, in row-major (y-major) order
-    #[prost(bytes = "vec", tag = "9")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "9")]
+    pub data: ::prost::bytes::Bytes,
 }
 /// Array of annotations for a 2D image
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -586,8 +586,8 @@ pub struct ModelPrimitive {
     #[prost(string, tag = "6")]
     pub media_type: ::prost::alloc::string::String,
     /// Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
-    #[prost(bytes = "vec", tag = "7")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "7")]
+    pub data: ::prost::bytes::Bytes,
 }
 /// A field present within each element in a byte array of packed elements.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -705,8 +705,8 @@ pub struct PointCloud {
     #[prost(message, repeated, tag = "5")]
     pub fields: ::prost::alloc::vec::Vec<PackedElementField>,
     /// Point data, interpreted using `fields`
-    #[prost(bytes = "vec", tag = "6")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "6")]
+    pub data: ::prost::bytes::Bytes,
 }
 /// An array of points on a 2D image
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -863,8 +863,8 @@ pub struct RawImage {
     #[prost(fixed32, tag = "5")]
     pub step: u32,
     /// Raw image data
-    #[prost(bytes = "vec", tag = "6")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "6")]
+    pub data: ::prost::bytes::Bytes,
 }
 /// A visual element in a 3D scene. An entity may be composed of multiple primitives which all share the same frame of reference.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/typescript/schemas/src/internal/generatePyclass.test.ts
+++ b/typescript/schemas/src/internal/generatePyclass.test.ts
@@ -10,6 +10,7 @@ describe("generatePyclass", () => {
         #![allow(clippy::enum_variant_names)]
         #![allow(non_snake_case)]
         use crate::schemas_wkt::{Duration, Timestamp};
+        use bytes::Bytes;
         use pyo3::prelude::*;
         use pyo3::types::PyBytes;
 
@@ -100,21 +101,21 @@ describe("generatePyclass", () => {
                     field_duration: field_duration.map(Into::into),
                     field_time: field_time.map(Into::into),
                     field_boolean,
-                    field_bytes: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+                    field_bytes: data.map(|x| Bytes::copy_from_slice(x.as_bytes())).unwrap_or_default(),
                     field_float64,
                     field_uint32,
                     field_string,
                     field_duration_array: field_duration_array.map(Into::into),
                     field_time_array: field_time_array.map(Into::into),
                     field_boolean_array,
-                    field_bytes_array: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+                    field_bytes_array: data.map(|x| Bytes::copy_from_slice(x.as_bytes())).unwrap_or_default(),
                     field_float64_array,
                     field_uint32_array,
                     field_string_array,
                     field_duration_fixed_array: field_duration_fixed_array.map(Into::into),
                     field_time_fixed_array: field_time_fixed_array.map(Into::into),
                     field_boolean_fixed_array,
-                    field_bytes_fixed_array: data.map(|x| x.as_bytes().to_vec()).unwrap_or_default(),
+                    field_bytes_fixed_array: data.map(|x| Bytes::copy_from_slice(x.as_bytes())).unwrap_or_default(),
                     field_float64_fixed_array,
                     field_uint32_fixed_array,
                     field_string_fixed_array,

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -23,6 +23,7 @@ export function generateSchemaPrelude(): string {
 
   const imports = [
     "use crate::schemas_wkt::{Duration, Timestamp};",
+    "use bytes::Bytes;",
     "use pyo3::prelude::*;",
     "use pyo3::types::PyBytes;",
   ];
@@ -161,7 +162,7 @@ function generateMessageClass(schema: FoxgloveMessageSchema): string {
   function fieldValue(field: FoxgloveMessageField): string {
     if (field.type.type === "primitive" && field.type.name === "bytes") {
       // Special case — this is an `Option<Bound<'_, PyBytes>>`; see `rustOutputType`
-      return `data.map(|x| x.as_bytes().to_vec()).unwrap_or_default()`;
+      return `data.map(|x| Bytes::copy_from_slice(x.as_bytes())).unwrap_or_default()`;
     }
     switch (field.type.type) {
       case "primitive":


### PR DESCRIPTION
For bytes fields on protobufs, we should use `Bytes` instead of `Vec<u8>`. This enables zero-copy for buffers that are already `Bytes` of course, but also for types `T: AsRef<[u8]> + Send + 'static` (via [`Bytes::from_owner`](https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.from_owner)), such as you'd find for an `Arc<Vec<u8>>` or [Mmap](https://docs.rs/memmap/latest/memmap/struct.Mmap.html) or other various memory views.