### PR TITLE
rust: Make channel fields private

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
+name = "delegate"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +650,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "delegate",
  "env_logger",
  "flume",
  "futures-util",

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -38,6 +38,7 @@ tokio-tungstenite.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+delegate = "0.13.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -27,9 +27,9 @@ impl ContextInner {
     /// Adds a channel to the context.
     fn add_channel(&mut self, channel: Arc<Channel>) -> Result<(), FoxgloveError> {
         // Insert channel.
-        let topic = &channel.topic;
-        let Entry::Vacant(entry) = self.channels_by_topic.entry(topic.clone()) else {
-            return Err(FoxgloveError::DuplicateChannel(topic.clone()));
+        let topic = channel.topic();
+        let Entry::Vacant(entry) = self.channels_by_topic.entry(topic.to_string()) else {
+            return Err(FoxgloveError::DuplicateChannel(topic.to_string()));
         };
         entry.insert(channel.clone());
         self.channels.insert(channel.id(), channel.clone());

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -554,8 +554,8 @@ impl ConnectedClient {
             handler.on_unsubscribe(
                 Client::new(self),
                 ChannelView {
-                    id: channel.id,
-                    topic: &channel.topic,
+                    id: channel.id(),
+                    topic: channel.topic(),
                 },
             );
         }
@@ -623,8 +623,8 @@ impl ConnectedClient {
                 handler.on_subscribe(
                     Client::new(self),
                     ChannelView {
-                        id: channel.id,
-                        topic: &channel.topic,
+                        id: channel.id(),
+                        topic: channel.topic(),
                     },
                 );
             }
@@ -991,7 +991,7 @@ impl ConnectedClient {
             Err(FoxgloveError::SchemaRequired) => {
                 tracing::error!(
                     "Ignoring advertise channel for {} because a schema is required",
-                    channel.topic
+                    channel.topic()
                 );
                 return;
             }
@@ -1006,8 +1006,8 @@ impl ConnectedClient {
         if self.send_control_msg(Message::text(message.clone())) {
             tracing::debug!(
                 "Advertised channel {} with id {} to client {}",
-                channel.topic,
-                channel.id,
+                channel.topic(),
+                channel.id(),
                 self.addr
             );
         }
@@ -1587,7 +1587,7 @@ impl Sink for ConnectedClient {
 
     fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {
         let subscriptions = self.subscriptions.lock();
-        let Some(subscription_id) = subscriptions.get_by_left(&channel.id).copied() else {
+        let Some(subscription_id) = subscriptions.get_by_left(&channel.id()).copied() else {
             return Ok(());
         };
 

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -189,9 +189,12 @@ fn is_schema_required(message_encoding: &str) -> bool {
 // Currently, Foxglove supports schemaless JSON messages.
 // https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#advertise
 pub fn advertisement(channel: &Channel) -> Result<String, FoxgloveError> {
-    let schema = channel.schema.as_ref();
+    let id = channel.id();
+    let topic = channel.topic();
+    let encoding = channel.message_encoding();
+    let schema = channel.schema();
 
-    if schema.is_none() && is_schema_required(channel.message_encoding.as_str()) {
+    if schema.is_none() && is_schema_required(encoding) {
         return Err(FoxgloveError::SchemaRequired);
     }
 
@@ -203,24 +206,24 @@ pub fn advertisement(channel: &Channel) -> Result<String, FoxgloveError> {
                 .map_err(|e| FoxgloveError::Unspecified(e.into()))?
         };
 
-        Ok::<Advertisement, FoxgloveError>(Advertisement {
-            id: channel.id,
-            topic: &channel.topic,
-            encoding: &channel.message_encoding,
+        Advertisement {
+            id,
+            topic,
+            encoding,
             schema_name: &schema.name,
             schema: schema_data,
             schema_encoding: Some(&schema.encoding),
-        })
+        }
     } else {
-        Ok(Advertisement {
-            id: channel.id,
-            topic: &channel.topic,
-            encoding: &channel.message_encoding,
+        Advertisement {
+            id,
+            topic,
+            encoding,
             schema_name: "",
             schema: "".to_string(),
             schema_encoding: None,
-        })
-    }?;
+        }
+    };
 
     Ok(json!({
         "op": "advertise",

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -278,8 +278,8 @@ async fn test_advertise_to_client() {
 
     let subscriptions = recording_listener.take_subscribe();
     assert_eq!(subscriptions.len(), 1);
-    assert_eq!(subscriptions[0].1.id, ch.id);
-    assert_eq!(subscriptions[0].1.topic, ch.topic);
+    assert_eq!(subscriptions[0].1.id, ch.id());
+    assert_eq!(subscriptions[0].1.topic, ch.topic());
 
     server.stop().await;
 }
@@ -449,21 +449,21 @@ async fn test_log_only_to_subscribers() {
 
     let subscriptions = recording_listener.take_subscribe();
     assert_eq!(subscriptions.len(), 4);
-    assert_eq!(subscriptions[0].1.id, ch1.id);
-    assert_eq!(subscriptions[1].1.id, ch2.id);
-    assert_eq!(subscriptions[2].1.id, ch1.id);
-    assert_eq!(subscriptions[3].1.id, ch2.id);
-    assert_eq!(subscriptions[0].1.topic, ch1.topic);
-    assert_eq!(subscriptions[1].1.topic, ch2.topic);
-    assert_eq!(subscriptions[2].1.topic, ch1.topic);
-    assert_eq!(subscriptions[3].1.topic, ch2.topic);
+    assert_eq!(subscriptions[0].1.id, ch1.id());
+    assert_eq!(subscriptions[1].1.id, ch2.id());
+    assert_eq!(subscriptions[2].1.id, ch1.id());
+    assert_eq!(subscriptions[3].1.id, ch2.id());
+    assert_eq!(subscriptions[0].1.topic, ch1.topic());
+    assert_eq!(subscriptions[1].1.topic, ch2.topic());
+    assert_eq!(subscriptions[2].1.topic, ch1.topic());
+    assert_eq!(subscriptions[3].1.topic, ch2.topic());
 
     let unsubscriptions = recording_listener.take_unsubscribe();
     assert_eq!(unsubscriptions.len(), 2);
-    assert_eq!(unsubscriptions[0].1.id, ch1.id);
-    assert_eq!(unsubscriptions[1].1.id, ch2.id);
-    assert_eq!(unsubscriptions[0].1.topic, ch1.topic);
-    assert_eq!(unsubscriptions[1].1.topic, ch2.topic);
+    assert_eq!(unsubscriptions[0].1.id, ch1.id());
+    assert_eq!(unsubscriptions[1].1.id, ch2.id());
+    assert_eq!(unsubscriptions[0].1.topic, ch1.topic());
+    assert_eq!(unsubscriptions[1].1.topic, ch2.topic());
 
     let metadata = PartialMetadata {
         log_time: Some(123456),


### PR DESCRIPTION
### Changelog
- rust: Added various getter methods to `Channel` and `TypedChannel`.

### Description
This change has three objectives:
- Add `pub(crate) Channel::new` constructor
- Make `Channel` fields private
- Add getter methods to both `Channel` and `TypedChannel`