### PR TITLE
Add Timestamp::now() convenience method

### DIFF
--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -38,6 +38,19 @@ impl Timestamp {
         self.0.nsec()
     }
 
+    /// Creates a :py:class:`Timestamp` from the current system time.
+    ///
+    /// Raises `OverflowError` if the timestamp cannot be represented.
+    /// :rtype: :py:class:`Timestamp`
+    #[staticmethod]
+    #[pyo3(signature = ())]
+    fn now() -> PyResult<Self> {
+        let now = std::time::SystemTime::now();
+        Ok(Self(foxglove::schemas::Timestamp::try_from(now).map_err(
+            |_| PyOverflowError::new_err("timestamp out of range"),
+        )?))
+    }
+
     /// Creates a :py:class:`Timestamp` from an epoch timestamp, such as is returned by
     /// :py:func:`time.time` or :py:func:`datetime.datetime.timestamp`.
     ///

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -339,6 +339,15 @@ impl Timestamp {
         Self::new_checked(sec, nsec).unwrap()
     }
 
+    /// Returns the current timestamp using SystemTime
+    pub fn now() -> Self {
+        let now = std::time::SystemTime::now();
+        let duration = now.duration_since(std::time::UNIX_EPOCH).unwrap();
+        let sec = duration.as_secs() as u32;
+        let nsec = duration.subsec_nanos();
+        Self::new(sec, nsec)
+    }
+
     /// Returns the number of seconds in the timestamp.
     pub fn sec(&self) -> u32 {
         self.sec
@@ -443,3 +452,5 @@ where
         }
     }
 }
+
+

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -339,7 +339,7 @@ impl Timestamp {
         Self::new_checked(sec, nsec).unwrap()
     }
 
-    /// Returns the current timestamp using SystemTime
+    /// Returns the current timestamp using [`SystemTime::now`][std::time::SystemTime::now].
     pub fn now() -> Self {
         let now = std::time::SystemTime::now();
         Self::try_from(now).expect("timestamp out of range")

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -342,10 +342,7 @@ impl Timestamp {
     /// Returns the current timestamp using SystemTime
     pub fn now() -> Self {
         let now = std::time::SystemTime::now();
-        let duration = now.duration_since(std::time::UNIX_EPOCH).unwrap();
-        let sec = duration.as_secs() as u32;
-        let nsec = duration.subsec_nanos();
-        Self::new(sec, nsec)
+        Self::try_from(now).expect("timestamp out of range")
     }
 
     /// Returns the number of seconds in the timestamp.
@@ -452,5 +449,3 @@ where
         }
     }
 }
-
-

--- a/rust/foxglove/src/schemas_wkt.rs
+++ b/rust/foxglove/src/schemas_wkt.rs
@@ -103,7 +103,7 @@ impl NormalizeResult {
 /// let duration: Duration = std::time::Duration::from_secs(u64::MAX).saturating_into();
 /// assert_eq!(duration, Duration::MAX);
 /// ```
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Duration {
     /// Seconds offset.
     sec: i32,
@@ -299,7 +299,7 @@ where
 ///     .saturating_into();
 /// assert_eq!(timestamp, Timestamp::MIN);
 /// ```
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Timestamp {
     /// Seconds since epoch.
     sec: u32,

--- a/rust/foxglove/src/schemas_wkt/tests.rs
+++ b/rust/foxglove/src/schemas_wkt/tests.rs
@@ -281,3 +281,14 @@ fn test_timestamp_from_system_time() {
     assert_matches!(Timestamp::try_from(orig), Err(RangeError::UpperBound));
     assert_eq!(Timestamp::saturating_from(orig), Timestamp::MAX);
 }
+
+#[test]
+fn test_timestamp_now() {
+    let now = std::time::SystemTime::now();
+    let before = Timestamp::try_from(now).unwrap();
+
+    let now = Timestamp::now();
+
+    assert!(now.sec() > before.sec() || (now.sec() == before.sec() && now.nsec() >= before.nsec()));
+    assert!(now.nsec() < 1_000_000_000);
+}

--- a/rust/foxglove/src/schemas_wkt/tests.rs
+++ b/rust/foxglove/src/schemas_wkt/tests.rs
@@ -289,6 +289,6 @@ fn test_timestamp_now() {
 
     let now = Timestamp::now();
 
-    assert!(now.sec() > before.sec() || (now.sec() == before.sec() && now.nsec() >= before.nsec()));
+    assert!(now >= before);
     assert!(now.nsec() < 1_000_000_000);
 }


### PR DESCRIPTION
I really wanted a Timestamp::now() method during the hack week. The try_from SystemTime works, but it's verbose.

