### PR TITLE
Preserve schema name in encodings

### DIFF
--- a/rust/foxglove-proto-gen/src/lib.rs
+++ b/rust/foxglove-proto-gen/src/lib.rs
@@ -142,6 +142,7 @@ fn generate_impls(out_dir: &Path, fds: &FileDescriptorSet) -> anyhow::Result<()>
         else {
             continue;
         };
+        let schema_name = name;
         // Special case for GeoJSON casing
         if name == "GeoJSON" {
             name = "GeoJson";
@@ -154,7 +155,7 @@ fn generate_impls(out_dir: &Path, fds: &FileDescriptorSet) -> anyhow::Result<()>
 
     fn get_schema() -> Option<Schema> {{
         Some(Schema::new(
-            \"foxglove.{name}\",
+            \"foxglove.{schema_name}\",
             \"protobuf\",
             descriptors::{descriptor_name},
         ))

--- a/rust/foxglove/src/schemas/impls.rs
+++ b/rust/foxglove/src/schemas/impls.rs
@@ -162,7 +162,7 @@ impl Encode for GeoJson {
 
     fn get_schema() -> Option<Schema> {
         Some(Schema::new(
-            "foxglove.GeoJson",
+            "foxglove.GeoJSON",
             "protobuf",
             descriptors::GEO_JSON,
         ))

--- a/rust/foxglove/src/tests.rs
+++ b/rust/foxglove/src/tests.rs
@@ -1,5 +1,6 @@
 use std::{error::Error, fmt::Display};
 mod logging;
+mod schemas;
 
 use crate::FoxgloveError;
 

--- a/rust/foxglove/src/tests/schemas.rs
+++ b/rust/foxglove/src/tests/schemas.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+mod test {
+    use crate::encode::Encode;
+    use crate::schemas::GeoJson;
+    #[test]
+    fn test_geojson_schema_preserves_schema_name() {
+        let schema = GeoJson::get_schema();
+        assert!(schema.is_some());
+        assert_eq!(schema.unwrap().name, "foxglove.GeoJSON");
+    }
+}


### PR DESCRIPTION
### Changelog
Fix: the schema name for GeoJSON channels capitalized correctly

### Description

foxglove-proto-gen renames the GeoJSON schema to GeoJson to match structure naming conventions, but incorrectly writes that as the schema name. This preserves the renaming behavior, but fixes the schema name for compatibility with the app. 