### PR TITLE
rust: Replace static_channel! with LazyChannel

### DIFF
--- a/rust/examples/mcap/src/main.rs
+++ b/rust/examples/mcap/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use clap::{Parser, ValueEnum};
-use foxglove::McapWriter;
+use foxglove::{LazyChannel, McapWriter};
 use mcap::{Compression, WriteOptions};
 use std::time::Duration;
 
@@ -48,7 +48,7 @@ struct Message {
     count: u32,
 }
 
-foxglove::static_channel!(pub MSG_CHANNEL, "/msg", Message);
+static MSG_CHANNEL: LazyChannel<Message> = LazyChannel::new("/msg");
 
 fn log_until(fps: u8, stop: Arc<AtomicBool>) {
     let mut count: u32 = 0;

--- a/rust/examples/quickstart/src/main.rs
+++ b/rust/examples/quickstart/src/main.rs
@@ -1,16 +1,13 @@
-use std::{
-    ops::Add,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::ops::Add;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-use foxglove::McapWriter;
+use foxglove::schemas::SceneUpdate;
+use foxglove::{LazyChannel, McapWriter};
 
 const FILE_NAME: &str = "quickstart-rust.mcap";
 
-foxglove::static_channel!(pub(crate) SCENE, "/scene", foxglove::schemas::SceneUpdate);
+static SCENE: LazyChannel<SceneUpdate> = LazyChannel::new("/scene");
 
 fn log_message() {
     let size = std::time::SystemTime::now()

--- a/rust/examples/ws-server-blocking/src/main.rs
+++ b/rust/examples/ws-server-blocking/src/main.rs
@@ -6,13 +6,15 @@ use std::time::Duration;
 
 use clap::Parser;
 
+use foxglove::LazyChannel;
+
 #[derive(Debug, serde::Serialize, schemars::JsonSchema)]
 struct Message {
     msg: String,
     count: u32,
 }
 
-foxglove::static_channel!(pub MSG_CHANNEL, "/msg", Message);
+static MSG_CHANNEL: LazyChannel<Message> = LazyChannel::new("/msg");
 
 fn log_until(fps: u8, stop: Arc<AtomicBool>) {
     let mut count: u32 = 0;

--- a/rust/examples/ws-server/src/main.rs
+++ b/rust/examples/ws-server/src/main.rs
@@ -3,7 +3,7 @@ use foxglove::convert::SaturatingInto;
 use foxglove::schemas::{
     Color, CubePrimitive, FrameTransform, Pose, Quaternion, SceneEntity, SceneUpdate, Vector3,
 };
-use foxglove::{static_channel, ChannelBuilder, RawChannel};
+use foxglove::{ChannelBuilder, LazyChannel, RawChannel};
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::sync::{Arc, LazyLock};
@@ -23,9 +23,9 @@ struct Message {
     count: u32,
 }
 
-static_channel!(pub BOX_CHANNEL, "/boxes", SceneUpdate);
-static_channel!(pub TF_CHANNEL, "/tf", FrameTransform);
-static_channel!(pub MSG_CHANNEL, "/msg", Message);
+static BOX_CHANNEL: LazyChannel<SceneUpdate> = LazyChannel::new("/boxes");
+static TF_CHANNEL: LazyChannel<FrameTransform> = LazyChannel::new("/tf");
+static MSG_CHANNEL: LazyChannel<Message> = LazyChannel::new("/msg");
 
 // Foxglove supports logging arbitrary JSON values without specifying a schema
 static SCHEMALESS_CHANNEL: LazyLock<Arc<RawChannel>> =

--- a/rust/examples/ws-server/src/main.rs
+++ b/rust/examples/ws-server/src/main.rs
@@ -3,10 +3,9 @@ use foxglove::convert::SaturatingInto;
 use foxglove::schemas::{
     Color, CubePrimitive, FrameTransform, Pose, Quaternion, SceneEntity, SceneUpdate, Vector3,
 };
-use foxglove::{ChannelBuilder, LazyChannel, RawChannel};
+use foxglove::{LazyChannel, LazyRawChannel};
 use schemars::JsonSchema;
 use serde::Serialize;
-use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -28,18 +27,7 @@ static TF_CHANNEL: LazyChannel<FrameTransform> = LazyChannel::new("/tf");
 static MSG_CHANNEL: LazyChannel<Message> = LazyChannel::new("/msg");
 
 // Foxglove supports logging arbitrary JSON values without specifying a schema
-static SCHEMALESS_CHANNEL: LazyLock<Arc<RawChannel>> =
-    LazyLock::new(|| {
-        match ChannelBuilder::new("/schemaless")
-            .message_encoding("json")
-            .build_raw()
-        {
-            Ok(chan) => chan,
-            Err(e) => {
-                panic!("example failed to create /schemaless channel: {e}");
-            }
-        }
-    });
+static SCHEMALESS_CHANNEL: LazyRawChannel = LazyRawChannel::new("/schemaless", "json");
 
 async fn log_forever(fps: u8) {
     let mut counter: u32 = 0;

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -12,7 +12,7 @@ use crate::{ChannelBuilder, Encode, FoxgloveError, PartialMetadata, Schema};
 mod lazy_channel;
 mod raw_channel;
 
-pub use lazy_channel::LazyChannel;
+pub use lazy_channel::{LazyChannel, LazyRawChannel};
 pub use raw_channel::RawChannel;
 
 /// Stack buffer size to use for encoding messages.

--- a/rust/foxglove/src/channel/lazy_channel.rs
+++ b/rust/foxglove/src/channel/lazy_channel.rs
@@ -1,11 +1,11 @@
 //! Lazily-initialized channels
 
-use std::ops::Deref;
 use std::sync::OnceLock;
+use std::{ops::Deref, sync::Arc};
 
-use crate::Encode;
+use crate::{ChannelBuilder, Encode, Schema};
 
-use super::Channel;
+use super::{Channel, RawChannel};
 
 /// A channel that is initialized lazily upon first use.
 ///
@@ -60,6 +60,89 @@ impl<T: Encode> LazyChannel<T> {
 
 impl<T: Encode> Deref for LazyChannel<T> {
     type Target = Channel<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.get_or_init()
+    }
+}
+
+/// A raw channel that is initialized lazily upon first use.
+///
+/// A common pattern is to create the channels once as static variables, and then use them
+/// throughout the application. But because channels do not have a const initializer, they must
+/// be initialized lazily. [`LazyRawChannel`] provides a convenient way to do this for raw
+/// channels.
+///
+/// Be careful when using this pattern. The channel will not be advertised to sinks until it is
+/// initialized, which is guaranteed to happen when the channel is first used. If you need to
+/// ensure the channel is initialized _before_ using it, you can use [`LazyRawChannel::init`].
+///
+/// # Example
+/// ```
+/// use foxglove::LazyRawChannel;
+///
+/// static RAW: LazyRawChannel = LazyRawChannel::new("/raw", "message encoding")
+///     .schema("schema name", "schema encoding", b"schema data");
+/// ```
+pub struct LazyRawChannel {
+    topic: &'static str,
+    message_encoding: &'static str,
+    schema: Option<(&'static str, &'static str, &'static [u8])>,
+    inner: OnceLock<Arc<RawChannel>>,
+}
+
+impl LazyRawChannel {
+    /// Creates a new lazily-initialized raw channel.
+    pub const fn new(topic: &'static str, message_encoding: &'static str) -> Self {
+        Self {
+            topic,
+            message_encoding,
+            schema: None,
+            inner: OnceLock::new(),
+        }
+    }
+
+    /// Sets the schema for the channel.
+    #[must_use]
+    pub const fn schema(
+        mut self,
+        name: &'static str,
+        encoding: &'static str,
+        data: &'static [u8],
+    ) -> Self {
+        self.schema = Some((name, encoding, data));
+        self
+    }
+
+    /// Ensures that the channel is initialized.
+    ///
+    /// If the channel is already initialized, this is a no-op.
+    pub fn init(&self) {
+        self.get_or_init();
+    }
+
+    /// Returns a reference to the channel, initializing it if necessary.
+    fn get_or_init(&self) -> &Arc<RawChannel> {
+        self.inner.get_or_init(|| {
+            let schema = self
+                .schema
+                .map(|(name, encoding, data)| Schema::new(name, encoding, data));
+            ChannelBuilder::new(self.topic)
+                .message_encoding(self.message_encoding)
+                .schema(schema)
+                .build_raw()
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to lazily initialize channel for {}: {e:?}",
+                        self.topic
+                    )
+                })
+        })
+    }
+}
+
+impl Deref for LazyRawChannel {
+    type Target = Arc<RawChannel>;
 
     fn deref(&self) -> &Self::Target {
         self.get_or_init()

--- a/rust/foxglove/src/channel/lazy_channel.rs
+++ b/rust/foxglove/src/channel/lazy_channel.rs
@@ -1,0 +1,67 @@
+//! Lazily-initialized channels
+
+use std::ops::Deref;
+use std::sync::OnceLock;
+
+use crate::Encode;
+
+use super::Channel;
+
+/// A channel that is initialized lazily upon first use.
+///
+/// A common pattern is to create the channels once as static variables, and then use them
+/// throughout the application. But because channels do not have a const initializer, they must
+/// be initialized lazily. [`LazyChannel`] provides a convenient way to do this.
+///
+/// Be careful when using this pattern. The channel will not be advertised to sinks until it is
+/// initialized, which is guaranteed to happen when the channel is first used. If you need to
+/// ensure the channel is initialized _before_ using it, you can use [`LazyChannel::init`].
+///
+/// # Example
+/// ```
+/// use foxglove::LazyChannel;
+/// use foxglove::schemas::FrameTransform;
+///
+/// static TF: LazyChannel<FrameTransform> = LazyChannel::new("/tf");
+/// ```
+pub struct LazyChannel<T: Encode> {
+    topic: &'static str,
+    inner: OnceLock<Channel<T>>,
+}
+
+impl<T: Encode> LazyChannel<T> {
+    /// Creates a new lazily-initialized channel.
+    pub const fn new(topic: &'static str) -> Self {
+        Self {
+            topic,
+            inner: OnceLock::new(),
+        }
+    }
+
+    /// Ensures that the channel is initialized.
+    ///
+    /// If the channel is already initialized, this is a no-op.
+    pub fn init(&self) {
+        self.get_or_init();
+    }
+
+    /// Returns a reference to the channel, initializing it if necessary.
+    fn get_or_init(&self) -> &Channel<T> {
+        self.inner.get_or_init(|| {
+            Channel::new(self.topic).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to lazily initialize channel for {}: {e:?}",
+                    self.topic
+                )
+            })
+        })
+    }
+}
+
+impl<T: Encode> Deref for LazyChannel<T> {
+    type Target = Channel<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.get_or_init()
+    }
+}

--- a/rust/foxglove/src/channel/lazy_channel.rs
+++ b/rust/foxglove/src/channel/lazy_channel.rs
@@ -81,8 +81,7 @@ impl<T: Encode> Deref for LazyChannel<T> {
 /// ```
 /// use foxglove::LazyRawChannel;
 ///
-/// static RAW: LazyRawChannel = LazyRawChannel::new("/raw", "message encoding")
-///     .schema("schema name", "schema encoding", b"schema data");
+/// static SCHEMALESS: LazyRawChannel = LazyRawChannel::new("/schemaless", "json");
 /// ```
 pub struct LazyRawChannel {
     topic: &'static str,

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -66,7 +66,8 @@ impl ChannelBuilder {
 
     /// Builds a [`RawChannel`].
     ///
-    /// Returns [`FoxgloveError::DuplicateChannel`] if a channel with the same topic already exists.
+    /// Returns [`FoxgloveError::DuplicateChannel`] if a channel with the same topic already exists,
+    /// or [`FoxgloveError::MessageEncodingRequired`] if no message encoding was specified.
     pub fn build_raw(self) -> Result<Arc<RawChannel>, FoxgloveError> {
         let channel = RawChannel::new(
             self.topic,

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -189,7 +189,7 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::{Channel, ChannelId, LazyChannel, RawChannel};
+pub use channel::{Channel, ChannelId, LazyChannel, LazyRawChannel, RawChannel};
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -69,17 +69,24 @@
 //! # Ok(()) }
 //! ```
 //!
+//! [jsonschema-trait]: https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html
+//!
 //! ### Static Channels
 //!
 //! A common pattern is to create the channels once as static variables, and then use them
-//! throughout the application. To support this, the [`static_channel!`] macro provides a
-//! convenient way to create static channels:
+//! throughout the application. But because channels do not have a const initializer, they must be
+//! initialized lazily. [`LazyChannel`] provides a convenient way to do this.
 //!
-//! ```no_run
-//! foxglove::static_channel!(pub(crate) BOXES, "/boxes", foxglove::schemas::SceneUpdate);
+//! Be careful when using this pattern. The channel will not be advertised to sinks until it is
+//! initialized, which is guaranteed to happen when the channel is first used. If you need to
+//! ensure the channel is initialized _before_ using it, you can use [`LazyChannel::init`].
+//!
 //! ```
+//! use foxglove::LazyChannel;
+//! use foxglove::schemas::SceneUpdate;
 //!
-//! [jsonschema-trait]: https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html
+//! static BOXES: LazyChannel<SceneUpdate> = LazyChannel::new("/boxes");
+//! ```
 //!
 //! ## Sinks
 //!
@@ -182,7 +189,7 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
-pub use channel::{Channel, ChannelId, RawChannel};
+pub use channel::{Channel, ChannelId, LazyChannel, RawChannel};
 pub use channel_builder::ChannelBuilder;
 #[doc(hidden)]
 pub use context::Context;


### PR DESCRIPTION
### Changelog
- rust: Replace `static_channel!` with `LazyChannel`

### Description
This change attempts to address some of the feedback we've received recently:
- `static_channel!` is weird, and merely obscures typing.
- Lazily-initialized channels are a footgun.

This change aims to address both concerns by introducing a new `LazyChannel` struct. This removes the macro weirdness, and updates the naming to make the laziness more overt.

The result is a little more verbose, but I think the clarity justifies the keystrokes:

```rust
// Before
static_channel!(pub(crate), TF, FrameTransform);

// After
pub(crate) static TF: LazyChannel<FrameTransform> = LazyChannel::new("/tf");
```

Fixes: FG-10886
Fixes: FG-10913