### PR TITLE
ci: Pin protoc to 5.29.3

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "29.x"
+          version: "29.3"
 
       - name: Install Flatbuffer compiler
         run: |


### PR DESCRIPTION
PR CI runs are [failing](https://github.com/foxglove/foxglove-sdk/actions/runs/13958484508/job/39075110751?pr=293) in the `python.yml` workflow:

```
FAILED tests/test_schemas.py::test_schemas - google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading foxglove/RawImage.proto: gencode 5.29.4 runtime 5.29.3. Runtime version cannot be older than the linked gencode version. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.
```

From [the linked article](https://protobuf.dev/support/cross-version-runtime-guarantee/):

> New Gencode + Old Runtime = Never Allowed

So let's pin CI to use the same version that we currently have locked for `foxglove-schemas-protobuf`.
