### PR TITLE
rust: Rename Channel->RawChannel, TypedChannel->Channel

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -131,7 +131,7 @@ pub struct FoxgloveWebSocketServer(Option<foxglove::WebSocketServerBlockingHandl
 
 // cbindgen does not actually generate a declaration for this, so we manually write one in
 // after_includes
-pub use foxglove::Channel as FoxgloveChannel;
+pub use foxglove::RawChannel as FoxgloveChannel;
 
 #[repr(C)]
 pub struct FoxgloveSchema {
@@ -388,7 +388,7 @@ pub unsafe extern "C" fn foxglove_channel_create(
         foxglove::ChannelBuilder::new(topic)
             .message_encoding(message_encoding)
             .schema(schema)
-            .build()
+            .build_raw()
             .expect("Failed to create channel"),
     )
     .cast_mut()

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -3,7 +3,7 @@
 
 use super::schemas;
 use crate::errors::PyFoxgloveError;
-use foxglove::{PartialMetadata, TypedChannel};
+use foxglove::{Channel, PartialMetadata};
 use pyo3::prelude::*;
 
 pub fn register_submodule(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -52,7 +52,7 @@ pub fn register_submodule(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 /// A channel for logging :py:class:`foxglove.schemas.CameraCalibration` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CameraCalibrationChannel(Option<TypedChannel<foxglove::schemas::CameraCalibration>>);
+struct CameraCalibrationChannel(Option<Channel<foxglove::schemas::CameraCalibration>>);
 
 #[pymethods]
 impl CameraCalibrationChannel {
@@ -61,7 +61,7 @@ impl CameraCalibrationChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -117,7 +117,7 @@ impl CameraCalibrationChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.CircleAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CircleAnnotationChannel(Option<TypedChannel<foxglove::schemas::CircleAnnotation>>);
+struct CircleAnnotationChannel(Option<Channel<foxglove::schemas::CircleAnnotation>>);
 
 #[pymethods]
 impl CircleAnnotationChannel {
@@ -126,7 +126,7 @@ impl CircleAnnotationChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -182,7 +182,7 @@ impl CircleAnnotationChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Color` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ColorChannel(Option<TypedChannel<foxglove::schemas::Color>>);
+struct ColorChannel(Option<Channel<foxglove::schemas::Color>>);
 
 #[pymethods]
 impl ColorChannel {
@@ -191,7 +191,7 @@ impl ColorChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -247,7 +247,7 @@ impl ColorChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.CompressedImage` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CompressedImageChannel(Option<TypedChannel<foxglove::schemas::CompressedImage>>);
+struct CompressedImageChannel(Option<Channel<foxglove::schemas::CompressedImage>>);
 
 #[pymethods]
 impl CompressedImageChannel {
@@ -256,7 +256,7 @@ impl CompressedImageChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -312,7 +312,7 @@ impl CompressedImageChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.CompressedVideo` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CompressedVideoChannel(Option<TypedChannel<foxglove::schemas::CompressedVideo>>);
+struct CompressedVideoChannel(Option<Channel<foxglove::schemas::CompressedVideo>>);
 
 #[pymethods]
 impl CompressedVideoChannel {
@@ -321,7 +321,7 @@ impl CompressedVideoChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -377,7 +377,7 @@ impl CompressedVideoChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.FrameTransform` messages.
 #[pyclass(module = "foxglove.channels")]
-struct FrameTransformChannel(Option<TypedChannel<foxglove::schemas::FrameTransform>>);
+struct FrameTransformChannel(Option<Channel<foxglove::schemas::FrameTransform>>);
 
 #[pymethods]
 impl FrameTransformChannel {
@@ -386,7 +386,7 @@ impl FrameTransformChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -442,7 +442,7 @@ impl FrameTransformChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.FrameTransforms` messages.
 #[pyclass(module = "foxglove.channels")]
-struct FrameTransformsChannel(Option<TypedChannel<foxglove::schemas::FrameTransforms>>);
+struct FrameTransformsChannel(Option<Channel<foxglove::schemas::FrameTransforms>>);
 
 #[pymethods]
 impl FrameTransformsChannel {
@@ -451,7 +451,7 @@ impl FrameTransformsChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -507,7 +507,7 @@ impl FrameTransformsChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.GeoJson` messages.
 #[pyclass(module = "foxglove.channels")]
-struct GeoJsonChannel(Option<TypedChannel<foxglove::schemas::GeoJson>>);
+struct GeoJsonChannel(Option<Channel<foxglove::schemas::GeoJson>>);
 
 #[pymethods]
 impl GeoJsonChannel {
@@ -516,7 +516,7 @@ impl GeoJsonChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -572,7 +572,7 @@ impl GeoJsonChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Grid` messages.
 #[pyclass(module = "foxglove.channels")]
-struct GridChannel(Option<TypedChannel<foxglove::schemas::Grid>>);
+struct GridChannel(Option<Channel<foxglove::schemas::Grid>>);
 
 #[pymethods]
 impl GridChannel {
@@ -581,7 +581,7 @@ impl GridChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -637,7 +637,7 @@ impl GridChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.ImageAnnotations` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ImageAnnotationsChannel(Option<TypedChannel<foxglove::schemas::ImageAnnotations>>);
+struct ImageAnnotationsChannel(Option<Channel<foxglove::schemas::ImageAnnotations>>);
 
 #[pymethods]
 impl ImageAnnotationsChannel {
@@ -646,7 +646,7 @@ impl ImageAnnotationsChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -702,7 +702,7 @@ impl ImageAnnotationsChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.KeyValuePair` messages.
 #[pyclass(module = "foxglove.channels")]
-struct KeyValuePairChannel(Option<TypedChannel<foxglove::schemas::KeyValuePair>>);
+struct KeyValuePairChannel(Option<Channel<foxglove::schemas::KeyValuePair>>);
 
 #[pymethods]
 impl KeyValuePairChannel {
@@ -711,7 +711,7 @@ impl KeyValuePairChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -767,7 +767,7 @@ impl KeyValuePairChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.LaserScan` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LaserScanChannel(Option<TypedChannel<foxglove::schemas::LaserScan>>);
+struct LaserScanChannel(Option<Channel<foxglove::schemas::LaserScan>>);
 
 #[pymethods]
 impl LaserScanChannel {
@@ -776,7 +776,7 @@ impl LaserScanChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -832,7 +832,7 @@ impl LaserScanChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.LocationFix` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LocationFixChannel(Option<TypedChannel<foxglove::schemas::LocationFix>>);
+struct LocationFixChannel(Option<Channel<foxglove::schemas::LocationFix>>);
 
 #[pymethods]
 impl LocationFixChannel {
@@ -841,7 +841,7 @@ impl LocationFixChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -897,7 +897,7 @@ impl LocationFixChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Log` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LogChannel(Option<TypedChannel<foxglove::schemas::Log>>);
+struct LogChannel(Option<Channel<foxglove::schemas::Log>>);
 
 #[pymethods]
 impl LogChannel {
@@ -906,7 +906,7 @@ impl LogChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -962,7 +962,7 @@ impl LogChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneEntityDeletion` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneEntityDeletionChannel(Option<TypedChannel<foxglove::schemas::SceneEntityDeletion>>);
+struct SceneEntityDeletionChannel(Option<Channel<foxglove::schemas::SceneEntityDeletion>>);
 
 #[pymethods]
 impl SceneEntityDeletionChannel {
@@ -971,7 +971,7 @@ impl SceneEntityDeletionChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1027,7 +1027,7 @@ impl SceneEntityDeletionChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneEntity` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneEntityChannel(Option<TypedChannel<foxglove::schemas::SceneEntity>>);
+struct SceneEntityChannel(Option<Channel<foxglove::schemas::SceneEntity>>);
 
 #[pymethods]
 impl SceneEntityChannel {
@@ -1036,7 +1036,7 @@ impl SceneEntityChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1092,7 +1092,7 @@ impl SceneEntityChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneUpdate` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneUpdateChannel(Option<TypedChannel<foxglove::schemas::SceneUpdate>>);
+struct SceneUpdateChannel(Option<Channel<foxglove::schemas::SceneUpdate>>);
 
 #[pymethods]
 impl SceneUpdateChannel {
@@ -1101,7 +1101,7 @@ impl SceneUpdateChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1157,7 +1157,7 @@ impl SceneUpdateChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.PackedElementField` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PackedElementFieldChannel(Option<TypedChannel<foxglove::schemas::PackedElementField>>);
+struct PackedElementFieldChannel(Option<Channel<foxglove::schemas::PackedElementField>>);
 
 #[pymethods]
 impl PackedElementFieldChannel {
@@ -1166,7 +1166,7 @@ impl PackedElementFieldChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1222,7 +1222,7 @@ impl PackedElementFieldChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Point2` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Point2Channel(Option<TypedChannel<foxglove::schemas::Point2>>);
+struct Point2Channel(Option<Channel<foxglove::schemas::Point2>>);
 
 #[pymethods]
 impl Point2Channel {
@@ -1231,7 +1231,7 @@ impl Point2Channel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1287,7 +1287,7 @@ impl Point2Channel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Point3` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Point3Channel(Option<TypedChannel<foxglove::schemas::Point3>>);
+struct Point3Channel(Option<Channel<foxglove::schemas::Point3>>);
 
 #[pymethods]
 impl Point3Channel {
@@ -1296,7 +1296,7 @@ impl Point3Channel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1352,7 +1352,7 @@ impl Point3Channel {
 
 /// A channel for logging :py:class:`foxglove.schemas.PointCloud` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PointCloudChannel(Option<TypedChannel<foxglove::schemas::PointCloud>>);
+struct PointCloudChannel(Option<Channel<foxglove::schemas::PointCloud>>);
 
 #[pymethods]
 impl PointCloudChannel {
@@ -1361,7 +1361,7 @@ impl PointCloudChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1417,7 +1417,7 @@ impl PointCloudChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.PointsAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PointsAnnotationChannel(Option<TypedChannel<foxglove::schemas::PointsAnnotation>>);
+struct PointsAnnotationChannel(Option<Channel<foxglove::schemas::PointsAnnotation>>);
 
 #[pymethods]
 impl PointsAnnotationChannel {
@@ -1426,7 +1426,7 @@ impl PointsAnnotationChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1482,7 +1482,7 @@ impl PointsAnnotationChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Pose` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PoseChannel(Option<TypedChannel<foxglove::schemas::Pose>>);
+struct PoseChannel(Option<Channel<foxglove::schemas::Pose>>);
 
 #[pymethods]
 impl PoseChannel {
@@ -1491,7 +1491,7 @@ impl PoseChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1547,7 +1547,7 @@ impl PoseChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.PoseInFrame` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PoseInFrameChannel(Option<TypedChannel<foxglove::schemas::PoseInFrame>>);
+struct PoseInFrameChannel(Option<Channel<foxglove::schemas::PoseInFrame>>);
 
 #[pymethods]
 impl PoseInFrameChannel {
@@ -1556,7 +1556,7 @@ impl PoseInFrameChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1612,7 +1612,7 @@ impl PoseInFrameChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.PosesInFrame` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PosesInFrameChannel(Option<TypedChannel<foxglove::schemas::PosesInFrame>>);
+struct PosesInFrameChannel(Option<Channel<foxglove::schemas::PosesInFrame>>);
 
 #[pymethods]
 impl PosesInFrameChannel {
@@ -1621,7 +1621,7 @@ impl PosesInFrameChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1677,7 +1677,7 @@ impl PosesInFrameChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Quaternion` messages.
 #[pyclass(module = "foxglove.channels")]
-struct QuaternionChannel(Option<TypedChannel<foxglove::schemas::Quaternion>>);
+struct QuaternionChannel(Option<Channel<foxglove::schemas::Quaternion>>);
 
 #[pymethods]
 impl QuaternionChannel {
@@ -1686,7 +1686,7 @@ impl QuaternionChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1742,7 +1742,7 @@ impl QuaternionChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.RawImage` messages.
 #[pyclass(module = "foxglove.channels")]
-struct RawImageChannel(Option<TypedChannel<foxglove::schemas::RawImage>>);
+struct RawImageChannel(Option<Channel<foxglove::schemas::RawImage>>);
 
 #[pymethods]
 impl RawImageChannel {
@@ -1751,7 +1751,7 @@ impl RawImageChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1807,7 +1807,7 @@ impl RawImageChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.TextAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct TextAnnotationChannel(Option<TypedChannel<foxglove::schemas::TextAnnotation>>);
+struct TextAnnotationChannel(Option<Channel<foxglove::schemas::TextAnnotation>>);
 
 #[pymethods]
 impl TextAnnotationChannel {
@@ -1816,7 +1816,7 @@ impl TextAnnotationChannel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1872,7 +1872,7 @@ impl TextAnnotationChannel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Vector2` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Vector2Channel(Option<TypedChannel<foxglove::schemas::Vector2>>);
+struct Vector2Channel(Option<Channel<foxglove::schemas::Vector2>>);
 
 #[pymethods]
 impl Vector2Channel {
@@ -1881,7 +1881,7 @@ impl Vector2Channel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 
@@ -1937,7 +1937,7 @@ impl Vector2Channel {
 
 /// A channel for logging :py:class:`foxglove.schemas.Vector3` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Vector3Channel(Option<TypedChannel<foxglove::schemas::Vector3>>);
+struct Vector3Channel(Option<Channel<foxglove::schemas::Vector3>>);
 
 #[pymethods]
 impl Vector3Channel {
@@ -1946,7 +1946,7 @@ impl Vector3Channel {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -1,6 +1,6 @@
 use errors::PyFoxgloveError;
 use foxglove::{
-    Channel, ChannelBuilder, Context, McapWriter, McapWriterHandle, PartialMetadata, Schema,
+    ChannelBuilder, Context, McapWriter, McapWriterHandle, PartialMetadata, RawChannel, Schema,
 };
 use generated::channels;
 use generated::schemas;
@@ -57,7 +57,7 @@ impl From<PySchema> for foxglove::Schema {
 }
 
 #[pyclass(module = "foxglove")]
-struct BaseChannel(Option<Arc<Channel>>);
+struct BaseChannel(Option<Arc<RawChannel>>);
 
 /// A writer for logging messages to an MCAP file.
 ///
@@ -122,7 +122,7 @@ impl BaseChannel {
             .message_encoding(message_encoding)
             .schema(schema.map(Schema::from))
             .metadata(metadata.unwrap_or_default())
-            .build()
+            .build_raw()
             .map_err(PyFoxgloveError::from)?;
 
         Ok(BaseChannel(Some(channel)))

--- a/rust/examples-unstable/ws-stream-mcap/src/main.rs
+++ b/rust/examples-unstable/ws-stream-mcap/src/main.rs
@@ -15,7 +15,7 @@ use bytes::Buf;
 use clap::Parser;
 use foxglove::websocket::Capability;
 use foxglove::{
-    Channel, ChannelBuilder, PartialMetadata, Schema, WebSocketServer,
+    ChannelBuilder, PartialMetadata, RawChannel, Schema, WebSocketServer,
     WebSocketServerBlockingHandle,
 };
 use mcap::records::{MessageHeader, Record, SchemaHeader};
@@ -117,7 +117,7 @@ where
 struct Summary {
     path: PathBuf,
     schemas: HashMap<u16, Schema>,
-    channels: HashMap<u16, Arc<Channel>>,
+    channels: HashMap<u16, Arc<RawChannel>>,
 }
 
 impl Summary {
@@ -195,7 +195,7 @@ impl Summary {
             let channel = ChannelBuilder::new(record.topic)
                 .message_encoding(&record.message_encoding)
                 .schema(schema)
-                .build()?;
+                .build_raw()?;
             entry.insert(channel);
         }
         Ok(())
@@ -204,13 +204,13 @@ impl Summary {
 
 struct FileStream<'a> {
     path: PathBuf,
-    channels: &'a HashMap<u16, Arc<Channel>>,
+    channels: &'a HashMap<u16, Arc<RawChannel>>,
     time_tracker: Option<TimeTracker>,
 }
 
 impl<'a> FileStream<'a> {
     /// Creates a new file stream.
-    fn new(path: &Path, channels: &'a HashMap<u16, Arc<Channel>>) -> Self {
+    fn new(path: &Path, channels: &'a HashMap<u16, Arc<RawChannel>>) -> Self {
         Self {
             path: path.to_owned(),
             channels,

--- a/rust/examples/client-publish/src/main.rs
+++ b/rust/examples/client-publish/src/main.rs
@@ -12,7 +12,7 @@ use foxglove::convert::SaturatingInto;
 use foxglove::schemas::log::Level;
 use foxglove::schemas::Log;
 use foxglove::websocket::{Capability, Client, ClientChannel, ServerListener};
-use foxglove::{PartialMetadata, TypedChannel, WebSocketServer};
+use foxglove::{Channel, PartialMetadata, WebSocketServer};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio_util::sync::CancellationToken;
@@ -81,7 +81,7 @@ async fn main() {
 }
 
 async fn log_forever() {
-    let channel = TypedChannel::new("/log").expect("Failed to create channel");
+    let channel = Channel::new("/log").expect("Failed to create channel");
     let start = Instant::now();
     let mut sequence = 0;
     let mut interval = tokio::time::interval(Duration::from_secs(1));

--- a/rust/examples/mcap/src/main.rs
+++ b/rust/examples/mcap/src/main.rs
@@ -48,7 +48,7 @@ struct Message {
     count: u32,
 }
 
-foxglove::static_typed_channel!(pub MSG_CHANNEL, "/msg", Message);
+foxglove::static_channel!(pub MSG_CHANNEL, "/msg", Message);
 
 fn log_until(fps: u8, stop: Arc<AtomicBool>) {
     let mut count: u32 = 0;

--- a/rust/examples/quickstart/src/main.rs
+++ b/rust/examples/quickstart/src/main.rs
@@ -10,7 +10,7 @@ use foxglove::McapWriter;
 
 const FILE_NAME: &str = "quickstart-rust.mcap";
 
-foxglove::static_typed_channel!(pub(crate) SCENE, "/scene", foxglove::schemas::SceneUpdate);
+foxglove::static_channel!(pub(crate) SCENE, "/scene", foxglove::schemas::SceneUpdate);
 
 fn log_message() {
     let size = std::time::SystemTime::now()

--- a/rust/examples/ws-server-blocking/src/main.rs
+++ b/rust/examples/ws-server-blocking/src/main.rs
@@ -12,7 +12,7 @@ struct Message {
     count: u32,
 }
 
-foxglove::static_typed_channel!(pub MSG_CHANNEL, "/msg", Message);
+foxglove::static_channel!(pub MSG_CHANNEL, "/msg", Message);
 
 fn log_until(fps: u8, stop: Arc<AtomicBool>) {
     let mut count: u32 = 0;

--- a/rust/examples/ws-server/src/main.rs
+++ b/rust/examples/ws-server/src/main.rs
@@ -3,7 +3,7 @@ use foxglove::convert::SaturatingInto;
 use foxglove::schemas::{
     Color, CubePrimitive, FrameTransform, Pose, Quaternion, SceneEntity, SceneUpdate, Vector3,
 };
-use foxglove::{static_typed_channel, Channel, ChannelBuilder};
+use foxglove::{static_typed_channel, ChannelBuilder, RawChannel};
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::sync::{Arc, LazyLock};
@@ -28,17 +28,18 @@ static_typed_channel!(pub TF_CHANNEL, "/tf", FrameTransform);
 static_typed_channel!(pub MSG_CHANNEL, "/msg", Message);
 
 // Foxglove supports logging arbitrary JSON values without specifying a schema
-static SCHEMALESS_CHANNEL: LazyLock<Arc<Channel>> = LazyLock::new(|| {
-    match ChannelBuilder::new("/schemaless")
-        .message_encoding("json")
-        .build()
-    {
-        Ok(chan) => chan,
-        Err(e) => {
-            panic!("example failed to create /schemaless channel: {e}");
+static SCHEMALESS_CHANNEL: LazyLock<Arc<RawChannel>> =
+    LazyLock::new(|| {
+        match ChannelBuilder::new("/schemaless")
+            .message_encoding("json")
+            .build_raw()
+        {
+            Ok(chan) => chan,
+            Err(e) => {
+                panic!("example failed to create /schemaless channel: {e}");
+            }
         }
-    }
-});
+    });
 
 async fn log_forever(fps: u8) {
     let mut counter: u32 = 0;

--- a/rust/examples/ws-server/src/main.rs
+++ b/rust/examples/ws-server/src/main.rs
@@ -3,7 +3,7 @@ use foxglove::convert::SaturatingInto;
 use foxglove::schemas::{
     Color, CubePrimitive, FrameTransform, Pose, Quaternion, SceneEntity, SceneUpdate, Vector3,
 };
-use foxglove::{static_typed_channel, ChannelBuilder, RawChannel};
+use foxglove::{static_channel, ChannelBuilder, RawChannel};
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::sync::{Arc, LazyLock};
@@ -23,9 +23,9 @@ struct Message {
     count: u32,
 }
 
-static_typed_channel!(pub BOX_CHANNEL, "/boxes", SceneUpdate);
-static_typed_channel!(pub TF_CHANNEL, "/tf", FrameTransform);
-static_typed_channel!(pub MSG_CHANNEL, "/msg", Message);
+static_channel!(pub BOX_CHANNEL, "/boxes", SceneUpdate);
+static_channel!(pub TF_CHANNEL, "/tf", FrameTransform);
+static_channel!(pub MSG_CHANNEL, "/msg", Message);
 
 // Foxglove supports logging arbitrary JSON values without specifying a schema
 static SCHEMALESS_CHANNEL: LazyLock<Arc<RawChannel>> =

--- a/rust/foxglove/README.md
+++ b/rust/foxglove/README.md
@@ -18,7 +18,7 @@ A "sink" is a destination for logged messages — either an MCAP file or a live 
 A "channel" gives a way to log related messages which have the same schema. Each channel is instantiated with a unique topic name.
 
 The SDK provides structs for well-known schemas. These can be used in conjunction with
-`TypedChannel` for type-safe logging, which ensures at compile time that
+`Channel` for type-safe logging, which ensures at compile time that
 messages logged to a channel all share a common schema.
 
 You can also define your own custom data types by implementing the `Encode` trait. This

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -142,21 +142,21 @@ impl<T: Encode> Channel<T> {
 ///
 /// # Example
 /// ```
-/// use foxglove::static_typed_channel;
+/// use foxglove::static_channel;
 /// use foxglove::schemas::{FrameTransform, SceneUpdate};
 ///
 /// // A locally-scoped typed channel.
-/// static_typed_channel!(TF, "/tf", FrameTransform);
+/// static_channel!(TF, "/tf", FrameTransform);
 ///
 /// // A pub(crate)-scoped typed channel.
-/// static_typed_channel!(pub(crate) BOXES, "/boxes", SceneUpdate);
+/// static_channel!(pub(crate) BOXES, "/boxes", SceneUpdate);
 ///
 /// // Usage (you would populate the structs, rather than using `default()`).
 /// TF.log(&FrameTransform::default());
 /// BOXES.log(&SceneUpdate::default());
 /// ```
 #[macro_export]
-macro_rules! static_typed_channel {
+macro_rules! static_channel {
     ($vis:vis $ident: ident, $topic: literal, $ty: ty) => {
         $vis static $ident: std::sync::LazyLock<$crate::Channel<$ty>> =
             std::sync::LazyLock::new(|| match $crate::Channel::new($topic) {

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::Relaxed;
 
@@ -37,64 +36,13 @@ impl std::fmt::Display for ChannelId {
     }
 }
 
-/// A Schema is a description of the data format of messages in a channel.
-///
-/// It allows Foxglove to validate messages and provide richer visualizations.
-/// You can use the well known types provided in the [crate::schemas] module or provide your own.
-/// See the [MCAP spec](https://mcap.dev/spec#schema-op0x03) for more information.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Schema {
-    /// An identifier for the schema.
-    pub name: String,
-    /// The encoding of the schema data. For example "jsonschema" or "protobuf".
-    /// The [well-known schema encodings](https://mcap.dev/spec/registry#well-known-schema-encodings) are preferred.
-    pub encoding: String,
-    /// Must conform to the schema encoding. If encoding is an empty string, data should be 0 length.
-    pub data: Cow<'static, [u8]>,
-}
-
-impl std::fmt::Debug for Schema {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Schema")
-            .field("name", &self.name)
-            .field("encoding", &self.encoding)
-            .finish_non_exhaustive()
-    }
-}
-
-impl Schema {
-    /// Returns a new schema.
-    pub fn new(
-        name: impl Into<String>,
-        encoding: impl Into<String>,
-        data: impl Into<Cow<'static, [u8]>>,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            encoding: encoding.into(),
-            data: data.into(),
-        }
-    }
-
-    /// Returns a JSON schema for the specified type.
-    pub fn json_schema<T: schemars::JsonSchema>() -> Self {
-        let json_schema = schemars::schema_for!(T);
-        Self::new(
-            std::any::type_name::<T>(),
-            "jsonschema",
-            serde_json::to_vec(&json_schema).expect("Failed to serialize schema"),
-        )
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::channel_builder::ChannelBuilder;
     use crate::collection::collection;
     use crate::log_sink_set::ERROR_LOGGING_MESSAGE;
     use crate::testutil::RecordingSink;
-    use crate::{Channel, Context};
+    use crate::{Channel, Context, Schema};
     use std::collections::BTreeMap;
     use std::sync::Arc;
     use tracing_test::traced_test;

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -61,9 +61,9 @@ impl<T: Encode> Channel<T> {
         ChannelBuilder::new(topic).build()
     }
 
-    pub(crate) fn from_channel(channel: Arc<RawChannel>) -> Self {
+    pub(crate) fn from_raw_channel(raw_channel: Arc<RawChannel>) -> Self {
         Self {
-            inner: channel,
+            inner: raw_channel,
             _phantom: std::marker::PhantomData,
         }
     }

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -56,7 +56,7 @@ pub struct Channel<T: Encode> {
 impl<T: Encode> Channel<T> {
     /// Constructs a new typed channel with default settings.
     ///
-    /// If you want to override the channel configuration, use [`ChannelBuilder::build_typed`].
+    /// If you want to override the channel configuration, use [`ChannelBuilder`].
     pub fn new(topic: impl Into<String>) -> Result<Self, FoxgloveError> {
         ChannelBuilder::new(topic).build()
     }

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -1,15 +1,13 @@
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::atomic::{AtomicU32, AtomicU64};
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::log_sink_set::LogSinkSet;
-use crate::sink::SmallSinkVec;
-use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata};
+mod raw_channel;
+pub use raw_channel::Channel;
 
+/// Uniquely identifies a channel in the context of this program.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 pub struct ChannelId(u64);
 
@@ -89,159 +87,6 @@ impl Schema {
     }
 }
 
-/// A log channel that can be used to log binary messages.
-///
-/// A "channel" is conceptually the same as a [MCAP channel]: it is a stream of messages which all
-/// have the same type, or schema. Each channel is instantiated with a unique "topic", or name,
-/// which is typically prefixed by a `/`.
-///
-/// [MCAP channel]: https://mcap.dev/guides/concepts#channel
-///
-/// If a schema was provided, all messages must be encoded according to the schema.
-/// This is not checked. See [`TypedChannel`](crate::TypedChannel) for type-safe channels.
-/// Channels are immutable, returned as `Arc<Channel>` and can be shared between threads.
-///
-/// Channels are created using [`ChannelBuilder`](crate::ChannelBuilder).
-///
-/// # Example
-/// ```
-/// use foxglove::{ChannelBuilder, Schema};
-/// ```
-pub struct Channel {
-    id: ChannelId,
-    topic: String,
-    message_encoding: String,
-    schema: Option<Schema>,
-    metadata: BTreeMap<String, String>,
-    message_sequence: AtomicU32,
-    sinks: LogSinkSet,
-}
-
-impl Channel {
-    pub(crate) fn new(
-        topic: String,
-        message_encoding: String,
-        schema: Option<Schema>,
-        metadata: BTreeMap<String, String>,
-    ) -> Arc<Self> {
-        Arc::new(Self {
-            id: ChannelId::next(),
-            topic,
-            message_encoding,
-            schema,
-            metadata,
-            message_sequence: AtomicU32::new(1),
-            sinks: LogSinkSet::new(),
-        })
-    }
-
-    /// Returns the channel ID.
-    pub fn id(&self) -> ChannelId {
-        self.id
-    }
-
-    /// Returns the channel topic.
-    pub fn topic(&self) -> &str {
-        &self.topic
-    }
-
-    /// Returns the channel schema.
-    pub fn schema(&self) -> Option<&Schema> {
-        self.schema.as_ref()
-    }
-
-    /// Returns the message encoding for this channel.
-    pub fn message_encoding(&self) -> &str {
-        &self.message_encoding
-    }
-
-    /// Returns the metadata for this channel.
-    pub fn metadata(&self) -> &BTreeMap<String, String> {
-        &self.metadata
-    }
-
-    /// Atomically increments and returns the next message sequence number.
-    pub fn next_sequence(&self) -> u32 {
-        self.message_sequence.fetch_add(1, Relaxed)
-    }
-
-    /// Updates the set of sinks that are subscribed to this channel.
-    pub(crate) fn update_sinks(&self, sinks: SmallSinkVec) {
-        self.sinks.store(sinks);
-    }
-
-    /// Clears the set of subscribed sinks.
-    pub(crate) fn clear_sinks(&self) {
-        self.sinks.clear();
-    }
-
-    /// Returns true if at least one sink is subscribed to this channel.
-    pub fn has_sinks(&self) -> bool {
-        !self.sinks.is_empty()
-    }
-
-    /// Returns the count of sinks subscribed to this channel.
-    #[cfg(test)]
-    pub(crate) fn num_sinks(&self) -> usize {
-        self.sinks.len()
-    }
-
-    /// Logs a message.
-    pub fn log(&self, msg: &[u8]) {
-        if self.has_sinks() {
-            self.log_to_sinks(msg, PartialMetadata::default());
-        }
-    }
-
-    /// Logs a message with additional metadata.
-    pub fn log_with_meta(&self, msg: &[u8], opts: PartialMetadata) {
-        if self.has_sinks() {
-            self.log_to_sinks(msg, opts);
-        }
-    }
-
-    /// Logs a message with additional metadata.
-    pub(crate) fn log_to_sinks(&self, msg: &[u8], opts: PartialMetadata) {
-        let mut metadata = Metadata {
-            sequence: opts.sequence.unwrap_or_else(|| self.next_sequence()),
-            log_time: opts.log_time.unwrap_or_else(nanoseconds_since_epoch),
-            publish_time: opts.publish_time.unwrap_or_default(),
-        };
-        // If publish_time is not set, use log_time.
-        if opts.publish_time.is_none() {
-            metadata.publish_time = metadata.log_time
-        }
-
-        self.sinks.for_each(|sink| sink.log(self, msg, &metadata));
-    }
-}
-
-#[cfg(test)]
-impl PartialEq for Channel {
-    fn eq(&self, other: &Self) -> bool {
-        self.topic == other.topic
-            && self.message_encoding == other.message_encoding
-            && self.schema == other.schema
-            && self.metadata == other.metadata
-            && self.message_sequence.load(Relaxed) == other.message_sequence.load(Relaxed)
-    }
-}
-
-#[cfg(test)]
-impl Eq for Channel {}
-
-impl std::fmt::Debug for Channel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Channel")
-            .field("id", &self.id)
-            .field("topic", &self.topic)
-            .field("message_encoding", &self.message_encoding)
-            .field("schema", &self.schema)
-            .field("metadata", &self.metadata)
-            .finish_non_exhaustive()
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -250,6 +95,7 @@ mod test {
     use crate::log_sink_set::ERROR_LOGGING_MESSAGE;
     use crate::testutil::RecordingSink;
     use crate::{Channel, Context};
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use tracing_test::traced_test;
 
@@ -287,11 +133,11 @@ mod test {
             .context(&ctx)
             .build()
             .expect("Failed to create channel");
-        assert!(u64::from(channel.id) > 0);
-        assert_eq!(channel.topic, topic);
-        assert_eq!(channel.message_encoding, message_encoding);
-        assert_eq!(channel.schema, Some(schema));
-        assert_eq!(channel.metadata, metadata);
+        assert!(u64::from(channel.id()) > 0);
+        assert_eq!(channel.topic(), topic);
+        assert_eq!(channel.message_encoding(), message_encoding);
+        assert_eq!(channel.schema(), Some(&schema));
+        assert_eq!(channel.metadata(), &metadata);
         assert_eq!(ctx.get_channel_by_topic(topic), Some(channel));
     }
 

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -1,10 +1,18 @@
+use std::collections::BTreeMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
 
+use delegate::delegate;
 use serde::{Deserialize, Serialize};
+
+use crate::{ChannelBuilder, Encode, FoxgloveError, PartialMetadata, Schema};
 
 mod raw_channel;
 pub use raw_channel::Channel;
+
+/// Stack buffer size to use for encoding messages.
+const STACK_BUFFER_SIZE: usize = 128 * 1024;
 
 /// Uniquely identifies a channel in the context of this program.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
@@ -34,6 +42,130 @@ impl std::fmt::Display for ChannelId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+/// A typed [`Channel`] for messages that implement [`Encode`].
+///
+/// Channels are immutable, returned as `Arc<Channel>` and can be shared between threads.
+#[derive(Debug)]
+pub struct TypedChannel<T: Encode> {
+    inner: Arc<Channel>,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: Encode> TypedChannel<T> {
+    /// Constructs a new typed channel with default settings.
+    ///
+    /// If you want to override the channel configuration, use [`ChannelBuilder::build_typed`].
+    pub fn new(topic: impl Into<String>) -> Result<Self, FoxgloveError> {
+        ChannelBuilder::new(topic).build_typed()
+    }
+
+    pub(crate) fn from_channel(channel: Arc<Channel>) -> Self {
+        Self {
+            inner: channel,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    delegate! { to self.inner {
+        /// Returns the channel ID.
+        pub fn id(&self) -> ChannelId;
+
+        /// Returns the topic name of the channel.
+        pub fn topic(&self) -> &str;
+
+        /// Returns the channel schema.
+        pub fn schema(&self) -> Option<&Schema>;
+
+        /// Returns the message encoding for this channel.
+        pub fn message_encoding(&self) -> &str;
+
+        /// Returns the metadata for this channel.
+        pub fn metadata(&self) -> &BTreeMap<String, String>;
+
+        /// Returns true if there's at least one sink subscribed to this channel.
+        pub fn has_sinks(&self) -> bool;
+    } }
+
+    /// Encodes the message and logs it on the channel.
+    pub fn log(&self, msg: &T) {
+        if self.has_sinks() {
+            self.log_to_sinks(msg, PartialMetadata::default());
+        }
+    }
+
+    /// Encodes the message and logs it on the channel with additional metadata.
+    pub fn log_with_meta(&self, msg: &T, metadata: PartialMetadata) {
+        if self.has_sinks() {
+            self.log_to_sinks(msg, metadata);
+        }
+    }
+
+    fn log_to_sinks(&self, msg: &T, metadata: PartialMetadata) {
+        // Try to avoid heap allocation by using a stack buffer.
+        let mut stack_buf = [0u8; STACK_BUFFER_SIZE];
+        let mut cursor = &mut stack_buf[..];
+
+        match msg.encode(&mut cursor) {
+            Ok(()) => {
+                // Compute the written amount of bytes
+                let written = cursor.as_ptr() as usize - stack_buf.as_ptr() as usize;
+                self.inner.log_to_sinks(&stack_buf[..written], metadata);
+            }
+            Err(_) => {
+                // Likely the stack buffer was too small, so fall back to a heap buffer.
+                let mut size = msg.encoded_len().unwrap_or(STACK_BUFFER_SIZE * 2);
+                if size <= STACK_BUFFER_SIZE {
+                    // The estimate in `encoded_len` was too small, fall back to stack buffer size * 2
+                    size = STACK_BUFFER_SIZE * 2;
+                }
+                let mut buf = Vec::with_capacity(size);
+                if let Err(err) = msg.encode(&mut buf) {
+                    tracing::error!("failed to encode message: {:?}", err);
+                }
+                self.inner.log_to_sinks(&buf, metadata);
+            }
+        }
+    }
+}
+
+/// Registers a static [`TypedChannel`] for the provided topic and message type.
+///
+/// This macro is a wrapper around [`LazyLock<TypedChannel<T>>`](std::sync::LazyLock),
+/// which initializes the channel lazily upon first use. If the initialization fails (e.g., due to
+/// [`FoxgloveError::DuplicateChannel`]), the program will panic.
+///
+/// If you don't require a static variable, you can just use [`TypedChannel::new()`] directly.
+///
+/// The channel is created with the provided visibility and identifier, and the topic and message type.
+///
+/// # Example
+/// ```
+/// use foxglove::static_typed_channel;
+/// use foxglove::schemas::{FrameTransform, SceneUpdate};
+///
+/// // A locally-scoped typed channel.
+/// static_typed_channel!(TF, "/tf", FrameTransform);
+///
+/// // A pub(crate)-scoped typed channel.
+/// static_typed_channel!(pub(crate) BOXES, "/boxes", SceneUpdate);
+///
+/// // Usage (you would populate the structs, rather than using `default()`).
+/// TF.log(&FrameTransform::default());
+/// BOXES.log(&SceneUpdate::default());
+/// ```
+#[macro_export]
+macro_rules! static_typed_channel {
+    ($vis:vis $ident: ident, $topic: literal, $ty: ty) => {
+        $vis static $ident: std::sync::LazyLock<$crate::TypedChannel<$ty>> =
+            std::sync::LazyLock::new(|| match $crate::TypedChannel::new($topic) {
+                Ok(channel) => channel,
+                Err(e) => {
+                    panic!("Failed to create channel for {}: {:?}", $topic, e);
+                }
+            });
+    };
 }
 
 #[cfg(test)]

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -28,7 +28,7 @@ use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata, Schema};
 /// ```
 /// use foxglove::{ChannelBuilder, Schema};
 /// ```
-pub struct Channel {
+pub struct RawChannel {
     id: ChannelId,
     topic: String,
     message_encoding: String,
@@ -38,7 +38,7 @@ pub struct Channel {
     sinks: LogSinkSet,
 }
 
-impl Channel {
+impl RawChannel {
     pub(crate) fn new(
         topic: String,
         message_encoding: String,
@@ -138,7 +138,7 @@ impl Channel {
 }
 
 #[cfg(test)]
-impl PartialEq for Channel {
+impl PartialEq for RawChannel {
     fn eq(&self, other: &Self) -> bool {
         self.topic == other.topic
             && self.message_encoding == other.message_encoding
@@ -149,9 +149,9 @@ impl PartialEq for Channel {
 }
 
 #[cfg(test)]
-impl Eq for Channel {}
+impl Eq for RawChannel {}
 
-impl std::fmt::Debug for Channel {
+impl std::fmt::Debug for RawChannel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Channel")
             .field("id", &self.id)

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -1,0 +1,164 @@
+//! A raw channel.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+
+use super::ChannelId;
+use crate::log_sink_set::LogSinkSet;
+use crate::sink::SmallSinkVec;
+use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata, Schema};
+
+/// A log channel that can be used to log binary messages.
+///
+/// A "channel" is conceptually the same as a [MCAP channel]: it is a stream of messages which all
+/// have the same type, or schema. Each channel is instantiated with a unique "topic", or name,
+/// which is typically prefixed by a `/`.
+///
+/// [MCAP channel]: https://mcap.dev/guides/concepts#channel
+///
+/// If a schema was provided, all messages must be encoded according to the schema.
+/// This is not checked. See [`TypedChannel`](crate::TypedChannel) for type-safe channels.
+/// Channels are immutable, returned as `Arc<Channel>` and can be shared between threads.
+///
+/// Channels are created using [`ChannelBuilder`](crate::ChannelBuilder).
+///
+/// # Example
+/// ```
+/// use foxglove::{ChannelBuilder, Schema};
+/// ```
+pub struct Channel {
+    id: ChannelId,
+    topic: String,
+    message_encoding: String,
+    schema: Option<Schema>,
+    metadata: BTreeMap<String, String>,
+    message_sequence: AtomicU32,
+    sinks: LogSinkSet,
+}
+
+impl Channel {
+    pub(crate) fn new(
+        topic: String,
+        message_encoding: String,
+        schema: Option<Schema>,
+        metadata: BTreeMap<String, String>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            id: ChannelId::next(),
+            topic,
+            message_encoding,
+            schema,
+            metadata,
+            message_sequence: AtomicU32::new(1),
+            sinks: LogSinkSet::new(),
+        })
+    }
+
+    /// Returns the channel ID.
+    pub fn id(&self) -> ChannelId {
+        self.id
+    }
+
+    /// Returns the channel topic.
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    /// Returns the channel schema.
+    pub fn schema(&self) -> Option<&Schema> {
+        self.schema.as_ref()
+    }
+
+    /// Returns the message encoding for this channel.
+    pub fn message_encoding(&self) -> &str {
+        &self.message_encoding
+    }
+
+    /// Returns the metadata for this channel.
+    pub fn metadata(&self) -> &BTreeMap<String, String> {
+        &self.metadata
+    }
+
+    /// Atomically increments and returns the next message sequence number.
+    pub fn next_sequence(&self) -> u32 {
+        self.message_sequence.fetch_add(1, Relaxed)
+    }
+
+    /// Updates the set of sinks that are subscribed to this channel.
+    pub(crate) fn update_sinks(&self, sinks: SmallSinkVec) {
+        self.sinks.store(sinks);
+    }
+
+    /// Clears the set of subscribed sinks.
+    pub(crate) fn clear_sinks(&self) {
+        self.sinks.clear();
+    }
+
+    /// Returns true if at least one sink is subscribed to this channel.
+    pub fn has_sinks(&self) -> bool {
+        !self.sinks.is_empty()
+    }
+
+    /// Returns the count of sinks subscribed to this channel.
+    #[cfg(test)]
+    pub(crate) fn num_sinks(&self) -> usize {
+        self.sinks.len()
+    }
+
+    /// Logs a message.
+    pub fn log(&self, msg: &[u8]) {
+        if self.has_sinks() {
+            self.log_to_sinks(msg, PartialMetadata::default());
+        }
+    }
+
+    /// Logs a message with additional metadata.
+    pub fn log_with_meta(&self, msg: &[u8], opts: PartialMetadata) {
+        if self.has_sinks() {
+            self.log_to_sinks(msg, opts);
+        }
+    }
+
+    /// Logs a message with additional metadata.
+    pub(crate) fn log_to_sinks(&self, msg: &[u8], opts: PartialMetadata) {
+        let mut metadata = Metadata {
+            sequence: opts.sequence.unwrap_or_else(|| self.next_sequence()),
+            log_time: opts.log_time.unwrap_or_else(nanoseconds_since_epoch),
+            publish_time: opts.publish_time.unwrap_or_default(),
+        };
+        // If publish_time is not set, use log_time.
+        if opts.publish_time.is_none() {
+            metadata.publish_time = metadata.log_time
+        }
+
+        self.sinks.for_each(|sink| sink.log(self, msg, &metadata));
+    }
+}
+
+#[cfg(test)]
+impl PartialEq for Channel {
+    fn eq(&self, other: &Self) -> bool {
+        self.topic == other.topic
+            && self.message_encoding == other.message_encoding
+            && self.schema == other.schema
+            && self.metadata == other.metadata
+            && self.message_sequence.load(Relaxed) == other.message_sequence.load(Relaxed)
+    }
+}
+
+#[cfg(test)]
+impl Eq for Channel {}
+
+impl std::fmt::Debug for Channel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Channel")
+            .field("id", &self.id)
+            .field("topic", &self.topic)
+            .field("message_encoding", &self.message_encoding)
+            .field("schema", &self.schema)
+            .field("metadata", &self.metadata)
+            .finish_non_exhaustive()
+    }
+}

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -23,11 +23,6 @@ use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata, Schema};
 /// immutable, returned as `Arc<Channel>` and can be shared between threads.
 ///
 /// Channels are created using [`ChannelBuilder`](crate::ChannelBuilder).
-///
-/// # Example
-/// ```
-/// use foxglove::{ChannelBuilder, Schema};
-/// ```
 pub struct RawChannel {
     id: ChannelId,
     topic: String,

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -19,8 +19,8 @@ use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata, Schema};
 /// [MCAP channel]: https://mcap.dev/guides/concepts#channel
 ///
 /// If a schema was provided, all messages must be encoded according to the schema.
-/// This is not checked. See [`TypedChannel`](crate::TypedChannel) for type-safe channels.
-/// Channels are immutable, returned as `Arc<Channel>` and can be shared between threads.
+/// This is not checked. See [`Channel`](crate::Channel) for type-safe channels. Channels are
+/// immutable, returned as `Arc<Channel>` and can be shared between threads.
 ///
 /// Channels are created using [`ChannelBuilder`](crate::ChannelBuilder).
 ///

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::{Channel, Context, Encode, FoxgloveError, Schema, TypedChannel};
+use crate::{Context, Encode, FoxgloveError, RawChannel, Schema, TypedChannel};
 
-/// ChannelBuilder is a builder for creating a new [`Channel`] or [`TypedChannel`].
+/// ChannelBuilder is a builder for creating a new [`RawChannel`] or [`TypedChannel`].
 #[must_use]
 #[derive(Debug)]
 pub struct ChannelBuilder {
@@ -63,10 +63,11 @@ impl ChannelBuilder {
         self
     }
 
-    /// Build the channel and return it in an [`Arc`] as a Result.
+    /// Builds a [`RawChannel`].
+    ///
     /// Returns [`FoxgloveError::DuplicateChannel`] if a channel with the same topic already exists.
-    pub fn build(self) -> Result<Arc<Channel>, FoxgloveError> {
-        let channel = Channel::new(
+    pub fn build_raw(self) -> Result<Arc<RawChannel>, FoxgloveError> {
+        let channel = RawChannel::new(
             self.topic,
             self.message_encoding
                 .ok_or_else(|| FoxgloveError::MessageEncodingRequired)?,
@@ -87,7 +88,7 @@ impl ChannelBuilder {
         if self.schema.is_none() {
             self.schema = <T as Encode>::get_schema();
         }
-        let channel = self.build()?;
+        let channel = self.build_raw()?;
         Ok(TypedChannel::from_channel(channel))
     }
 }

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::encode::TypedChannel;
-use crate::{Channel, Context, Encode, FoxgloveError, Schema};
+use crate::{Channel, Context, Encode, FoxgloveError, Schema, TypedChannel};
 
 /// ChannelBuilder is a builder for creating a new [`Channel`] or [`TypedChannel`].
 #[must_use]

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::{Context, Encode, FoxgloveError, RawChannel, Schema, TypedChannel};
+use crate::{Channel, Context, Encode, FoxgloveError, RawChannel, Schema};
 
-/// ChannelBuilder is a builder for creating a new [`RawChannel`] or [`TypedChannel`].
+/// ChannelBuilder is a builder for creating a new [`RawChannel`] or [`Channel`].
 #[must_use]
 #[derive(Debug)]
 pub struct ChannelBuilder {
@@ -35,8 +35,9 @@ impl ChannelBuilder {
     }
 
     /// Set the message encoding for the channel.
-    /// This is required for Channel, but not for [`TypedChannel`] (it's provided by the [`Encode`]
-    /// trait for [`TypedChannel`].) Foxglove supports several well-known message encodings:
+    ///
+    /// This is required for [`RawChannel`], but not for [`Channel`] (it's provided by the
+    /// [`Encode`] trait for [`Channel`].) Foxglove supports several well-known message encodings:
     /// <https://docs.foxglove.dev/docs/visualization/message-schemas/introduction>
     pub fn message_encoding(mut self, encoding: &str) -> Self {
         self.message_encoding = Some(encoding.to_string());
@@ -78,10 +79,13 @@ impl ChannelBuilder {
         Ok(channel)
     }
 
-    /// Build the channel and return it as a [`TypedChannel`] as a Result.
+    /// Builds a [`Channel`].
+    ///
     /// `T` must implement [`Encode`].
-    /// Returns [`FoxgloveError::DuplicateChannel`] if a channel with the same topic already exists.
-    pub fn build_typed<T: Encode>(mut self) -> Result<TypedChannel<T>, FoxgloveError> {
+    ///
+    /// Returns [`FoxgloveError::DuplicateChannel`] if a channel with the same topic already
+    /// exists.
+    pub fn build<T: Encode>(mut self) -> Result<Channel<T>, FoxgloveError> {
         if self.message_encoding.is_none() {
             self.message_encoding = Some(<T as Encode>::get_message_encoding());
         }
@@ -89,6 +93,6 @@ impl ChannelBuilder {
             self.schema = <T as Encode>::get_schema();
         }
         let channel = self.build_raw()?;
-        Ok(TypedChannel::from_channel(channel))
+        Ok(Channel::from_channel(channel))
     }
 }

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -93,6 +93,6 @@ impl ChannelBuilder {
             self.schema = <T as Encode>::get_schema();
         }
         let channel = self.build_raw()?;
-        Ok(Channel::from_channel(channel))
+        Ok(Channel::from_raw_channel(channel))
     }
 }

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::{Channel, Context, Encode, FoxgloveError, RawChannel, Schema};
 
-/// ChannelBuilder is a builder for creating a new [`RawChannel`] or [`Channel`].
+/// A builder for creating a [`Channel`] or [`RawChannel`].
 #[must_use]
 #[derive(Debug)]
 pub struct ChannelBuilder {

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -6,26 +6,26 @@ use std::sync::{Arc, LazyLock};
 use parking_lot::RwLock;
 
 use crate::channel::ChannelId;
-use crate::{Channel, FoxgloveError, Sink, SinkId};
+use crate::{FoxgloveError, RawChannel, Sink, SinkId};
 
 mod subscriptions;
 use subscriptions::Subscriptions;
 
 #[derive(Default)]
 struct ContextInner {
-    channels: HashMap<ChannelId, Arc<Channel>>,
-    channels_by_topic: HashMap<String, Arc<Channel>>,
+    channels: HashMap<ChannelId, Arc<RawChannel>>,
+    channels_by_topic: HashMap<String, Arc<RawChannel>>,
     sinks: HashMap<SinkId, Arc<dyn Sink>>,
     subs: Subscriptions,
 }
 impl ContextInner {
     /// Returns the channel for the specified topic, if there is one.
-    fn get_channel_by_topic(&self, topic: &str) -> Option<&Arc<Channel>> {
+    fn get_channel_by_topic(&self, topic: &str) -> Option<&Arc<RawChannel>> {
         self.channels_by_topic.get(topic)
     }
 
     /// Adds a channel to the context.
-    fn add_channel(&mut self, channel: Arc<Channel>) -> Result<(), FoxgloveError> {
+    fn add_channel(&mut self, channel: Arc<RawChannel>) -> Result<(), FoxgloveError> {
         // Insert channel.
         let topic = channel.topic();
         let Entry::Vacant(entry) = self.channels_by_topic.entry(topic.to_string()) else {
@@ -131,7 +131,7 @@ impl ContextInner {
     }
 
     /// Updates the set of connected sinks on the specified channels.
-    fn update_channel_sinks(&self, channels: impl IntoIterator<Item = impl AsRef<Channel>>) {
+    fn update_channel_sinks(&self, channels: impl IntoIterator<Item = impl AsRef<RawChannel>>) {
         for channel in channels {
             let channel = channel.as_ref();
             let sinks = self.subs.get_subscribers(channel.id());
@@ -176,12 +176,12 @@ impl Context {
     }
 
     /// Returns the channel for the specified topic, if there is one.
-    pub fn get_channel_by_topic(&self, topic: &str) -> Option<Arc<Channel>> {
+    pub fn get_channel_by_topic(&self, topic: &str) -> Option<Arc<RawChannel>> {
         self.0.read().get_channel_by_topic(topic).cloned()
     }
 
     /// Adds a channel to the context.
-    pub fn add_channel(&self, channel: Arc<Channel>) -> Result<(), FoxgloveError> {
+    pub fn add_channel(&self, channel: Arc<RawChannel>) -> Result<(), FoxgloveError> {
         self.0.write().add_channel(channel)
     }
 
@@ -234,11 +234,11 @@ mod tests {
     use crate::log_sink_set::ERROR_LOGGING_MESSAGE;
     use crate::testutil::{ErrorSink, MockSink, RecordingSink};
     use crate::{context::*, ChannelBuilder};
-    use crate::{nanoseconds_since_epoch, Channel, PartialMetadata, Schema};
+    use crate::{nanoseconds_since_epoch, PartialMetadata, RawChannel, Schema};
     use std::sync::Arc;
     use tracing_test::traced_test;
 
-    fn new_test_channel(ctx: &Arc<Context>, topic: &str) -> Result<Arc<Channel>, FoxgloveError> {
+    fn new_test_channel(ctx: &Arc<Context>, topic: &str) -> Result<Arc<RawChannel>, FoxgloveError> {
         ChannelBuilder::new(topic)
             .context(ctx)
             .message_encoding("message_encoding")
@@ -254,7 +254,7 @@ mod tests {
                 }"#,
             ))
             .metadata(collection! {"key".to_string() => "value".to_string()})
-            .build()
+            .build_raw()
     }
 
     #[test]
@@ -472,7 +472,7 @@ mod tests {
         let ch = ChannelBuilder::new("topic")
             .message_encoding("json")
             .context(&ctx)
-            .build()
+            .build_raw()
             .unwrap();
         assert!(ch.has_sinks());
         ctx.remove_sink(s1.id());

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -5,8 +5,7 @@ use std::sync::{Arc, LazyLock};
 
 use parking_lot::RwLock;
 
-use crate::channel::ChannelId;
-use crate::{FoxgloveError, RawChannel, Sink, SinkId};
+use crate::{ChannelId, FoxgloveError, RawChannel, Sink, SinkId};
 
 mod subscriptions;
 use subscriptions::Subscriptions;

--- a/rust/foxglove/src/context/subscriptions.rs
+++ b/rust/foxglove/src/context/subscriptions.rs
@@ -3,9 +3,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::channel::ChannelId;
 use crate::sink::SmallSinkVec;
-use crate::{Sink, SinkId};
+use crate::{ChannelId, Sink, SinkId};
 
 #[cfg(test)]
 mod tests;

--- a/rust/foxglove/src/context/subscriptions/tests.rs
+++ b/rust/foxglove/src/context/subscriptions/tests.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use crate::channel::ChannelId;
 use crate::testutil::MockSink;
-use crate::Sink;
+use crate::{ChannelId, Sink};
 
 use super::Subscriptions;
 

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -8,8 +8,8 @@ use crate::Schema;
 
 /// A trait representing a message that can be logged to a channel.
 ///
-/// Implementing this trait for your type `T` enables the use of [`TypedChannel<T>`],
-/// which offers a type-checked `log` method.
+/// Implementing this trait for your type `T` enables the use of [`Channel<T>`], which offers a
+/// type-checked `log` method.
 pub trait Encode {
     /// The error type returned by methods in this trait.
     type Error: std::error::Error;
@@ -115,7 +115,7 @@ mod test {
         let ctx = Context::new();
         let channel = ChannelBuilder::new("topic2")
             .context(&ctx)
-            .build_typed::<TestMessage>()
+            .build::<TestMessage>()
             .expect("failed to build channel");
 
         let message = TestMessage {

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use crate::Schema;
 
-/// A trait representing a message that can be logged to a [`Channel`].
+/// A trait representing a message that can be logged to a channel.
 ///
 /// Implementing this trait for your type `T` enables the use of [`TypedChannel<T>`],
 /// which offers a type-checked `log` method.

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -8,8 +8,8 @@ use crate::Schema;
 
 /// A trait representing a message that can be logged to a channel.
 ///
-/// Implementing this trait for your type `T` enables the use of [`Channel<T>`], which offers a
-/// type-checked `log` method.
+/// Implementing this trait for your type `T` enables the use of [`Channel<T>`][crate::Channel],
+/// which offers a type-checked `log` method.
 pub trait Encode {
     /// The error type returned by methods in this trait.
     type Error: std::error::Error;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -14,13 +14,13 @@
 //! called `"/log"`. Then we write one log message and close the file.
 //!
 //! ```no_run
-//! use foxglove::{McapWriter, TypedChannel};
+//! use foxglove::{McapWriter, Channel};
 //! use foxglove::schemas::Log;
 //!
 //! # fn func() -> Result<(), foxglove::FoxgloveError> {
 //! let mcap = McapWriter::new().create_new_buffered_file("test.mcap")?;
 //!
-//! let channel = TypedChannel::new("/log")?;
+//! let channel = Channel::new("/log")?;
 //! channel.log(&Log{
 //!     message: "Hello, Foxglove!".to_string(),
 //!     ..Default::default()
@@ -42,15 +42,15 @@
 //!
 //! ### Well-known types
 //!
-//! The SDK provides [structs for well-known schemas](schemas). These can be used in
-//! conjunction with [`TypedChannel`] for type-safe logging, which ensures at compile time that
-//! messages logged to a channel all share a common schema.
+//! The SDK provides [structs for well-known schemas](schemas). These can be used in conjunction
+//! with [`Channel`] for type-safe logging, which ensures at compile time that messages logged to a
+//! channel all share a common schema.
 //!
 //! ### Custom data
 //!
 //! You can also define your own custom data types by implementing the [`Encode`] trait. This
-//! allows you to log arbitrary custom data types. Notably, the `Encode` trait is
-//! automatically implemented for types that implement [`Serialize`](serde::Serialize) and
+//! allows you to log arbitrary custom data types. Notably, the `Encode` trait is automatically
+//! implemented for types that implement [`Serialize`](serde::Serialize) and
 //! [`JsonSchema`][jsonschema-trait]. This makes it easy to define new custom messages:
 //!
 //! ```no_run
@@ -61,7 +61,7 @@
 //! }
 //!
 //! # fn func() -> Result<(), foxglove::FoxgloveError> {
-//! let channel = foxglove::TypedChannel::new("/custom")?;
+//! let channel = foxglove::Channel::new("/custom")?;
 //! channel.log(&Custom{
 //!     msg: "custom",
 //!     count: 42
@@ -182,7 +182,7 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::{RawChannel, TypedChannel};
+pub use channel::{Channel, RawChannel};
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -72,11 +72,11 @@
 //! ### Static Channels
 //!
 //! A common pattern is to create the channels once as static variables, and then use them
-//! throughout the application. To support this, the [`static_typed_channel!`] macro
-//! provides a convenient way to create static channels:
+//! throughout the application. To support this, the [`static_channel!`] macro provides a
+//! convenient way to create static channels:
 //!
 //! ```no_run
-//! foxglove::static_typed_channel!(pub(crate) BOXES, "/boxes", foxglove::schemas::SceneUpdate);
+//! foxglove::static_channel!(pub(crate) BOXES, "/boxes", foxglove::schemas::SceneUpdate);
 //! ```
 //!
 //! [jsonschema-trait]: https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -182,11 +182,11 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::Channel;
+pub use channel::{Channel, TypedChannel};
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;
-pub use encode::{Encode, TypedChannel};
+pub use encode::Encode;
 pub use mcap_writer::{McapWriter, McapWriterHandle};
 pub use metadata::{Metadata, PartialMetadata};
 pub(crate) use runtime::get_runtime_handle;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -182,7 +182,7 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::{Channel, TypedChannel};
+pub use channel::{RawChannel, TypedChannel};
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -182,7 +182,7 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::{Channel, RawChannel};
+pub use channel::{Channel, ChannelId, RawChannel};
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -170,6 +170,7 @@ mod log_sink_set;
 mod mcap_writer;
 mod metadata;
 mod runtime;
+mod schema;
 pub mod schemas;
 mod schemas_wkt;
 mod sink;
@@ -181,7 +182,7 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::{Channel, Schema};
+pub use channel::Channel;
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;
@@ -190,6 +191,7 @@ pub use mcap_writer::{McapWriter, McapWriterHandle};
 pub use metadata::{Metadata, PartialMetadata};
 pub(crate) use runtime::get_runtime_handle;
 pub use runtime::shutdown_runtime;
+pub use schema::Schema;
 pub use sink::{Sink, SinkId};
 pub(crate) use time::nanoseconds_since_epoch;
 pub use websocket_server::{WebSocketServer, WebSocketServerBlockingHandle, WebSocketServerHandle};

--- a/rust/foxglove/src/mcap_writer/mcap_sink.rs
+++ b/rust/foxglove/src/mcap_writer/mcap_sink.rs
@@ -1,6 +1,6 @@
 //! [`Sink`] implementation for an MCAP writer.
 use crate::channel::ChannelId;
-use crate::{Channel, FoxgloveError, Metadata, Sink, SinkId};
+use crate::{FoxgloveError, Metadata, RawChannel, Sink, SinkId};
 use mcap::WriteOptions;
 use parking_lot::Mutex;
 use std::collections::hash_map::Entry;
@@ -25,7 +25,7 @@ impl<W: Write + Seek> WriterState<W> {
 
     fn log(
         &mut self,
-        channel: &Channel,
+        channel: &RawChannel,
         msg: &[u8],
         metadata: &Metadata,
     ) -> Result<(), FoxgloveError> {
@@ -110,7 +110,12 @@ impl<W: Write + Seek + Send> Sink for McapSink<W> {
         self.sink_id
     }
 
-    fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {
+    fn log(
+        &self,
+        channel: &RawChannel,
+        msg: &[u8],
+        metadata: &Metadata,
+    ) -> Result<(), FoxgloveError> {
         _ = metadata;
         let mut guard = self.inner.lock();
         let writer = guard.as_mut().ok_or(FoxgloveError::SinkClosed)?;
@@ -126,8 +131,8 @@ mod tests {
     use std::path::Path;
     use tempfile::NamedTempFile;
 
-    fn new_test_channel(topic: String, schema_name: String) -> Arc<Channel> {
-        Channel::new(
+    fn new_test_channel(topic: String, schema_name: String) -> Arc<RawChannel> {
+        RawChannel::new(
             topic,
             "message_encoding".to_string(),
             Some(Schema::new(

--- a/rust/foxglove/src/mcap_writer/mcap_sink.rs
+++ b/rust/foxglove/src/mcap_writer/mcap_sink.rs
@@ -1,6 +1,5 @@
 //! [`Sink`] implementation for an MCAP writer.
-use crate::channel::ChannelId;
-use crate::{FoxgloveError, Metadata, RawChannel, Sink, SinkId};
+use crate::{ChannelId, FoxgloveError, Metadata, RawChannel, Sink, SinkId};
 use mcap::WriteOptions;
 use parking_lot::Mutex;
 use std::collections::hash_map::Entry;

--- a/rust/foxglove/src/schema.rs
+++ b/rust/foxglove/src/schema.rs
@@ -1,0 +1,51 @@
+use std::borrow::Cow;
+
+/// A Schema is a description of the data format of messages in a channel.
+///
+/// It allows Foxglove to validate messages and provide richer visualizations.
+/// You can use the well known types provided in the [crate::schemas] module or provide your own.
+/// See the [MCAP spec](https://mcap.dev/spec#schema-op0x03) for more information.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Schema {
+    /// An identifier for the schema.
+    pub name: String,
+    /// The encoding of the schema data. For example "jsonschema" or "protobuf".
+    /// The [well-known schema encodings](https://mcap.dev/spec/registry#well-known-schema-encodings) are preferred.
+    pub encoding: String,
+    /// Must conform to the schema encoding. If encoding is an empty string, data should be 0 length.
+    pub data: Cow<'static, [u8]>,
+}
+
+impl std::fmt::Debug for Schema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Schema")
+            .field("name", &self.name)
+            .field("encoding", &self.encoding)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Schema {
+    /// Returns a new schema.
+    pub fn new(
+        name: impl Into<String>,
+        encoding: impl Into<String>,
+        data: impl Into<Cow<'static, [u8]>>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            encoding: encoding.into(),
+            data: data.into(),
+        }
+    }
+
+    /// Returns a JSON schema for the specified type.
+    pub fn json_schema<T: schemars::JsonSchema>() -> Self {
+        let json_schema = schemars::schema_for!(T);
+        Self::new(
+            std::any::type_name::<T>(),
+            "jsonschema",
+            serde_json::to_vec(&json_schema).expect("Failed to serialize schema"),
+        )
+    }
+}

--- a/rust/foxglove/src/schemas.rs
+++ b/rust/foxglove/src/schemas.rs
@@ -4,7 +4,7 @@
 //! and a better experience in the Foxglove App.
 //!
 //! They're encoded as compact, binary protobuf messages,
-//! and can be conveniently used with the [`TypedChannel`](crate::TypedChannel) API.
+//! and can be conveniently used with the [`Channel`](crate::Channel) API.
 
 pub(crate) mod descriptors;
 #[allow(missing_docs)]

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use smallvec::SmallVec;
 
 use crate::metadata::Metadata;
-use crate::{Channel, FoxgloveError};
+use crate::{FoxgloveError, RawChannel};
 
 /// Uniquely identifies a [`Sink`] in the context of this program.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -23,7 +23,7 @@ impl std::fmt::Display for SinkId {
     }
 }
 
-/// A [`Sink`] writes a message from a [`Channel`] to a destination.
+/// A [`Sink`] writes a message from a channel to a destination.
 ///
 /// Sinks are thread-safe and can be shared between threads. Usually you'd use our implementations
 /// like [`McapWriter`](crate::McapWriter) or [`WebSocketServer`](crate::WebSocketServer).
@@ -36,7 +36,12 @@ pub trait Sink: Send + Sync {
     /// Writes the message for the channel to the sink.
     ///
     /// Metadata contains optional message metadata that may be used by some sink implementations.
-    fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError>;
+    fn log(
+        &self,
+        channel: &RawChannel,
+        msg: &[u8],
+        metadata: &Metadata,
+    ) -> Result<(), FoxgloveError>;
 
     /// Called when a new channel is made available within the [`Context`][ctx].
     ///
@@ -57,7 +62,7 @@ pub trait Sink: Send + Sync {
     ///
     /// [ctx]: crate::Context
     /// [sub]: crate::Context::subscribe_channels
-    fn add_channel(&self, _channel: &Arc<Channel>) -> bool {
+    fn add_channel(&self, _channel: &Arc<RawChannel>) -> bool {
         false
     }
 
@@ -71,7 +76,7 @@ pub trait Sink: Send + Sync {
     ///
     /// [ctx]: crate::Context
     /// [unsub]: crate::Context::unsubscribe_channels
-    fn remove_channel(&self, _channel: &Channel) {}
+    fn remove_channel(&self, _channel: &RawChannel) {}
 
     /// Indicates whether this sink automatically subscribes to all channels.
     ///

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -3,9 +3,8 @@ use std::sync::Arc;
 
 use smallvec::SmallVec;
 
-use crate::channel::Channel;
 use crate::metadata::Metadata;
-use crate::FoxgloveError;
+use crate::{Channel, FoxgloveError};
 
 /// Uniquely identifies a [`Sink`] in the context of this program.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/rust/foxglove/src/tests/logging.rs
+++ b/rust/foxglove/src/tests/logging.rs
@@ -52,7 +52,7 @@ async fn test_logging_to_file_and_live_sinks() {
             }"#,
         ))
         .context(&ctx)
-        .build()
+        .build_raw()
         .expect("Failed to create channel");
 
     {

--- a/rust/foxglove/src/testutil.rs
+++ b/rust/foxglove/src/testutil.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use parking_lot::Mutex;
 
-use crate::channel::ChannelId;
 use crate::websocket::{
     ChannelView, Client, ClientChannel, ClientChannelId, ClientId, Parameter, ServerListener,
 };
+use crate::ChannelId;
 
 mod sink;
 pub use sink::{ErrorSink, MockSink, RecordingSink};

--- a/rust/foxglove/src/testutil/sink.rs
+++ b/rust/foxglove/src/testutil/sink.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::channel::ChannelId;
-use crate::{Channel, FoxgloveError, Metadata, Sink, SinkId};
+use crate::{FoxgloveError, Metadata, RawChannel, Sink, SinkId};
 use parking_lot::Mutex;
 
 pub struct MockSink(SinkId);
@@ -18,7 +18,7 @@ impl Sink for MockSink {
 
     fn log(
         &self,
-        _channel: &Channel,
+        _channel: &RawChannel,
         _msg: &[u8],
         _metadata: &Metadata,
     ) -> Result<(), FoxgloveError> {
@@ -69,11 +69,16 @@ impl Sink for RecordingSink {
         self.auto_subscribe
     }
 
-    fn add_channel(&self, _channel: &Arc<Channel>) -> bool {
+    fn add_channel(&self, _channel: &Arc<RawChannel>) -> bool {
         self.add_channel_rval
     }
 
-    fn log(&self, channel: &Channel, msg: &[u8], metadata: &Metadata) -> Result<(), FoxgloveError> {
+    fn log(
+        &self,
+        channel: &RawChannel,
+        msg: &[u8],
+        metadata: &Metadata,
+    ) -> Result<(), FoxgloveError> {
         let mut recorded = self.recorded.lock();
         recorded.push(LogCall {
             channel_id: channel.id(),
@@ -107,7 +112,7 @@ impl Sink for ErrorSink {
 
     fn log(
         &self,
-        _channel: &Channel,
+        _channel: &RawChannel,
         _msg: &[u8],
         _metadata: &Metadata,
     ) -> Result<(), FoxgloveError> {

--- a/rust/foxglove/src/testutil/sink.rs
+++ b/rust/foxglove/src/testutil/sink.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use crate::channel::ChannelId;
-use crate::{FoxgloveError, Metadata, RawChannel, Sink, SinkId};
+use crate::{ChannelId, FoxgloveError, Metadata, RawChannel, Sink, SinkId};
 use parking_lot::Mutex;
 
 pub struct MockSink(SinkId);

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -21,9 +21,10 @@ use tokio_tungstenite::tungstenite::{self, handshake::server, http::HeaderValue,
 use tokio_tungstenite::WebSocketStream;
 use tokio_util::sync::CancellationToken;
 
-use crate::channel::ChannelId;
 use crate::cow_vec::CowVec;
-use crate::{get_runtime_handle, Context, FoxgloveError, Metadata, RawChannel, Sink, SinkId};
+use crate::{
+    get_runtime_handle, ChannelId, Context, FoxgloveError, Metadata, RawChannel, Sink, SinkId,
+};
 
 mod fetch_asset;
 pub use fetch_asset::{AssetHandler, AssetResponder};

--- a/rust/foxglove/src/websocket/protocol/client.rs
+++ b/rust/foxglove/src/websocket/protocol/client.rs
@@ -1,10 +1,8 @@
 //! Definitions of client-to-server messages in ws-protocol.
 //! Serializations are derived for testing.
 
-use crate::{
-    channel::ChannelId,
-    websocket::service::{CallId, ServiceId},
-};
+use crate::websocket::service::{CallId, ServiceId};
+use crate::ChannelId;
 use base64::{prelude::BASE64_STANDARD, Engine};
 use bytes::{Buf, Bytes};
 use serde::{Deserialize, Serialize};

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -1,11 +1,8 @@
-use crate::channel::ChannelId;
-use crate::channel::RawChannel;
-use crate::websocket::service::CallId;
-use crate::websocket::service::ServiceId;
-use crate::websocket::service::{self, Service};
+use crate::websocket::service::{self, CallId, Service, ServiceId};
 use crate::websocket::Capability;
 use crate::FoxgloveError;
 use crate::Schema;
+use crate::{ChannelId, RawChannel};
 use base64::prelude::*;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};

--- a/rust/foxglove/src/websocket/protocol/server.rs
+++ b/rust/foxglove/src/websocket/protocol/server.rs
@@ -1,5 +1,5 @@
-use crate::channel::Channel;
 use crate::channel::ChannelId;
+use crate::channel::RawChannel;
 use crate::websocket::service::CallId;
 use crate::websocket::service::ServiceId;
 use crate::websocket::service::{self, Service};
@@ -205,7 +205,7 @@ fn encode_schema_data(schema: &Schema) -> Result<Cow<str>, FoxgloveError> {
 // A `schema` in the channel is optional except for message_encodings which require a schema.
 // Currently, Foxglove supports schemaless JSON messages.
 // https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#advertise
-pub fn advertisement(channel: &Channel) -> Result<String, FoxgloveError> {
+pub fn advertisement(channel: &RawChannel) -> Result<String, FoxgloveError> {
     let id = channel.id();
     let topic = channel.topic();
     let encoding = channel.message_encoding();

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -17,7 +17,9 @@ use crate::websocket::{
     BlockingAssetHandlerFn, Capability, ClientChannelId, ConnectionGraph, Parameter, ParameterType,
     ParameterValue, Status, StatusLevel,
 };
-use crate::{collection, Channel, ChannelBuilder, Context, FoxgloveError, PartialMetadata, Schema};
+use crate::{
+    collection, ChannelBuilder, Context, FoxgloveError, PartialMetadata, RawChannel, Schema,
+};
 
 fn make_message(id: usize) -> Message {
     Message::Text(format!("{id}").into())
@@ -72,7 +74,7 @@ fn test_send_lossy() {
     assert_eq!(received, ((TOTAL - BACKLOG)..TOTAL).collect::<Vec<_>>());
 }
 
-fn new_channel(topic: &str, ctx: &Arc<Context>) -> Arc<Channel> {
+fn new_channel(topic: &str, ctx: &Arc<Context>) -> Arc<RawChannel> {
     ChannelBuilder::new(topic)
         .message_encoding("message_encoding")
         .schema(Schema::new(
@@ -82,7 +84,7 @@ fn new_channel(topic: &str, ctx: &Arc<Context>) -> Arc<Channel> {
         ))
         .metadata(collection! {"key".to_string() => "value".to_string()})
         .context(ctx)
-        .build()
+        .build_raw()
         .expect("Failed to create channel")
 }
 
@@ -312,7 +314,7 @@ async fn test_advertise_schemaless_channels() {
     let json_chan = ChannelBuilder::new("/schemaless_json")
         .message_encoding("json")
         .context(&ctx)
-        .build()
+        .build_raw()
         .expect("Failed to create channel");
 
     json_chan.log(b"{\"a\": 1}");
@@ -331,7 +333,7 @@ async fn test_advertise_schemaless_channels() {
     let invalid_chan = ChannelBuilder::new("/schemaless_other")
         .message_encoding("protobuf")
         .context(&ctx)
-        .build()
+        .build_raw()
         .expect("Failed to create channel");
 
     invalid_chan.log(b"1");

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -540,7 +540,7 @@ export function generateChannelClasses(messageSchemas: FoxgloveMessageSchema[]):
   ].join("\n");
 
   const imports = [
-    `use foxglove::{TypedChannel, PartialMetadata};`,
+    `use foxglove::{Channel, PartialMetadata};`,
     `use pyo3::prelude::*;`,
     `use crate::errors::PyFoxgloveError;`,
     `use super::schemas;`,
@@ -554,7 +554,7 @@ export function generateChannelClasses(messageSchemas: FoxgloveMessageSchema[]):
     return `
 /// A channel for logging :py:class:\`foxglove.schemas.${schemaClass}\` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ${channelClass}(Option<TypedChannel<foxglove::schemas::${schemaClass}>>);
+struct ${channelClass}(Option<Channel<foxglove::schemas::${schemaClass}>>);
 
 #[pymethods]
 impl ${channelClass} {
@@ -563,7 +563,7 @@ impl ${channelClass} {
     /// :param topic: The topic to log messages to.
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
-        let base = TypedChannel::new(topic).map_err(PyFoxgloveError::from)?;
+        let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(Some(base)))
     }
 


### PR DESCRIPTION
### Changelog
- rust: Renamed `Channel` to `RawChannel`, and `TypedChannel` to `Channel`.

### Description
We realized that we want to encourage rust users to use the typed channel interface, rather than the untyped one. This change adjusts the naming of those structs to be `Channel` and `RawChannel`.