### PR TITLE
Add some basic benchmarks for mcap and websocketserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -313,6 +314,12 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "core-foundation-sys"
@@ -417,6 +424,31 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0583193020b29b03682d8d33bb53a5b0f50df6daacece12ca99b904cfdcb8c4"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -639,6 +671,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "divan",
  "env_logger",
  "flume",
  "futures-util",
@@ -997,6 +1030,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "lock_api"
@@ -1505,6 +1544,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,7 +1576,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1842,7 +1900,17 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -11,6 +11,13 @@ default = []
 chrono = ["dep:chrono"]
 unstable = []
 
+[[bench]]
+name = "mcap_bench"
+harness = false
+[[bench]]
+name = "websocketserver_bench"
+harness = false
+
 [lints]
 workspace = true
 
@@ -45,3 +52,4 @@ env_logger = "0.11.5"
 futures-util = "0.3.31"
 tempfile = "3.15.0"
 tracing-test = "0.2.5"
+divan = "0.1.17"

--- a/rust/foxglove/benches/mcap_bench.rs
+++ b/rust/foxglove/benches/mcap_bench.rs
@@ -1,0 +1,138 @@
+use std::time::Duration;
+
+use foxglove::convert::SaturatingInto;
+use foxglove::schemas::log::Level;
+use foxglove::schemas::{
+    Color, CubePrimitive, Log, Pose, Quaternion, SceneEntity, SceneUpdate, Timestamp, Vector3,
+};
+use foxglove::McapWriter;
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}
+
+const PRINTABLE: &str = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+
+#[divan::bench(args = [50, 100, 200, 400])]
+fn log_json_message(bencher: divan::Bencher, num_chars: usize) {
+    #[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+    struct Message {
+        msg: &'static str,
+        count: u32,
+    }
+
+    foxglove::static_typed_channel!(pub MSG_CHANNEL, "/msg", Message);
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let path = tmpdir.path().join("test.mcap");
+    let _writer = McapWriter::new()
+        .create_new_buffered_file(&path)
+        .expect("Failed to start mcap writer");
+
+    let message = Message {
+        msg: "warmup",
+        count: num_chars as u32,
+    };
+    MSG_CHANNEL.log(&message);
+
+    bencher.bench(|| {
+        for _ in 0..100 {
+            let message = Message {
+                msg: &PRINTABLE[..num_chars],
+                count: (num_chars as u32) << 12,
+            };
+            MSG_CHANNEL.log(&message);
+        }
+    });
+}
+
+#[divan::bench(args = [1, 2, 4, 8])]
+fn log_scene_update(bencher: divan::Bencher, num_entities: usize) {
+    foxglove::static_typed_channel!(pub SCENE_CHANNEL, "/boxes", SceneUpdate);
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let path = tmpdir.path().join("test.mcap");
+    let _writer = McapWriter::new()
+        .create_new_buffered_file(&path)
+        .expect("Failed to start mcap writer");
+
+    bencher.bench(|| {
+        let mut entities = Vec::with_capacity(num_entities);
+        for i in 0..num_entities {
+            entities.push(SceneEntity {
+                frame_id: "box".to_string(),
+                id: "box_1".to_string(),
+                lifetime: Some(Duration::from_millis(10_100).saturating_into()),
+                cubes: vec![CubePrimitive {
+                    pose: Some(Pose {
+                        position: Some(Vector3 {
+                            x: 0.0,
+                            y: 0.0,
+                            z: 3.0,
+                        }),
+                        orientation: Some(Quaternion {
+                            x: i as f64 * -0.1,
+                            y: i as f64 * 0.1,
+                            z: 0.0,
+                            w: 1.0,
+                        }),
+                    }),
+                    size: Some(Vector3 {
+                        x: 1.0,
+                        y: 1.0,
+                        z: 1.0,
+                    }),
+                    color: Some(Color {
+                        r: 1.0,
+                        g: 0.0,
+                        b: 0.0,
+                        a: 1.0,
+                    }),
+                }],
+                ..Default::default()
+            });
+        }
+
+        for _ in 0..100 {
+            SCENE_CHANNEL.log(&SceneUpdate {
+                deletions: vec![],
+                entities: entities.clone(),
+            });
+        }
+    });
+}
+
+#[divan::bench(args = [1, 2, 4, 8, 16, 32])]
+fn mutlithreaded_log(bencher: divan::Bencher, num_threads: usize) {
+    foxglove::static_typed_channel!(pub LOG_CHANNEL, "/logs", Log);
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let path = tmpdir.path().join("test.mcap");
+    let _writer = McapWriter::new()
+        .create_new_buffered_file(&path)
+        .expect("Failed to start mcap writer");
+
+    bencher.bench(|| {
+        let mut threads = Vec::with_capacity(num_threads);
+        for _ in 0..num_threads {
+            let handle = std::thread::spawn(move || {
+                for _ in 0..4096 / num_threads {
+                    LOG_CHANNEL.log(&Log {
+                        timestamp: Some(Timestamp::new(1234567890, 123456789)),
+                        level: Level::Info as i32,
+                        message: PRINTABLE[..100].to_string(),
+                        name: "node name".to_string(),
+                        file: "file_name.rs".to_string(),
+                        line: 1111,
+                    });
+                }
+            });
+            threads.push(handle);
+        }
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    });
+}

