### PR TITLE
Python: improve high-level log API 

### DIFF
--- a/python/foxglove-sdk-examples/live-visualization/main.py
+++ b/python/foxglove-sdk-examples/live-visualization/main.py
@@ -9,11 +9,6 @@ from math import cos, sin
 import foxglove
 import numpy as np
 from foxglove import Channel, Schema
-from foxglove.channels import (
-    FrameTransformsChannel,
-    PointCloudChannel,
-    SceneUpdateChannel,
-)
 from foxglove.schemas import (
     Color,
     CubePrimitive,
@@ -134,11 +129,6 @@ def main() -> None:
         supported_encodings=["json"],
     )
 
-    # Log messages having well-known Foxglove schemas using the appropriate channel type.
-    box_chan = SceneUpdateChannel("/boxes")
-    tf_chan = FrameTransformsChannel("/tf")
-    point_chan = PointCloudChannel("/pointcloud")
-
     # Log messages with a custom schema and any encoding.
     sin_chan = Channel(
         topic="/sine",
@@ -171,7 +161,8 @@ def main() -> None:
 
             json_chan.log(json_msg)
 
-            tf_chan.log(
+            foxglove.log(
+                "/tf",
                 FrameTransforms(
                     transforms=[
                         FrameTransform(
@@ -190,7 +181,8 @@ def main() -> None:
                 )
             )
 
-            box_chan.log(
+            foxglove.log(
+                "/boxes",
                 SceneUpdate(
                     entities=[
                         SceneEntity(
@@ -215,7 +207,10 @@ def main() -> None:
                 )
             )
 
-            point_chan.log(make_point_cloud())
+            foxglove.log(
+                "/pointcloud",
+                make_point_cloud(),
+            )
 
             # Or use high-level log API without needing to manage explicit Channels.
             foxglove.log(

--- a/python/foxglove-sdk-examples/write-mcap-file/main.py
+++ b/python/foxglove-sdk-examples/write-mcap-file/main.py
@@ -2,7 +2,6 @@ import argparse
 import inspect
 
 import foxglove
-from foxglove.channels import LogChannel
 from foxglove.schemas import Log, LogLevel
 
 parser = argparse.ArgumentParser()
@@ -13,13 +12,12 @@ args = parser.parse_args()
 def main() -> None:
     # Create a new mcap file at the given path for recording
     with foxglove.open_mcap(args.path):
-        channel = LogChannel("/hello")
-
         for i in range(10):
             frame = inspect.currentframe()
             frameinfo = inspect.getframeinfo(frame) if frame else None
 
-            channel.log(
+            foxglove.log(
+                "/hello",
                 Log(
                     level=LogLevel.Info,
                     name="SDK example",

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas.pyi
@@ -5,6 +5,9 @@ from typing import List, Optional
 from .schemas_wkt import Duration as Duration
 from .schemas_wkt import Timestamp as Timestamp
 
+class FoxgloveSchema:
+    pass
+
 #
 # Enums
 #
@@ -78,7 +81,7 @@ class SceneEntityDeletionType(Enum):
 # Classes
 #
 
-class ArrowPrimitive:
+class ArrowPrimitive(FoxgloveSchema):
     """
     A primitive representing an arrow
     """
@@ -94,7 +97,7 @@ class ArrowPrimitive:
         color: "Optional[Color]" = None,
     ) -> "ArrowPrimitive": ...
 
-class CameraCalibration:
+class CameraCalibration(FoxgloveSchema):
     """
     Camera calibration parameters
     """
@@ -113,7 +116,7 @@ class CameraCalibration:
         P: "Optional[List[float]]" = [],
     ) -> "CameraCalibration": ...
 
-class CircleAnnotation:
+class CircleAnnotation(FoxgloveSchema):
     """
     A circle annotation on a 2D image
     """
@@ -129,7 +132,7 @@ class CircleAnnotation:
         outline_color: "Optional[Color]" = None,
     ) -> "CircleAnnotation": ...
 
-class Color:
+class Color(FoxgloveSchema):
     """
     A color in RGBA format
     """
@@ -143,7 +146,7 @@ class Color:
         a: "Optional[float]" = 0.0,
     ) -> "Color": ...
 
-class CompressedImage:
+class CompressedImage(FoxgloveSchema):
     """
     A compressed image
     """
@@ -157,7 +160,7 @@ class CompressedImage:
         format: "Optional[str]" = "",
     ) -> "CompressedImage": ...
 
-class CompressedVideo:
+class CompressedVideo(FoxgloveSchema):
     """
     A single frame of a compressed video bitstream
     """
@@ -171,7 +174,7 @@ class CompressedVideo:
         format: "Optional[str]" = "",
     ) -> "CompressedVideo": ...
 
-class CubePrimitive:
+class CubePrimitive(FoxgloveSchema):
     """
     A primitive representing a cube or rectangular prism
     """
@@ -184,7 +187,7 @@ class CubePrimitive:
         color: "Optional[Color]" = None,
     ) -> "CubePrimitive": ...
 
-class CylinderPrimitive:
+class CylinderPrimitive(FoxgloveSchema):
     """
     A primitive representing a cylinder, elliptic cylinder, or truncated cone
     """
@@ -199,7 +202,7 @@ class CylinderPrimitive:
         color: "Optional[Color]" = None,
     ) -> "CylinderPrimitive": ...
 
-class FrameTransform:
+class FrameTransform(FoxgloveSchema):
     """
     A transform between two reference frames in 3D space
     """
@@ -214,7 +217,7 @@ class FrameTransform:
         rotation: "Optional[Quaternion]" = None,
     ) -> "FrameTransform": ...
 
-class FrameTransforms:
+class FrameTransforms(FoxgloveSchema):
     """
     An array of FrameTransform messages
     """
@@ -223,14 +226,14 @@ class FrameTransforms:
         cls, *, transforms: "Optional[List[FrameTransform]]" = []
     ) -> "FrameTransforms": ...
 
-class GeoJson:
+class GeoJson(FoxgloveSchema):
     """
     GeoJSON data for annotating maps
     """
 
     def __new__(cls, *, geojson: "Optional[str]" = "") -> "GeoJson": ...
 
-class Grid:
+class Grid(FoxgloveSchema):
     """
     A 2D grid of data
     """
@@ -249,7 +252,7 @@ class Grid:
         data: "Optional[bytes]" = b"",
     ) -> "Grid": ...
 
