### PR TITLE
rust: Fix websocket service schema encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +442,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enumset"
@@ -642,6 +660,7 @@ dependencies = [
  "env_logger",
  "flume",
  "futures-util",
+ "insta",
  "mcap",
  "parking_lot",
  "prost",
@@ -943,6 +962,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1026,12 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1225,6 +1264,26 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.7.1",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1715,6 +1774,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,6 @@
 {
   "testMatch": ["<rootDir>/**/*.test.ts"],
+  "testPathIgnorePatterns": ["<rootDir>/rust"],
   "transform": {
     "^.+\\.ts$": [
       "ts-jest",

--- a/rust/examples/ws-services/src/client.rs
+++ b/rust/examples/ws-services/src/client.rs
@@ -144,7 +144,7 @@ impl Client {
     async fn call_echo(&self, msg: String) -> Result<String> {
         let req = msg.into_bytes().into();
         let resp = self
-            .service_call("/echo", "raw", req)
+            .service_call("/echo", "json", req)
             .await
             .context("failed to call /echo")?;
         let resp = String::from_utf8(resp.to_vec()).context("invalid echo response")?;
@@ -152,14 +152,14 @@ impl Client {
     }
 
     async fn call_sleep(&self) -> Result<()> {
-        self.service_call("/sleep", "raw", Bytes::new())
+        self.service_call("/sleep", "json", Bytes::new())
             .await
             .context("failed to call /sleep")?;
         Ok(())
     }
 
     async fn call_blocking(&self) -> Result<()> {
-        self.service_call("/blocking", "raw", Bytes::new())
+        self.service_call("/blocking", "json", Bytes::new())
             .await
             .context("failed to call /blocking")?;
         Ok(())

--- a/rust/examples/ws-services/src/client.rs
+++ b/rust/examples/ws-services/src/client.rs
@@ -13,6 +13,7 @@ use protocol::{
     AdvertiseServices, ServerMessage, ServiceCallFailure, ServiceCallRequest, ServiceCallResponse,
     UnadvertiseServices, SDK_SUBPROTOCOL,
 };
+use serde_json::json;
 use tokio::sync::oneshot;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
@@ -142,7 +143,7 @@ impl Client {
     }
 
     async fn call_echo(&self, msg: String) -> Result<String> {
-        let req = msg.into_bytes().into();
+        let req = json!({ "msg": msg }).to_string().into();
         let resp = self
             .service_call("/echo", "json", req)
             .await

--- a/rust/examples/ws-services/src/server.rs
+++ b/rust/examples/ws-services/src/server.rs
@@ -17,7 +17,7 @@ pub async fn main(config: Config) -> Result<()> {
         .name(env!("CARGO_PKG_NAME"))
         .bind(&config.host, config.port)
         .capabilities([Capability::Services])
-        .supported_encodings(["json", "raw"])
+        .supported_encodings(["json"])
         .start()
         .await
         .context("Failed to start server")?;
@@ -72,10 +72,10 @@ fn empty_schema() -> ServiceSchema {
 }
 
 fn echo_schema() -> ServiceSchema {
-    // A simple schema with a well-specified request & response.
-    ServiceSchema::new("/custom_srvs/RawEcho")
-        .with_request("raw", Schema::new("raw", "none", b""))
-        .with_response("raw", Schema::new("raw", "none", b""))
+    // A simple schema with a specified request & response type.
+    ServiceSchema::new("/custom_srvs/Echo")
+        .with_request("json", Schema::new("any", "jsonschema", b"true"))
+        .with_response("json", Schema::new("any", "jsonschema", b"true"))
 }
 
 fn int_bin_schema() -> ServiceSchema {
@@ -115,7 +115,7 @@ fn int_bin_handler(req: Request) -> Result<Bytes> {
         "/IntBin/add" => req.a.saturating_add(req.b),
         "/IntBin/sub" => req.a.saturating_sub(req.b),
         "/IntBin/mul" => req.a.saturating_mul(req.b),
-        "/IntBin/mod" => req.a % req.b,
+        "/IntBin/mod" => req.a.checked_rem(req.b).unwrap_or(0),
         m => return Err(anyhow::anyhow!("unexpected service: {m}")),
     };
 

--- a/rust/examples/ws-services/src/server.rs
+++ b/rust/examples/ws-services/src/server.rs
@@ -14,10 +14,10 @@ use crate::Config;
 
 pub async fn main(config: Config) -> Result<()> {
     let server = foxglove::WebSocketServer::new()
-        .name("echo")
+        .name(env!("CARGO_PKG_NAME"))
         .bind(&config.host, config.port)
         .capabilities([Capability::Services])
-        .supported_encodings(["raw"])
+        .supported_encodings(["json", "raw"])
         .start()
         .await
         .context("Failed to start server")?;
@@ -112,9 +112,9 @@ fn int_bin_handler(req: Request) -> Result<Bytes> {
     // Shared handlers can use `Request::service_name` to disambiguate the service endpoint.
     // Service names are guaranteed to be unique.
     let result = match service_name {
-        "/IntBin/add" => req.a + req.b,
-        "/IntBin/sub" => req.a - req.b,
-        "/IntBin/mul" => req.a * req.b,
+        "/IntBin/add" => req.a.saturating_add(req.b),
+        "/IntBin/sub" => req.a.saturating_sub(req.b),
+        "/IntBin/mul" => req.a.saturating_mul(req.b),
         "/IntBin/mod" => req.a % req.b,
         m => return Err(anyhow::anyhow!("unexpected service: {m}")),
     };

--- a/rust/examples/ws-services/src/server.rs
+++ b/rust/examples/ws-services/src/server.rs
@@ -73,9 +73,10 @@ fn empty_schema() -> ServiceSchema {
 
 fn echo_schema() -> ServiceSchema {
     // A simple schema with a specified request & response type.
+    let any_object = Schema::new("any object", "jsonschema", br#"{"type":"object"}"#);
     ServiceSchema::new("/custom_srvs/Echo")
-        .with_request("json", Schema::new("any", "jsonschema", b"true"))
-        .with_response("json", Schema::new("any", "jsonschema", b"true"))
+        .with_request("json", any_object.clone())
+        .with_response("json", any_object)
 }
 
 fn int_bin_schema() -> ServiceSchema {

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -44,5 +44,6 @@ assert_matches = "1.5.0"
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"
 futures-util = "0.3.31"
+insta = { version = "1.42.2", features = ["json"] }
 tempfile = "3.15.0"
 tracing-test = "0.2.5"

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -314,16 +314,15 @@ impl<'a> TryFrom<&'a service::MessageSchema> for AdvertiseServiceMessageSchema<'
 pub(crate) fn advertise_services<'a>(services: impl IntoIterator<Item = &'a Service>) -> String {
     let services: Vec<_> = services
         .into_iter()
-        .filter_map(|s| {
-            AdvertiseService::try_from(s)
-                .inspect_err(|e| {
-                    error!(
-                        "Failed to encode service advertisement for {}: {e}",
-                        s.name()
-                    )
-                })
-                .ok()
-                .map(|s| json!(s))
+        .filter_map(|s| match AdvertiseService::try_from(s) {
+            Ok(adv) => Some(json!(adv)),
+            Err(e) => {
+                error!(
+                    "Failed to encode service advertisement for {}: {e}",
+                    s.name()
+                );
+                None
+            }
         })
         .collect();
     json!({

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_repr::Serialize_repr;
 use serde_with::{base64::Base64, serde_as};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use tracing::error;
 
 #[repr(u8)]
 pub enum BinaryOpcode {
@@ -31,7 +33,7 @@ pub struct Advertisement<'a> {
     pub topic: &'a str,
     pub encoding: &'a str,
     pub schema_name: &'a str,
-    pub schema: String,
+    pub schema: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_encoding: Option<&'a str>,
 }
@@ -185,6 +187,23 @@ fn is_schema_required(message_encoding: &str) -> bool {
         || message_encoding == "cdr"
 }
 
+/// Encodes schema data, based on message encoding.
+///
+/// For binary encodings, the schema data is base64-encoded. For other encodings, the schema must
+/// be valid UTF-8, or this function will return an error.
+fn encode_schema_data<'a>(
+    message_encoding: &str,
+    data: &'a [u8],
+) -> Result<Cow<'a, str>, FoxgloveError> {
+    if super::is_known_binary_schema_encoding(message_encoding) {
+        Ok(Cow::Owned(BASE64_STANDARD.encode(data)))
+    } else {
+        std::str::from_utf8(data)
+            .map_err(|e| FoxgloveError::Unspecified(e.into()))
+            .map(Cow::Borrowed)
+    }
+}
+
 // A `schema` in the channel is optional except for message_encodings which require a schema.
 // Currently, Foxglove supports schemaless JSON messages.
 // https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#advertise
@@ -196,13 +215,7 @@ pub fn advertisement(channel: &Channel) -> Result<String, FoxgloveError> {
     }
 
     let advertisement = if let Some(schema) = schema {
-        let schema_data = if super::is_known_binary_schema_encoding(&schema.encoding) {
-            BASE64_STANDARD.encode(&schema.data)
-        } else {
-            String::from_utf8(schema.data.to_vec())
-                .map_err(|e| FoxgloveError::Unspecified(e.into()))?
-        };
-
+        let schema_data = encode_schema_data(&schema.encoding, &schema.data)?;
         Ok::<Advertisement, FoxgloveError>(Advertisement {
             id: channel.id,
             topic: &channel.topic,
@@ -217,7 +230,7 @@ pub fn advertisement(channel: &Channel) -> Result<String, FoxgloveError> {
             topic: &channel.topic,
             encoding: &channel.message_encoding,
             schema_name: "",
-            schema: "".to_string(),
+            schema: Cow::Borrowed(""),
             schema_encoding: None,
         })
     }?;
@@ -254,20 +267,22 @@ struct AdvertiseService<'a> {
     response_schema: Option<&'a str>,
 }
 
-impl<'a> From<&'a Service> for AdvertiseService<'a> {
-    fn from(service: &'a Service) -> Self {
+impl<'a> TryFrom<&'a Service> for AdvertiseService<'a> {
+    type Error = FoxgloveError;
+
+    fn try_from(service: &'a Service) -> Result<Self, Self::Error> {
         let schema = service.schema();
         let request = schema.request();
         let response = schema.response();
-        Self {
+        Ok(Self {
             id: service.id(),
             name: service.name(),
             r#type: schema.name(),
-            request: request.map(|r| r.into()),
+            request: request.map(|r| r.try_into()).transpose()?,
             request_schema: if request.is_none() { Some("") } else { None },
-            response: response.map(|r| r.into()),
+            response: response.map(|r| r.try_into()).transpose()?,
             response_schema: if response.is_none() { Some("") } else { None },
-        }
+        })
     }
 }
 
@@ -277,18 +292,21 @@ struct AdvertiseServiceMessageSchema<'a> {
     encoding: &'a str,
     schema_name: &'a str,
     schema_encoding: &'a str,
-    schema: &'a [u8],
+    schema: Cow<'a, str>,
 }
 
-impl<'a> From<&'a service::MessageSchema> for AdvertiseServiceMessageSchema<'a> {
-    fn from(ms: &'a service::MessageSchema) -> Self {
+impl<'a> TryFrom<&'a service::MessageSchema> for AdvertiseServiceMessageSchema<'a> {
+    type Error = FoxgloveError;
+
+    fn try_from(ms: &'a service::MessageSchema) -> Result<Self, Self::Error> {
         let schema = &ms.schema;
-        Self {
+        let schema_data = encode_schema_data(&ms.encoding, &schema.data)?;
+        Ok(Self {
             encoding: &ms.encoding,
             schema_name: &schema.name,
             schema_encoding: &schema.encoding,
-            schema: &schema.data,
-        }
+            schema: schema_data,
+        })
     }
 }
 
@@ -296,7 +314,17 @@ impl<'a> From<&'a service::MessageSchema> for AdvertiseServiceMessageSchema<'a> 
 pub(crate) fn advertise_services<'a>(services: impl IntoIterator<Item = &'a Service>) -> String {
     let services: Vec<_> = services
         .into_iter()
-        .map(|s| json!(AdvertiseService::from(s)))
+        .filter_map(|s| {
+            AdvertiseService::try_from(s)
+                .inspect_err(|e| {
+                    error!(
+                        "Failed to encode service advertisement for {}: {e}",
+                        s.name()
+                    )
+                })
+                .ok()
+                .map(|s| json!(s))
+        })
         .collect();
     json!({
         "op": "advertiseServices",
@@ -417,6 +445,7 @@ impl ConnectionGraphDiff<'_> {
 #[cfg(test)]
 mod tests {
     use service::ServiceSchema;
+    use tracing_test::traced_test;
 
     use crate::Schema;
 
@@ -626,6 +655,7 @@ mod tests {
     }
 
     #[test]
+    #[traced_test]
     fn test_advertise_services() {
         let s1_schema = ServiceSchema::new("std_srvs/Empty");
         let s1 = Service::builder("foo", s1_schema)
@@ -649,40 +679,29 @@ mod tests {
             .with_id(ServiceId::new(2))
             .handler_fn(|_| Err("not implemented"));
 
-        let adv = advertise_services(&[s1, s2]);
-        assert_eq!(
-            adv,
-            json!({
-                "op": "advertiseServices",
-                "services": [
-                    {
-                        "id": 1,
-                        "name": "foo",
-                        "type": "std_srvs/Empty",
-                        "requestSchema": "",
-                        "responseSchema": ""
-                    },
-                    {
-                        "id": 2,
-                        "name": "set_bool",
-                        "type": "std_srvs/SetBool",
-                        "request": {
-                            "encoding": "ros1",
-                            "schemaName": "std_srvs/SetBool_Request",
-                            "schemaEncoding": "ros1msg",
-                            "schema": b"bool data"
-                        },
-                        "response": {
-                            "encoding": "ros1",
-                            "schemaName": "std_srvs/SetBool_Response",
-                            "schemaEncoding": "ros1msg",
-                            "schema": b"bool success\nstring message"
-                        }
-                    }
-                ]
-            })
-            .to_string()
+        let s3_schema = ServiceSchema::new("invalid_schema").with_request(
+            "json",
+            Schema::new("invalid", "jsonschema", &[0, 159, 146, 150]),
         );
+        let s3 = Service::builder("invalid_schema", s3_schema)
+            .with_id(ServiceId::new(3))
+            .handler_fn(|_| Err("not implemented"));
+
+        let s4_schema = ServiceSchema::new("pb/and_jelly")
+            .with_request("protobuf", Schema::new("pb.Request", "protobuf", b"req"))
+            .with_response("protobuf", Schema::new("pb.Response", "protobuf", b"resp"));
+        let s4 = Service::builder("sandwich", s4_schema)
+            .with_id(ServiceId::new(4))
+            .handler_fn(|_| Err("not implemented"));
+
+        let adv = advertise_services(&[s1, s2, s3, s4]);
+
+        assert!(logs_contain(
+            "Failed to encode service advertisement for invalid_schema: invalid utf-8"
+        ));
+
+        let obj: serde_json::Value = serde_json::from_str(&adv).unwrap();
+        insta::assert_json_snapshot!(obj);
     }
 
     #[test]

--- a/rust/foxglove/src/websocket/protocol/snapshots/foxglove__websocket__protocol__server__tests__advertise_services.snap
+++ b/rust/foxglove/src/websocket/protocol/snapshots/foxglove__websocket__protocol__server__tests__advertise_services.snap
@@ -1,0 +1,50 @@
+---
+source: rust/foxglove/src/websocket/protocol/server.rs
+expression: obj
+---
+{
+  "op": "advertiseServices",
+  "services": [
+    {
+      "id": 1,
+      "name": "foo",
+      "requestSchema": "",
+      "responseSchema": "",
+      "type": "std_srvs/Empty"
+    },
+    {
+      "id": 2,
+      "name": "set_bool",
+      "request": {
+        "encoding": "ros1",
+        "schema": "bool data",
+        "schemaEncoding": "ros1msg",
+        "schemaName": "std_srvs/SetBool_Request"
+      },
+      "response": {
+        "encoding": "ros1",
+        "schema": "bool success\nstring message",
+        "schemaEncoding": "ros1msg",
+        "schemaName": "std_srvs/SetBool_Response"
+      },
+      "type": "std_srvs/SetBool"
+    },
+    {
+      "id": 4,
+      "name": "sandwich",
+      "request": {
+        "encoding": "protobuf",
+        "schema": "cmVx",
+        "schemaEncoding": "protobuf",
+        "schemaName": "pb.Request"
+      },
+      "response": {
+        "encoding": "protobuf",
+        "schema": "cmVzcA==",
+        "schemaEncoding": "protobuf",
+        "schemaName": "pb.Response"
+      },
+      "type": "pb/and_jelly"
+    }
+  ]
+}


### PR DESCRIPTION
### Description
When I implemented websocket services, I didn't know about the Service Call panel in the UI, and so I did all my testing with a custom client in rust. Turns out I botched the request/response schema encoding.

This change fixes the schema encoding, using the same logic that we use for encoding channel schemas. The ws-services example is now compatible with the UI.