### PR TITLE
websocket: don't send msg for empty add_services call

### DIFF
--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -1417,6 +1417,9 @@ impl Server {
         if !self.capabilities.contains(&Capability::Services) {
             return Err(FoxgloveError::ServicesNotSupported);
         }
+        if new_services.is_empty() {
+            return Ok(());
+        }
 
         let mut new_names = HashMap::with_capacity(new_services.len());
         for service in &new_services {


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Tiny optimization. If no services are being added, there is no need to send a message to clients.