--- a/rust/foxglove/benches/websocketserver_bench.rs
+++ b/rust/foxglove/benches/websocketserver_bench.rs
@@ -1,0 +1,309 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use foxglove::convert::SaturatingInto;
+use foxglove::schemas::log::Level;
+use foxglove::schemas::{
+    Color, CubePrimitive, Log, Pose, Quaternion, SceneEntity, SceneUpdate, Timestamp, Vector3,
+};
+use foxglove::WebSocketServer;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue, Message};
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}
+
+const PRINTABLE: &str = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+
+#[divan::bench(args = [1, 2, 4, 8])]
+fn roundtrip_json_message(bencher: divan::Bencher, num_clients: usize) {
+    #[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+    struct CustomMessage {
+        msg: &'static str,
+        count: u32,
+    }
+
+    foxglove::static_typed_channel!(pub MSG_CHANNEL, "/json_msg", CustomMessage);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    let server = runtime.block_on(async move {
+        WebSocketServer::new()
+            .bind("127.0.0.1", 0)
+            .start()
+            .await
+            .unwrap()
+    });
+    let port = server.port();
+
+    // Round trip 100 messages to the client
+    bencher
+        .with_inputs(|| {
+            runtime.block_on(async move {
+                let mut ws_clients = Vec::with_capacity(num_clients);
+                for _ in 0..num_clients {
+                    // Create a client and subscribe to the channel
+                    let mut ws_client =
+                        connect_client(format!("127.0.0.1:{}", port).parse().unwrap()).await;
+                    let subscribe = json!({
+                        "op": "subscribe",
+                        "subscriptions": [
+                            {
+                                "id": 1,
+                                "channelId": MSG_CHANNEL.id(),
+                            }
+                        ]
+                    });
+                    ws_client
+                        .send(Message::text(subscribe.to_string()))
+                        .await
+                        .expect("Failed to send");
+
+                    _ = ws_client.next().await.expect("No serverInfo sent");
+
+                    // FG-10395 replace this with something more precise
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    ws_clients.push(ws_client);
+                }
+                ws_clients
+            })
+        })
+        .bench_values(|mut ws_clients| {
+            for _ in 0..50 {
+                let message = CustomMessage {
+                    msg: PRINTABLE,
+                    count: (num_clients as u32) << 12,
+                };
+                MSG_CHANNEL.log(&message);
+            }
+
+            runtime.block_on(async move {
+                for _ in 0..50 {
+                    for ws_client in &mut ws_clients {
+                        _ = ws_client.next().await.expect("missing message");
+                    }
+                }
+            });
+        });
+}
+
+#[divan::bench(args = [1, 2, 4, 8])]
+fn roundtrip_scene_update(bencher: divan::Bencher, num_clients: usize) {
+    foxglove::static_typed_channel!(pub SCENE_CHANNEL, "/boxes", SceneUpdate);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    let server = runtime.block_on(async move {
+        WebSocketServer::new()
+            .bind("127.0.0.1", 0)
+            .start()
+            .await
+            .unwrap()
+    });
+    let port = server.port();
+
+    // Round trip 100 messages to the client
+    bencher
+        .with_inputs(|| {
+            runtime.block_on(async move {
+                let mut ws_clients = Vec::with_capacity(num_clients);
+                for _ in 0..num_clients {
+                    // Create a client and subscribe to the channel
+                    let mut ws_client =
+                        connect_client(format!("127.0.0.1:{}", port).parse().unwrap()).await;
+                    let subscribe = json!({
+                        "op": "subscribe",
+                        "subscriptions": [
+                            {
+                                "id": 1,
+                                "channelId": SCENE_CHANNEL.id(),
+                            }
+                        ]
+                    });
+                    ws_client
+                        .send(Message::text(subscribe.to_string()))
+                        .await
+                        .expect("Failed to send");
+
+                    _ = ws_client.next().await.expect("No serverInfo sent");
+
+                    // FG-10395 replace this with something more precise
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    ws_clients.push(ws_client);
+                }
+                ws_clients
+            })
+        })
+        .bench_values(|mut ws_clients| {
+            let mut entities = Vec::with_capacity(num_clients);
+            for i in 0..num_clients {
+                entities.push(SceneEntity {
+                    frame_id: "box".to_string(),
+                    id: "box_1".to_string(),
+                    lifetime: Some(Duration::from_millis(10_100).saturating_into()),
+                    cubes: vec![CubePrimitive {
+                        pose: Some(Pose {
+                            position: Some(Vector3 {
+                                x: 0.0,
+                                y: 0.0,
+                                z: 3.0,
+                            }),
+                            orientation: Some(Quaternion {
+                                x: i as f64 * -0.1,
+                                y: i as f64 * 0.1,
+                                z: 0.0,
+                                w: 1.0,
+                            }),
+                        }),
+                        size: Some(Vector3 {
+                            x: 1.0,
+                            y: 1.0,
+                            z: 1.0,
+                        }),
+                        color: Some(Color {
+                            r: 1.0,
+                            g: 0.0,
+                            b: 0.0,
+                            a: 1.0,
+                        }),
+                    }],
+                    ..Default::default()
+                });
+            }
+
+            for _ in 0..50 {
+                SCENE_CHANNEL.log(&SceneUpdate {
+                    deletions: vec![],
+                    entities: entities.clone(),
+                });
+            }
+
+            runtime.block_on(async move {
+                for _ in 0..50 {
+                    for ws_client in &mut ws_clients {
+                        _ = ws_client.next().await.expect("missing message");
+                    }
+                }
+            });
+        });
+}
+
+#[divan::bench(args = [1, 2, 4, 8, 16, 32])]
+fn roundtrip_mutlithreaded(bencher: divan::Bencher, num_threads: usize) {
+    foxglove::static_typed_channel!(pub LOG_CHANNEL, "/logs", Log);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    let server = runtime.block_on(async move {
+        WebSocketServer::new()
+            .bind("127.0.0.1", 0)
+            .start()
+            .await
+            .unwrap()
+    });
+    let port = server.port();
+
+    const NUM_CLIENTS: usize = 4;
+
+    bencher
+        .with_inputs(|| {
+            runtime.block_on(async move {
+                let mut ws_clients = Vec::with_capacity(NUM_CLIENTS);
+                for _ in 0..NUM_CLIENTS {
+                    // Create a client and subscribe to the channel
+                    let mut ws_client =
+                        connect_client(format!("127.0.0.1:{}", port).parse().unwrap()).await;
+                    let subscribe = json!({
+                        "op": "subscribe",
+                        "subscriptions": [
+                            {
+                                "id": 1,
+                                "channelId": LOG_CHANNEL.id(),
+                            }
+                        ]
+                    });
+                    ws_client
+                        .send(Message::text(subscribe.to_string()))
+                        .await
+                        .expect("Failed to send");
+
+                    _ = ws_client.next().await.expect("No serverInfo sent");
+
+                    // FG-10395 replace this with something more precise
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    ws_clients.push(ws_client);
+                }
+                ws_clients
+            })
+        })
+        .bench_values(|mut ws_clients| {
+            let num_messages = 2048 / num_threads;
+            let mut threads = Vec::with_capacity(num_threads);
+            for _ in 0..num_threads {
+                let handle = std::thread::spawn(move || {
+                    for _ in 0..num_messages {
+                        LOG_CHANNEL.log(&Log {
+                            timestamp: Some(Timestamp::new(1234567890, 123456789)),
+                            level: Level::Info as i32,
+                            message: PRINTABLE[..100].to_string(),
+                            name: "node name".to_string(),
+                            file: "file_name.rs".to_string(),
+                            line: 1111,
+                        });
+                    }
+                });
+                threads.push(handle);
+            }
+
+            runtime.block_on(async move {
+                for _ in 0..num_messages {
+                    for ws_client in &mut ws_clients {
+                        _ = ws_client.next().await.expect("missing message");
+                    }
+                }
+            });
+
+            for thread in threads {
+                thread.join().unwrap();
+            }
+        });
+}
+
+/// Connect to a server, ensuring the protocol header is set, and return the client WS stream
+async fn connect_client(
+    addr: SocketAddr,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    const SUBPROTOCOL: &str = "foxglove.sdk.v1";
+
+    let mut request = format!("ws://{}/", addr)
+        .into_client_request()
+        .expect("Failed to build request");
+
+    request.headers_mut().insert(
+        "sec-websocket-protocol",
+        HeaderValue::from_static(SUBPROTOCOL),
+    );
+
+    let (ws_stream, response) = tokio_tungstenite::connect_async(request)
+        .await
+        .expect("Failed to connect");
+
+    assert_eq!(
+        response.headers().get("sec-websocket-protocol"),
+        Some(&HeaderValue::from_static(SUBPROTOCOL))
+    );
+
+    ws_stream
+}

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -1,4 +1,4 @@
-use crate::{Channel, ChannelBuilder, FoxgloveError, PartialMetadata, Schema};
+use crate::{channel::ChannelId, Channel, ChannelBuilder, FoxgloveError, PartialMetadata, Schema};
 use bytes::BufMut;
 use schemars::{gen::SchemaSettings, JsonSchema};
 use serde::Serialize;
