### PR TITLE
python: organize websocket code into submodule

### DIFF
--- a/python/foxglove-sdk-examples/live-visualization/main.py
+++ b/python/foxglove-sdk-examples/live-visualization/main.py
@@ -8,7 +8,7 @@ from math import cos, sin
 
 import foxglove
 import numpy as np
-from foxglove import Capability, Schema
+from foxglove import Channel, Schema
 from foxglove.channels import (
     FrameTransformsChannel,
     PointCloudChannel,
@@ -31,6 +31,7 @@ from foxglove.schemas import (
     Timestamp,
     Vector3,
 )
+from foxglove.websocket import Capability, ChannelView, Client, ServerListener
 
 any_schema = {
     "type": "object",
@@ -46,7 +47,7 @@ plot_schema = {
 }
 
 
-class ExampleListener(foxglove.ServerListener):
+class ExampleListener(ServerListener):
     def __init__(self) -> None:
         self.subscribers: set[int] = set()
 
@@ -55,8 +56,8 @@ class ExampleListener(foxglove.ServerListener):
 
     def on_subscribe(
         self,
-        client: foxglove.Client,
-        channel: foxglove.ChannelView,
+        client: Client,
+        channel: ChannelView,
     ) -> None:
         """
         Called by the server when a client subscribes to a channel.
@@ -67,8 +68,8 @@ class ExampleListener(foxglove.ServerListener):
 
     def on_unsubscribe(
         self,
-        client: foxglove.Client,
-        channel: foxglove.ChannelView,
+        client: Client,
+        channel: ChannelView,
     ) -> None:
         """
         Called by the server when a client unsubscribes from a channel.
@@ -78,8 +79,8 @@ class ExampleListener(foxglove.ServerListener):
 
     def on_message_data(
         self,
-        client: foxglove.Client,
-        channel: foxglove.ChannelView,
+        client: Client,
+        channel: ChannelView,
         data: bytes,
     ) -> None:
         """
@@ -108,10 +109,10 @@ def main() -> None:
     point_chan = PointCloudChannel("/pointcloud")
 
     # Log dicts using JSON encoding
-    json_chan = foxglove.Channel(topic="/json", schema=plot_schema)
+    json_chan = Channel(topic="/json", schema=plot_schema)
 
     # Log messages with a custom schema and any encoding
-    sin_chan = foxglove.Channel(
+    sin_chan = Channel(
         topic="/sine",
         message_encoding="json",
         schema=Schema(

--- a/python/foxglove-sdk-examples/ws-connection-graph/main.py
+++ b/python/foxglove-sdk-examples/ws-connection-graph/main.py
@@ -1,7 +1,8 @@
 import logging
 import time
 
-from foxglove import Capability, ConnectionGraph, ServerListener, start_server
+import foxglove
+from foxglove.websocket import Capability, ConnectionGraph, ServerListener
 
 
 class SubscriptionWatcher(ServerListener):
@@ -22,6 +23,8 @@ class SubscriptionWatcher(ServerListener):
 
 
 def main() -> None:
+    foxglove.set_log_level("DEBUG")
+
     graph = ConnectionGraph()
     graph.set_published_topic("/example-topic", ["1", "2"])
     graph.set_subscribed_topic("/subscribed-topic", ["3", "4"])
@@ -29,7 +32,7 @@ def main() -> None:
 
     logging.debug(graph)
 
-    server = start_server(
+    server = foxglove.start_server(
         server_listener=SubscriptionWatcher(),
         capabilities=[Capability.ConnectionGraph],
     )

--- a/python/foxglove-sdk-examples/ws-param-server/main.py
+++ b/python/foxglove-sdk-examples/ws-param-server/main.py
@@ -10,7 +10,13 @@ import time
 from typing import List, Optional
 
 import foxglove
-from foxglove import Capability, Parameter, ParameterType, ParameterValue
+from foxglove.websocket import (
+    Capability,
+    Client,
+    Parameter,
+    ParameterType,
+    ParameterValue,
+)
 
 
 class ParameterStore(foxglove.ServerListener):
@@ -23,7 +29,7 @@ class ParameterStore(foxglove.ServerListener):
     # Foxglove server callback
     def on_get_parameters(
         self,
-        client: foxglove.Client,
+        client: Client,
         param_names: list[str],
         request_id: Optional[str] = None,
     ) -> list[Parameter]:
@@ -36,10 +42,10 @@ class ParameterStore(foxglove.ServerListener):
 
     def on_set_parameters(
         self,
-        client: foxglove.Client,
-        parameters: list[foxglove.Parameter],
+        client: Client,
+        parameters: list[Parameter],
         request_id: str | None = None,
-    ) -> list[foxglove.Parameter]:
+    ) -> list[Parameter]:
         logging.debug(f"on_set_parameters: {parameters}, {client.id}, {request_id}")
         for changed_param in parameters:
             if changed_param.value is None:

--- a/python/foxglove-sdk-examples/ws-services/main.py
+++ b/python/foxglove-sdk-examples/ws-services/main.py
@@ -8,18 +8,18 @@ https://docs.foxglove.dev/docs/visualization/panels/service-call
 import argparse
 import logging
 
-from foxglove import (
+import foxglove
+from foxglove.websocket import (
     Capability,
-    Request,
     Service,
+    ServiceRequest,
     ServiceSchema,
-    start_server,
 )
 
 
 # A handler can also be a bare function.
 def logging_handler(
-    request: Request,
+    request: ServiceRequest,
 ) -> bytes:
     """
     A handler for the service, adhering to the `ServiceHandler` type.
@@ -34,13 +34,13 @@ def logging_handler(
 class EchoService:
     def __call__(
         self,
-        request: Request,
+        request: ServiceRequest,
     ) -> bytes:
         log_request(request)
         return request.payload
 
 
-def log_request(r: Request):
+def log_request(r: ServiceRequest):
     logging.debug(
         f"[{r.service_name}] "
         f"client {r.client_id} call {r.call_id}: "
@@ -53,6 +53,8 @@ def main():
     This example demonstrates how to use the Foxglove WebSocket API to implement services which can
     be called from the Foxglove app.
     """
+    foxglove.set_log_level("DEBUG")
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--host", type=str, default="127.0.0.1")
@@ -74,7 +76,7 @@ def main():
         handler=EchoService(),
     )
 
-    server = start_server(
+    server = foxglove.start_server(
         name="ws-services-example",
         port=args.port,
         host=args.host,

--- a/python/foxglove-sdk-examples/ws-stream-mcap/main.py
+++ b/python/foxglove-sdk-examples/ws-stream-mcap/main.py
@@ -3,16 +3,12 @@ import logging
 import time
 from typing import Optional
 
+import foxglove
 import mcap
 import mcap.reader
 import mcap.records
-from foxglove import (
-    Capability,
-    Channel,
-    Schema,
-    WebSocketServer,
-    start_server,
-)
+from foxglove import Channel, Schema
+from foxglove.websocket import Capability, WebSocketServer
 
 channels: dict[str, Channel] = {}
 
@@ -26,7 +22,7 @@ def main():
 
     file_name = args.file
 
-    server = start_server(
+    server = foxglove.start_server(
         name=file_name, port=args.port, host=args.host, capabilities=[Capability.Time]
     )
 

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -71,7 +71,7 @@ Parameters
 
 Used with the parameter service during live visualization. Requires the :py:data:`Capability.Parameters` capability.
 
-.. autoclass:: foxglove.ParameterType
+.. autoclass:: foxglove.websocket.ParameterType
 
    .. py:data:: ByteArray
 
@@ -85,7 +85,7 @@ Used with the parameter service during live visualization. Requires the :py:data
 
       An array of decimal or integer values that can be represented as 64-bit floating point numbers.
 
-.. autoclass:: foxglove.ParameterValue
+.. autoclass:: foxglove.websocket.ParameterValue
 
    .. py:class:: Number(value: float)
 

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -10,27 +10,29 @@ import logging
 from typing import Callable, List, Optional, Protocol, Union
 
 from ._foxglove_py import (
-    Capability,
-    ChannelView,
-    Client,
-    ConnectionGraph,
     MCAPWriter,
-    MessageSchema,
-    Parameter,
-    ParameterType,
-    ParameterValue,
     Schema,
-    Service,
-    ServiceRequest,
-    ServiceSchema,
-    StatusLevel,
-    WebSocketServer,
     enable_logging,
     open_mcap,
     shutdown,
 )
 from ._foxglove_py import start_server as _start_server
 from .channel import Channel, log
+from .websocket import (
+    Capability,
+    ChannelView,
+    Client,
+    ConnectionGraph,
+    MessageSchema,
+    Parameter,
+    ParameterType,
+    ParameterValue,
+    Service,
+    ServiceRequest,
+    ServiceSchema,
+    StatusLevel,
+    WebSocketServer,
+)
 
 atexit.register(shutdown)
 

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -7,7 +7,7 @@ schemas.
 
 import atexit
 import logging
-from typing import Callable, List, Optional, Protocol, Union
+from typing import List, Optional, Union
 
 from ._foxglove_py import (
     MCAPWriter,
@@ -19,175 +19,14 @@ from ._foxglove_py import (
 from ._foxglove_py import start_server as _start_server
 from .channel import Channel, log
 from .websocket import (
+    AssetHandler,
     Capability,
-    ChannelView,
-    Client,
-    ConnectionGraph,
-    MessageSchema,
-    Parameter,
-    ParameterType,
-    ParameterValue,
+    ServerListener,
     Service,
-    ServiceRequest,
-    ServiceSchema,
-    StatusLevel,
     WebSocketServer,
 )
 
 atexit.register(shutdown)
-
-
-class ServerListener(Protocol):
-    """
-    A mechanism to register callbacks for handling client message events.
-    """
-
-    def on_subscribe(self, client: Client, channel: ChannelView) -> None:
-        """
-        Called by the server when a client subscribes to a channel.
-
-        :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
-        :param channel: The channel (id, topic) that the message was sent on.
-        :type channel: :py:class:`ChannelView`
-        """
-        return None
-
-    def on_unsubscribe(self, client: Client, channel: ChannelView) -> None:
-        """
-        Called by the server when a client unsubscribes from a channel.
-
-        :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
-        :param channel: The channel (id, topic) that the message was sent on.
-        :type channel: :py:class:`ChannelView`
-        """
-        return None
-
-    def on_client_advertise(self, client: Client, channel: ChannelView) -> None:
-        """
-        Called by the server when a client advertises a channel.
-
-        :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
-        :param channel: The channel (id, topic) that the message was sent on.
-        :type channel: :py:class:`ChannelView`
-        """
-        return None
-
-    def on_client_unadvertise(self, client: Client, channel: ChannelView) -> None:
-        """
-        Called by the server when a client unadvertises a channel.
-
-        :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
-        :param channel: The channel (id, topic) that the message was sent on.
-        :type channel: :py:class:`ChannelView`
-        """
-        return None
-
-    def on_message_data(
-        self, client: Client, channel: ChannelView, data: bytes
-    ) -> None:
-        """
-        Called by the server when a message is received from a client.
-
-        :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
-        :param channel: The channel (id, topic) that the message was sent on.
-        :type channel: :py:class:`ChannelView`
-        :param data: The message data.
-        :type data: bytes
-        """
-        return None
-
-    def on_get_parameters(
-        self,
-        client: Client,
-        param_names: List[str],
-        request_id: Optional[str] = None,
-    ) -> List["Parameter"]:
-        """
-        Called by the server when a client requests parameters.
-
-        Requires :py:data:`Capability.Parameters`.
-
-        :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
-        :param param_names: The names of the parameters to get.
-        :type param_names: list[str]
-        :param request_id: An optional request id.
-        :type request_id: Optional[str]
-        """
-        return []
-
-    def on_set_parameters(
-        self,
-        client: Client,
-        parameters: List["Parameter"],
-        request_id: Optional[str] = None,
-    ) -> List["Parameter"]:
-        """
-        Called by the server when a client sets parameters.
-        Note that only `parameters` which have changed are included in the callback, but the return
-        value must include all parameters.
-
-        Requires :py:data:`Capability.Parameters`.
-
-        :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
-        :param parameters: The parameters to set.
-        :type parameters: list[:py:class:`Parameter`]
-        :param request_id: An optional request id.
-        :type request_id: Optional[str]
-        """
-        return parameters
-
-    def on_parameters_subscribe(
-        self,
-        param_names: List[str],
-    ) -> None:
-        """
-        Called by the server when a client subscribes to one or more parameters for the first time.
-
-        Requires :py:data:`Capability.Parameters`.
-
-        :param param_names: The names of the parameters to subscribe to.
-        :type param_names: list[str]
-        """
-        return None
-
-    def on_parameters_unsubscribe(
-        self,
-        param_names: List[str],
-    ) -> None:
-        """
-        Called by the server when the last client subscription to one or more parameters has been
-        removed.
-
-        Requires :py:data:`Capability.Parameters`.
-
-        :param param_names: The names of the parameters to unsubscribe from.
-        :type param_names: list[str]
-        """
-        return None
-
-    def on_connection_graph_subscribe(self) -> None:
-        """
-        Called by the server when the first client subscribes to the connection graph.
-        """
-        return None
-
-    def on_connection_graph_unsubscribe(self) -> None:
-        """
-        Called by the server when the last client unsubscribes from the connection graph.
-        """
-        return None
-
-
-# Redefine types from the stub interface so they're available for documentation.
-ServiceHandler = Callable[["ServiceRequest"], bytes]
-AssetHandler = Callable[[str], Optional[bytes]]
 
 
 def start_server(
@@ -279,24 +118,9 @@ def _level_names() -> dict[str, int]:
 
 
 __all__ = [
-    "Capability",
     "Channel",
-    "ChannelView",
-    "Client",
-    "ConnectionGraph",
     "MCAPWriter",
-    "MessageSchema",
-    "Parameter",
-    "ParameterType",
-    "ParameterValue",
     "Schema",
-    "ServerListener",
-    "Service",
-    "ServiceHandler",
-    "ServiceRequest",
-    "ServiceSchema",
-    "StatusLevel",
-    "WebSocketServer",
     "log",
     "open_mcap",
     "set_log_level",

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -1,6 +1,7 @@
-from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple
+
+from .websocket import AssetHandler, Capability, Service, WebSocketServer
 
 class MCAPWriter:
     """
@@ -28,31 +29,6 @@ class MCAPWriter:
         """
         ...
 
-class StatusLevel(Enum):
-    Info = ...
-    Warning = ...
-    Error = ...
-
-class WebSocketServer:
-    """
-    A websocket server for live visualization.
-    """
-
-    def __new__(cls) -> "WebSocketServer": ...
-    @property
-    def port(self) -> int: ...
-    def stop(self) -> None: ...
-    def clear_session(self, session_id: Optional[str] = None) -> None: ...
-    def broadcast_time(self, timestamp_nanos: int) -> None: ...
-    def publish_parameter_values(self, parameters: List["Parameter"]) -> None: ...
-    def publish_status(
-        self, message: str, level: "StatusLevel", id: Optional[str] = None
-    ) -> None: ...
-    def remove_status(self, ids: list[str]) -> None: ...
-    def add_services(self, services: list["Service"]) -> None: ...
-    def remove_services(self, names: list[str]) -> None: ...
-    def publish_connection_graph(self, graph: "ConnectionGraph") -> None: ...
-
 class BaseChannel:
     """
     A channel for logging messages.
@@ -74,178 +50,6 @@ class BaseChannel:
     ) -> None: ...
     def close(self) -> None: ...
 
-class Capability(Enum):
-    """
-    An enumeration of capabilities that the websocket server can advertise to its clients.
-    """
-
-    ClientPublish = ...
-    """Allow clients to advertise channels to send data messages to the server."""
-
-    Connectiongraph = ...
-    """Allow clients to subscribe and make connection graph updates"""
-
-    Parameters = ...
-    """Allow clients to get & set parameters."""
-
-    Services = ...
-    """Allow clients to call services."""
-
-    Time = ...
-    """Inform clients about the latest server time."""
-
-class Client:
-    """
-    A client that is connected to a running websocket server.
-    """
-
-    id: int = ...
-
-class ChannelView:
-    """
-    Information about a channel.
-    """
-
-    id: int = ...
-    topic: str = ...
-
-class Parameter:
-    """
-    A parameter.
-    """
-
-    name: str
-    type: Optional["ParameterType"]
-    value: Optional["AnyParameterValue"]
-
-    def __init__(
-        self,
-        name: str,
-        *,
-        type: Optional["ParameterType"] = None,
-        value: Optional["AnyParameterValue"] = None,
-    ) -> None: ...
-
-class ParameterType(Enum):
-    """
-    The type of a parameter.
-    """
-
-    ByteArray = ...
-    """A byte array."""
-
-    Float64 = ...
-    """A decimal or integer value that can be represented as a `float64`."""
-
-    Float64Array = ...
-    """An array of decimal or integer values that can be represented as `float64`s."""
-
-class ParameterValue:
-    """
-    The value of a parameter.
-    """
-
-    class Bool:
-        """A boolean value."""
-
-        def __new__(cls, value: bool) -> "ParameterValue.Bool": ...
-
-    class Number:
-        """A decimal or integer value."""
-
-        def __new__(cls, value: float) -> "ParameterValue.Number": ...
-
-    class Bytes:
-        """A byte array."""
-
-        def __new__(cls, value: bytes) -> "ParameterValue.Bytes": ...
-
-    class Array:
-        """An array of parameter values."""
-
-        def __new__(
-            cls, value: List["AnyParameterValue"]
-        ) -> "ParameterValue.Array": ...
-
-    class Dict:
-        """An associative map of parameter values."""
-
-        def __new__(
-            cls, value: dict[str, "AnyParameterValue"]
-        ) -> "ParameterValue.Dict": ...
-
-AnyParameterValue = Union[
-    ParameterValue.Bool,
-    ParameterValue.Number,
-    ParameterValue.Bytes,
-    ParameterValue.Array,
-    ParameterValue.Dict,
-]
-
-AssetHandler = Callable[[str], Optional[bytes]]
-
-class ServiceRequest:
-    """
-    A websocket service request.
-    """
-
-    service_name: str
-    client_id: int
-    call_id: int
-    encoding: str
-    payload: bytes
-
-ServiceHandler = Callable[["ServiceRequest"], bytes]
-
-class Service:
-    """
-    A websocket service.
-    """
-
-    name: str
-    schema: "ServiceSchema"
-    handler: "ServiceHandler"
-
-    def __new__(
-        cls,
-        *,
-        name: str,
-        schema: "ServiceSchema",
-        handler: "ServiceHandler",
-    ) -> "Service": ...
-
-class ServiceSchema:
-    """
-    A websocket service schema.
-    """
-
-    name: str
-    request: Optional["MessageSchema"]
-    response: Optional["MessageSchema"]
-
-    def __new__(
-        cls,
-        *,
-        name: str,
-        request: Optional["MessageSchema"] = None,
-        response: Optional["MessageSchema"] = None,
-    ) -> "ServiceSchema": ...
-
-class MessageSchema:
-    """
-    A service request or response schema.
-    """
-
-    encoding: str
-    schema: "Schema"
-
-    def __new__(
-        cls,
-        *,
-        encoding: str,
-        schema: "Schema",
-    ) -> "MessageSchema": ...
-
 class Schema:
     """
     A schema for a message or service call.
@@ -262,16 +66,6 @@ class Schema:
         encoding: str,
         data: bytes,
     ) -> "Schema": ...
-
-class ConnectionGraph:
-    """
-    A graph of connections between clients.
-    """
-
-    def __new__(cls) -> "ConnectionGraph": ...
-    def set_published_topic(self, topic: str, publisher_ids: List[str]) -> None: ...
-    def set_subscribed_topic(self, topic: str, subscriber_ids: List[str]) -> None: ...
-    def set_advertised_service(self, service: str, provider_ids: List[str]) -> None: ...
 
 def start_server(
     *,

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -1,0 +1,212 @@
+from collections.abc import Callable
+from enum import Enum
+from typing import List, Optional, Union
+
+from . import Schema
+
+class Capability(Enum):
+    """
+    An enumeration of capabilities that the websocket server can advertise to its clients.
+    """
+
+    ClientPublish = ...
+    """Allow clients to advertise channels to send data messages to the server."""
+
+    Connectiongraph = ...
+    """Allow clients to subscribe and make connection graph updates"""
+
+    Parameters = ...
+    """Allow clients to get & set parameters."""
+
+    Services = ...
+    """Allow clients to call services."""
+
+    Time = ...
+    """Inform clients about the latest server time."""
+
+class Client:
+    """
+    A client that is connected to a running websocket server.
+    """
+
+    id: int = ...
+
+class ChannelView:
+    """
+    Information about a channel.
+    """
+
+    id: int = ...
+    topic: str = ...
+
+class ConnectionGraph:
+    """
+    A graph of connections between clients.
+    """
+
+    def __new__(cls) -> "ConnectionGraph": ...
+    def set_published_topic(self, topic: str, publisher_ids: List[str]) -> None: ...
+    def set_subscribed_topic(self, topic: str, subscriber_ids: List[str]) -> None: ...
+    def set_advertised_service(self, service: str, provider_ids: List[str]) -> None: ...
+
+class MessageSchema:
+    """
+    A service request or response schema.
+    """
+
+    encoding: str
+    schema: "Schema"
+
+    def __new__(
+        cls,
+        *,
+        encoding: str,
+        schema: "Schema",
+    ) -> "MessageSchema": ...
+
+class Parameter:
+    """
+    A parameter.
+    """
+
+    name: str
+    type: Optional["ParameterType"]
+    value: Optional["AnyParameterValue"]
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        type: Optional["ParameterType"] = None,
+        value: Optional["AnyParameterValue"] = None,
+    ) -> None: ...
+
+class ParameterType(Enum):
+    """
+    The type of a parameter.
+    """
+
+    ByteArray = ...
+    """A byte array."""
+
+    Float64 = ...
+    """A decimal or integer value that can be represented as a `float64`."""
+
+    Float64Array = ...
+    """An array of decimal or integer values that can be represented as `float64`s."""
+
+class ParameterValue:
+    """
+    The value of a parameter.
+    """
+
+    class Bool:
+        """A boolean value."""
+
+        def __new__(cls, value: bool) -> "ParameterValue.Bool": ...
+
+    class Number:
+        """A decimal or integer value."""
+
+        def __new__(cls, value: float) -> "ParameterValue.Number": ...
+
+    class Bytes:
+        """A byte array."""
+
+        def __new__(cls, value: bytes) -> "ParameterValue.Bytes": ...
+
+    class Array:
+        """An array of parameter values."""
+
+        def __new__(
+            cls, value: List["AnyParameterValue"]
+        ) -> "ParameterValue.Array": ...
+
+    class Dict:
+        """An associative map of parameter values."""
+
+        def __new__(
+            cls, value: dict[str, "AnyParameterValue"]
+        ) -> "ParameterValue.Dict": ...
+
+AnyParameterValue = Union[
+    ParameterValue.Bool,
+    ParameterValue.Number,
+    ParameterValue.Bytes,
+    ParameterValue.Array,
+    ParameterValue.Dict,
+]
+
+AssetHandler = Callable[[str], Optional[bytes]]
+
+class ServiceRequest:
+    """
+    A websocket service request.
+    """
+
+    service_name: str
+    client_id: int
+    call_id: int
+    encoding: str
+    payload: bytes
+
+ServiceHandler = Callable[["ServiceRequest"], bytes]
+
+class Service:
+    """
+    A websocket service.
+    """
+
+    name: str
+    schema: "ServiceSchema"
+    handler: "ServiceHandler"
+
+    def __new__(
+        cls,
+        *,
+        name: str,
+        schema: "ServiceSchema",
+        handler: "ServiceHandler",
+    ) -> "Service": ...
+
+class ServiceSchema:
+    """
+    A websocket service schema.
+    """
+
+    name: str
+    request: Optional["MessageSchema"]
+    response: Optional["MessageSchema"]
+
+    def __new__(
+        cls,
+        *,
+        name: str,
+        request: Optional["MessageSchema"] = None,
+        response: Optional["MessageSchema"] = None,
+    ) -> "ServiceSchema": ...
+
+class StatusLevel(Enum):
+    Info = ...
+    Warning = ...
+    Error = ...
+
+class WebSocketServer:
+    """
+    A websocket server for live visualization.
+    """
+
+    def __new__(cls) -> "WebSocketServer": ...
+    @property
+    def port(self) -> int: ...
+    def stop(self) -> None: ...
+    def clear_session(self, session_id: Optional[str] = None) -> None: ...
+    def broadcast_time(self, timestamp_nanos: int) -> None: ...
+    def publish_parameter_values(self, parameters: List["Parameter"]) -> None: ...
+    def publish_status(
+        self, message: str, level: "StatusLevel", id: Optional[str] = None
+    ) -> None: ...
+    def remove_status(self, ids: list[str]) -> None: ...
+    def add_services(self, services: list["Service"]) -> None: ...
+    def remove_services(self, names: list[str]) -> None: ...
+    def publish_connection_graph(self, graph: "ConnectionGraph") -> None: ...

--- a/python/foxglove-sdk/python/foxglove/tests/test_server.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_server.py
@@ -5,10 +5,9 @@ from foxglove import (
     Capability,
     ServerListener,
     Service,
-    ServiceSchema,
-    StatusLevel,
     start_server,
 )
+from foxglove.websocket import ServiceSchema, StatusLevel
 
 
 class TestServer(unittest.TestCase):

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import List, Optional, Protocol
+
 from ._foxglove_py.websocket import (
     Capability,
     ChannelView,
@@ -14,6 +17,159 @@ from ._foxglove_py.websocket import (
     WebSocketServer,
 )
 
+# Redefine types from the stub interface so they're available for documentation.
+ServiceHandler = Callable[["ServiceRequest"], bytes]
+AssetHandler = Callable[[str], Optional[bytes]]
+
+
+class ServerListener(Protocol):
+    """
+    A mechanism to register callbacks for handling client message events.
+    """
+
+    def on_subscribe(self, client: Client, channel: ChannelView) -> None:
+        """
+        Called by the server when a client subscribes to a channel.
+
+        :param client: The client (id) that sent the message.
+        :type client: :py:class:`Client`
+        :param channel: The channel (id, topic) that the message was sent on.
+        :type channel: :py:class:`ChannelView`
+        """
+        return None
+
+    def on_unsubscribe(self, client: Client, channel: ChannelView) -> None:
+        """
+        Called by the server when a client unsubscribes from a channel.
+
+        :param client: The client (id) that sent the message.
+        :type client: :py:class:`Client`
+        :param channel: The channel (id, topic) that the message was sent on.
+        :type channel: :py:class:`ChannelView`
+        """
+        return None
+
+    def on_client_advertise(self, client: Client, channel: ChannelView) -> None:
+        """
+        Called by the server when a client advertises a channel.
+
+        :param client: The client (id) that sent the message.
+        :type client: :py:class:`Client`
+        :param channel: The channel (id, topic) that the message was sent on.
+        :type channel: :py:class:`ChannelView`
+        """
+        return None
+
+    def on_client_unadvertise(self, client: Client, channel: ChannelView) -> None:
+        """
+        Called by the server when a client unadvertises a channel.
+
+        :param client: The client (id) that sent the message.
+        :type client: :py:class:`Client`
+        :param channel: The channel (id, topic) that the message was sent on.
+        :type channel: :py:class:`ChannelView`
+        """
+        return None
+
+    def on_message_data(
+        self, client: Client, channel: ChannelView, data: bytes
+    ) -> None:
+        """
+        Called by the server when a message is received from a client.
+
+        :param client: The client (id) that sent the message.
+        :type client: :py:class:`Client`
+        :param channel: The channel (id, topic) that the message was sent on.
+        :type channel: :py:class:`ChannelView`
+        :param data: The message data.
+        :type data: bytes
+        """
+        return None
+
+    def on_get_parameters(
+        self,
+        client: Client,
+        param_names: List[str],
+        request_id: Optional[str] = None,
+    ) -> List["Parameter"]:
+        """
+        Called by the server when a client requests parameters.
+
+        Requires :py:data:`Capability.Parameters`.
+
+        :param client: The client (id) that sent the message.
+        :type client: :py:class:`Client`
+        :param param_names: The names of the parameters to get.
+        :type param_names: list[str]
+        :param request_id: An optional request id.
+        :type request_id: Optional[str]
+        """
+        return []
+
+    def on_set_parameters(
+        self,
+        client: Client,
+        parameters: List["Parameter"],
+        request_id: Optional[str] = None,
+    ) -> List["Parameter"]:
+        """
+        Called by the server when a client sets parameters.
+        Note that only `parameters` which have changed are included in the callback, but the return
+        value must include all parameters.
+
+        Requires :py:data:`Capability.Parameters`.
+
+        :param client: The client (id) that sent the message.
+        :type client: :py:class:`Client`
+        :param parameters: The parameters to set.
+        :type parameters: list[:py:class:`Parameter`]
+        :param request_id: An optional request id.
+        :type request_id: Optional[str]
+        """
+        return parameters
+
+    def on_parameters_subscribe(
+        self,
+        param_names: List[str],
+    ) -> None:
+        """
+        Called by the server when a client subscribes to one or more parameters for the first time.
+
+        Requires :py:data:`Capability.Parameters`.
+
+        :param param_names: The names of the parameters to subscribe to.
+        :type param_names: list[str]
+        """
+        return None
+
+    def on_parameters_unsubscribe(
+        self,
+        param_names: List[str],
+    ) -> None:
+        """
+        Called by the server when the last client subscription to one or more parameters has been
+        removed.
+
+        Requires :py:data:`Capability.Parameters`.
+
+        :param param_names: The names of the parameters to unsubscribe from.
+        :type param_names: list[str]
+        """
+        return None
+
+    def on_connection_graph_subscribe(self) -> None:
+        """
+        Called by the server when the first client subscribes to the connection graph.
+        """
+        return None
+
+    def on_connection_graph_unsubscribe(self) -> None:
+        """
+        Called by the server when the last client unsubscribes from the connection graph.
+        """
+        return None
+
+
 __all__ = [
     "Capability",
     "ChannelView",
@@ -23,7 +179,9 @@ __all__ = [
     "Parameter",
     "ParameterType",
     "ParameterValue",
+    "ServerListener",
     "Service",
+    "ServiceHandler",
     "ServiceRequest",
     "ServiceSchema",
     "StatusLevel",

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -1,0 +1,31 @@
+from ._foxglove_py.websocket import (
+    Capability,
+    ChannelView,
+    Client,
+    ConnectionGraph,
+    MessageSchema,
+    Parameter,
+    ParameterType,
+    ParameterValue,
+    Service,
+    ServiceRequest,
+    ServiceSchema,
+    StatusLevel,
+    WebSocketServer,
+)
+
+__all__ = [
+    "Capability",
+    "ChannelView",
+    "Client",
+    "ConnectionGraph",
+    "MessageSchema",
+    "Parameter",
+    "ParameterType",
+    "ParameterValue",
+    "Service",
+    "ServiceRequest",
+    "ServiceSchema",
+    "StatusLevel",
+    "WebSocketServer",
+]


### PR DESCRIPTION
### Changelog

- [python] Move websocket-related classes into a `websocket` module

### Docs
None
### Description

This re-organizes existing python code by introducing a `websocket` module. `start_server` is still in the top-level namespace, along with all other functions. I think we could go either way on this, but this sort of follows the rust organization, which has the server at the top level, with supporting classes in a websocket module.