### PR TITLE
python: add benchmark tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,7 +41,7 @@ jobs:
       - run: poetry install
       - run: poetry run maturin develop
       - run: poetry run mypy .
-      - run: poetry run pytest
+      - run: poetry run pytest --with-benchmarks
 
   schemas:
     runs-on: ubuntu-latest

--- a/python/foxglove-sdk/CONTRIBUTING.md
+++ b/python/foxglove-sdk/CONTRIBUTING.md
@@ -54,6 +54,16 @@ Run unit tests:
 poetry run pytest
 ```
 
+Benchmark tests should be marked with `@pytest.mark.benchmark`. These are not run by default.
+
+```sh
+# to run with benchmarks
+poetry run pytest --with-benchmarks
+
+# to run only benchmarks
+poetry run pytest -m benchmark
+```
+
 ### Examples
 
 Examples exist in the `foxglove-sdk-examples` directotry. See each example's readme for usage.

--- a/python/foxglove-sdk/conftest.py
+++ b/python/foxglove-sdk/conftest.py
@@ -1,6 +1,6 @@
 # Configure pytest to skip tests marked with `benchmark` unless a `--with-benchmarks` flag is
 # provided. The `benchmark` marker is defined by `pytest_benchmark`.
-# - https://docs.pytest.org/en/stable/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+# - https://docs.pytest.org/en/stable/example/simple.html#control-skipping-of-tests-according-to-command-line-option # noqa: E501
 #
 # In order to define the option flag, this file must be in the root of the project.
 

--- a/python/foxglove-sdk/conftest.py
+++ b/python/foxglove-sdk/conftest.py
@@ -1,0 +1,28 @@
+# Configure pytest to skip tests marked with `benchmark` unless a `--with-benchmarks` flag is
+# provided. The `benchmark` marker is defined by `pytest_benchmark`.
+# - https://docs.pytest.org/en/stable/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+#
+# In order to define the option flag, this file must be in the root of the project.
+
+from typing import List
+
+import pytest
+
+option_flag = "--with-benchmarks"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        option_flag, action="store_true", default=False, help="run benchmarks"
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: List[pytest.Item]
+) -> None:
+    if config.getoption(option_flag):
+        return
+    skip_marker = pytest.mark.skip(reason=f"need {option_flag} option to run")
+    for item in items:
+        if "benchmark" in item.keywords:
+            item.add_marker(skip_marker)

--- a/python/foxglove-sdk/conftest.py
+++ b/python/foxglove-sdk/conftest.py
@@ -22,6 +22,8 @@ def pytest_collection_modifyitems(
 ) -> None:
     if config.getoption(option_flag):
         return
+    if config.getoption("-m") == "benchmark":  # running only benchmark tests
+        return
     skip_marker = pytest.mark.skip(reason=f"need {option_flag} option to run")
     for item in items:
         if "benchmark" in item.keywords:

--- a/python/foxglove-sdk/poetry.lock
+++ b/python/foxglove-sdk/poetry.lock
@@ -919,6 +919,18 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+description = "Get CPU info with pure Python"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
+    {file = "py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.12.1"
 description = "Python style guide checker"
@@ -979,6 +991,27 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.1.0"
+description = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-benchmark-5.1.0.tar.gz", hash = "sha256:9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105"},
+    {file = "pytest_benchmark-5.1.0-py3-none-any.whl", hash = "sha256:922de2dfa3033c227c96da942d1878191afa135a29485fb942e85dff1c592c89"},
+]
+
+[package.dependencies]
+py-cpuinfo = "*"
+pytest = ">=8.1"
+
+[package.extras]
+aspect = ["aspectlib"]
+elasticsearch = ["elasticsearch"]
+histogram = ["pygal", "pygaljs", "setuptools"]
 
 [[package]]
 name = "requests"
@@ -1496,4 +1529,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "a5330e6fd5b7e9075ebcb50d8011f01790c1d2a08dfa19d96ec4e512156d6d06"
+content-hash = "f582c9ee771bdc0fd045f8d5fc17582e1d7dc6007bd2a1d76a6d310a9ecea55b"

--- a/python/foxglove-sdk/pyproject.toml
+++ b/python/foxglove-sdk/pyproject.toml
@@ -34,6 +34,7 @@ isort = "^6.0.0"
 maturin = "^1.7.4"
 mypy = "^1.13.0"
 pytest = "^8.3.4"
+pytest-benchmark = "^5.1.0"
 sphinx = "^7.0.0"
 
 [tool.mypy]

--- a/python/foxglove-sdk/python/foxglove/benchmarks/test_mcap_serialization.py
+++ b/python/foxglove-sdk/python/foxglove/benchmarks/test_mcap_serialization.py
@@ -1,0 +1,133 @@
+import math
+import os
+import struct
+import time
+from pathlib import Path
+from typing import Generator, List
+
+import foxglove
+import pytest
+from foxglove.channels import PointCloudChannel, SceneUpdateChannel
+from foxglove.schemas import (
+    Color,
+    CubePrimitive,
+    Duration,
+    PackedElementField,
+    PackedElementFieldNumericType,
+    PointCloud,
+    Pose,
+    Quaternion,
+    SceneEntity,
+    SceneUpdate,
+    Vector3,
+)
+from pytest_benchmark.fixture import BenchmarkFixture  # type: ignore
+
+
+@pytest.fixture
+def tmp_mcap(tmpdir: os.PathLike[str]) -> Generator[Path, None, None]:
+    dir = Path(tmpdir)
+    mcap = dir / "test.mcap"
+    yield mcap
+    mcap.unlink()
+    dir.rmdir()
+
+
+def build_entities(entity_count: int) -> List[SceneEntity]:
+    assert entity_count > 0
+    return [
+        SceneEntity(
+            id=f"box_{i}",
+            frame_id="box",
+            lifetime=Duration(10, nsec=int(100 * 1e6)),
+            cubes=[
+                CubePrimitive(
+                    pose=Pose(
+                        position=Vector3(x=0.0, y=0.0, z=3.0),
+                        orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+                    ),
+                    size=Vector3(x=1.0, y=1.0, z=1.0),
+                    color=Color(r=1.0, g=0.0, b=0.0, a=1.0),
+                )
+            ],
+        )
+        for i in range(entity_count)
+    ]
+
+
+def write_scene_entity_mcap(
+    tmp_mcap: Path, channel: SceneUpdateChannel, entities: List[SceneEntity]
+) -> None:
+    with foxglove.open_mcap(tmp_mcap, allow_overwrite=True):
+        for _ in range(100):
+            channel.log(SceneUpdate(entities=entities))
+
+
+def make_point_cloud(point_count: int) -> PointCloud:
+    """
+    https://foxglove.dev/blog/visualizing-point-clouds-with-custom-colors
+    """
+    point_struct = struct.Struct("<fffBBBB")
+    f32 = PackedElementFieldNumericType.Float32
+    u32 = PackedElementFieldNumericType.Uint32
+
+    t = time.time()
+    count = math.ceil(math.sqrt(point_count))
+    points = [
+        (x + math.cos(t + y / 5), y, 0) for x in range(count) for y in range(count)
+    ]
+
+    buffer = bytearray(point_struct.size * len(points))
+    for i, point in enumerate(points):
+        x, y, z = point
+        r = g = b = a = 128
+        point_struct.pack_into(buffer, i * point_struct.size, x, y, z, b, g, r, a)
+
+    return PointCloud(
+        frame_id="points",
+        pose=Pose(
+            position=Vector3(x=0, y=0, z=0),
+            orientation=Quaternion(x=0, y=0, z=0, w=1),
+        ),
+        point_stride=16,  # 4 fields * 4 bytes
+        fields=[
+            PackedElementField(name="x", offset=0, type=f32),
+            PackedElementField(name="y", offset=4, type=f32),
+            PackedElementField(name="z", offset=8, type=f32),
+            PackedElementField(name="rgba", offset=12, type=u32),
+        ],
+        data=bytes(buffer),
+    )
+
+
+def write_point_cloud_mcap(
+    tmp_mcap: Path, channel: PointCloudChannel, point_cloud: PointCloud
+) -> None:
+    with foxglove.open_mcap(tmp_mcap, allow_overwrite=True):
+        for _ in range(10):
+            channel.log(point_cloud)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("entity_count", [1, 2, 4, 8])
+def test_write_scene_update_mcap(
+    benchmark: BenchmarkFixture,
+    entity_count: int,
+    tmp_mcap: Path,
+) -> None:
+    channel = SceneUpdateChannel(f"/scene_{entity_count}")
+    entities = build_entities(entity_count)
+    benchmark(write_scene_entity_mcap, tmp_mcap, channel, entities)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("point_count", [100, 1000, 10000])
+def test_write_point_cloud_mcap(
+    benchmark: BenchmarkFixture,
+    point_count: int,
+    tmp_mcap: Path,
+) -> None:
+    print("test_write_point_cloud_mcap")
+    channel = PointCloudChannel(f"/point_cloud_{point_count}")
+    point_cloud = make_point_cloud(point_count)
+    benchmark(write_point_cloud_mcap, tmp_mcap, channel, point_cloud)

--- a/python/foxglove-sdk/python/foxglove/benchmarks/test_mcap_serialization.py
+++ b/python/foxglove-sdk/python/foxglove/benchmarks/test_mcap_serialization.py
@@ -145,7 +145,7 @@ def test_write_point_cloud_mcap(
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("message_count", [10, 100, 1000])
-def test_wite_untyped_channel_mcap(
+def test_write_untyped_channel_mcap(
     benchmark: BenchmarkFixture,
     message_count: int,
     tmp_mcap: Path,


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This adds a few benchmark tests to python, with a dependency on `pytest_benchmark`. The benchmarks all use an mcap sink, and write different kinds of data (scene update, large point cloud, pre-serialized bytes).

```
------------------------------------------------------------------------------------------ benchmark: 10 tests ------------------------------------------------------------------------------------------
Name (time in ms)                            Min                Max              Mean            StdDev            Median               IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_write_point_cloud_mcap[100]          0.5719 (1.36)      4.6453 (2.86)     0.6508 (1.29)     0.1575 (4.10)     0.6400 (1.33)     0.0404 (1.18)         6;19  1,536.6772 (0.77)       1158           1
test_write_point_cloud_mcap[1000]         1.0784 (2.56)     11.8320 (7.29)     1.2251 (2.43)     0.4850 (12.62)    1.1762 (2.44)     0.0664 (1.94)         6;35    816.2806 (0.41)        660           1
test_write_point_cloud_mcap[10000]        6.9380 (16.47)     9.9852 (6.15)     7.1386 (14.17)    0.2976 (7.75)     7.0628 (14.67)    0.1379 (4.02)        11;13    140.0826 (0.07)        127           1
test_write_scene_update_mcap[1]           1.9003 (4.51)      2.3758 (1.46)     1.9740 (3.92)     0.0782 (2.03)     1.9492 (4.05)     0.0563 (1.64)        19;17    506.5756 (0.26)        169           1
test_write_scene_update_mcap[2]           2.4123 (5.73)      2.7516 (1.69)     2.4751 (4.91)     0.0421 (1.09)     2.4664 (5.12)     0.0459 (1.34)         73;8    404.0286 (0.20)        361           1
test_write_scene_update_mcap[4]           3.4532 (8.20)      3.9926 (2.46)     3.5417 (7.03)     0.0804 (2.09)     3.5218 (7.31)     0.0494 (1.44)        23;18    282.3519 (0.14)        270           1
test_write_scene_update_mcap[8]           5.4362 (12.90)     6.1027 (3.76)     5.5273 (10.97)    0.0649 (1.69)     5.5159 (11.46)    0.0526 (1.53)         21;7    180.9197 (0.09)        177           1
test_write_untyped_channel_mcap[10]       0.4212 (1.0)       5.7503 (3.54)     0.5037 (1.0)      0.2007 (5.22)     0.4815 (1.0)      0.0438 (1.28)        25;56  1,985.1845 (1.0)        1632           1
test_write_untyped_channel_mcap[100]      0.7830 (1.86)      1.6240 (1.0)      0.8419 (1.67)     0.0384 (1.0)      0.8369 (1.74)     0.0343 (1.0)        146;16  1,187.7625 (0.60)        975           1
test_write_untyped_channel_mcap[1000]     3.9943 (9.48)      5.7795 (3.56)     4.1152 (8.17)     0.1775 (4.62)     4.0800 (8.47)     0.0578 (1.69)        13;19    243.0007 (0.12)        231           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```