### PR TITLE
rust: Manage websocket channel subscriptions dynamically

### DIFF
--- a/rust/foxglove/src/websocket/unstable_tests.rs
+++ b/rust/foxglove/src/websocket/unstable_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use crate::Context;
+
 use super::tests::connect_client;
 use super::{create_server, protocol, Capability, ServerOptions};
 use bytes::Buf;
@@ -8,10 +10,14 @@ use tokio_tungstenite::tungstenite::Message;
 
 #[tokio::test]
 async fn test_broadcast_time() {
-    let server = create_server(ServerOptions {
-        capabilities: Some(HashSet::from([Capability::Time])),
-        ..Default::default()
-    });
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(HashSet::from([Capability::Time])),
+            ..Default::default()
+        },
+    );
     let addr = server
         .start("127.0.0.1", 0)
         .await


### PR DESCRIPTION
### Changelog
- Skip message serialization for a `TypedChannel` that has no subscribed websocket clients.

### Description
This change makes use of the new subscription manager, to teach the websocket to manage channel subscriptions dynamically based on client demand. The websocket no longer automatically subscribes to all channels. Instead, it only subscribes to channels that have one or more subscribed clients.

To make that happen, we move the implementation of `Sink` from `Server` to `ConnectedClient`. This is a bit simpler than the alternative, which would involve maintaining an aggregation layer for propagating client subscriptions back to the context. Anyway, it feels a bit more natural to treat the clients as sinks.