### PR TITLE
rust: Miscellaneous tidying

### DIFF
--- a/rust/examples/client-publish/src/main.rs
+++ b/rust/examples/client-publish/src/main.rs
@@ -23,16 +23,26 @@ struct Cli {
     port: u16,
     #[arg(long, default_value = "127.0.0.1")]
     host: String,
-    #[arg(long, default_value = "example-json-server")]
-    server_name: String,
 }
 
 struct ExampleCallbackHandler;
 impl ServerListener for ExampleCallbackHandler {
-    fn on_message_data(&self, _client: Client, channel: &ClientChannel, message: &[u8]) {
+    fn on_message_data(&self, client: Client, channel: &ClientChannel, message: &[u8]) {
         let json: serde_json::Value =
             serde_json::from_slice(message).expect("Failed to parse message");
-        println!("Received message on channel {}: {json}", channel.id);
+        println!(
+            "Client {} published to channel {}: {json}",
+            client.id(),
+            channel.id
+        );
+    }
+
+    fn on_client_advertise(&self, client: Client, channel: &ClientChannel) {
+        println!(
+            "Client {} advertised channel: {}",
+            client.id(),
+            channel.topic
+        );
     }
 }
 
@@ -44,10 +54,11 @@ async fn main() {
     let args = Cli::parse();
 
     let server = WebSocketServer::new()
-        .name("client-publish")
+        .name(env!("CARGO_PKG_NAME"))
         .bind(args.host, args.port)
         .capabilities([Capability::ClientPublish])
         .listener(Arc::new(ExampleCallbackHandler))
+        .supported_encodings(["json"])
         .start()
         .await
         .expect("Failed to start server");

--- a/rust/examples/client-publish/src/main.rs
+++ b/rust/examples/client-publish/src/main.rs
@@ -44,6 +44,14 @@ impl ServerListener for ExampleCallbackHandler {
             channel.topic
         );
     }
+
+    fn on_client_unadvertise(&self, client: Client, channel: &ClientChannel) {
+        println!(
+            "Client {} unadvertised channel: {}",
+            client.id(),
+            channel.topic
+        );
+    }
 }
 
 #[tokio::main]

--- a/rust/examples/param-server/src/main.rs
+++ b/rust/examples/param-server/src/main.rs
@@ -153,7 +153,7 @@ async fn main() {
     }
 
     let server = WebSocketServer::new()
-        .name("param server")
+        .name(env!("CARGO_PKG_NAME"))
         .capabilities([Capability::Parameters])
         .listener(listener.clone())
         .bind(args.host, args.port)

--- a/rust/examples/ws-server-blocking/src/main.rs
+++ b/rust/examples/ws-server-blocking/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
     .expect("Failed to set SIGINT handler");
 
     let server = foxglove::WebSocketServer::new()
-        .name("ws-demo")
+        .name(env!("CARGO_PKG_NAME"))
         .bind(&args.host, args.port)
         .start_blocking()
         .expect("Server failed to start");

