### PR TITLE
rust: Add SinkId for identifying sinks

### DIFF
--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -187,9 +187,9 @@ mod tests {
     #[test]
     fn test_add_and_remove_sink() {
         let ctx = Context::new();
-        let sink = Arc::new(MockSink);
-        let sink2 = Arc::new(MockSink);
-        let sink3 = Arc::new(MockSink);
+        let sink = Arc::new(MockSink::default());
+        let sink2 = Arc::new(MockSink::default());
+        let sink3 = Arc::new(MockSink::default());
 
         // Test adding a sink
         assert!(ctx.add_sink(sink.clone()));
@@ -257,7 +257,7 @@ mod tests {
     #[test]
     fn test_log_calls_other_sinks_after_error() {
         let ctx = Context::new();
-        let error_sink = Arc::new(ErrorSink);
+        let error_sink = Arc::new(ErrorSink::default());
         let recording_sink = Arc::new(RecordingSink::new());
 
         assert!(ctx.add_sink(error_sink.clone()));

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -190,7 +190,7 @@ pub use mcap_writer::{McapWriter, McapWriterHandle};
 pub use metadata::{Metadata, PartialMetadata};
 pub(crate) use runtime::get_runtime_handle;
 pub use runtime::shutdown_runtime;
-pub use sink::Sink;
+pub use sink::{Sink, SinkId};
 pub(crate) use time::nanoseconds_since_epoch;
 pub use websocket_server::{WebSocketServer, WebSocketServerBlockingHandle, WebSocketServerHandle};
 

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -1,13 +1,29 @@
 use crate::channel::Channel;
 use crate::metadata::Metadata;
 use crate::FoxgloveError;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+
+/// Uniquely identifies a [`Sink`] in the context of this program.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SinkId(u64);
+impl SinkId {
+    /// Allocates the next sink ID.
+    pub fn next() -> Self {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        Self(id)
+    }
+}
 
 /// A [`Sink`] writes a message from a [`Channel`] to a destination.
 ///
 /// Sinks are thread-safe and can be shared between threads. Usually you'd use our implementations
 /// like [`McapWriter`](crate::McapWriter) or [`WebSocketServer`](crate::WebSocketServer).
 pub trait Sink: Send + Sync {
+    /// Returns the sink's unique ID.
+    fn id(&self) -> SinkId;
+
     /// Writes the message for the channel to the sink.
     ///
     /// Metadata contains optional message metadata that may be used by some sink implementations.

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -10,7 +10,7 @@ pub struct SinkId(u64);
 impl SinkId {
     /// Allocates the next sink ID.
     pub fn next() -> Self {
-        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
         Self(id)
     }


### PR DESCRIPTION
### Changelog
- rust: Add `SinkId` and new mandatory `Sink::id()` trait method.

### Description
We've been using Arc pointers to compare log sinks, which is… fine. But it'd be a bit nicer if we just had a SinkId to use, like we have a ChannelId. That would give us a natural way of indexing sinks, which will be useful for both sink deregistration as well as subscription management.