### PR TITLE
C++: fix schema lifetime issue in Channel constructor

### DIFF
--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 struct foxglove_channel;
 
@@ -32,6 +33,7 @@ public:
 
 private:
   std::unique_ptr<foxglove_channel, void (*)(foxglove_channel*)> _impl;
+  std::vector<uint8_t> _storedSchema;
 };
 
 }  // namespace foxglove

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -8,14 +8,25 @@ Channel::Channel(
 )
     : _impl(nullptr, foxglove_channel_free) {
   foxglove_schema cSchema = {};
+  std::optional<foxglove_schema*> schemaPtr = std::nullopt;
+
   if (schema) {
     cSchema.name = schema->name.data();
     cSchema.encoding = schema->encoding.data();
-    cSchema.data = reinterpret_cast<const uint8_t*>(schema->data);
-    cSchema.data_len = schema->dataLen;
+
+    if (schema->data && schema->dataLen > 0) {
+      _storedSchema.assign(
+        reinterpret_cast<const uint8_t*>(schema->data),
+        reinterpret_cast<const uint8_t*>(schema->data) + schema->dataLen
+      );
+      cSchema.data = _storedSchema.data();
+      cSchema.data_len = _storedSchema.size();
+    }
+
+    schemaPtr = &cSchema;
   }
   _impl.reset(
-    foxglove_channel_create(topic.data(), messageEncoding.data(), schema ? &cSchema : nullptr)
+    foxglove_channel_create(topic.c_str(), messageEncoding.c_str(), schemaPtr.value_or(nullptr))
   );
 }
 

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -65,6 +65,53 @@ std::string readFile(const std::string& path) {
   return std::string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
 }
 
+TEST_CASE("Stores the schema in the channel") {
+  FileCleanup cleanup("test.mcap");
+
+  foxglove::McapWriterOptions options = {};
+  options.path = "test.mcap";
+  foxglove::McapWriter writer(options);
+
+  std::string schemaJson = R"({
+    "type": "object",
+    "properties": {
+      "my_totally_custom_schema_field": { "type": "integer" }
+    },
+    "required": ["my_totally_custom_schema_field"]
+  })";
+
+  const size_t dataLen = schemaJson.size();
+  std::unique_ptr<std::byte[]> tempBuffer(new std::byte[dataLen]);
+  std::memcpy(tempBuffer.get(), schemaJson.data(), dataLen);
+
+  foxglove::Schema schema = {
+    .name = "TempSchema",
+    .encoding = "jsonschema",
+    .data = tempBuffer.get(),
+    .dataLen = dataLen,
+  };
+
+  // Construct the channel using the temporary buffer
+  foxglove::Channel channel("/temp", "json", schema);
+
+  // Overwrite the original memory to simulate the schema lifetime ending
+  std::memset(tempBuffer.get(), 0xFF, dataLen);
+
+  const char* jsonMessage = R"({"timestamp":12345678})";
+  const std::byte* messageBytes = reinterpret_cast<const std::byte*>(jsonMessage);
+  size_t messageLength = std::strlen(jsonMessage);
+
+  channel.log(messageBytes, messageLength);
+
+  writer.close();
+
+  REQUIRE(std::filesystem::exists("test.mcap"));
+  std::string content = readFile("test.mcap");
+
+  // Verify that the schema is present in the file
+  REQUIRE(content.find(schemaJson) != std::string::npos);
+}
+
 TEST_CASE("specify profile") {
   FileCleanup cleanup("test.mcap");
 

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -84,12 +84,11 @@ TEST_CASE("Stores the schema in the channel") {
   std::unique_ptr<std::byte[]> tempBuffer(new std::byte[dataLen]);
   std::memcpy(tempBuffer.get(), schemaJson.data(), dataLen);
 
-  foxglove::Schema schema = {
-    .name = "TempSchema",
-    .encoding = "jsonschema",
-    .data = tempBuffer.get(),
-    .dataLen = dataLen,
-  };
+  foxglove::Schema schema;
+  schema.name = "TempSchema";
+  schema.encoding = "jsonschema";
+  schema.data = tempBuffer.get();
+  schema.dataLen = dataLen;
 
   // Construct the channel using the temporary buffer
   foxglove::Channel channel("/temp", "json", schema);


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Updates the C++ wrapper's `Channel` implementation to deep copy the schema data into an internal `std::vector<uint8_t>` — this ensures that the memory remains valid for the lifetime of the channel, so the copied data can be passed to the C API at the user's convenience.

The `foxglove::Channel` constructor previously stored a raw pointer to schema data passed via the Schema struct. This was a problem because if the original memory was invalidated after construction, it could lead to dangling pointers, which lead to a corrupted schema, which lead to this error:

<img src="https://github.com/user-attachments/assets/19111a05-4235-4b5f-a5b8-467cc394bbd4" width=350 />