-class ImageAnnotations:
+class ImageAnnotations(FoxgloveSchema):
     """
     Array of annotations for a 2D image
     """
@@ -262,7 +265,7 @@ class ImageAnnotations:
         texts: "Optional[List[TextAnnotation]]" = [],
     ) -> "ImageAnnotations": ...
 
-class KeyValuePair:
+class KeyValuePair(FoxgloveSchema):
     """
     A key with its associated value
     """
@@ -271,7 +274,7 @@ class KeyValuePair:
         cls, *, key: "Optional[str]" = "", value: "Optional[str]" = ""
     ) -> "KeyValuePair": ...
 
-class LaserScan:
+class LaserScan(FoxgloveSchema):
     """
     A single scan from a planar laser range-finder
     """
@@ -288,7 +291,7 @@ class LaserScan:
         intensities: "Optional[List[float]]" = [],
     ) -> "LaserScan": ...
 
-class LinePrimitive:
+class LinePrimitive(FoxgloveSchema):
     """
     A primitive representing a series of points connected by lines
     """
@@ -306,7 +309,7 @@ class LinePrimitive:
         indices: "Optional[List[int]]" = [],
     ) -> "LinePrimitive": ...
 
-class LocationFix:
+class LocationFix(FoxgloveSchema):
     """
     A navigation satellite fix for any Global Navigation Satellite System
     """
@@ -323,7 +326,7 @@ class LocationFix:
         position_covariance_type: "Optional[LocationFixPositionCovarianceType]" = LocationFixPositionCovarianceType.Unknown,
     ) -> "LocationFix": ...
 
-class Log:
+class Log(FoxgloveSchema):
     """
     A log message
     """
@@ -339,7 +342,7 @@ class Log:
         line: "Optional[int]" = 0,
     ) -> "Log": ...
 
-class ModelPrimitive:
+class ModelPrimitive(FoxgloveSchema):
     """
     A primitive representing a 3D model file loaded from an external URL or embedded data
     """
@@ -356,7 +359,7 @@ class ModelPrimitive:
         data: "Optional[bytes]" = b"",
     ) -> "ModelPrimitive": ...
 
-class PackedElementField:
+class PackedElementField(FoxgloveSchema):
     """
     A field present within each element in a byte array of packed elements.
     """
