### PR TITLE
rust: Expose ChannelId struct

### DIFF
--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -10,6 +10,7 @@ use crate::log_sink_set::LogSinkSet;
 use crate::sink::SmallSinkVec;
 use crate::{nanoseconds_since_epoch, Metadata, PartialMetadata};
 
+/// Unique identifier of a channel.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
 pub struct ChannelId(u64);
 

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -181,7 +181,7 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::{Channel, Schema};
+pub use channel::{Channel, ChannelId, Schema};
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;


### PR DESCRIPTION
### Changelog
rust: Expose `ChannelId` struct

### Docs
TBD

### Description
In my custom Sink, I'd like to use a `HashMap<ChannelId, T>`. This PR exposes the `ChannelId` struct publicly to support that use case.