### PR TITLE
python: migrate to pytest in sdk

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,8 +41,7 @@ jobs:
       - run: poetry install
       - run: poetry run maturin develop
       - run: poetry run mypy .
-      - run: poetry run python -m unittest
-        working-directory: python/foxglove-sdk/python
+      - run: poetry run pytest
 
   schemas:
     runs-on: ubuntu-latest

--- a/python/foxglove-sdk/CONTRIBUTING.md
+++ b/python/foxglove-sdk/CONTRIBUTING.md
@@ -51,7 +51,7 @@ poetry run flake8 .
 Run unit tests:
 
 ```sh
-cd python && poetry run python -m unittest
+poetry run pytest
 ```
 
 ### Examples

--- a/python/foxglove-sdk/poetry.lock
+++ b/python/foxglove-sdk/poetry.lock
@@ -405,6 +405,22 @@ all = ["sphinx (>=3.4.0)", "sphinx-jinja2-compat (>=0.1.1)", "sphinx-toolbox (>=
 sphinx = ["sphinx (>=3.4.0)", "sphinx-jinja2-compat (>=0.1.1)", "sphinx-toolbox (>=2.16.0)"]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "python_version < \"3.11\""
+files = [
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "filelock"
 version = "3.17.0"
 description = "A platform independent file lock."
@@ -511,6 +527,18 @@ enabler = ["pytest-enabler (>=2.2)"]
 perf = ["ipython"]
 test = ["flufl.flake8", "importlib_resources (>=1.3) ; python_version < \"3.9\"", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
 type = ["pytest-mypy"]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
 
 [[package]]
 name = "isort"
@@ -875,6 +903,22 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-
 type = ["mypy (>=1.11.2)"]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pycodestyle"
 version = "2.12.1"
 description = "Python style guide checker"
@@ -912,6 +956,29 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "requests"
@@ -1429,4 +1496,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "08f24af64326f0ec1a20500d939786f616d83fd73ed4978e11e7d11448499aef"
+content-hash = "a5330e6fd5b7e9075ebcb50d8011f01790c1d2a08dfa19d96ec4e512156d6d06"

--- a/python/foxglove-sdk/pyproject.toml
+++ b/python/foxglove-sdk/pyproject.toml
@@ -27,13 +27,14 @@ package-mode = false
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-mypy = "^1.13.0"
-maturin = "^1.7.4"
 black = "^24.2.0"
-flake8 = "^7.0.0"
-sphinx = "^7.0.0"
-isort = "^6.0.0"
 enum-tools = { extras = ["sphinx"], version = "^0.12.0" }
+flake8 = "^7.0.0"
+isort = "^6.0.0"
+maturin = "^1.7.4"
+mypy = "^1.13.0"
+pytest = "^8.3.4"
+sphinx = "^7.0.0"
 
 [tool.mypy]
 python_version = "3.9"

--- a/python/foxglove-sdk/python/foxglove/tests/test_logging.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_logging.py
@@ -1,15 +1,16 @@
 import logging
-import unittest
 
+import pytest
 from foxglove import set_log_level
 
 
-class TestMcap(unittest.TestCase):
-    def test_set_log_level_accepts_string_or_int(self) -> None:
-        set_log_level("DEBUG")
-        set_log_level(logging.DEBUG)
-        self.assertRaises(ValueError, set_log_level, "debug")
+def test_set_log_level_accepts_string_or_int() -> None:
+    set_log_level("DEBUG")
+    set_log_level(logging.DEBUG)
+    with pytest.raises(ValueError):
+        set_log_level("debug")
 
-    def test_set_log_level_clamps_illegal_values(self) -> None:
-        set_log_level(-1)
-        set_log_level(2**64)
+
+def test_set_log_level_clamps_illegal_values() -> None:
+    set_log_level(-1)
+    set_log_level(2**64)

--- a/python/foxglove-sdk/python/foxglove/tests/test_server.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_server.py
@@ -1,6 +1,6 @@
 import time
-import unittest
 
+import pytest
 from foxglove import (
     Capability,
     ServerListener,
@@ -10,59 +10,59 @@ from foxglove import (
 from foxglove.websocket import ServiceSchema, StatusLevel
 
 
-class TestServer(unittest.TestCase):
-    def test_server_interface(self) -> None:
-        """
-        Exercise the server interface; will also be checked with mypy.
-        """
-        server = start_server(port=0)
-        self.assertTrue(isinstance(server.port, int))
-        self.assertNotEqual(server.port, 0)
-        server.publish_status("test message", StatusLevel.Info, "some-id")
-        server.broadcast_time(time.time_ns())
-        server.remove_status(["some-id"])
-        server.clear_session()
-        server.stop()
+def test_server_interface() -> None:
+    """
+    Exercise the server interface; will also be checked with mypy.
+    """
+    server = start_server(port=0)
+    assert isinstance(server.port, int)
+    assert server.port != 0
+    server.publish_status("test message", StatusLevel.Info, "some-id")
+    server.broadcast_time(time.time_ns())
+    server.remove_status(["some-id"])
+    server.clear_session()
+    server.stop()
 
-    def test_server_listener_provides_default_implementation(self) -> None:
 
-        class DefaultServerListener(ServerListener):
-            pass
+def test_server_listener_provides_default_implementation() -> None:
+    class DefaultServerListener(ServerListener):
+        pass
 
-        listener = DefaultServerListener()
+    listener = DefaultServerListener()
 
-        listener.on_parameters_subscribe(["test"])
-        listener.on_parameters_unsubscribe(["test"])
+    listener.on_parameters_subscribe(["test"])
+    listener.on_parameters_unsubscribe(["test"])
 
-    def test_services_interface(self) -> None:
-        test_svc = Service(
-            name="test",
-            schema=ServiceSchema(name="test-schema"),
-            handler=lambda *_: b"{}",
-        )
-        test2_svc = Service(
-            name="test2",
-            schema=ServiceSchema(name="test-schema"),
-            handler=lambda *_: b"{}",
-        )
-        server = start_server(
-            port=0,
-            capabilities=[Capability.Services],
-            supported_encodings=["json"],
-            services=[test_svc],
-        )
 
-        # Add a new service.
-        server.add_services([test2_svc])
+def test_services_interface() -> None:
+    test_svc = Service(
+        name="test",
+        schema=ServiceSchema(name="test-schema"),
+        handler=lambda *_: b"{}",
+    )
+    test2_svc = Service(
+        name="test2",
+        schema=ServiceSchema(name="test-schema"),
+        handler=lambda *_: b"{}",
+    )
+    server = start_server(
+        port=0,
+        capabilities=[Capability.Services],
+        supported_encodings=["json"],
+        services=[test_svc],
+    )
 
-        # Can't add a service with the same name.
-        with self.assertRaises(RuntimeError):
-            server.add_services([test_svc])
+    # Add a new service.
+    server.add_services([test2_svc])
 
-        # Remove services.
-        server.remove_services(["test", "test2"])
-
-        # Re-add a service.
+    # Can't add a service with the same name.
+    with pytest.raises(RuntimeError):
         server.add_services([test_svc])
 
-        server.stop()
+    # Remove services.
+    server.remove_services(["test", "test2"])
+
+    # Re-add a service.
+    server.add_services([test_svc])
+
+    server.stop()

--- a/python/foxglove-sdk/python/foxglove/tests/test_time.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_time.py
@@ -1,159 +1,137 @@
 import datetime
-import unittest
 
+import pytest
 from foxglove.schemas import Duration, Timestamp
 
 
-class TestTime(unittest.TestCase):
-    def test_duration_normalization(self) -> None:
-        self.assertEqual(
-            Duration(sec=0, nsec=1_111_222_333),
-            Duration(sec=1, nsec=111_222_333),
-        )
-        self.assertEqual(
-            Duration(sec=0, nsec=2**32 - 1),
-            Duration(sec=4, nsec=294_967_295),
-        )
-        self.assertEqual(
-            Duration(sec=-2, nsec=1_000_000_001),
-            Duration(sec=-1, nsec=1),
-        )
-        self.assertEqual(
-            Duration(sec=-(2**31), nsec=1_000_000_001),
-            Duration(sec=-(2**31) + 1, nsec=1),
-        )
+def test_duration_normalization() -> None:
+    assert Duration(sec=0, nsec=1_111_222_333) == Duration(sec=1, nsec=111_222_333)
+    assert Duration(sec=0, nsec=2**32 - 1) == Duration(sec=4, nsec=294_967_295)
+    assert Duration(sec=-2, nsec=1_000_000_001) == Duration(sec=-1, nsec=1)
+    assert Duration(sec=-(2**31), nsec=1_000_000_001) == Duration(
+        sec=-(2**31) + 1, nsec=1
+    )
 
-        # argument conversions
-        d = Duration(sec=-(2**31))
-        self.assertEqual(d.sec, -(2**31))
-        self.assertEqual(d.nsec, 0)
+    # argument conversions
+    d = Duration(sec=-(2**31))
+    assert d.sec == -(2**31)
+    assert d.nsec == 0
 
-        d = Duration(sec=0, nsec=2**32 - 1)
-        self.assertEqual(d.sec, 4)
-        self.assertEqual(d.nsec, 294_967_295)
+    d = Duration(sec=0, nsec=2**32 - 1)
+    assert d.sec == 4
+    assert d.nsec == 294_967_295
 
-        d = Duration(sec=2**31 - 1, nsec=999_999_999)
-        self.assertEqual(d.sec, 2**31 - 1)
-        self.assertEqual(d.nsec, 999_999_999)
+    d = Duration(sec=2**31 - 1, nsec=999_999_999)
+    assert d.sec == 2**31 - 1
+    assert d.nsec == 999_999_999
 
-        with self.assertRaises(OverflowError):
-            Duration(sec=-(2**31) - 1)
-        with self.assertRaises(OverflowError):
-            Duration(sec=2**31)
-        with self.assertRaises(OverflowError):
-            Duration(sec=0, nsec=-1)
-        with self.assertRaises(OverflowError):
-            Duration(sec=0, nsec=2**32)
+    with pytest.raises(OverflowError):
+        Duration(sec=-(2**31) - 1)
+    with pytest.raises(OverflowError):
+        Duration(sec=2**31)
+    with pytest.raises(OverflowError):
+        Duration(sec=0, nsec=-1)
+    with pytest.raises(OverflowError):
+        Duration(sec=0, nsec=2**32)
 
-        # overflow past upper bound
-        with self.assertRaises(OverflowError):
-            Duration(sec=2**31 - 1, nsec=1_000_000_000)
+    # overflow past upper bound
+    with pytest.raises(OverflowError):
+        Duration(sec=2**31 - 1, nsec=1_000_000_000)
 
-        # we don't handle this corner case, where seconds is beyond the lower
-        # bound, but nanoseconds overflow to bring the duration within range.
-        with self.assertRaises(OverflowError):
-            Duration(sec=-(2**31) - 1, nsec=1_000_000_000)
+    # we don't handle this corner case, where seconds is beyond the lower
+    # bound, but nanoseconds overflow to bring the duration within range.
+    with pytest.raises(OverflowError):
+        Duration(sec=-(2**31) - 1, nsec=1_000_000_000)
 
-    def test_duration_from_secs(self) -> None:
-        self.assertEqual(Duration.from_secs(1.123), Duration(sec=1, nsec=123_000_000))
-        self.assertEqual(Duration.from_secs(-0.123), Duration(sec=-1, nsec=877_000_000))
-        self.assertEqual(Duration.from_secs(-1.123), Duration(sec=-2, nsec=877_000_000))
 
-        with self.assertRaises(OverflowError):
-            Duration.from_secs(-1e42)
+def test_duration_from_secs() -> None:
+    assert Duration.from_secs(1.123) == Duration(sec=1, nsec=123_000_000)
+    assert Duration.from_secs(-0.123) == Duration(sec=-1, nsec=877_000_000)
+    assert Duration.from_secs(-1.123) == Duration(sec=-2, nsec=877_000_000)
 
-        with self.assertRaises(OverflowError):
-            Duration.from_secs(1e42)
+    with pytest.raises(OverflowError):
+        Duration.from_secs(-1e42)
 
-    def test_duration_from_timedelta(self) -> None:
-        td = datetime.timedelta(seconds=1, milliseconds=123)
-        self.assertEqual(Duration.from_timedelta(td), Duration(sec=1, nsec=123_000_000))
+    with pytest.raises(OverflowError):
+        Duration.from_secs(1e42)
 
-        # no loss of precision
-        td = datetime.timedelta(days=9876, microseconds=123_456)
-        self.assertEqual(
-            Duration.from_timedelta(td), Duration(sec=853_286_400, nsec=123_456_000)
-        )
 
-        # timedeltas are normalized
-        td = datetime.timedelta(seconds=8 * 24 * 3600, milliseconds=99_111)
-        self.assertEqual(
-            Duration.from_timedelta(td), Duration(sec=691_299, nsec=111_000_000)
-        )
+def test_duration_from_timedelta() -> None:
+    td = datetime.timedelta(seconds=1, milliseconds=123)
+    assert Duration.from_timedelta(td) == Duration(sec=1, nsec=123_000_000)
 
-        with self.assertRaises(OverflowError):
-            Duration.from_timedelta(datetime.timedelta.min)
+    # no loss of precision
+    td = datetime.timedelta(days=9876, microseconds=123_456)
+    assert Duration.from_timedelta(td) == Duration(sec=853_286_400, nsec=123_456_000)
 
-        with self.assertRaises(OverflowError):
-            Duration.from_timedelta(datetime.timedelta.max)
+    # timedeltas are normalized
+    td = datetime.timedelta(seconds=8 * 24 * 3600, milliseconds=99_111)
+    assert Duration.from_timedelta(td) == Duration(sec=691_299, nsec=111_000_000)
 
-    def test_timestamp_normalization(self) -> None:
-        self.assertEqual(
-            Timestamp(sec=0, nsec=1_111_222_333),
-            Timestamp(sec=1, nsec=111_222_333),
-        )
-        self.assertEqual(
-            Timestamp(sec=0, nsec=2**32 - 1),
-            Timestamp(sec=4, nsec=294_967_295),
-        )
+    with pytest.raises(OverflowError):
+        Duration.from_timedelta(datetime.timedelta.min)
 
-        # argument conversions
-        t = Timestamp(sec=0)
-        self.assertEqual(t.sec, 0)
-        self.assertEqual(t.nsec, 0)
+    with pytest.raises(OverflowError):
+        Duration.from_timedelta(datetime.timedelta.max)
 
-        t = Timestamp(sec=0, nsec=2**32 - 1)
-        self.assertEqual(t.sec, 4)
-        self.assertEqual(t.nsec, 294_967_295)
 
-        t = Timestamp(sec=2**32 - 1, nsec=999_999_999)
-        self.assertEqual(t.sec, 2**32 - 1)
-        self.assertEqual(t.nsec, 999_999_999)
+def test_timestamp_normalization() -> None:
+    assert Timestamp(sec=0, nsec=1_111_222_333) == Timestamp(sec=1, nsec=111_222_333)
+    assert Timestamp(sec=0, nsec=2**32 - 1) == Timestamp(sec=4, nsec=294_967_295)
 
-        with self.assertRaises(OverflowError):
-            Timestamp(sec=-1)
-        with self.assertRaises(OverflowError):
-            Timestamp(sec=2**32)
-        with self.assertRaises(OverflowError):
-            Timestamp(sec=0, nsec=-1)
-        with self.assertRaises(OverflowError):
-            Timestamp(sec=0, nsec=2**32)
+    # argument conversions
+    t = Timestamp(sec=0)
+    assert t.sec == 0
+    assert t.nsec == 0
 
-        # overflow past upper bound
-        with self.assertRaises(OverflowError):
-            Timestamp(sec=2**32 - 1, nsec=1_000_000_000)
+    t = Timestamp(sec=0, nsec=2**32 - 1)
+    assert t.sec == 4
+    assert t.nsec == 294_967_295
 
-    def test_timestamp_from_epoch_secs(self) -> None:
-        self.assertEqual(
-            Timestamp.from_epoch_secs(1.123), Timestamp(sec=1, nsec=123_000_000)
-        )
+    t = Timestamp(sec=2**32 - 1, nsec=999_999_999)
+    assert t.sec == 2**32 - 1
+    assert t.nsec == 999_999_999
 
-        with self.assertRaises(OverflowError):
-            Timestamp.from_epoch_secs(-1.0)
+    with pytest.raises(OverflowError):
+        Timestamp(sec=-1)
+    with pytest.raises(OverflowError):
+        Timestamp(sec=2**32)
+    with pytest.raises(OverflowError):
+        Timestamp(sec=0, nsec=-1)
+    with pytest.raises(OverflowError):
+        Timestamp(sec=0, nsec=2**32)
 
-        with self.assertRaises(OverflowError):
-            Timestamp.from_epoch_secs(1e42)
+    # overflow past upper bound
+    with pytest.raises(OverflowError):
+        Timestamp(sec=2**32 - 1, nsec=1_000_000_000)
 
-    def test_timestamp_from_datetime(self) -> None:
-        utc = datetime.timezone.utc
-        dt = datetime.datetime(1970, 1, 1, tzinfo=utc)
-        self.assertEqual(Timestamp.from_datetime(dt), Timestamp(sec=0))
 
-        # no loss of precision
-        dt = datetime.datetime(2025, 1, 1, microsecond=42, tzinfo=utc)
-        self.assertEqual(
-            Timestamp.from_datetime(dt), Timestamp(sec=1_735_689_600, nsec=42_000)
-        )
+def test_timestamp_from_epoch_secs() -> None:
+    assert Timestamp.from_epoch_secs(1.123) == Timestamp(sec=1, nsec=123_000_000)
 
-        # alternative timezone
-        local_tz = datetime.timezone(datetime.timedelta(hours=-1))
-        dt = datetime.datetime(1970, 1, 1, 0, 0, 1, 123_000, tzinfo=local_tz)
-        self.assertEqual(
-            Timestamp.from_datetime(dt), Timestamp(sec=3601, nsec=123_000_000)
-        )
+    with pytest.raises(OverflowError):
+        Timestamp.from_epoch_secs(-1.0)
 
-        with self.assertRaises(OverflowError):
-            Timestamp.from_datetime(datetime.datetime(1969, 12, 31, tzinfo=utc))
+    with pytest.raises(OverflowError):
+        Timestamp.from_epoch_secs(1e42)
 
-        with self.assertRaises(OverflowError):
-            Timestamp.from_datetime(datetime.datetime(2106, 2, 8, tzinfo=utc))
+
+def test_timestamp_from_datetime() -> None:
+    utc = datetime.timezone.utc
+    dt = datetime.datetime(1970, 1, 1, tzinfo=utc)
+    assert Timestamp.from_datetime(dt) == Timestamp(sec=0)
+
+    # no loss of precision
+    dt = datetime.datetime(2025, 1, 1, microsecond=42, tzinfo=utc)
+    assert Timestamp.from_datetime(dt) == Timestamp(sec=1_735_689_600, nsec=42_000)
+
+    # alternative timezone
+    local_tz = datetime.timezone(datetime.timedelta(hours=-1))
+    dt = datetime.datetime(1970, 1, 1, 0, 0, 1, 123_000, tzinfo=local_tz)
+    assert Timestamp.from_datetime(dt) == Timestamp(sec=3601, nsec=123_000_000)
+
+    with pytest.raises(OverflowError):
+        Timestamp.from_datetime(datetime.datetime(1969, 12, 31, tzinfo=utc))
+
+    with pytest.raises(OverflowError):
+        Timestamp.from_datetime(datetime.datetime(2106, 2, 8, tzinfo=utc))


### PR DESCRIPTION
### Changelog

None

### Description

This adds `pytest` to the SDK dev dependencies, and rewrites the tests from unittest.

Note that you no longer need to cd into the inner python directory to run tests.

Supports FG-10513.