### PR TITLE
Check for doc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo build --verbose
       - run: cargo clippy --no-deps --all-targets --tests -- -D warnings
+      - run: cargo rustdoc -p foxglove -- -D warnings
       - run: cargo test --features unstable --verbose
         timeout-minutes: 10
       - run: cargo publish --package foxglove --dry-run

--- a/rust/foxglove/src/websocket/connection_graph.rs
+++ b/rust/foxglove/src/websocket/connection_graph.rs
@@ -6,8 +6,8 @@ use std::collections::{HashMap, HashSet};
 /// A HashMap where the keys are the topic or service name and the value is a set of string ids.
 type MapOfSets = HashMap<String, HashSet<String>>;
 
-/// The connection graph data. Requires capability [`Capability::ConnectionGraph`].
-/// See https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#connection-graph-update
+/// The connection graph data. Requires capability [`ConnectionGraph`](super::Capability::ConnectionGraph).
+/// See <https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#connection-graph-update>
 #[derive(Debug, Default, Clone)]
 pub struct ConnectionGraph {
     /// A map of active topic names to the set of string publisher ids.


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This adds a CI step generate rust docs and fail if any warnings are encountered; also fixes a couple of warnings. The capability here was only a broken link, but this should guard against invalid identifiers as well.