### PR TITLE
Hide _foxglove_py imports where possible

### DIFF
--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -9,14 +9,14 @@ import atexit
 import logging
 from typing import List, Optional, Union
 
+from . import _foxglove_py as _foxglove
+
+# Re-export these imports
 from ._foxglove_py import (
     MCAPWriter,
     Schema,
-    enable_logging,
     open_mcap,
-    shutdown,
 )
-from ._foxglove_py import start_server as _start_server
 from .channel import Channel, log
 from .websocket import (
     AssetHandler,
@@ -26,7 +26,7 @@ from .websocket import (
     WebSocketServer,
 )
 
-atexit.register(shutdown)
+atexit.register(_foxglove.shutdown)
 
 
 def start_server(
@@ -61,7 +61,7 @@ def start_server(
         it doesn't exist.
     :type asset_handler: Optional[:py:class:`AssetHandler`] = None
     """
-    return _start_server(
+    return _foxglove.start_server(
         name=name,
         host=host,
         port=port,
@@ -100,7 +100,7 @@ def set_log_level(level: Union[int, str] = "INFO") -> None:
     else:
         level = max(0, min(2**32 - 1, level))
 
-    enable_logging(level)
+    _foxglove.enable_logging(level)
 
 
 def _level_names() -> dict[str, int]:

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -1,7 +1,8 @@
 import json
 from typing import Any, Dict, Optional, Union
 
-from ._foxglove_py import BaseChannel, Schema, channels
+from . import _foxglove_py as _foxglove
+from ._foxglove_py import channels as _channels
 
 JsonSchema = Dict[str, Any]
 JsonMessage = Dict[str, Any]
@@ -13,14 +14,14 @@ class Channel:
     """
 
     __slots__ = ["base", "message_encoding"]
-    base: BaseChannel
+    base: _foxglove.BaseChannel
     message_encoding: str
 
     def __init__(
         self,
         topic: str,
         *,
-        schema: Union[JsonSchema, Schema, None] = None,
+        schema: Union[JsonSchema, _foxglove.Schema, None] = None,
         message_encoding: Optional[str] = None,
     ):
         """
@@ -43,7 +44,7 @@ class Channel:
 
         self.message_encoding = message_encoding
 
-        self.base = BaseChannel(
+        self.base = _foxglove.BaseChannel(
             topic,
             message_encoding,
             schema,
@@ -92,7 +93,7 @@ def log(topic: str, message: Any) -> None:
     if channel is None:
         schema_name = type(message).__name__
         channel_name = f"{schema_name}Channel"
-        channel_cls = getattr(channels, channel_name, None)
+        channel_cls = getattr(_channels, channel_name, None)
         if channel_cls is not None:
             channel = channel_cls(topic)
         if channel is None:
@@ -109,9 +110,9 @@ def log(topic: str, message: Any) -> None:
 
 def _normalize_schema(
     message_encoding: Optional[str],
-    schema: Union[JsonSchema, Schema, None] = None,
-) -> tuple[str, Optional[Schema]]:
-    if isinstance(schema, Schema) or schema is None:
+    schema: Union[JsonSchema, _foxglove.Schema, None] = None,
+) -> tuple[str, Optional[_foxglove.Schema]]:
+    if isinstance(schema, _foxglove.Schema) or schema is None:
         if message_encoding is None:
             raise ValueError("message encoding is required")
         return message_encoding, schema
@@ -120,7 +121,7 @@ def _normalize_schema(
             raise ValueError("Only object schemas are supported")
         return (
             message_encoding or "json",
-            Schema(
+            _foxglove.Schema(
                 name=schema.get("title", "json_schema"),
                 encoding="jsonschema",
                 data=json.dumps(schema).encode("utf-8"),
@@ -128,3 +129,6 @@ def _normalize_schema(
         )
     else:
         raise ValueError(f"Invalid schema type: {type(schema)}")
+
+
+__all__ = ["Channel", "log"]


### PR DESCRIPTION
### Changelog

[python] Re-organize some undocumented imports (private API)

### Description

Currently our `foxglove` module imports classes & functions from the generated `_foxglove_py` library, making them available through the public module. This adjusts the import definitions so that we only re-export items that we intend to. For example, `BaseChannel` is not intended to be part of the public API today.