@@ -79,6 +79,11 @@ impl<T: Encode> TypedChannel<T> {
     /// Returns the topic name of the channel.
     pub fn topic(&self) -> &str {
         &self.inner.topic
+    }
+
+    /// Returns the channel ID.
+    pub fn id(&self) -> ChannelId {
+        self.inner.id
     }
 }
 


### PR DESCRIPTION
This adds 3 benchmark scenarios each for mcap writing and websocketserver.

One for json messages, one for large protobuf (SceneUpdate) and one for multiple threads. Each scenario has 4+ parameterized benchmarks to see how it scales along the dimension of interest.

Multi-threaded performance follows a U-shape with performance best in the middle. Adding threads helps, up to a point where contention starts to dominate the runtime.

We can use this to get a baseline when profiling and optimizing performance.

Here's the results on my machine:

```
> cargo bench -p foxglove

     Running benches/mcap_bench.rs (target/release/deps/mcap_bench-8552836f6882eaf7)
Timer precision: 10 ns
mcap_bench            fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ log_json_message                 │               │               │               │         │
│  ├─ 50              173.5 µs      │ 3.171 ms      │ 197.8 µs      │ 239.9 µs      │ 100     │ 100
│  ├─ 100             183.6 µs      │ 2.472 ms      │ 204.4 µs      │ 243 µs        │ 100     │ 100
│  ├─ 200             178.4 µs      │ 1.944 ms      │ 196.8 µs      │ 244.5 µs      │ 100     │ 100
│  ╰─ 400             189.6 µs      │ 2.177 ms      │ 209 µs        │ 293.4 µs      │ 100     │ 100
├─ log_scene_update                 │               │               │               │         │
│  ├─ 1               187.8 µs      │ 2.696 ms      │ 209.3 µs      │ 258 µs        │ 100     │ 100
│  ├─ 2               200.7 µs      │ 2.057 ms      │ 244.2 µs      │ 321 µs        │ 100     │ 100
│  ├─ 4               248.6 µs      │ 2.734 ms      │ 284.8 µs      │ 428.8 µs      │ 100     │ 100
│  ╰─ 8               330.6 µs      │ 2.018 ms      │ 374.2 µs      │ 536.2 µs      │ 100     │ 100
╰─ mutlithreaded_log                │               │               │               │         │
   ├─ 1               8.342 ms      │ 34.25 ms      │ 17.8 ms       │ 18.58 ms      │ 100     │ 100
   ├─ 2               4.804 ms      │ 27.94 ms      │ 14.74 ms      │ 14.96 ms      │ 100     │ 100
   ├─ 4               4.777 ms      │ 11.83 ms      │ 6.694 ms      │ 6.653 ms      │ 100     │ 100
   ├─ 8               5.128 ms      │ 32.91 ms      │ 15.99 ms      │ 15.75 ms      │ 100     │ 100
   ├─ 16              8.569 ms      │ 32.62 ms      │ 29.33 ms      │ 28 ms         │ 100     │ 100
   ╰─ 32              15.31 ms      │ 34.91 ms      │ 32.27 ms      │ 31.58 ms      │ 100     │ 100

     Running benches/websocketserver_bench.rs (target/release/deps/websocketserver_bench-aadf4b8711f23b7c)
Timer precision: 46 ns
websocketserver_bench       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ roundtrip_json_message                 │               │               │               │         │
│  ├─ 1                     1.478 ms      │ 42.46 ms      │ 41.36 ms      │ 41 ms         │ 100     │ 100
│  ├─ 2                     40.56 ms      │ 42.86 ms      │ 41.72 ms      │ 41.78 ms      │ 100     │ 100
│  ├─ 4                     40.89 ms      │ 43.99 ms      │ 42.22 ms      │ 42.28 ms      │ 100     │ 100
│  ╰─ 8                     41.86 ms      │ 44.72 ms      │ 43.23 ms      │ 43.35 ms      │ 100     │ 100
├─ roundtrip_mutlithreaded                │               │               │               │         │
│  ├─ 1                     12.52 ms      │ 65.63 ms      │ 37.81 ms      │ 41.03 ms      │ 100     │ 100
│  ├─ 2                     10.31 ms      │ 21.69 ms      │ 16.12 ms      │ 16.01 ms      │ 100     │ 100
│  ├─ 4                     5.695 ms      │ 22.45 ms      │ 12.38 ms      │ 13.62 ms      │ 100     │ 100
│  ├─ 8                     6.038 ms      │ 21.16 ms      │ 12.14 ms      │ 13.29 ms      │ 100     │ 100
│  ├─ 16                    4.911 ms      │ 23.31 ms      │ 16.28 ms      │ 14.7 ms       │ 100     │ 100
│  ╰─ 32                    13.49 ms      │ 26.26 ms      │ 20.29 ms      │ 20 ms         │ 100     │ 100
╰─ roundtrip_scene_update                 │               │               │               │         │
   ├─ 1                     1.399 ms      │ 43.29 ms      │ 41.39 ms      │ 41.28 ms      │ 100     │ 100
   ├─ 2                     41.23 ms      │ 44.5 ms       │ 42.26 ms      │ 42.27 ms      │ 100     │ 100
   ├─ 4                     41.51 ms      │ 44.68 ms      │ 42.75 ms      │ 42.92 ms      │ 100     │ 100
   ╰─ 8                     41.73 ms      │ 45.51 ms      │ 43.97 ms      │ 44.08 ms      │ 100     │ 100
```