### PR TITLE
rust: Remove arbitrary sleeps from tests

### DIFF
--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -138,6 +138,12 @@ impl Channel {
         !self.sinks.is_empty()
     }
 
+    /// Returns the count of sinks subscribed to this channel.
+    #[cfg(test)]
+    pub(crate) fn num_sinks(&self) -> usize {
+        self.sinks.len()
+    }
+
     /// Logs a message.
     pub fn log(&self, msg: &[u8]) {
         if self.has_sinks() {

--- a/rust/foxglove/src/log_sink_set.rs
+++ b/rust/foxglove/src/log_sink_set.rs
@@ -20,6 +20,12 @@ impl LogSinkSet {
         self.0.load().is_empty()
     }
 
+    /// Returns the number of sinks in the set.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.0.load().len()
+    }
+
     /// Replaces the set of sinks in the set.
     pub fn store(&self, sinks: SmallSinkVec) {
         self.0.store(Arc::new(sinks));

--- a/rust/foxglove/src/testutil.rs
+++ b/rust/foxglove/src/testutil.rs
@@ -240,8 +240,5 @@ pub async fn assert_eventually(cond: impl Fn() -> bool) {
         }
     })
     .await;
-    assert!(
-        result.is_ok(),
-        "condition not met within the specified timeout"
-    );
+    assert!(result.is_ok(), "condition not met within {timeout:?}");
 }

--- a/rust/foxglove/src/testutil.rs
+++ b/rust/foxglove/src/testutil.rs
@@ -1,12 +1,15 @@
 //! Test utilities.
 
-mod sink;
+use std::time::Duration;
+
+use parking_lot::Mutex;
 
 use crate::channel::ChannelId;
 use crate::websocket::{
     ChannelView, Client, ClientChannel, ClientChannelId, ClientId, Parameter, ServerListener,
 };
-use parking_lot::Mutex;
+
+mod sink;
 pub use sink::{ErrorSink, MockSink, RecordingSink};
 
 #[allow(dead_code)]
@@ -86,6 +89,26 @@ impl RecordingServerListener {
             parameters_set: Mutex::new(Vec::new()),
             parameters_get_result: Mutex::new(Vec::new()),
         }