@@ -369,7 +372,7 @@ class PackedElementField:
         type: "Optional[PackedElementFieldNumericType]" = PackedElementFieldNumericType.Unknown,
     ) -> "PackedElementField": ...
 
-class Point2:
+class Point2(FoxgloveSchema):
     """
     A point representing a position in 2D space
     """
@@ -378,7 +381,7 @@ class Point2:
         cls, *, x: "Optional[float]" = 0.0, y: "Optional[float]" = 0.0
     ) -> "Point2": ...
 
-class Point3:
+class Point3(FoxgloveSchema):
     """
     A point representing a position in 3D space
     """
@@ -391,7 +394,7 @@ class Point3:
         z: "Optional[float]" = 0.0,
     ) -> "Point3": ...
 
-class PointCloud:
+class PointCloud(FoxgloveSchema):
     """
     A collection of N-dimensional points, which may contain additional fields with information like normals, intensity, etc.
     """
@@ -407,7 +410,7 @@ class PointCloud:
         data: "Optional[bytes]" = b"",
     ) -> "PointCloud": ...
 
-class PointsAnnotation:
+class PointsAnnotation(FoxgloveSchema):
     """
     An array of points on a 2D image
     """
@@ -424,7 +427,7 @@ class PointsAnnotation:
         thickness: "Optional[float]" = 0.0,
     ) -> "PointsAnnotation": ...
 
-class Pose:
+class Pose(FoxgloveSchema):
     """
     A position and orientation for an object or reference frame in 3D space
     """
@@ -436,7 +439,7 @@ class Pose:
         orientation: "Optional[Quaternion]" = None,
     ) -> "Pose": ...
 
-class PoseInFrame:
+class PoseInFrame(FoxgloveSchema):
     """
     A timestamped pose for an object or reference frame in 3D space
     """
@@ -449,7 +452,7 @@ class PoseInFrame:
         pose: "Optional[Pose]" = None,
     ) -> "PoseInFrame": ...
 
-class PosesInFrame:
+class PosesInFrame(FoxgloveSchema):
     """
     An array of timestamped poses for an object or reference frame in 3D space
     """
@@ -462,7 +465,7 @@ class PosesInFrame:
         poses: "Optional[List[Pose]]" = [],
     ) -> "PosesInFrame": ...
 
-class Quaternion:
+class Quaternion(FoxgloveSchema):
     """
     A [quaternion](https://eater.net/quaternions) representing a rotation in 3D space
     """
@@ -476,7 +479,7 @@ class Quaternion:
         w: "Optional[float]" = 0.0,
     ) -> "Quaternion": ...
 
-class RawImage:
+class RawImage(FoxgloveSchema):
     """
     A raw image
     """
@@ -493,7 +496,7 @@ class RawImage:
         data: "Optional[bytes]" = b"",
     ) -> "RawImage": ...
 
-class SceneEntity:
+class SceneEntity(FoxgloveSchema):
     """
     A visual element in a 3D scene. An entity may be composed of multiple primitives which all share the same frame of reference.
     """
@@ -517,7 +520,7 @@ class SceneEntity:
         models: "Optional[List[ModelPrimitive]]" = [],
     ) -> "SceneEntity": ...
 
-class SceneEntityDeletion:
+class SceneEntityDeletion(FoxgloveSchema):
     """
     Command to remove previously published entities
     """
@@ -530,7 +533,7 @@ class SceneEntityDeletion:
         id: "Optional[str]" = "",
     ) -> "SceneEntityDeletion": ...
 
-class SceneUpdate:
+class SceneUpdate(FoxgloveSchema):
     """
     An update to the entities displayed in a 3D scene
     """
@@ -542,7 +545,7 @@ class SceneUpdate:
         entities: "Optional[List[SceneEntity]]" = [],
     ) -> "SceneUpdate": ...
 
-class SpherePrimitive:
+class SpherePrimitive(FoxgloveSchema):
     """
     A primitive representing a sphere or ellipsoid
     """
@@ -555,7 +558,7 @@ class SpherePrimitive:
         color: "Optional[Color]" = None,
     ) -> "SpherePrimitive": ...
 
-class TextAnnotation:
+class TextAnnotation(FoxgloveSchema):
     """
     A text label on a 2D image
     """
