### PR TITLE
rust: Use subscription manager

### DIFF
--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -128,6 +128,11 @@ impl Channel {
         self.sinks.store(sinks);
     }
 
+    /// Clears the set of subscribed sinks.
+    pub(crate) fn clear_sinks(&self) {
+        self.sinks.clear();
+    }
+
     /// Returns true if at least one sink is subscribed to this channel.
     pub fn has_sinks(&self) -> bool {
         !self.sinks.is_empty()

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -1,11 +1,13 @@
-use crate::log_sink_set::LogSinkSet;
-use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata, Sink};
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::log_sink_set::LogSinkSet;
+use crate::sink::SmallSinkVec;
+use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 pub struct ChannelId(u64);
@@ -122,7 +124,7 @@ impl Channel {
     }
 
     /// Updates the set of sinks that are subscribed to this channel.
-    pub(crate) fn update_sinks(&self, sinks: Vec<Arc<dyn Sink>>) {
+    pub(crate) fn update_sinks(&self, sinks: SmallSinkVec) {
         self.sinks.store(sinks);
     }
 

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -1,10 +1,11 @@
 use crate::log_sink_set::LogSinkSet;
-use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata};
+use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata, Sink};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 pub struct ChannelId(u64);
@@ -88,7 +89,6 @@ impl Schema {
 /// ```
 pub struct Channel {
     // TODO add public read-only accessors for these for the Rust API.
-    // TODO add a list of contexts here as well (or restrict to one context per channel?)
     pub(crate) sinks: LogSinkSet,
     /// id is a unique identifier for the channel inside the process,
     /// it's used to map a channel to a channel_id or subscription_id in log sinks.
@@ -121,18 +121,32 @@ impl Channel {
         self.message_sequence.fetch_add(1, Relaxed)
     }
 
+    /// Updates the set of sinks that are subscribed to this channel.
+    pub(crate) fn update_sinks(&self, sinks: Vec<Arc<dyn Sink>>) {
+        self.sinks.store(sinks);
+    }
+
+    /// Returns true if at least one sink is subscribed to this channel.
+    pub fn has_sinks(&self) -> bool {
+        !self.sinks.is_empty()
+    }
+
     /// Logs a message.
     pub fn log(&self, msg: &[u8]) {
-        self.log_with_meta(msg, PartialMetadata::default());
+        if self.has_sinks() {
+            self.log_to_sinks(msg, PartialMetadata::default());
+        }
     }
 
     /// Logs a message with additional metadata.
     pub fn log_with_meta(&self, msg: &[u8], opts: PartialMetadata) {
-        // Bail out early if there are no sinks (logging is disabled).
-        if self.sinks.is_empty() {
-            return;
+        if self.has_sinks() {
+            self.log_to_sinks(msg, opts);
         }
+    }
 
+    /// Logs a message with additional metadata.
+    pub(crate) fn log_to_sinks(&self, msg: &[u8], opts: PartialMetadata) {
         let mut metadata = Metadata {
             sequence: opts.sequence.unwrap_or_else(|| self.next_sequence()),
             log_time: opts.log_time.unwrap_or_else(nanoseconds_since_epoch),
@@ -170,15 +184,6 @@ impl std::fmt::Debug for Channel {
             .field("schema", &self.schema)
             .field("metadata", &self.metadata)
             .finish()
-    }
-}
-
-impl Drop for Channel {
-    fn drop(&mut self) {
-        self.sinks.for_each(|sink| {
-            sink.remove_channel(self);
-            Ok(())
-        });
     }
 }
 

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -89,10 +89,10 @@ impl ContextInner {
         }
 
         // Add requested subscriptions.
-        if auto_subscribe && self.subs.subscribe_global(sink.clone()) {
-            self.update_channel_sinks(self.channels.values());
-        } else if !auto_subscribe && self.subs.subscribe_channels(&sink, &sub_channel_ids) {
+        if !sub_channel_ids.is_empty() && self.subs.subscribe_channels(&sink, &sub_channel_ids) {
             self.update_channel_sinks_by_ids(&sub_channel_ids);
+        } else if auto_subscribe && self.subs.subscribe_global(sink.clone()) {
+            self.update_channel_sinks(self.channels.values());
         }
 
         true

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -41,7 +41,7 @@ impl ContextInner {
 
         // Connect channel sinks.
         let sinks = self.subs.get_subscribers(channel.id());
-        channel.update_sinks(sinks.to_vec());
+        channel.update_sinks(sinks);
 
         Ok(())
     }
@@ -118,7 +118,7 @@ impl ContextInner {
     fn update_all_channel_sinks(&self) {
         for (id, channel) in &self.channels {
             let sinks = self.subs.get_subscribers(*id);
-            channel.update_sinks(sinks.to_vec());
+            channel.update_sinks(sinks);
         }
     }
 
@@ -127,7 +127,7 @@ impl ContextInner {
         for id in channel_ids {
             if let Some(channel) = self.channels.get(id) {
                 let sinks = self.subs.get_subscribers(*id);
-                channel.update_sinks(sinks.to_vec());
+                channel.update_sinks(sinks);
             }
         }
     }

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -5,25 +5,151 @@ use std::sync::{Arc, LazyLock};
 
 use parking_lot::RwLock;
 
-#[allow(dead_code)]
-mod subscriptions;
+use crate::channel::ChannelId;
+use crate::{Channel, FoxgloveError, Sink, SinkId};
 
-use crate::log_sink_set::LogSinkSet;
-use crate::{Channel, FoxgloveError, Sink};
+mod subscriptions;
+use subscriptions::Subscriptions;
+
+#[derive(Default)]
+struct ContextInner {
+    channels: HashMap<ChannelId, Arc<Channel>>,
+    channels_by_topic: HashMap<String, Arc<Channel>>,
+    sinks: HashMap<SinkId, Arc<dyn Sink>>,
+    subs: Subscriptions,
+}
+impl ContextInner {
+    /// Returns the channel for the specified topic, if there is one.
+    fn get_channel_by_topic(&self, topic: &str) -> Option<&Arc<Channel>> {
+        self.channels_by_topic.get(topic)
+    }
+
+    /// Adds a channel to the context.
+    fn add_channel(&mut self, channel: Arc<Channel>) -> Result<(), FoxgloveError> {
+        // Insert channel.
+        let topic = &channel.topic;
+        let Entry::Vacant(entry) = self.channels_by_topic.entry(topic.clone()) else {
+            return Err(FoxgloveError::DuplicateChannel(topic.clone()));
+        };
+        entry.insert(channel.clone());
+        self.channels.insert(channel.id(), channel.clone());
+
+        // Notify sinks of new channel.
+        for sink in self.sinks.values() {
+            sink.add_channel(&channel);
+        }
+
+        // Connect channel sinks.
+        let sinks = self.subs.get_subscribers(channel.id());
+        channel.update_sinks(sinks.to_vec());
+
+        Ok(())
+    }
+
+    /// Removes the channel for the specified topic.
+    fn remove_channel_for_topic(&mut self, topic: &str) -> bool {
+        let Some(channel) = self.channels_by_topic.remove(topic) else {
+            return false;
+        };
+        self.channels.remove(&channel.id());
+
+        // Remove subscriptions for this channel.
+        self.subs.remove_channel_subscriptions(channel.id());
+
+        // Disconnect channel sinks.
+        channel.sinks.clear();
+
+        // Notify sinks of removed channel.
+        for sink in self.sinks.values() {
+            sink.remove_channel(&channel);
+        }
+
+        true
+    }
+
+    /// Adds a sink to the context.
+    fn add_sink(&mut self, sink: Arc<dyn Sink>) -> bool {
+        let sink_id = sink.id();
+        let Entry::Vacant(entry) = self.sinks.entry(sink_id) else {
+            return false;
+        };
+        entry.insert(sink.clone());
+
+        // Notify sink of existing channels.
+        for channel in self.channels.values() {
+            sink.add_channel(channel);
+        }
+
+        // Auto-subscribe sink to all channels, if requested.
+        if sink.auto_subscribe() && self.subs.subscribe_global(sink.clone()) {
+            self.update_all_channel_sinks();
+        }
+
+        true
+    }
+
+    /// Removes a sink from the context.
+    fn remove_sink(&mut self, sink_id: SinkId) -> bool {
+        // Remove sink's subscriptions. If this wasn't a no-op, update channel sinks.
+        if self.subs.remove_subscriber(sink_id) {
+            self.update_all_channel_sinks();
+        }
+
+        self.sinks.remove(&sink_id).is_some()
+    }
+
+    /// Subscribes a sink to the specified channels.
+    fn subscribe_channels(&mut self, sink_id: SinkId, channel_ids: &[ChannelId]) {
+        if let Some(sink) = self.sinks.get(&sink_id) {
+            if self.subs.subscribe_channels(sink, channel_ids) {
+                self.update_channel_sinks(channel_ids);
+            }
+        }
+    }
+
+    /// Unsubscribes a sink from the specified channels.
+    fn unsubscribe_channels(&mut self, sink_id: SinkId, channel_ids: &[ChannelId]) {
+        if self.subs.unsubscribe_channels(sink_id, channel_ids) {
+            self.update_channel_sinks(channel_ids);
+        }
+    }
+
+    /// Updates the set of connected sinks on all channels.
+    fn update_all_channel_sinks(&self) {
+        for (id, channel) in &self.channels {
+            let sinks = self.subs.get_subscribers(*id);
+            channel.update_sinks(sinks.to_vec());
+        }
+    }
+
+    /// Updates the set of connected sinks on the specified channels.
+    fn update_channel_sinks(&self, channel_ids: &[ChannelId]) {
+        for id in channel_ids {
+            if let Some(channel) = self.channels.get(id) {
+                let sinks = self.subs.get_subscribers(*id);
+                channel.update_sinks(sinks.to_vec());
+            }
+        }
+    }
+
+    /// Removes all channels and sinks from the context.
+    fn clear(&mut self) {
+        self.channels.clear();
+        self.channels_by_topic.clear();
+        self.sinks.clear();
+        self.subs.clear();
+    }
+}
 
 /// A context is a collection of channels and sinks.
 ///
 /// To obtain a reference to the default context, use [`Context::get_default`]. To construct a new
 /// context, use [`Context::new`].
-pub struct Context {
-    /// Map of channels by topic.
-    channels: RwLock<HashMap<String, Arc<Channel>>>,
-    sinks: LogSinkSet,
-}
+pub struct Context(RwLock<ContextInner>);
 
 impl Debug for Context {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Context").finish_non_exhaustive()
+        f.debug_tuple("Context").finish_non_exhaustive()
     }
 }
 
@@ -31,10 +157,7 @@ impl Context {
     /// Instantiates a new context.
     #[allow(clippy::new_without_default)] // avoid confusion with Context::get_default()
     pub fn new() -> Arc<Self> {
-        Arc::new(Self {
-            channels: RwLock::default(),
-            sinks: LogSinkSet::new(),
-        })
+        Arc::new(Self(RwLock::default()))
     }
 
     /// Returns a reference to the default context.
@@ -47,134 +170,72 @@ impl Context {
 
     /// Returns the channel for the specified topic, if there is one.
     pub fn get_channel_by_topic(&self, topic: &str) -> Option<Arc<Channel>> {
-        let channels = self.channels.read();
-        channels.get(topic).cloned()
+        self.0.read().get_channel_by_topic(topic).cloned()
     }
 
     /// Adds a channel to the context.
     pub fn add_channel(&self, channel: Arc<Channel>) -> Result<(), FoxgloveError> {
-        {
-            // Wrapped in a block, so we release the lock immediately.
-            let mut channels = self.channels.write();
-            let topic = &channel.topic;
-            let Entry::Vacant(entry) = channels.entry(topic.clone()) else {
-                return Err(FoxgloveError::DuplicateChannel(topic.clone()));
-            };
-            entry.insert(channel.clone());
-        }
-        self.sinks.for_each(|sink| {
-            if channel.sinks.add_sink(sink.clone()) {
-                sink.add_channel(&channel);
-            }
-            Ok(())
-        });
-        Ok(())
+        self.0.write().add_channel(channel)
     }
 
     /// Removes the channel for the specified topic.
     pub fn remove_channel_for_topic(&self, topic: &str) -> bool {
-        let maybe_channel_by_topic = {
-            let mut channels = self.channels.write();
-            channels.remove(topic)
-        };
-
-        let Some(channel_by_topic) = maybe_channel_by_topic else {
-            // Channel not found.
-            return false;
-        };
-        let channel = &*channel_by_topic;
-
-        self.sinks.for_each(|sink| {
-            if channel.sinks.remove_sink(sink) {
-                sink.remove_channel(channel);
-            }
-            Ok(())
-        });
-        true
+        self.0.write().remove_channel_for_topic(topic)
     }
 
     /// Adds a sink to the context.
+    ///
+    /// The sink will be synchronously notified of all registered channels.
+    ///
+    /// If [`Sink::auto_subscribe`] returns true, the sink will be automatically subscribed to all
+    /// present and future channels on the context. Otherwise, the sink is expected to manage its
+    /// subscriptions dynamically with [`Context::subscribe_channels`] and
+    /// [`Context::unsubscribe_channels`].
     pub fn add_sink(&self, sink: Arc<dyn Sink>) -> bool {
-        if !self.sinks.add_sink(sink.clone()) {
-            return false;
-        }
-
-        // Add the sink to all existing channels.
-        for channel in self.channels.read().values() {
-            if channel.sinks.add_sink(sink.clone()) {
-                sink.add_channel(channel);
-            }
-        }
-
-        true
+        self.0.write().add_sink(sink)
     }
 
     /// Removes a sink from the context.
-    pub fn remove_sink(&self, sink: &Arc<dyn Sink>) -> bool {
-        if !self.sinks.remove_sink(sink) {
-            return false;
-        }
-
-        // TODO this has a bug, if the same sink was added to a channel twice, via two different contexts,
-        // this will remove the sink from the channel, even although they're still associated via the other context.
-        // If we stored the contexts on the channel, and removed the contexts, it would fix it,
-        // But logging would be via an extra indirection to context (slower) and
-        // having it associated with the same sink twice would result in two log calls to the sink,
-        // which is a more serious bug.
-        // I think the solution should be to have both the contexts and the sinks on the channel.
-        // This also fixes the problems with Channel::close().
-        // FG-9893
-
-        // Remove the sink from all existing channels.
-        for channel in self.channels.read().values() {
-            if channel.sinks.remove_sink(sink) {
-                sink.remove_channel(channel);
-            }
-        }
-
-        true
+    pub fn remove_sink(&self, sink_id: SinkId) -> bool {
+        self.0.write().remove_sink(sink_id)
     }
 
-    /// Removes all channels and sinks from the context.
-    pub fn clear(&self) {
-        let channels: HashMap<_, _> = std::mem::take(&mut self.channels.write());
-        self.sinks.for_each(|sink| {
-            for channel in channels.values() {
-                sink.remove_channel(channel);
-                channel.sinks.clear();
-            }
-            Ok(())
-        });
-        self.sinks.clear();
+    /// Subscribes a sink to the specified channels.
+    ///
+    /// This method has no effect for sinks that return true from [`Sink::auto_subscribe`].
+    pub fn subscribe_channels(&self, sink_id: SinkId, channel_ids: &[ChannelId]) {
+        self.0.write().subscribe_channels(sink_id, channel_ids);
+    }
+
+    /// Unsubscribes a sink from the specified channels.
+    ///
+    /// This method has no effect for sinks that return true from [`Sink::auto_subscribe`].
+    pub fn unsubscribe_channels(&self, sink_id: SinkId, channel_ids: &[ChannelId]) {
+        self.0.write().unsubscribe_channels(sink_id, channel_ids);
     }
 }
 
 impl Drop for Context {
     fn drop(&mut self) {
-        self.clear();
+        self.0.write().clear();
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::channel::ChannelId;
     use crate::collection::collection;
-    use crate::context::*;
     use crate::log_sink_set::ERROR_LOGGING_MESSAGE;
     use crate::testutil::{ErrorSink, MockSink, RecordingSink};
+    use crate::{context::*, ChannelBuilder};
     use crate::{nanoseconds_since_epoch, Channel, PartialMetadata, Schema};
-    use std::sync::atomic::AtomicU32;
     use std::sync::Arc;
     use tracing_test::traced_test;
 
-    fn new_test_channel(id: u64) -> Arc<Channel> {
-        Arc::new(Channel {
-            sinks: LogSinkSet::new(),
-            id: ChannelId::new(id),
-            message_sequence: AtomicU32::new(1),
-            topic: "topic".to_string(),
-            message_encoding: "message_encoding".to_string(),
-            schema: Some(Schema::new(
+    fn new_test_channel(ctx: &Arc<Context>, topic: &str) -> Result<Arc<Channel>, FoxgloveError> {
+        ChannelBuilder::new(topic)
+            .context(ctx)
+            .message_encoding("message_encoding")
+            .schema(Schema::new(
                 "name",
                 "encoding",
                 br#"{
@@ -184,9 +245,9 @@ mod tests {
                         "count": {"type": "number"},
                     },
                 }"#,
-            )),
-            metadata: collection! {"key".to_string() => "value".to_string()},
-        })
+            ))
+            .metadata(collection! {"key".to_string() => "value".to_string()})
+            .build()
     }
 
     #[test]
@@ -203,16 +264,13 @@ mod tests {
         assert!(ctx.add_sink(sink2.clone()));
 
         // Test removing a sink
-        let sink: Arc<dyn Sink> = sink;
-        assert!(ctx.remove_sink(&sink));
+        assert!(ctx.remove_sink(sink.id()));
 
         // Try to remove a sink that doesn't exist
-        let sink3: Arc<dyn Sink> = sink3;
-        assert!(!ctx.remove_sink(&sink3));
+        assert!(!ctx.remove_sink(sink3.id()));
 
         // Test removing the last sink
-        let sink2: Arc<dyn Sink> = sink2;
-        assert!(ctx.remove_sink(&sink2));
+        assert!(ctx.remove_sink(sink2.id()));
     }
 
     #[traced_test]
@@ -225,8 +283,7 @@ mod tests {
         assert!(ctx.add_sink(sink1.clone()));
         assert!(ctx.add_sink(sink2.clone()));
 
-        let channel = new_test_channel(1);
-        ctx.add_channel(channel.clone()).unwrap();
+        let channel = new_test_channel(&ctx, "topic").unwrap();
         let msg = b"test_message";
 
         let now = nanoseconds_since_epoch();
@@ -269,8 +326,7 @@ mod tests {
         assert!(!ctx.add_sink(error_sink.clone()));
         assert!(ctx.add_sink(recording_sink.clone()));
 
-        let channel = new_test_channel(1);
-        ctx.add_channel(channel.clone()).unwrap();
+        let channel = new_test_channel(&ctx, "topic").unwrap();
         let msg = b"test_message";
         let opts = PartialMetadata {
             sequence: Some(1),
@@ -295,10 +351,101 @@ mod tests {
     #[traced_test]
     #[test]
     fn test_log_msg_no_sinks() {
-        let channel = Arc::new(new_test_channel(1));
+        let ctx = Context::new();
+        let channel = new_test_channel(&ctx, "topic").unwrap();
         let msg = b"test_message";
-
         channel.log(msg);
         assert!(!logs_contain(ERROR_LOGGING_MESSAGE));
+    }
+
+    #[test]
+    fn test_remove_channel() {
+        let ctx = Context::new();
+        let _ = new_test_channel(&ctx, "topic").unwrap();
+        assert!(ctx.remove_channel_for_topic("topic"));
+        assert!(ctx.0.read().channels.is_empty());
+    }
+
+    #[test]
+    fn test_auto_subscribe() {
+        let ctx = Context::new();
+        let c1 = new_test_channel(&ctx, "t1").unwrap();
+        let c2 = new_test_channel(&ctx, "t2").unwrap();
+        let sink = Arc::new(RecordingSink::new());
+
+        assert!(!c1.has_sinks());
+        assert!(!c2.has_sinks());
+
+        // Auto-subscribe to existing channels.
+        ctx.add_sink(sink.clone());
+        assert!(c1.has_sinks());
+        assert!(c2.has_sinks());
+
+        // Auto-subscribe to new channels.
+        assert!(ctx.remove_channel_for_topic(c1.topic()));
+        assert!(!c1.has_sinks());
+        assert!(c2.has_sinks());
+        ctx.add_channel(c1.clone()).unwrap();
+        assert!(c1.has_sinks());
+        assert!(c2.has_sinks());
+
+        // Sink subscriptions are removed with the sink.
+        ctx.remove_sink(sink.id());
+        assert!(!c1.has_sinks());
+    }
+
+    #[test]
+    fn test_no_auto_subscribe() {
+        let ctx = Context::new();
+        let c1 = new_test_channel(&ctx, "t1").unwrap();
+        let c2 = new_test_channel(&ctx, "t2").unwrap();
+        let sink = Arc::new(RecordingSink::new().auto_subscribe(false));
+
+        assert!(!c1.has_sinks());
+        assert!(!c2.has_sinks());
+
+        // No auto-subscribe to existing channels.
+        ctx.add_sink(sink.clone());
+        assert!(!c1.has_sinks());
+        assert!(!c2.has_sinks());
+
+        // No auto-subscribe to new channels.
+        assert!(ctx.remove_channel_for_topic(c1.topic()));
+        ctx.add_channel(c1.clone()).unwrap();
+        assert!(!c1.has_sinks());
+
+        // Subscribe to a channel.
+        ctx.subscribe_channels(sink.id(), &[c1.id()]);
+        assert!(c1.has_sinks());
+        assert!(!c2.has_sinks());
+        ctx.subscribe_channels(sink.id(), &[c2.id()]);
+        assert!(c1.has_sinks());
+        assert!(c2.has_sinks());
+
+        // If a channel is removed and re-added, its subscriptions are lost. This isn't a workflow
+        // we expect to happen. Note that the sink will receive `remove_channel` and `add_channel`
+        // callbacks, so it has an opportunity to reinstall subscriptions if it wants to.
+        assert!(ctx.remove_channel_for_topic(c1.topic()));
+        assert!(!c1.has_sinks());
+        assert!(c2.has_sinks());
+        ctx.add_channel(c1.clone()).unwrap();
+        assert!(!c1.has_sinks());
+        assert!(c2.has_sinks());
+        ctx.subscribe_channels(sink.id(), &[c1.id()]);
+        assert!(c1.has_sinks());
+        assert!(c2.has_sinks());
+
+        // Unsubscribe from a channel.
+        ctx.unsubscribe_channels(sink.id(), &[c1.id()]);
+        assert!(!c1.has_sinks());
+        assert!(c2.has_sinks());
+
+        // Sink subscriptions are removed with the sink.
+        ctx.subscribe_channels(sink.id(), &[c1.id(), c2.id()]);
+        assert!(c1.has_sinks());
+        assert!(c2.has_sinks());
+        ctx.remove_sink(sink.id());
+        assert!(!c1.has_sinks());
+        assert!(!c2.has_sinks());
     }
 }

--- a/rust/foxglove/src/log_sink_set.rs
+++ b/rust/foxglove/src/log_sink_set.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 
+use crate::sink::SmallSinkVec;
 use crate::{FoxgloveError, Sink};
 
 pub(crate) const ERROR_LOGGING_MESSAGE: &str = "error logging message";
 
 #[derive(Default)]
-pub(crate) struct LogSinkSet(ArcSwap<Vec<Arc<dyn Sink>>>);
+pub(crate) struct LogSinkSet(ArcSwap<SmallSinkVec>);
 
 impl LogSinkSet {
     pub fn new() -> Self {
@@ -20,7 +21,7 @@ impl LogSinkSet {
     }
 
     /// Replaces the set of sinks in the set.
-    pub fn store(&self, sinks: Vec<Arc<dyn Sink>>) {
+    pub fn store(&self, sinks: SmallSinkVec) {
         self.0.store(Arc::new(sinks));
     }
 

--- a/rust/foxglove/src/log_sink_set.rs
+++ b/rust/foxglove/src/log_sink_set.rs
@@ -1,45 +1,27 @@
-use crate::{FoxgloveError, Sink};
-use parking_lot::RwLock;
 use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use crate::{FoxgloveError, Sink};
 
 pub(crate) const ERROR_LOGGING_MESSAGE: &str = "error logging message";
 
-// Future optimization: lock-free chain of struct {
-//    array: [MAX_SINKS_PER_CHANNEL]AtomicPtr<Arc<dyn LogSink>>,
-//    next: AtomicPtr<Self>,
-// }
-
-pub(crate) struct LogSinkSet(RwLock<Vec<Arc<dyn Sink>>>);
+#[derive(Default)]
+pub(crate) struct LogSinkSet(ArcSwap<Vec<Arc<dyn Sink>>>);
 
 impl LogSinkSet {
-    pub const fn new() -> Self {
-        Self(RwLock::new(Vec::new()))
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Returns true if the set is empty.
-    #[inline(always)]
-    pub(crate) fn is_empty(&self) -> bool {
-        // It's too expensive to lock the whole set just to check if it's empty, for now we don't implement this
-        false
+    pub fn is_empty(&self) -> bool {
+        self.0.load().is_empty()
     }
 
-    /// Add a sink to the set. Returns false if the sink was already in the set.
-    pub fn add_sink(&self, sink: Arc<dyn Sink>) -> bool {
-        let mut sinks = self.0.write();
-        // Check if the sink is already in the set.
-        if sinks.iter().any(|s| Arc::ptr_eq(s, &sink)) {
-            return false;
-        }
-        sinks.push(sink);
-        true
-    }
-
-    /// Remove a sink from the set. Returns true if the sink was removed.
-    pub fn remove_sink(&self, sink: &Arc<dyn Sink>) -> bool {
-        let mut sinks = self.0.write();
-        let len_before = sinks.len();
-        sinks.retain(|s| !Arc::ptr_eq(s, sink));
-        sinks.len() < len_before
+    /// Replaces the set of sinks in the set.
+    pub fn store(&self, sinks: Vec<Arc<dyn Sink>>) {
+        self.0.store(Arc::new(sinks));
     }
 
     /// Iterate over all the sinks in the set, calling the given function on each,
@@ -48,15 +30,15 @@ impl LogSinkSet {
     where
         F: FnMut(&Arc<dyn Sink>) -> Result<(), FoxgloveError>,
     {
-        let sinks = self.0.read();
-        for sink in sinks.iter() {
+        for sink in self.0.load().iter() {
             if let Err(err) = f(sink) {
                 tracing::warn!("{ERROR_LOGGING_MESSAGE}: {:?}", err);
             }
         }
     }
 
+    /// Clears the set.
     pub fn clear(&self) {
-        self.0.write().clear();
+        self.0.store(Arc::default());
     }
 }

--- a/rust/foxglove/src/mcap_writer.rs
+++ b/rust/foxglove/src/mcap_writer.rs
@@ -111,9 +111,8 @@ impl<W: Write + Seek + Send + 'static> McapWriterHandle<W> {
     }
 
     fn finish(&self) -> Result<Option<W>, FoxgloveError> {
-        let sink = self.sink.clone() as Arc<dyn Sink>;
         if let Some(context) = self.context.upgrade() {
-            context.remove_sink(&sink);
+            context.remove_sink(self.sink.id());
         }
         self.sink.finish()
     }

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -45,6 +45,18 @@ pub trait Sink: Send + Sync {
     ///
     /// Sinks can clean up any channel-related state they have or take other actions.
     fn remove_channel(&self, _channel: &Channel) {}
+
+    /// Indicates whether this sink automatically subscribes to all channels.
+    ///
+    /// The default implementation returns true.
+    ///
+    /// A sink implementation may return false to indicate that it intends to manage its
+    /// subscriptions dynamically using
+    /// [`Context::subscribe_channels`][crate::Context::subscribe_channels] and
+    /// [`Context::unsubscribe_channels`][crate::Context::unsubscribe_channels].
+    fn auto_subscribe(&self) -> bool {
+        true
+    }
 }
 
 /// A small group of sinks.

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -24,6 +24,7 @@ impl SinkId {
 /// Sinks are thread-safe and can be shared between threads. Usually you'd use our implementations
 /// like [`McapWriter`](crate::McapWriter) or [`WebSocketServer`](crate::WebSocketServer).
 ///
+#[doc(hidden)]
 pub trait Sink: Send + Sync {
     /// Returns the sink's unique ID.
     fn id(&self) -> SinkId;

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -23,6 +23,7 @@ impl SinkId {
 ///
 /// Sinks are thread-safe and can be shared between threads. Usually you'd use our implementations
 /// like [`McapWriter`](crate::McapWriter) or [`WebSocketServer`](crate::WebSocketServer).
+///
 pub trait Sink: Send + Sync {
     /// Returns the sink's unique ID.
     fn id(&self) -> SinkId;
@@ -32,18 +33,39 @@ pub trait Sink: Send + Sync {
     /// Metadata contains optional message metadata that may be used by some sink implementations.
     fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError>;
 
-    /// Called when a new channel is made available within the [`Context`][crate::Context].
+    /// Called when a new channel is made available within the [`Context`][ctx].
     ///
     /// Sinks can track channels seen, and do new channel-related things the first time they see a
     /// channel, rather than in this method. The choice is up to the implementor.
     ///
     /// When the sink is first registered with a context, this callback is automatically invoked
     /// with each of the channels registered to that context.
-    fn add_channel(&self, _channel: &Arc<Channel>) {}
+    ///
+    /// For sinks that manage their channel subscriptions dynamically, note that it is NOT safe to
+    /// call [`Context::subscribe_channels`][sub] from the context of this callback. The
+    /// implementation may return true to immediately subscribe to the channel, or it may return
+    /// false and subscribe later by calling [`Context::subscribe_channels`][sub] at some later
+    /// time.
+    ///
+    /// For sinks that [auto-subscribe][Sink::auto_subscribe] to all channels, the return value of
+    /// this method is ignored.
+    ///
+    /// [ctx]: crate::Context
+    /// [sub]: crate::Context::subscribe_channels
+    fn add_channel(&self, _channel: &Arc<Channel>) -> bool {
+        false
+    }
 
-    /// Called when a channel is unregistered from the [`Context`][crate::Context].
+    /// Called when a channel is unregistered from the [`Context`][ctx].
     ///
     /// Sinks can clean up any channel-related state they have or take other actions.
+    ///
+    /// For sinks that manage their channel subscriptions dynamically, it is not necessary to call
+    /// [`Context::unsubscribe_channels`][unsub] for this sink; subscriptions for a channel are
+    /// automatically removed when that channel is removed.
+    ///
+    /// [ctx]: crate::Context
+    /// [unsub]: crate::Context::unsubscribe_channels
     fn remove_channel(&self, _channel: &Channel) {}
 
     /// Indicates whether this sink automatically subscribes to all channels.
@@ -51,9 +73,11 @@ pub trait Sink: Send + Sync {
     /// The default implementation returns true.
     ///
     /// A sink implementation may return false to indicate that it intends to manage its
-    /// subscriptions dynamically using
-    /// [`Context::subscribe_channels`][crate::Context::subscribe_channels] and
-    /// [`Context::unsubscribe_channels`][crate::Context::unsubscribe_channels].
+    /// subscriptions dynamically using [`Sink::add_channel`],
+    /// [`Context::subscribe_channels`][sub], and [`Context::unsubscribe_channels`][unsub].
+    ///
+    /// [sub]: crate::Context::subscribe_channels
+    /// [unsub]: crate::Context::unsubscribe_channels
     fn auto_subscribe(&self) -> bool {
         true
     }

--- a/rust/foxglove/src/testutil/sink.rs
+++ b/rust/foxglove/src/testutil/sink.rs
@@ -32,6 +32,7 @@ pub struct LogCall {
 
 pub struct RecordingSink {
     id: SinkId,
+    auto_subscribe: bool,
     pub recorded: Mutex<Vec<LogCall>>,
 }
 
@@ -39,14 +40,24 @@ impl RecordingSink {
     pub fn new() -> Self {
         Self {
             id: SinkId::next(),
+            auto_subscribe: true,
             recorded: Mutex::new(Vec::new()),
         }
+    }
+
+    pub fn auto_subscribe(mut self, value: bool) -> Self {
+        self.auto_subscribe = value;
+        self
     }
 }
 
 impl Sink for RecordingSink {
     fn id(&self) -> SinkId {
         self.id
+    }
+
+    fn auto_subscribe(&self) -> bool {
+        self.auto_subscribe
     }
 
     fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {

--- a/rust/foxglove/src/testutil/sink.rs
+++ b/rust/foxglove/src/testutil/sink.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::channel::ChannelId;
 use crate::{Channel, FoxgloveError, Metadata, Sink, SinkId};
 use parking_lot::Mutex;
@@ -33,6 +35,7 @@ pub struct LogCall {
 pub struct RecordingSink {
     id: SinkId,
     auto_subscribe: bool,
+    add_channel_rval: bool,
     pub recorded: Mutex<Vec<LogCall>>,
 }
 
@@ -41,8 +44,14 @@ impl RecordingSink {
         Self {
             id: SinkId::next(),
             auto_subscribe: true,
+            add_channel_rval: false,
             recorded: Mutex::new(Vec::new()),
         }
+    }
+
+    pub fn add_channel_rval(mut self, value: bool) -> Self {
+        self.add_channel_rval = value;
+        self
     }
 
     pub fn auto_subscribe(mut self, value: bool) -> Self {
@@ -58,6 +67,10 @@ impl Sink for RecordingSink {
 
     fn auto_subscribe(&self) -> bool {
         self.auto_subscribe
+    }
+
+    fn add_channel(&self, _channel: &Arc<Channel>) -> bool {
+        self.add_channel_rval
     }
 
     fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -1630,9 +1630,10 @@ impl Sink for Server {
     }
 
     /// Server has an available channel. Advertise to all clients.
-    fn add_channel(&self, channel: &Arc<Channel>) {
+    fn add_channel(&self, channel: &Arc<Channel>) -> bool {
         let server = self.arc();
         server.advertise_channel(channel);
+        false
     }
 
     /// A channel is being removed. Unadvertise to all clients.

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -300,9 +300,8 @@ impl WebSocketServerHandle {
 
     /// Gracefully shutdown the websocket server.
     pub async fn stop(self) {
-        let sink = self.server.clone() as Arc<dyn Sink>;
         if let Some(context) = self.context.upgrade() {
-            context.remove_sink(&sink);
+            context.remove_sink(self.server.id());
         }
         self.server.stop().await;
     }


### PR DESCRIPTION
### Changelog
- Skip message serialization for a `TypedChannel` that has no subscribed sinks.
- rust: Add `Channel::has_sinks` and `TypedChannel::has_sinks`.
- rust: Hide `Sink` trait for now.

### Description
This change enhances the old channel->sinks linkage with the new subscription manager.

Structural changes:
- `Context` is now an `RwLock` wrapper around an inner struct.
  - Most updates impact multiple resources.
  - Difficult to reason about sequencing and raciness.
  - The lock should be mostly uncontended.
- `ContextInner`:
  - Holds a `Subscriptions` instance, which it uses to update channel sinks.
  - Indexes sinks by `SinkId`, instead of by `Arc` pointer.
  - Indexes channels by `ChannelId` in addition to topic, to support (un)subscribe-by-id.
- `Channel` no longer implements `Drop`; its lifecycle is managed by the `Context`.
- `LogSinkSet` is now an `ArcSwap` instead of `RwLock`, since we always replace the entire vec.
- `Sink::auto_subscribe()` method indicates whether a sink subscribes to all channels, default true.
- `Sink::add_channel()` now returns `bool`, for a dynamic subscriber to add a subscription synchronously.
- `TypedChannel` queries for subscribers before serialization.

For now, the `websocket::Server` sink still auto-subscribes to all channels. The next PR in this series will switch to using dynamic registration.

Part of: FG-10743