+    }
+
+    pub fn message_data_len(&self) -> usize {
+        self.message_data.lock().len()
+    }
+
+    pub fn client_advertise_len(&self) -> usize {
+        self.client_advertise.lock().len()
+    }
+
+    pub fn client_unadvertise_len(&self) -> usize {
+        self.client_unadvertise.lock().len()
+    }
+
+    pub fn parameters_subscribe_len(&self) -> usize {
+        self.parameters_subscribe.lock().len()
+    }
+
+    pub fn parameters_unsubscribe_len(&self) -> usize {
+        self.parameters_unsubscribe.lock().len()
     }
 
     pub fn take_message_data(&self) -> Vec<MessageData> {
@@ -198,4 +221,27 @@ impl ServerListener for RecordingServerListener {
         let mut unsubs = self.parameters_unsubscribe.lock();
         unsubs.push(param_names.clone());
     }
+}
+
+/// Asserts that `cond` returns true within 50ms, polling every 1ms.
+///
+/// When using this, you probably want to wrap the things you're testing in `dbg!()` macros so that
+/// you get helpful debug logs when a test fails:
+///
+/// ```
+/// assert_eventually(|| dbg!(x.len()) == 2);
+/// ```
+pub async fn assert_eventually(cond: impl Fn() -> bool) {
+    let timeout = Duration::from_millis(50);
+    let poll_interval = Duration::from_millis(1);
+    let result = tokio::time::timeout(timeout, async {
+        while !cond() {
+            tokio::time::sleep(poll_interval).await;
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "condition not met within the specified timeout"
+    );
 }

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -11,7 +11,7 @@ use tracing_test::traced_test;
 use tungstenite::client::IntoClientRequest;
 
 use super::{create_server, send_lossy, SendLossyResult, ServerOptions, SUBPROTOCOL};
-use crate::testutil::RecordingServerListener;
+use crate::testutil::{assert_eventually, RecordingServerListener};
 use crate::websocket::service::{CallId, Service, ServiceId, ServiceSchema};
 use crate::websocket::{
     BlockingAssetHandlerFn, Capability, ClientChannelId, ConnectionGraph, Parameter, ParameterType,
@@ -245,23 +245,11 @@ async fn test_advertise_to_client() {
         .send(Message::text(subscribe.to_string()))
         .await
         .expect("Failed to send");
-    // Send a duplicate subscribe message (ignored)
-    client_sender
-        .send(Message::text(subscribe.to_string()))
-        .await
-        .expect("Failed to send");
 
     // Allow the server to process the subscription
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert_eventually(|| dbg!(ch.num_sinks()) == 1).await;
 
     ch.log(b"{\"a\":1}");
-
-    let result = client_receiver.next().await.unwrap();
-    let msg = result.expect("Failed to parse message");
-    let data = msg.into_data();
-    let data_str = std::str::from_utf8(&data).unwrap();
-    assert!(data_str.contains("Client is already subscribed to channel"));
 
     let msg = client_receiver
         .next()
@@ -280,6 +268,18 @@ async fn test_advertise_to_client() {
     assert_eq!(subscriptions.len(), 1);
     assert_eq!(subscriptions[0].1.id, ch.id);
     assert_eq!(subscriptions[0].1.topic, ch.topic);
+
+    // Send a duplicate subscribe message (ignored)
+    client_sender
+        .send(Message::text(subscribe.to_string()))
+        .await
+        .expect("Failed to send");
+
+    let result = client_receiver.next().await.unwrap();
+    let msg = result.expect("Failed to parse message");
+    let data = msg.into_data();
+    let data_str = std::str::from_utf8(&data).unwrap();
+    assert!(data_str.contains("Client is already subscribed to channel"));
 
     server.stop().await;
 }
@@ -401,10 +401,7 @@ async fn test_log_only_to_subscribers() {
     let subscribe1 = json!({
         "op": "subscribe",
         "subscriptions": [
-            {
-                "id": 1,
-                "channelId": ch1.id(),
-            }
+            { "id": 1, "channelId": ch1.id() }
         ]
     });
     client1
@@ -415,10 +412,7 @@ async fn test_log_only_to_subscribers() {
     let subscribe2 = json!({
         "op": "subscribe",
         "subscriptions": [
-            {
-                "id": 2,
-                "channelId": ch2.id(),
-            }
+            { "id": 2, "channelId": ch2.id() }
         ]
     });
     client2
@@ -426,26 +420,35 @@ async fn test_log_only_to_subscribers() {
         .await
         .expect("Failed to send");
 
-    let unsubscribe_both = json!({
-        "op": "unsubscribe",
-        "subscriptionIds": [1, 2],
+    // Allow the server to process the subscriptions
+    assert_eventually(|| dbg!(ch1.num_sinks()) == 1 && dbg!(ch2.num_sinks()) == 1).await;
+
+    let subscribe_both = json!({
+        "op": "subscribe",
+        "subscriptions": [
+            { "id": 111, "channelId": ch1.id() },
+            { "id": 222, "channelId": ch2.id() },
+        ]
     });
     client3
-        .send(Message::text(subscribe1.to_string()))
+        .send(Message::text(subscribe_both.to_string()))
         .await
         .expect("Failed to send");
-    client3
-        .send(Message::text(subscribe2.to_string()))
-        .await
-        .expect("Failed to send");
+
+    // Allow the server to process the subscriptions
+    assert_eventually(|| dbg!(ch1.num_sinks()) == 2 && dbg!(ch2.num_sinks()) == 2).await;
+
+    let unsubscribe_both = json!({
+        "op": "unsubscribe",
+        "subscriptionIds": [111, 222],
+    });
     client3
         .send(Message::text(unsubscribe_both.to_string()))
         .await
         .expect("Failed to send");
 
-    // Allow the server to process the subscription
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // Allow the server to process the unsubscriptions
+    assert_eventually(|| dbg!(ch1.num_sinks()) == 1 && dbg!(ch2.num_sinks()) == 1).await;
 
     let subscriptions = recording_listener.take_subscribe();
     assert_eq!(subscriptions.len(), 4);
@@ -850,8 +853,12 @@ async fn test_client_advertising() {
         .await
         .expect("Failed to send unadvertise");
 
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eventually(|| {
+        dbg!(recording_listener.message_data_len()) == 1
+            && dbg!(recording_listener.client_advertise_len()) == 1
+            && dbg!(recording_listener.client_unadvertise_len()) == 1
+    })
+    .await;
 
     // Server should have received one message
     let mut received = recording_listener.take_message_data();
@@ -877,10 +884,12 @@ async fn test_client_advertising() {
 #[tokio::test]
 async fn test_parameter_values() {
     let ctx = Context::new();
+    let recording_listener = Arc::new(RecordingServerListener::new());
     let server = create_server(
         &ctx,
         ServerOptions {
             capabilities: Some(HashSet::from([Capability::Parameters])),
+            listener: Some(recording_listener.clone()),
             ..Default::default()
         },
     );
@@ -900,8 +909,9 @@ async fn test_parameter_values() {
         .await
         .expect("Failed to send subscribe parameter updates");
 
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    ws_client.next().await.expect("No serverInfo sent").unwrap();
+
+    assert_eventually(|| dbg!(recording_listener.parameters_subscribe_len()) == 1).await;
 
     let parameter = Parameter {
         name: "some-float-value".to_string(),
@@ -909,11 +919,6 @@ async fn test_parameter_values() {
         r#type: Some(ParameterType::Float64),
     };
     server.publish_parameter_values(vec![parameter]);
-
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-    _ = ws_client.next().await.expect("No serverInfo sent");
 
     let msg = ws_client.next().await.expect("No message received");
     let msg = msg.expect("Failed to parse message");
@@ -966,7 +971,11 @@ async fn test_parameter_unsubscribe_no_updates() {
 
     _ = ws_client.next().await.expect("No serverInfo sent");
 
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eventually(|| {
+        dbg!(recording_listener.parameters_subscribe_len()) == 1
+            && dbg!(recording_listener.parameters_unsubscribe_len()) == 1
+    })
+    .await;
 
     let parameter_names = recording_listener
         .take_parameters_subscribe()
@@ -987,8 +996,9 @@ async fn test_parameter_unsubscribe_no_updates() {
     };
     server.publish_parameter_values(vec![parameter]);
 
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Sleep for a little while to give the server time to flush its queues, to ensure that it
+    // doesn't send a parameter message to an unsubscribed client.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     server.stop().await;
 
@@ -1028,8 +1038,7 @@ async fn test_set_parameters() {
         .await
         .expect("Failed to send subscribe parameter updates");
 
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eventually(|| dbg!(recording_listener.parameters_subscribe_len()) == 1).await;
 
     ws_client
         .send(Message::text(
@@ -1037,34 +1046,6 @@ async fn test_set_parameters() {
         ))
         .await
         .expect("Failed to send set parameters");
-
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-    let set_parameters = recording_listener.take_parameters_set().pop().unwrap();
-    assert_eq!(set_parameters.parameters.len(), 3);
-    assert_eq!(set_parameters.parameters[0].name, "foo");
-    assert_eq!(
-        set_parameters.parameters[0].value,
-        Some(ParameterValue::Number(1.0))
-    );
-    assert_eq!(
-        set_parameters.parameters[0].r#type,
-        Some(ParameterType::Float64)
-    );
-    assert_eq!(set_parameters.parameters[1].name, "bar");
-    assert_eq!(
-        set_parameters.parameters[1].value,
-        Some(ParameterValue::String(Vec::from("hello".as_bytes())))
-    );
-    assert_eq!(set_parameters.parameters[1].r#type, None);
-    assert_eq!(set_parameters.parameters[2].name, "baz");
-    assert_eq!(
-        set_parameters.parameters[2].value,
-        Some(ParameterValue::Bool(true))
-    );
-    assert_eq!(set_parameters.parameters[2].r#type, None);
-    assert_eq!(set_parameters.request_id, Some("123".to_string()));
 
     _ = ws_client.next().await.expect("No serverInfo sent");
 
@@ -1106,6 +1087,31 @@ async fn test_set_parameters() {
     );
     assert_eq!(params[1].r#type, None);
 
+    let set_parameters = recording_listener.take_parameters_set().pop().unwrap();
+    assert_eq!(set_parameters.parameters.len(), 3);
+    assert_eq!(set_parameters.parameters[0].name, "foo");
+    assert_eq!(
+        set_parameters.parameters[0].value,
+        Some(ParameterValue::Number(1.0))
+    );
+    assert_eq!(
+        set_parameters.parameters[0].r#type,
+        Some(ParameterType::Float64)
+    );
+    assert_eq!(set_parameters.parameters[1].name, "bar");
+    assert_eq!(
+        set_parameters.parameters[1].value,
+        Some(ParameterValue::String(Vec::from("hello".as_bytes())))
+    );
+    assert_eq!(set_parameters.parameters[1].r#type, None);
+    assert_eq!(set_parameters.parameters[2].name, "baz");
+    assert_eq!(
+        set_parameters.parameters[2].value,
+        Some(ParameterValue::Bool(true))
+    );
+    assert_eq!(set_parameters.parameters[2].r#type, None);
+    assert_eq!(set_parameters.request_id, Some("123".to_string()));
+
     server.stop().await;
 }
 
@@ -1142,13 +1148,6 @@ async fn test_get_parameters() {
         .await
         .expect("Failed to send get parameters");
 
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-    let get_parameters = recording_listener.take_parameters_get().pop().unwrap();
-    assert_eq!(get_parameters.param_names, vec!["foo", "bar", "baz"]);
-    assert_eq!(get_parameters.request_id, Some("123".to_string()));
-
     _ = ws_client.next().await.expect("No serverInfo sent");
 
     let msg = ws_client.next().await.expect("No message received");
@@ -1161,6 +1160,10 @@ async fn test_get_parameters() {
     assert_eq!(params[0].name, "foo");
     assert_eq!(params[0].value, Some(ParameterValue::Number(1.0)));
     assert_eq!(params[0].r#type, Some(ParameterType::Float64));
+
+    let get_parameters = recording_listener.take_parameters_get().pop().unwrap();
+    assert_eq!(get_parameters.param_names, vec!["foo", "bar", "baz"]);
+    assert_eq!(get_parameters.request_id, Some("123".to_string()));
 
     server.stop().await;
 }
@@ -1413,9 +1416,6 @@ async fn test_fetch_asset() {
         .await
         .expect("Failed to send fetch asset");
 
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
     let result = ws_client.next().await.unwrap();
     let msg = result.expect("Failed to parse message");
     let data = msg.into_data();
@@ -1475,9 +1475,6 @@ async fn test_update_connection_graph() {
 
     _ = ws_client.next().await.expect("No serverInfo sent");
 
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
     let msg = ws_client.next().await.expect("No message received");
     let msg = msg.expect("Failed to parse message");
     let text = msg.into_text().expect("Failed to get message text");
@@ -1494,9 +1491,6 @@ async fn test_update_connection_graph() {
     assert_eq!(msg["advertisedServices"][0]["providerIds"][0], "provider1");
     assert_eq!(msg["removedTopics"], json!([]));
     assert_eq!(msg["removedServices"], json!([]));
-
-    // FG-10395 replace this with something more precise
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     let mut graph = ConnectionGraph::new();
     // Update publisher for topic1
@@ -1550,8 +1544,6 @@ async fn test_slow_client() {
         let status = Status::new(StatusLevel::Error, format!("msg{}", i));
         server.publish_status(status);
     }
-
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     _ = ws_client.next().await.expect("No serverInfo sent");
 


### PR DESCRIPTION
### Description
Now that we have websocket clients represented as individual sinks, we can remove a couple arbitrary 100ms sleeps from our tests, and instead periodically poll the number of subscribed sinks on a channel.

While we're at it, we might as well get rid of some other arbitrary sleeps as well, by polling on `RecordingServerListener` state, or simply waiting to receive messages on the websocket client.

I ran tests in a loop on my machine for ten minutes and didn't see any failures.