### PR TITLE
python: use published SDK for examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "generate": "ts-node ./scripts/generate.ts",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "lint": "eslint --report-unused-disable-directives --fix .",
-    "run-python-sdk-examples": "ts-node ./scripts/runPythonSdkExamples.ts",
+    "run-python-sdk-examples": "ts-node ./scripts/runPythonSdkExamples.ts --install-sdk-from-path",
     "test": "jest"
   },
   "devDependencies": {

--- a/python/foxglove-sdk-examples/live-visualization/pyproject.toml
+++ b/python/foxglove-sdk-examples/live-visualization/pyproject.toml
@@ -5,6 +5,7 @@ description = "Example of live visualization in Foxglove"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0", "numpy>=2.0"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,10 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
-numpy = "^2.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/python/foxglove-sdk-examples/quickstart/pyproject.toml
+++ b/python/foxglove-sdk-examples/quickstart/pyproject.toml
@@ -5,6 +5,7 @@ description = "Log to MCAP and visualize inFoxglove"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0", "mcap>=1.2"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,10 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
-mcap = "^1.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/python/foxglove-sdk-examples/write-mcap-file/pyproject.toml
+++ b/python/foxglove-sdk-examples/write-mcap-file/pyproject.toml
@@ -5,6 +5,7 @@ description = "Example of writing to an mcap file"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0", "mcap>=1.2"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,10 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
-mcap = "^1.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/python/foxglove-sdk-examples/ws-asset-server/pyproject.toml
+++ b/python/foxglove-sdk-examples/ws-asset-server/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,9 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/python/foxglove-sdk-examples/ws-connection-graph/pyproject.toml
+++ b/python/foxglove-sdk-examples/ws-connection-graph/pyproject.toml
@@ -5,6 +5,7 @@ description = "Visualize a connection graph in Foxglove"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,9 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/python/foxglove-sdk-examples/ws-param-server/pyproject.toml
+++ b/python/foxglove-sdk-examples/ws-param-server/pyproject.toml
@@ -5,6 +5,7 @@ description = "A parameter server for Foxglove live visualization"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,9 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/python/foxglove-sdk-examples/ws-services/pyproject.toml
+++ b/python/foxglove-sdk-examples/ws-services/pyproject.toml
@@ -5,6 +5,7 @@ description = "Example of implementing websocket services"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,9 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/python/foxglove-sdk-examples/ws-stream-mcap/pyproject.toml
+++ b/python/foxglove-sdk-examples/ws-stream-mcap/pyproject.toml
@@ -5,6 +5,7 @@ description = "Example of streaming an MCAP file over a WebSocket connection"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["foxglove-sdk>=0.4.0", "mcap>=1.2"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -12,10 +13,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
-
-[tool.poetry.dependencies]
-foxglove-sdk = { path = "../../foxglove-sdk/" }
-mcap = "^1.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/scripts/runPythonSdkExamples.ts
+++ b/scripts/runPythonSdkExamples.ts
@@ -8,6 +8,10 @@ import path from "node:path";
 /**
  * Run each example in the Python SDK, after installing dependencies.
  *
+ * If `--install-sdk-from-path` is passed, then the project dependencies will be updated to refer
+ * to the SDK at a local path, relative to the example directory. CI uses this to test with the
+ * latest SDK; by default, examples specify the published version in their pyproject.toml.
+ *
  * Many of the examples start a live server which is run until interrupted; all examples are run
  * with a timeout (default 5s). These are run serially since they use the default Foxglove port
  * number and, for simplicity, don't illustrate that configuration.
@@ -17,10 +21,11 @@ const pyExamplesDir = path.resolve(__dirname, "../python/foxglove-sdk-examples")
 
 const tempFiles: string[] = [];
 
-async function main({ timeout }: { timeout: string }) {
+async function main(opts: { timeout: string; installSdkFromPath: boolean }) {
   for (const example of await readdir(pyExamplesDir)) {
-    await installDependencies(example);
-    await runExample(example, parseInt(timeout));
+    console.debug(`Install & run example ${example}`);
+    await installDependencies(example, { installSdkFromPath: opts.installSdkFromPath });
+    await runExample(example, parseInt(opts.timeout));
   }
 }
 
@@ -48,10 +53,11 @@ async function runExample(name: string, timeoutMillis = 5000) {
   });
 }
 
-async function installDependencies(name: string) {
+async function installDependencies(name: string, opts: { installSdkFromPath: boolean }) {
   const dir = path.join(pyExamplesDir, name);
   return await new Promise((resolve, reject) => {
-    const child = spawn("poetry", ["install"], {
+    const args = opts.installSdkFromPath ? ["add", "foxglove-sdk@../../foxglove-sdk"] : ["install"];
+    const child = spawn("poetry", args, {
       cwd: dir,
     });
     child.stdout.on("data", (data: Buffer | string) => {
@@ -104,6 +110,7 @@ async function extraArgs(example: string) {
 
 program
   .option("--timeout [duration]", "timeout for each example in milliseconds", "5000")
+  .option("--install-sdk-from-path", "use local sdk instead of version from pyproject", false)
   .action(main)
   .hook("postAction", removeTempFiles)
   .parse();


### PR DESCRIPTION
### Changelog

python: update examples to use the published package

### Description

We no longer require local build environments to run these python examples.