### PR TITLE
Fix lifetime issues

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn foxglove_channel_create(
             .to_str()
             .expect("schema encoding is invalid");
         let data = unsafe { std::slice::from_raw_parts(schema.data, schema.data_len) };
-        foxglove::Schema::new(name, encoding, data)
+        foxglove::Schema::new(name, encoding, data.to_owned())
     });
     Arc::into_raw(
         foxglove::ChannelBuilder::new(topic)

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -372,18 +372,16 @@ pub unsafe extern "C" fn foxglove_channel_create(
     let message_encoding = unsafe { CStr::from_ptr(message_encoding) }
         .to_str()
         .expect("message_encoding is invalid");
-    let schema = unsafe {
-        schema.as_ref().map(|schema| {
-            let name = CStr::from_ptr(schema.name)
-                .to_str()
-                .expect("schema name is invalid");
-            let encoding = CStr::from_ptr(schema.encoding)
-                .to_str()
-                .expect("schema encoding is invalid");
-            let data = std::slice::from_raw_parts(schema.data, schema.data_len);
-            foxglove::Schema::new(name, encoding, data)
-        })
-    };
+    let schema = unsafe { schema.as_ref() }.map(|schema| {
+        let name = unsafe { CStr::from_ptr(schema.name) }
+            .to_str()
+            .expect("schema name is invalid");
+        let encoding = unsafe { CStr::from_ptr(schema.encoding) }
+            .to_str()
+            .expect("schema encoding is invalid");
+        let data = unsafe { std::slice::from_raw_parts(schema.data, schema.data_len) };
+        foxglove::Schema::new(name, encoding, data)
+    });
     Arc::into_raw(
         foxglove::ChannelBuilder::new(topic)
             .message_encoding(message_encoding)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -44,8 +44,8 @@ FetchContent_Declare(asio
 FetchContent_MakeAvailable(asio)
 
 if(DEFINED SANITIZE)
-  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    message(FATAL_ERROR "Sanitizers are only supported with Clang")
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    message(FATAL_ERROR "Sanitizers are only supported with Clang, not ${CMAKE_CXX_COMPILER_ID}")
   endif()
   set(SANITIZER_COMPILE_OPTIONS -fsanitize=${SANITIZE} -fsanitize-ignorelist=${CMAKE_CURRENT_SOURCE_DIR}/sanitize-ignorelist.txt -fno-omit-frame-pointer -fno-sanitize-recover=all)
   set(SANITIZER_LINK_OPTIONS -fsanitize=${SANITIZE})

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -4,9 +4,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <optional>
+
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::Equals;
 

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <optional>
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::Equals;
 
@@ -142,4 +143,38 @@ TEST_CASE("lz4 compression") {
   // Check that it contains the word "lz4"
   std::string content = readFile("test.mcap");
   REQUIRE_THAT(content, ContainsSubstring("lz4"));
+}
+
+TEST_CASE("Channel can outlive Schema") {
+  FileCleanup cleanup("test.mcap");
+
+  foxglove::McapWriterOptions options = {};
+  options.path = "test.mcap";
+  foxglove::McapWriter writer(options);
+
+  // Write message
+  std::optional<foxglove::Channel> channel;
+  {
+    foxglove::Schema schema;
+    schema.name = "ExampleSchema";
+    schema.encoding = "unknown";
+    std::string data = "FAKESCHEMA";
+    schema.data = reinterpret_cast<const std::byte*>(data.data());
+    schema.dataLen = data.size();
+    channel = foxglove::Channel{"example", "json", schema};
+    // Channel should copy the schema, so this modification has no effect on the output
+    data[2] = 'I';
+    data[3] = 'L';
+  }
+
+  const std::array<uint8_t, 3> data = {4, 5, 6};
+  channel->log(reinterpret_cast<const std::byte*>(data.data()), data.size());
+
+  writer.close();
+
+  REQUIRE(std::filesystem::exists("test.mcap"));
+
+  std::string content = readFile("test.mcap");
+  REQUIRE_THAT(content, !ContainsSubstring("FAILSCHEMA"));
+  REQUIRE_THAT(content, ContainsSubstring("FAKESCHEMA"));
 }

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -46,6 +46,29 @@ TEST_CASE("Log a message with and without metadata") {
   channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size(), 1, 2, 3);
 }
 
+TEST_CASE("Channel can outlive Schema") {
+  foxglove::WebSocketServerOptions options;
+  options.name = "unit-test";
+  options.host = "127.0.0.1";
+  options.port = 0;
+  foxglove::WebSocketServer server{options};
+  REQUIRE(server.port() != 0);
+
+  std::optional<foxglove::Channel> channel;
+  {
+    foxglove::Schema schema;
+    schema.name = "ExampleSchema";
+    schema.encoding = "unknown";
+    const std::array<uint8_t, 3> data = {1, 2, 3};
+    schema.data = reinterpret_cast<const std::byte*>(data.data());
+    schema.dataLen = data.size();
+    channel = foxglove::Channel{"example", "json", schema};
+  }
+
+  const std::array<uint8_t, 3> data = {4, 5, 6};
+  channel->log(reinterpret_cast<const std::byte*>(data.data()), data.size());
+}
+
 TEST_CASE("Subscribe and unsubscribe callbacks") {
   std::mutex mutex;
   std::condition_variable cv;

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -46,29 +46,6 @@ TEST_CASE("Log a message with and without metadata") {
   channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size(), 1, 2, 3);
 }
 
-TEST_CASE("Channel can outlive Schema") {
-  foxglove::WebSocketServerOptions options;
-  options.name = "unit-test";
-  options.host = "127.0.0.1";
-  options.port = 0;
-  foxglove::WebSocketServer server{options};
-  REQUIRE(server.port() != 0);
-
-  std::optional<foxglove::Channel> channel;
-  {
-    foxglove::Schema schema;
-    schema.name = "ExampleSchema";
-    schema.encoding = "unknown";
-    const std::array<uint8_t, 3> data = {1, 2, 3};
-    schema.data = reinterpret_cast<const std::byte*>(data.data());
-    schema.dataLen = data.size();
-    channel = foxglove::Channel{"example", "json", schema};
-  }
-
-  const std::array<uint8_t, 3> data = {4, 5, 6};
-  channel->log(reinterpret_cast<const std::byte*>(data.data()), data.size());
-}
-
 TEST_CASE("Subscribe and unsubscribe callbacks") {
   std::mutex mutex;
   std::condition_variable cv;


### PR DESCRIPTION
### Changelog
C++: fixed a potential use-after-free by adding a missing copy.

### Docs

None

### Description

Reported in #320 

It was intended that the Schema data should never be used again after the Channel constructor, but because it was held by a Cow, it was not actually being copied. Introduce an explicit `to_owned()` to fix the issue.