--- a/rust/examples/ws-server-fetch-asset/src/main.rs
+++ b/rust/examples/ws-server-fetch-asset/src/main.rs
@@ -49,7 +49,7 @@ async fn main() {
     let asset_server = AssetServer::new();
 
     let server = foxglove::WebSocketServer::new()
-        .name("ws-demo")
+        .name(env!("CARGO_PKG_NAME"))
         .bind(&args.host, args.port)
         .fetch_asset_handler(Box::new(asset_server))
         .start()

--- a/rust/examples/ws-server/src/main.rs
+++ b/rust/examples/ws-server/src/main.rs
@@ -35,7 +35,7 @@ static SCHEMALESS_CHANNEL: LazyLock<Arc<Channel>> = LazyLock::new(|| {
     {
         Ok(chan) => chan,
         Err(e) => {
-            panic!("example failed to create /schemaless channel: {:?}", e);
+            panic!("example failed to create /schemaless channel: {e}");
         }
     }
 });
@@ -119,7 +119,7 @@ async fn main() {
     let args = Cli::parse();
 
     let server = foxglove::WebSocketServer::new()
-        .name("ws-demo")
+        .name(env!("CARGO_PKG_NAME"))
         .bind(&args.host, args.port)
         .start()
         .await

--- a/rust/examples/ws-services/src/server.rs
+++ b/rust/examples/ws-services/src/server.rs
@@ -108,7 +108,7 @@ fn int_bin_handler(req: Request) -> Result<Bytes> {
     let service_name = req.service_name();
     let client_id = req.client_id();
     let req: IntBinRequest = serde_json::from_slice(req.payload())?;
-    info!("Client {client_id:?}: {service_name}: {req:?}");
+    info!("Client {client_id}: {service_name}: {req:?}");
 
     // Shared handlers can use `Request::service_name` to disambiguate the service endpoint.
     // Service names are guaranteed to be unique.
@@ -135,7 +135,7 @@ impl SyncHandler for Flag {
         // Decode the payload.
         let client_id = req.client_id();
         let req: SetBoolRequest = serde_json::from_slice(req.payload())?;
-        info!("Client {client_id:?}: {req:?}");
+        info!("Client {client_id}: {req:?}");
 
         // Update the flag.
         let prev = self.0.swap(req.data, std::sync::atomic::Ordering::Relaxed);

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -14,7 +14,8 @@ use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata};
 pub struct ChannelId(u64);
 
 impl ChannelId {
-    pub fn new(id: u64) -> Self {
+    #[cfg(test)]
+    pub(crate) fn new(id: u64) -> Self {
         Self(id)
     }
 
@@ -43,7 +44,7 @@ impl std::fmt::Display for ChannelId {
 /// It allows Foxglove to validate messages and provide richer visualizations.
 /// You can use the well known types provided in the [crate::schemas] module or provide your own.
 /// See the [MCAP spec](https://mcap.dev/spec#schema-op0x03) for more information.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Schema {
     /// An identifier for the schema.
     pub name: String,
@@ -52,6 +53,15 @@ pub struct Schema {
     pub encoding: String,
     /// Must conform to the schema encoding. If encoding is an empty string, data should be 0 length.
     pub data: Cow<'static, [u8]>,
+}
+
+impl std::fmt::Debug for Schema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Schema")
+            .field("name", &self.name)
+            .field("encoding", &self.encoding)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Schema {
@@ -228,7 +238,7 @@ impl std::fmt::Debug for Channel {
             .field("message_encoding", &self.message_encoding)
             .field("schema", &self.schema)
             .field("metadata", &self.metadata)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -6,7 +6,7 @@ use crate::{Channel, Context, Encode, FoxgloveError, Schema};
 
 /// ChannelBuilder is a builder for creating a new [`Channel`] or [`TypedChannel`].
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ChannelBuilder {
     topic: String,
     message_encoding: Option<String>,

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -6,6 +6,7 @@ use crate::{Channel, Context, Encode, FoxgloveError, Schema};
 
 /// ChannelBuilder is a builder for creating a new [`Channel`] or [`TypedChannel`].
 #[must_use]
+#[derive(Debug, Clone)]
 pub struct ChannelBuilder {
     topic: String,
     message_encoding: Option<String>,

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -73,6 +73,7 @@ impl<T: Serialize + JsonSchema> Encode for T {
 /// A typed [`Channel`] for messages that implement [`Encode`].
 ///
 /// Channels are immutable, returned as `Arc<Channel>` and can be shared between threads.
+#[derive(Debug)]
 pub struct TypedChannel<T: Encode> {
     inner: Arc<Channel>,
     _phantom: std::marker::PhantomData<T>,

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -18,6 +18,11 @@ impl SinkId {
         Self(id)
     }
 }
+impl std::fmt::Display for SinkId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// A [`Sink`] writes a message from a [`Channel`] to a destination.
 ///

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -77,6 +77,12 @@ impl From<ClientId> for u32 {
     }
 }
 
+impl std::fmt::Display for ClientId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A connected client session with the websocket server.
 #[derive(Debug, Clone)]
 pub struct Client {

--- a/rust/foxglove/src/websocket/fetch_asset.rs
+++ b/rust/foxglove/src/websocket/fetch_asset.rs
@@ -49,6 +49,7 @@ where
 
 /// Wraps a weak reference to a Client and provides a method
 /// to respond to the fetch asset request from that client.
+#[derive(Debug)]
 pub struct AssetResponder {
     /// The client requesting the asset.
     client: Client,

--- a/rust/foxglove/src/websocket/protocol/client.rs
+++ b/rust/foxglove/src/websocket/protocol/client.rs
@@ -227,7 +227,7 @@ pub(crate) struct JsonClientChannel {
 }
 
 /// Information about a channel advertised by the client
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ClientChannel {
     /// An identifier for this channel, assigned by the client
     pub id: ClientChannelId,

--- a/rust/foxglove/src/websocket/protocol/client.rs
+++ b/rust/foxglove/src/websocket/protocol/client.rs
@@ -227,7 +227,7 @@ pub(crate) struct JsonClientChannel {
 }
 
 /// Information about a channel advertised by the client
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientChannel {
     /// An identifier for this channel, assigned by the client
     pub id: ClientChannelId,

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -39,7 +39,7 @@ pub struct Advertisement<'a> {
 }
 
 /// A parameter type.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ParameterType {
     /// A byte array, encoded as a base64-encoded string.
@@ -93,7 +93,7 @@ pub enum ServerMessage<'a> {
 }
 
 /// The log level for a [`Status`] message.
-#[derive(Debug, Copy, Clone, Serialize_repr)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize_repr)]
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum StatusLevel {

--- a/rust/foxglove/src/websocket/service.rs
+++ b/rust/foxglove/src/websocket/service.rs
@@ -36,7 +36,7 @@ impl ServiceId {
     pub fn next() -> Self {
         static NEXT_ID: AtomicU32 = AtomicU32::new(1);
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-        assert_ne!(id, 0);
+        assert_ne!(id, 0, "ServiceId overflowed");
         Self(id)
     }
 }

--- a/rust/foxglove/src/websocket/service.rs
+++ b/rust/foxglove/src/websocket/service.rs
@@ -31,6 +31,14 @@ impl ServiceId {
     pub fn new(id: u32) -> Self {
         Self(id)
     }
+
+    /// Allocates the next service ID.
+    pub fn next() -> Self {
+        static NEXT_ID: AtomicU32 = AtomicU32::new(1);
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        assert_ne!(id, 0);
+        Self(id)
+    }
 }
 
 impl From<ServiceId> for u32 {
@@ -79,11 +87,8 @@ pub struct ServiceBuilder {
 impl ServiceBuilder {
     /// Creates a new builder for a websocket service.
     fn new(name: impl Into<String>, schema: ServiceSchema) -> Self {
-        static ID: AtomicU32 = AtomicU32::new(1);
-        let id = ID.fetch_add(1, Ordering::Relaxed);
-        assert_ne!(id, 0);
         Self {
-            id: ServiceId::new(id),
+            id: ServiceId::next(),
             name: name.into(),
             schema,
         }

--- a/rust/foxglove/src/websocket/service/request.rs
+++ b/rust/foxglove/src/websocket/service/request.rs
@@ -9,13 +9,24 @@ use crate::websocket::ClientId;
 use super::{CallId, Service};
 
 /// A service call request.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Request {
     service: Arc<Service>,
     client_id: ClientId,
     call_id: CallId,
     encoding: String,
     payload: Bytes,
+}
+
+impl std::fmt::Debug for Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Request")
+            .field("service", &self.service)
+            .field("client_id", &self.client_id)
+            .field("call_id", &self.call_id)
+            .field("encoding", &self.encoding)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Request {


### PR DESCRIPTION
### Description
Odds and ends included here:
- For ws examples, use the crate name as the ws server name.
- Add `Display` impl for newtyped IDs.
- Hide `new()` constructors for IDs that users shouldn't create.
- Adjust `Debug` impls for `Schema` and `Request` to elide payloads.
- Derive `Clone` and `Eq` for a few public structures where it makes sense.
- Fix client-publish example by advertising support for JSON encoding