### PR TITLE
Optimize buffering in log_to_sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
+ "smallbytes",
  "smallvec",
  "strum 0.26.3",
  "tempfile",
@@ -1830,6 +1831,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "smallbytes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058d68c846e75e40719a9f772887608604e8af199157a2fa58a3ae4bad6ee934"
+dependencies = [
+ "bytes",
+ "smallvec",
 ]
 
 [[package]]

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -32,6 +32,7 @@ serde_repr = "0.1.19"
 serde_with = { version = "3.12.0", features = ["macros", "base64"] }
 serde.workspace = true
 smallvec = "1.14.0"
+smallbytes = "0.1.0"
 strum = { version = "0.26", features = ["derive"] }
 thiserror.workspace = true
 tokio-tungstenite.workspace = true

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -112,6 +112,9 @@ impl<T: Encode> Channel<T> {
     fn log_to_sinks(&self, msg: &T, metadata: PartialMetadata) {
         // Try to avoid heap allocation by using a stack buffer.
         let mut buf: SmallBytes<STACK_BUFFER_SIZE> = SmallBytes::new();
+        if let Some(estimated_size) = msg.encoded_len() {
+            buf.reserve(estimated_size);
+        }
 
         msg.encode(&mut buf).unwrap();
         self.inner.log_to_sinks(&buf, metadata);

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use crate::Schema;
 
-/// A trait representing a message that can be logged to a [`Channel`].
+/// A trait representing a message that can be logged to a channel.
 ///
 /// Implementing this trait for your type `T` enables the use of [`Channel<T>`][crate::Channel],
 /// which offers a type-checked `log` method.


### PR DESCRIPTION
### Changelog

Improve logging performance by ~20%

### Description

This actually simplifies the code. I had to bring in the SmallBytes crate for a BufMut wrapper around SmallVec.