@@ -571,7 +574,7 @@ class TextAnnotation:
         background_color: "Optional[Color]" = None,
     ) -> "TextAnnotation": ...
 
-class TextPrimitive:
+class TextPrimitive(FoxgloveSchema):
     """
     A primitive representing a text label
     """
@@ -587,7 +590,7 @@ class TextPrimitive:
         text: "Optional[str]" = "",
     ) -> "TextPrimitive": ...
 
-class TriangleListPrimitive:
+class TriangleListPrimitive(FoxgloveSchema):
     """
     A primitive representing a set of triangles or a surface tiled by triangles
     """
@@ -602,7 +605,7 @@ class TriangleListPrimitive:
         indices: "Optional[List[int]]" = [],
     ) -> "TriangleListPrimitive": ...
 
-class Vector2:
+class Vector2(FoxgloveSchema):
     """
     A vector in 2D space that represents a direction only
     """
@@ -611,7 +614,7 @@ class Vector2:
         cls, *, x: "Optional[float]" = 0.0, y: "Optional[float]" = 0.0
     ) -> "Vector2": ...
 
-class Vector3:
+class Vector3(FoxgloveSchema):
     """
     A vector in 3D space that represents a direction only
     """

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -113,14 +113,15 @@ def log(topic: str, message: JsonMessage | list[Any] | bytes | str | schemas.Fox
         elif isinstance(message, (dict, list)):
             channel = Channel(topic, message_encoding="json")
         else:
+            assert isinstance(message, schemas.FoxgloveSchema), "unsupported message type"
             channel_name = f"{schema_name}Channel"
             channel_cls = getattr(channels, channel_name, None)
             if channel_cls is not None:
                 channel = channel_cls(topic)
-            if channel is None:
-                raise ValueError(
-                    f"No Foxglove schema channel found for message type {type(message).__name__}"
-                )
+        if channel is None:
+            raise ValueError(
+                f"No Foxglove schema channel found for message type {schema_name}"
+            )
         _channels_by_topic[topic] = channel
 
     channel.log(message)

--- a/python/foxglove-sdk/src/generated/schemas.rs
+++ b/python/foxglove-sdk/src/generated/schemas.rs
@@ -8,6 +8,9 @@ use bytes::Bytes;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
+#[pyclass(module = "foxglove.schemas")]
+pub(crate) struct FoxgloveSchema;
+
 /// An enumeration indicating how input points should be interpreted to create lines
 #[pyclass(eq, eq_int, module = "foxglove.schemas")]
 #[derive(PartialEq, Clone)]
@@ -83,7 +86,7 @@ pub(crate) enum LocationFixPositionCovarianceType {
 /// :param color: Color of the arrow
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/arrow-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct ArrowPrimitive(pub(crate) foxglove::schemas::ArrowPrimitive);
 #[pymethods]
@@ -139,7 +142,7 @@ impl From<ArrowPrimitive> for foxglove::schemas::ArrowPrimitive {
 /// :param P: Projection/camera matrix (3x4 row-major matrix)
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/camera-calibration
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct CameraCalibration(pub(crate) foxglove::schemas::CameraCalibration);
 #[pymethods]
@@ -201,7 +204,7 @@ impl From<CameraCalibration> for foxglove::schemas::CameraCalibration {
 /// :param outline_color: Outline color
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/circle-annotation
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct CircleAnnotation(pub(crate) foxglove::schemas::CircleAnnotation);
 #[pymethods]
@@ -252,7 +255,7 @@ impl From<CircleAnnotation> for foxglove::schemas::CircleAnnotation {
 /// :param a: Alpha value between 0 and 1
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/color
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Color(pub(crate) foxglove::schemas::Color);
 #[pymethods]
@@ -284,7 +287,7 @@ impl From<Color> for foxglove::schemas::Color {
 /// :param format: Image format
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/compressed-image
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct CompressedImage(pub(crate) foxglove::schemas::CompressedImage);
 #[pymethods]
@@ -328,7 +331,7 @@ impl From<CompressedImage> for foxglove::schemas::CompressedImage {
 /// :param format: Video format.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/compressed-video
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct CompressedVideo(pub(crate) foxglove::schemas::CompressedVideo);
 #[pymethods]
@@ -373,7 +376,7 @@ impl From<CompressedVideo> for foxglove::schemas::CompressedVideo {
 /// :param color: Color of the cylinder
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/cylinder-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct CylinderPrimitive(pub(crate) foxglove::schemas::CylinderPrimitive);
 #[pymethods]
@@ -420,7 +423,7 @@ impl From<CylinderPrimitive> for foxglove::schemas::CylinderPrimitive {
 /// :param color: Color of the cube
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/cube-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct CubePrimitive(pub(crate) foxglove::schemas::CubePrimitive);
 #[pymethods]
@@ -457,7 +460,7 @@ impl From<CubePrimitive> for foxglove::schemas::CubePrimitive {
 /// :param rotation: Rotation component of the transform
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/frame-transform
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct FrameTransform(pub(crate) foxglove::schemas::FrameTransform);
 #[pymethods]
@@ -502,7 +505,7 @@ impl From<FrameTransform> for foxglove::schemas::FrameTransform {
 /// :param transforms: Array of transforms
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/frame-transforms
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct FrameTransforms(pub(crate) foxglove::schemas::FrameTransforms);
 #[pymethods]
@@ -530,7 +533,7 @@ impl From<FrameTransforms> for foxglove::schemas::FrameTransforms {
 /// :param geojson: GeoJSON data encoded as a UTF-8 string
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/geo-json
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct GeoJson(pub(crate) foxglove::schemas::GeoJson);
 #[pymethods]
@@ -564,7 +567,7 @@ impl From<GeoJson> for foxglove::schemas::GeoJson {
 /// :param data: Grid cell data, interpreted using `fields`, in row-major (y-major) order
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/grid
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Grid(pub(crate) foxglove::schemas::Grid);
 #[pymethods]
@@ -625,7 +628,7 @@ impl From<Grid> for foxglove::schemas::Grid {
 /// :param texts: Text annotations
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/image-annotations
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct ImageAnnotations(pub(crate) foxglove::schemas::ImageAnnotations);
 #[pymethods]
@@ -663,7 +666,7 @@ impl From<ImageAnnotations> for foxglove::schemas::ImageAnnotations {
 /// :param value: Value
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/key-value-pair
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct KeyValuePair(pub(crate) foxglove::schemas::KeyValuePair);
 #[pymethods]
@@ -698,7 +701,7 @@ impl From<KeyValuePair> for foxglove::schemas::KeyValuePair {
 /// :param intensities: Intensity of detections
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/laser-scan
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct LaserScan(pub(crate) foxglove::schemas::LaserScan);
 #[pymethods]
@@ -756,7 +759,7 @@ impl From<LaserScan> for foxglove::schemas::LaserScan {
 /// :param indices: Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/line-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct LinePrimitive(pub(crate) foxglove::schemas::LinePrimitive);
 #[pymethods]
@@ -816,7 +819,7 @@ impl From<LinePrimitive> for foxglove::schemas::LinePrimitive {
 /// :param position_covariance_type: If `position_covariance` is available, `position_covariance_type` must be set to indicate the type of covariance.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/location-fix
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct LocationFix(pub(crate) foxglove::schemas::LocationFix);
 #[pymethods]
@@ -872,7 +875,7 @@ impl From<LocationFix> for foxglove::schemas::LocationFix {
 /// :param line: Line number in the file
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/log
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Log(pub(crate) foxglove::schemas::Log);
 #[pymethods]
@@ -917,7 +920,7 @@ impl From<Log> for foxglove::schemas::Log {
 /// :param id: Identifier which must match if `type` is `MATCHING_ID`.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/scene-entity-deletion
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct SceneEntityDeletion(pub(crate) foxglove::schemas::SceneEntityDeletion);
 #[pymethods]
@@ -963,7 +966,7 @@ impl From<SceneEntityDeletion> for foxglove::schemas::SceneEntityDeletion {
 /// :param models: Model primitives
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/scene-entity
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct SceneEntity(pub(crate) foxglove::schemas::SceneEntity);
 #[pymethods]
@@ -1036,7 +1039,7 @@ impl From<SceneEntity> for foxglove::schemas::SceneEntity {
 /// :param entities: Scene entities to add or replace
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/scene-update
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct SceneUpdate(pub(crate) foxglove::schemas::SceneUpdate);
 #[pymethods]
@@ -1074,7 +1077,7 @@ impl From<SceneUpdate> for foxglove::schemas::SceneUpdate {
 /// :param data: Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/model-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct ModelPrimitive(pub(crate) foxglove::schemas::ModelPrimitive);
 #[pymethods]
@@ -1129,7 +1132,7 @@ impl From<ModelPrimitive> for foxglove::schemas::ModelPrimitive {
 /// :param r#type: Type of data in the field. Integers are stored using little-endian byte order.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/packed-element-field
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct PackedElementField(pub(crate) foxglove::schemas::PackedElementField);
 #[pymethods]
@@ -1163,7 +1166,7 @@ impl From<PackedElementField> for foxglove::schemas::PackedElementField {
 /// :param y: y coordinate position
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/point2
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Point2(pub(crate) foxglove::schemas::Point2);
 #[pymethods]
@@ -1191,7 +1194,7 @@ impl From<Point2> for foxglove::schemas::Point2 {
 /// :param z: z coordinate position
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/point3
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Point3(pub(crate) foxglove::schemas::Point3);
 #[pymethods]
@@ -1225,7 +1228,7 @@ impl From<Point3> for foxglove::schemas::Point3 {
 /// :param data: Point data, interpreted using `fields`
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/point-cloud
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct PointCloud(pub(crate) foxglove::schemas::PointCloud);
 #[pymethods]
@@ -1281,7 +1284,7 @@ impl From<PointCloud> for foxglove::schemas::PointCloud {
 /// :param thickness: Stroke thickness in pixels
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/points-annotation
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct PointsAnnotation(pub(crate) foxglove::schemas::PointsAnnotation);
 #[pymethods]
@@ -1333,7 +1336,7 @@ impl From<PointsAnnotation> for foxglove::schemas::PointsAnnotation {
 /// :param orientation: Quaternion denoting orientation in 3D space
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/pose
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Pose(pub(crate) foxglove::schemas::Pose);
 #[pymethods]
@@ -1367,7 +1370,7 @@ impl From<Pose> for foxglove::schemas::Pose {
 /// :param pose: Pose in 3D space
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/pose-in-frame
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct PoseInFrame(pub(crate) foxglove::schemas::PoseInFrame);
 #[pymethods]
@@ -1402,7 +1405,7 @@ impl From<PoseInFrame> for foxglove::schemas::PoseInFrame {
 /// :param poses: Poses in 3D space
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/poses-in-frame
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct PosesInFrame(pub(crate) foxglove::schemas::PosesInFrame);
 #[pymethods]
@@ -1438,7 +1441,7 @@ impl From<PosesInFrame> for foxglove::schemas::PosesInFrame {
 /// :param w: w value
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/quaternion
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Quaternion(pub(crate) foxglove::schemas::Quaternion);
 #[pymethods]
@@ -1473,7 +1476,7 @@ impl From<Quaternion> for foxglove::schemas::Quaternion {
 /// :param data: Raw image data
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/raw-image
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct RawImage(pub(crate) foxglove::schemas::RawImage);
 #[pymethods]
@@ -1528,7 +1531,7 @@ impl From<RawImage> for foxglove::schemas::RawImage {
 /// :param color: Color of the sphere
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/sphere-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct SpherePrimitive(pub(crate) foxglove::schemas::SpherePrimitive);
 #[pymethods]
@@ -1566,7 +1569,7 @@ impl From<SpherePrimitive> for foxglove::schemas::SpherePrimitive {
 /// :param background_color: Background fill color
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/text-annotation
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct TextAnnotation(pub(crate) foxglove::schemas::TextAnnotation);
 #[pymethods]
@@ -1619,7 +1622,7 @@ impl From<TextAnnotation> for foxglove::schemas::TextAnnotation {
 /// :param text: Text
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/text-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct TextPrimitive(pub(crate) foxglove::schemas::TextPrimitive);
 #[pymethods]
@@ -1671,7 +1674,7 @@ impl From<TextPrimitive> for foxglove::schemas::TextPrimitive {
 /// :param indices: Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/triangle-list-primitive
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct TriangleListPrimitive(pub(crate) foxglove::schemas::TriangleListPrimitive);
 #[pymethods]
@@ -1713,7 +1716,7 @@ impl From<TriangleListPrimitive> for foxglove::schemas::TriangleListPrimitive {
 /// :param y: y coordinate length
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/vector2
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Vector2(pub(crate) foxglove::schemas::Vector2);
 #[pymethods]
@@ -1741,7 +1744,7 @@ impl From<Vector2> for foxglove::schemas::Vector2 {
 /// :param z: z coordinate length
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/vector3
-#[pyclass(module = "foxglove.schemas")]
+#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
 #[derive(Clone)]
 pub(crate) struct Vector3(pub(crate) foxglove::schemas::Vector3);
 #[pymethods]

--- a/rust/foxglove-proto-gen/src/lib.rs
+++ b/rust/foxglove-proto-gen/src/lib.rs
@@ -205,7 +205,14 @@ pub fn generate_protos(proto_path: &Path, out_dir: &Path) -> anyhow::Result<()> 
     config.bytes(["."]);
 
     let mut fds = config
-        .load_fds(&proto_files, &[proto_path])
+        .load_fds(
+            &proto_files,
+            &[
+                proto_path,
+                PathBuf::from("/usr/include"), // Standard location on Linux
+                PathBuf::from("/usr/local/include"), // Standard location on macOS and some Linux distros)
+            ],
+        )
         .context("Failed to load protos")?;
     fds.file.sort_unstable_by(|a, b| a.name.cmp(&b.name));
 

--- a/typescript/schemas/src/internal/generatePyclass.test.ts
+++ b/typescript/schemas/src/internal/generatePyclass.test.ts
@@ -14,6 +14,9 @@ describe("generatePyclass", () => {
         use pyo3::prelude::*;
         use pyo3::types::PyBytes;
 
+        #[pyclass(module = "foxglove.schemas")]
+        pub(crate) struct FoxgloveSchema;
+
         "
         `);
   });
@@ -63,7 +66,7 @@ describe("generatePyclass", () => {
         /// :param field_nested_array: A nested array field
         ///
         /// See https://docs.foxglove.dev/docs/visualization/message-schemas/example-message
-        #[pyclass(module = "foxglove.schemas")]
+        #[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]
         #[derive(Clone)]
         pub(crate) struct ExampleMessage(pub(crate) foxglove::schemas::ExampleMessage);
         #[pymethods]

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -28,7 +28,12 @@ export function generateSchemaPrelude(): string {
     "use pyo3::types::PyBytes;",
   ];
 
-  const outputSections = [docs.join("\n"), imports.join("\n")];
+  const prelude = [
+    "\n#[pyclass(module = \"foxglove.schemas\")]",
+    "pub(crate) struct FoxgloveSchema;",
+  ];
+
+  const outputSections = [docs.join("\n"), imports.join("\n"), prelude.join("\n")];
 
   return outputSections.join("\n") + "\n\n";
 }
@@ -52,6 +57,9 @@ export function generatePySchemaStub(schemas: FoxgloveSchema[]): string {
     // Use "from mod import X as X" syntax to explicitly re-export.
     "from .schemas_wkt import Duration as Duration",
     "from .schemas_wkt import Timestamp as Timestamp",
+    // Base class for all the foxglove schema types
+    "class FoxgloveSchema:",
+    "    pass",
   ].join("\n") + "\n";
 
   const enums = schemas
@@ -80,7 +88,7 @@ export function generatePySchemaStub(schemas: FoxgloveSchema[]): string {
     return {
       name,
       source: [
-        `class ${name}:`,
+        `class ${name}(FoxgloveSchema):`,
         ...doc,
         `    def __new__(`,
         "        cls,",
@@ -154,7 +162,7 @@ function generateMessageClass(schema: FoxgloveMessageSchema): string {
     ),
     `///`,
     `/// See https://docs.foxglove.dev/docs/visualization/message-schemas/${constantToKebabCase(className)}`,
-    `#[pyclass(module = "foxglove.schemas")]`,
+    `#[pyclass(module = "foxglove.schemas", extends = FoxgloveSchema)]`,
     `#[derive(Clone)]`,
     `pub(crate) struct ${className}(pub(crate) foxglove::schemas::${className});`,
   ];


### PR DESCRIPTION
Improves the Python `log(topic, message)` function:

Add more restrictive typings for the message, add a common base class for all foxglove schema types (to better support the typings), add support for dict, list, bytes, and str messages.

`dict | list` are serialized to json in a schemaless channel with message_encoding='json' 

`bytes | str` are serialized as-is, with str encoded to utf8 first