### PR TITLE
python: Channel.close() should remove channel from context

### DIFF
--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -150,7 +150,10 @@ impl BaseChannel {
     }
 
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            let ctx = Context::get_default();
+            ctx.remove_channel_for_topic(inner.topic());
+        }
     }
 }
 


### PR DESCRIPTION
### Changelog
- python: Fixed a bug with Channel.close(), which wasn't unregistering the channel

### Description
A straightforward change to make `Channel.close()` behave as advertised by unregistering the channel from the context.