### PR TITLE
rust: Add Channel::close

### DIFF
--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -84,7 +84,7 @@ class Channel:
         Close the channel.
 
         You do not need to call this unless you explicitly want to remove advertisements from live
-        visualization clients. Destroying all references to the channel will also close it.
+        visualization clients.
         """
         self.base.close()
 

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -83,8 +83,10 @@ class Channel:
         """
         Close the channel.
 
-        You do not need to call this unless you explicitly want to remove advertisements from live
-        visualization clients.
+        You can use this to explicitly unadvertise the channel to sinks that subscribe to
+        channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+
+        Attempts to log on a closed channel will elicit a throttled warning message.
         """
         self.base.close()
 

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -1,3 +1,4 @@
+import logging
 import random
 
 import pytest
@@ -55,25 +56,25 @@ def test_log_must_serialize_on_protobuf_channel(new_topic: str) -> None:
 def test_closed_channel_log(new_topic: str, caplog: pytest.LogCaptureFixture) -> None:
     channel = Channel(new_topic, schema={"type": "object"})
     channel.close()
-    with caplog.at_level("DEBUG"):
+    with caplog.at_level(logging.WARNING):
         channel.log(b"\x01")
 
     assert len(caplog.records) == 1
     for log_name, _, message in caplog.record_tuples:
-        assert log_name == "foxglove.channels"
-        assert message == "Cannot log() on a closed channel"
+        assert log_name == "foxglove.channel.raw_channel"
+        assert message == f"Cannot log on closed channel for {new_topic}"
 
 
 def test_close_typed_channel(new_topic: str, caplog: pytest.LogCaptureFixture) -> None:
     channel = LogChannel(new_topic)
     channel.close()
-    with caplog.at_level("DEBUG"):
+    with caplog.at_level(logging.WARNING):
         channel.log(Log())
 
     assert len(caplog.records) == 1
     for log_name, _, message in caplog.record_tuples:
-        assert log_name == "foxglove.channels"
-        assert message == "Cannot log() on a closed LogChannel"
+        assert log_name == "foxglove.channel.raw_channel"
+        assert message == f"Cannot log on closed channel for {new_topic}"
 
 
 def test_typed_channel_requires_kwargs_after_message(new_topic: str) -> None:

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -52,7 +52,7 @@ pub fn register_submodule(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 /// A channel for logging :py:class:`foxglove.schemas.CameraCalibration` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CameraCalibrationChannel(Option<Channel<foxglove::schemas::CameraCalibration>>);
+struct CameraCalibrationChannel(Channel<foxglove::schemas::CameraCalibration>);
 
 #[pymethods]
 impl CameraCalibrationChannel {
@@ -62,7 +62,7 @@ impl CameraCalibrationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -72,9 +72,7 @@ impl CameraCalibrationChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.CameraCalibration` message to the channel.
@@ -101,25 +99,17 @@ impl CameraCalibrationChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CameraCalibrationChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("CameraCalibrationChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "CameraCalibrationChannel (closed)".to_string()
-        }
+        format!("CameraCalibrationChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.CircleAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CircleAnnotationChannel(Option<Channel<foxglove::schemas::CircleAnnotation>>);
+struct CircleAnnotationChannel(Channel<foxglove::schemas::CircleAnnotation>);
 
 #[pymethods]
 impl CircleAnnotationChannel {
@@ -129,7 +119,7 @@ impl CircleAnnotationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -139,9 +129,7 @@ impl CircleAnnotationChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.CircleAnnotation` message to the channel.
@@ -168,25 +156,17 @@ impl CircleAnnotationChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CircleAnnotationChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("CircleAnnotationChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "CircleAnnotationChannel (closed)".to_string()
-        }
+        format!("CircleAnnotationChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Color` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ColorChannel(Option<Channel<foxglove::schemas::Color>>);
+struct ColorChannel(Channel<foxglove::schemas::Color>);
 
 #[pymethods]
 impl ColorChannel {
@@ -196,7 +176,7 @@ impl ColorChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -206,9 +186,7 @@ impl ColorChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Color` message to the channel.
@@ -235,25 +213,17 @@ impl ColorChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed ColorChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("ColorChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "ColorChannel (closed)".to_string()
-        }
+        format!("ColorChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.CompressedImage` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CompressedImageChannel(Option<Channel<foxglove::schemas::CompressedImage>>);
+struct CompressedImageChannel(Channel<foxglove::schemas::CompressedImage>);
 
 #[pymethods]
 impl CompressedImageChannel {
@@ -263,7 +233,7 @@ impl CompressedImageChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -273,9 +243,7 @@ impl CompressedImageChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.CompressedImage` message to the channel.
@@ -302,25 +270,17 @@ impl CompressedImageChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CompressedImageChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("CompressedImageChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "CompressedImageChannel (closed)".to_string()
-        }
+        format!("CompressedImageChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.CompressedVideo` messages.
 #[pyclass(module = "foxglove.channels")]
-struct CompressedVideoChannel(Option<Channel<foxglove::schemas::CompressedVideo>>);
+struct CompressedVideoChannel(Channel<foxglove::schemas::CompressedVideo>);
 
 #[pymethods]
 impl CompressedVideoChannel {
@@ -330,7 +290,7 @@ impl CompressedVideoChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -340,9 +300,7 @@ impl CompressedVideoChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.CompressedVideo` message to the channel.
@@ -369,25 +327,17 @@ impl CompressedVideoChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed CompressedVideoChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("CompressedVideoChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "CompressedVideoChannel (closed)".to_string()
-        }
+        format!("CompressedVideoChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.FrameTransform` messages.
 #[pyclass(module = "foxglove.channels")]
-struct FrameTransformChannel(Option<Channel<foxglove::schemas::FrameTransform>>);
+struct FrameTransformChannel(Channel<foxglove::schemas::FrameTransform>);
 
 #[pymethods]
 impl FrameTransformChannel {
@@ -397,7 +347,7 @@ impl FrameTransformChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -407,9 +357,7 @@ impl FrameTransformChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.FrameTransform` message to the channel.
@@ -436,25 +384,17 @@ impl FrameTransformChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed FrameTransformChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("FrameTransformChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "FrameTransformChannel (closed)".to_string()
-        }
+        format!("FrameTransformChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.FrameTransforms` messages.
 #[pyclass(module = "foxglove.channels")]
-struct FrameTransformsChannel(Option<Channel<foxglove::schemas::FrameTransforms>>);
+struct FrameTransformsChannel(Channel<foxglove::schemas::FrameTransforms>);
 
 #[pymethods]
 impl FrameTransformsChannel {
@@ -464,7 +404,7 @@ impl FrameTransformsChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -474,9 +414,7 @@ impl FrameTransformsChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.FrameTransforms` message to the channel.
@@ -503,25 +441,17 @@ impl FrameTransformsChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed FrameTransformsChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("FrameTransformsChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "FrameTransformsChannel (closed)".to_string()
-        }
+        format!("FrameTransformsChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.GeoJson` messages.
 #[pyclass(module = "foxglove.channels")]
-struct GeoJsonChannel(Option<Channel<foxglove::schemas::GeoJson>>);
+struct GeoJsonChannel(Channel<foxglove::schemas::GeoJson>);
 
 #[pymethods]
 impl GeoJsonChannel {
@@ -531,7 +461,7 @@ impl GeoJsonChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -541,9 +471,7 @@ impl GeoJsonChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.GeoJson` message to the channel.
@@ -570,25 +498,17 @@ impl GeoJsonChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed GeoJsonChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("GeoJsonChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "GeoJsonChannel (closed)".to_string()
-        }
+        format!("GeoJsonChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Grid` messages.
 #[pyclass(module = "foxglove.channels")]
-struct GridChannel(Option<Channel<foxglove::schemas::Grid>>);
+struct GridChannel(Channel<foxglove::schemas::Grid>);
 
 #[pymethods]
 impl GridChannel {
@@ -598,7 +518,7 @@ impl GridChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -608,9 +528,7 @@ impl GridChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Grid` message to the channel.
@@ -637,25 +555,17 @@ impl GridChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed GridChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("GridChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "GridChannel (closed)".to_string()
-        }
+        format!("GridChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.ImageAnnotations` messages.
 #[pyclass(module = "foxglove.channels")]
-struct ImageAnnotationsChannel(Option<Channel<foxglove::schemas::ImageAnnotations>>);
+struct ImageAnnotationsChannel(Channel<foxglove::schemas::ImageAnnotations>);
 
 #[pymethods]
 impl ImageAnnotationsChannel {
@@ -665,7 +575,7 @@ impl ImageAnnotationsChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -675,9 +585,7 @@ impl ImageAnnotationsChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.ImageAnnotations` message to the channel.
@@ -704,25 +612,17 @@ impl ImageAnnotationsChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed ImageAnnotationsChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("ImageAnnotationsChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "ImageAnnotationsChannel (closed)".to_string()
-        }
+        format!("ImageAnnotationsChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.KeyValuePair` messages.
 #[pyclass(module = "foxglove.channels")]
-struct KeyValuePairChannel(Option<Channel<foxglove::schemas::KeyValuePair>>);
+struct KeyValuePairChannel(Channel<foxglove::schemas::KeyValuePair>);
 
 #[pymethods]
 impl KeyValuePairChannel {
@@ -732,7 +632,7 @@ impl KeyValuePairChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -742,9 +642,7 @@ impl KeyValuePairChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.KeyValuePair` message to the channel.
@@ -771,25 +669,17 @@ impl KeyValuePairChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed KeyValuePairChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("KeyValuePairChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "KeyValuePairChannel (closed)".to_string()
-        }
+        format!("KeyValuePairChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.LaserScan` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LaserScanChannel(Option<Channel<foxglove::schemas::LaserScan>>);
+struct LaserScanChannel(Channel<foxglove::schemas::LaserScan>);
 
 #[pymethods]
 impl LaserScanChannel {
@@ -799,7 +689,7 @@ impl LaserScanChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -809,9 +699,7 @@ impl LaserScanChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.LaserScan` message to the channel.
@@ -838,25 +726,17 @@ impl LaserScanChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed LaserScanChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("LaserScanChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "LaserScanChannel (closed)".to_string()
-        }
+        format!("LaserScanChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.LocationFix` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LocationFixChannel(Option<Channel<foxglove::schemas::LocationFix>>);
+struct LocationFixChannel(Channel<foxglove::schemas::LocationFix>);
 
 #[pymethods]
 impl LocationFixChannel {
@@ -866,7 +746,7 @@ impl LocationFixChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -876,9 +756,7 @@ impl LocationFixChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.LocationFix` message to the channel.
@@ -905,25 +783,17 @@ impl LocationFixChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed LocationFixChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("LocationFixChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "LocationFixChannel (closed)".to_string()
-        }
+        format!("LocationFixChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Log` messages.
 #[pyclass(module = "foxglove.channels")]
-struct LogChannel(Option<Channel<foxglove::schemas::Log>>);
+struct LogChannel(Channel<foxglove::schemas::Log>);
 
 #[pymethods]
 impl LogChannel {
@@ -933,7 +803,7 @@ impl LogChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -943,9 +813,7 @@ impl LogChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Log` message to the channel.
@@ -972,25 +840,17 @@ impl LogChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed LogChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("LogChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "LogChannel (closed)".to_string()
-        }
+        format!("LogChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneEntityDeletion` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneEntityDeletionChannel(Option<Channel<foxglove::schemas::SceneEntityDeletion>>);
+struct SceneEntityDeletionChannel(Channel<foxglove::schemas::SceneEntityDeletion>);
 
 #[pymethods]
 impl SceneEntityDeletionChannel {
@@ -1000,7 +860,7 @@ impl SceneEntityDeletionChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1010,9 +870,7 @@ impl SceneEntityDeletionChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneEntityDeletion` message to the channel.
@@ -1039,25 +897,17 @@ impl SceneEntityDeletionChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed SceneEntityDeletionChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("SceneEntityDeletionChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "SceneEntityDeletionChannel (closed)".to_string()
-        }
+        format!("SceneEntityDeletionChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneEntity` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneEntityChannel(Option<Channel<foxglove::schemas::SceneEntity>>);
+struct SceneEntityChannel(Channel<foxglove::schemas::SceneEntity>);
 
 #[pymethods]
 impl SceneEntityChannel {
@@ -1067,7 +917,7 @@ impl SceneEntityChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1077,9 +927,7 @@ impl SceneEntityChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneEntity` message to the channel.
@@ -1106,25 +954,17 @@ impl SceneEntityChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed SceneEntityChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("SceneEntityChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "SceneEntityChannel (closed)".to_string()
-        }
+        format!("SceneEntityChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.SceneUpdate` messages.
 #[pyclass(module = "foxglove.channels")]
-struct SceneUpdateChannel(Option<Channel<foxglove::schemas::SceneUpdate>>);
+struct SceneUpdateChannel(Channel<foxglove::schemas::SceneUpdate>);
 
 #[pymethods]
 impl SceneUpdateChannel {
@@ -1134,7 +974,7 @@ impl SceneUpdateChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1144,9 +984,7 @@ impl SceneUpdateChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneUpdate` message to the channel.
@@ -1173,25 +1011,17 @@ impl SceneUpdateChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed SceneUpdateChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("SceneUpdateChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "SceneUpdateChannel (closed)".to_string()
-        }
+        format!("SceneUpdateChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PackedElementField` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PackedElementFieldChannel(Option<Channel<foxglove::schemas::PackedElementField>>);
+struct PackedElementFieldChannel(Channel<foxglove::schemas::PackedElementField>);
 
 #[pymethods]
 impl PackedElementFieldChannel {
@@ -1201,7 +1031,7 @@ impl PackedElementFieldChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1211,9 +1041,7 @@ impl PackedElementFieldChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.PackedElementField` message to the channel.
@@ -1240,25 +1068,17 @@ impl PackedElementFieldChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PackedElementFieldChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("PackedElementFieldChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "PackedElementFieldChannel (closed)".to_string()
-        }
+        format!("PackedElementFieldChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Point2` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Point2Channel(Option<Channel<foxglove::schemas::Point2>>);
+struct Point2Channel(Channel<foxglove::schemas::Point2>);
 
 #[pymethods]
 impl Point2Channel {
@@ -1268,7 +1088,7 @@ impl Point2Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1278,9 +1098,7 @@ impl Point2Channel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Point2` message to the channel.
@@ -1307,25 +1125,17 @@ impl Point2Channel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Point2Channel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("Point2Channel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "Point2Channel (closed)".to_string()
-        }
+        format!("Point2Channel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Point3` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Point3Channel(Option<Channel<foxglove::schemas::Point3>>);
+struct Point3Channel(Channel<foxglove::schemas::Point3>);
 
 #[pymethods]
 impl Point3Channel {
@@ -1335,7 +1145,7 @@ impl Point3Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1345,9 +1155,7 @@ impl Point3Channel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Point3` message to the channel.
@@ -1374,25 +1182,17 @@ impl Point3Channel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Point3Channel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("Point3Channel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "Point3Channel (closed)".to_string()
-        }
+        format!("Point3Channel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PointCloud` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PointCloudChannel(Option<Channel<foxglove::schemas::PointCloud>>);
+struct PointCloudChannel(Channel<foxglove::schemas::PointCloud>);
 
 #[pymethods]
 impl PointCloudChannel {
@@ -1402,7 +1202,7 @@ impl PointCloudChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1412,9 +1212,7 @@ impl PointCloudChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.PointCloud` message to the channel.
@@ -1441,25 +1239,17 @@ impl PointCloudChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PointCloudChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("PointCloudChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "PointCloudChannel (closed)".to_string()
-        }
+        format!("PointCloudChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PointsAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PointsAnnotationChannel(Option<Channel<foxglove::schemas::PointsAnnotation>>);
+struct PointsAnnotationChannel(Channel<foxglove::schemas::PointsAnnotation>);
 
 #[pymethods]
 impl PointsAnnotationChannel {
@@ -1469,7 +1259,7 @@ impl PointsAnnotationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1479,9 +1269,7 @@ impl PointsAnnotationChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.PointsAnnotation` message to the channel.
@@ -1508,25 +1296,17 @@ impl PointsAnnotationChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PointsAnnotationChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("PointsAnnotationChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "PointsAnnotationChannel (closed)".to_string()
-        }
+        format!("PointsAnnotationChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Pose` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PoseChannel(Option<Channel<foxglove::schemas::Pose>>);
+struct PoseChannel(Channel<foxglove::schemas::Pose>);
 
 #[pymethods]
 impl PoseChannel {
@@ -1536,7 +1316,7 @@ impl PoseChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1546,9 +1326,7 @@ impl PoseChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Pose` message to the channel.
@@ -1575,25 +1353,17 @@ impl PoseChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PoseChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("PoseChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "PoseChannel (closed)".to_string()
-        }
+        format!("PoseChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PoseInFrame` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PoseInFrameChannel(Option<Channel<foxglove::schemas::PoseInFrame>>);
+struct PoseInFrameChannel(Channel<foxglove::schemas::PoseInFrame>);
 
 #[pymethods]
 impl PoseInFrameChannel {
@@ -1603,7 +1373,7 @@ impl PoseInFrameChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1613,9 +1383,7 @@ impl PoseInFrameChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.PoseInFrame` message to the channel.
@@ -1642,25 +1410,17 @@ impl PoseInFrameChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PoseInFrameChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("PoseInFrameChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "PoseInFrameChannel (closed)".to_string()
-        }
+        format!("PoseInFrameChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.PosesInFrame` messages.
 #[pyclass(module = "foxglove.channels")]
-struct PosesInFrameChannel(Option<Channel<foxglove::schemas::PosesInFrame>>);
+struct PosesInFrameChannel(Channel<foxglove::schemas::PosesInFrame>);
 
 #[pymethods]
 impl PosesInFrameChannel {
@@ -1670,7 +1430,7 @@ impl PosesInFrameChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1680,9 +1440,7 @@ impl PosesInFrameChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.PosesInFrame` message to the channel.
@@ -1709,25 +1467,17 @@ impl PosesInFrameChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed PosesInFrameChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("PosesInFrameChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "PosesInFrameChannel (closed)".to_string()
-        }
+        format!("PosesInFrameChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Quaternion` messages.
 #[pyclass(module = "foxglove.channels")]
-struct QuaternionChannel(Option<Channel<foxglove::schemas::Quaternion>>);
+struct QuaternionChannel(Channel<foxglove::schemas::Quaternion>);
 
 #[pymethods]
 impl QuaternionChannel {
@@ -1737,7 +1487,7 @@ impl QuaternionChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1747,9 +1497,7 @@ impl QuaternionChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Quaternion` message to the channel.
@@ -1776,25 +1524,17 @@ impl QuaternionChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed QuaternionChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("QuaternionChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "QuaternionChannel (closed)".to_string()
-        }
+        format!("QuaternionChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.RawImage` messages.
 #[pyclass(module = "foxglove.channels")]
-struct RawImageChannel(Option<Channel<foxglove::schemas::RawImage>>);
+struct RawImageChannel(Channel<foxglove::schemas::RawImage>);
 
 #[pymethods]
 impl RawImageChannel {
@@ -1804,7 +1544,7 @@ impl RawImageChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1814,9 +1554,7 @@ impl RawImageChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.RawImage` message to the channel.
@@ -1843,25 +1581,17 @@ impl RawImageChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed RawImageChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("RawImageChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "RawImageChannel (closed)".to_string()
-        }
+        format!("RawImageChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.TextAnnotation` messages.
 #[pyclass(module = "foxglove.channels")]
-struct TextAnnotationChannel(Option<Channel<foxglove::schemas::TextAnnotation>>);
+struct TextAnnotationChannel(Channel<foxglove::schemas::TextAnnotation>);
 
 #[pymethods]
 impl TextAnnotationChannel {
@@ -1871,7 +1601,7 @@ impl TextAnnotationChannel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1881,9 +1611,7 @@ impl TextAnnotationChannel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.TextAnnotation` message to the channel.
@@ -1910,25 +1638,17 @@ impl TextAnnotationChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed TextAnnotationChannel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("TextAnnotationChannel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "TextAnnotationChannel (closed)".to_string()
-        }
+        format!("TextAnnotationChannel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Vector2` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Vector2Channel(Option<Channel<foxglove::schemas::Vector2>>);
+struct Vector2Channel(Channel<foxglove::schemas::Vector2>);
 
 #[pymethods]
 impl Vector2Channel {
@@ -1938,7 +1658,7 @@ impl Vector2Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -1948,9 +1668,7 @@ impl Vector2Channel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Vector2` message to the channel.
@@ -1977,25 +1695,17 @@ impl Vector2Channel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Vector2Channel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("Vector2Channel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "Vector2Channel (closed)".to_string()
-        }
+        format!("Vector2Channel(topic='{}')", self.0.topic()).to_string()
     }
 }
 
 /// A channel for logging :py:class:`foxglove.schemas.Vector3` messages.
 #[pyclass(module = "foxglove.channels")]
-struct Vector3Channel(Option<Channel<foxglove::schemas::Vector3>>);
+struct Vector3Channel(Channel<foxglove::schemas::Vector3>);
 
 #[pymethods]
 impl Vector3Channel {
@@ -2005,7 +1715,7 @@ impl Vector3Channel {
     #[new]
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
-        Ok(Self(Some(base)))
+        Ok(Self(base))
     }
 
     /// Close the channel.
@@ -2015,9 +1725,7 @@ impl Vector3Channel {
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 
     /// Log a :py:class:`foxglove.schemas.Vector3` message to the channel.
@@ -2044,18 +1752,10 @@ impl Vector3Channel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(&msg.0, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed Vector3Channel");
-        }
+        self.0.log_with_meta(&msg.0, metadata);
     }
 
     fn __repr__(&self) -> String {
-        if let Some(channel) = &self.0 {
-            format!("Vector3Channel(topic='{}')", channel.topic()).to_string()
-        } else {
-            "Vector3Channel (closed)".to_string()
-        }
+        format!("Vector3Channel(topic='{}')", self.0.topic()).to_string()
     }
 }

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -67,10 +67,10 @@ impl CameraCalibrationChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -124,10 +124,10 @@ impl CircleAnnotationChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -181,10 +181,10 @@ impl ColorChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -238,10 +238,10 @@ impl CompressedImageChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -295,10 +295,10 @@ impl CompressedVideoChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -352,10 +352,10 @@ impl FrameTransformChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -409,10 +409,10 @@ impl FrameTransformsChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -466,10 +466,10 @@ impl GeoJsonChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -523,10 +523,10 @@ impl GridChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -580,10 +580,10 @@ impl ImageAnnotationsChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -637,10 +637,10 @@ impl KeyValuePairChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -694,10 +694,10 @@ impl LaserScanChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -751,10 +751,10 @@ impl LocationFixChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -808,10 +808,10 @@ impl LogChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -865,10 +865,10 @@ impl SceneEntityDeletionChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -922,10 +922,10 @@ impl SceneEntityChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -979,10 +979,10 @@ impl SceneUpdateChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1036,10 +1036,10 @@ impl PackedElementFieldChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1093,10 +1093,10 @@ impl Point2Channel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1150,10 +1150,10 @@ impl Point3Channel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1207,10 +1207,10 @@ impl PointCloudChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1264,10 +1264,10 @@ impl PointsAnnotationChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1321,10 +1321,10 @@ impl PoseChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1378,10 +1378,10 @@ impl PoseInFrameChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1435,10 +1435,10 @@ impl PosesInFrameChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1492,10 +1492,10 @@ impl QuaternionChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1549,10 +1549,10 @@ impl RawImageChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1606,10 +1606,10 @@ impl TextAnnotationChannel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1663,10 +1663,10 @@ impl Vector2Channel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }
@@ -1720,10 +1720,10 @@ impl Vector3Channel {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
     ///
-    /// It is an error to call :py:meth:`log` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -68,11 +68,13 @@ impl CameraCalibrationChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.CameraCalibration` message to the channel.
@@ -133,11 +135,13 @@ impl CircleAnnotationChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.CircleAnnotation` message to the channel.
@@ -198,11 +202,13 @@ impl ColorChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Color` message to the channel.
@@ -263,11 +269,13 @@ impl CompressedImageChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.CompressedImage` message to the channel.
@@ -328,11 +336,13 @@ impl CompressedVideoChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.CompressedVideo` message to the channel.
@@ -393,11 +403,13 @@ impl FrameTransformChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.FrameTransform` message to the channel.
@@ -458,11 +470,13 @@ impl FrameTransformsChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.FrameTransforms` message to the channel.
@@ -523,11 +537,13 @@ impl GeoJsonChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.GeoJson` message to the channel.
@@ -588,11 +604,13 @@ impl GridChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Grid` message to the channel.
@@ -653,11 +671,13 @@ impl ImageAnnotationsChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.ImageAnnotations` message to the channel.
@@ -718,11 +738,13 @@ impl KeyValuePairChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.KeyValuePair` message to the channel.
@@ -783,11 +805,13 @@ impl LaserScanChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.LaserScan` message to the channel.
@@ -848,11 +872,13 @@ impl LocationFixChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.LocationFix` message to the channel.
@@ -913,11 +939,13 @@ impl LogChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Log` message to the channel.
@@ -978,11 +1006,13 @@ impl SceneEntityDeletionChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneEntityDeletion` message to the channel.
@@ -1043,11 +1073,13 @@ impl SceneEntityChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneEntity` message to the channel.
@@ -1108,11 +1140,13 @@ impl SceneUpdateChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.SceneUpdate` message to the channel.
@@ -1173,11 +1207,13 @@ impl PackedElementFieldChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.PackedElementField` message to the channel.
@@ -1238,11 +1274,13 @@ impl Point2Channel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Point2` message to the channel.
@@ -1303,11 +1341,13 @@ impl Point3Channel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Point3` message to the channel.
@@ -1368,11 +1408,13 @@ impl PointCloudChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.PointCloud` message to the channel.
@@ -1433,11 +1475,13 @@ impl PointsAnnotationChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.PointsAnnotation` message to the channel.
@@ -1498,11 +1542,13 @@ impl PoseChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Pose` message to the channel.
@@ -1563,11 +1609,13 @@ impl PoseInFrameChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.PoseInFrame` message to the channel.
@@ -1628,11 +1676,13 @@ impl PosesInFrameChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.PosesInFrame` message to the channel.
@@ -1693,11 +1743,13 @@ impl QuaternionChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Quaternion` message to the channel.
@@ -1758,11 +1810,13 @@ impl RawImageChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.RawImage` message to the channel.
@@ -1823,11 +1877,13 @@ impl TextAnnotationChannel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.TextAnnotation` message to the channel.
@@ -1888,11 +1944,13 @@ impl Vector2Channel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Vector2` message to the channel.
@@ -1953,11 +2011,13 @@ impl Vector3Channel {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:`log` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:`foxglove.schemas.Vector3` message to the channel.

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -151,8 +151,7 @@ impl BaseChannel {
 
     fn close(&mut self) {
         if let Some(inner) = self.0.take() {
-            let ctx = Context::get_default();
-            ctx.remove_channel_for_topic(inner.topic());
+            inner.close();
         }
     }
 }

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -57,7 +57,7 @@ impl From<PySchema> for foxglove::Schema {
 }
 
 #[pyclass(module = "foxglove")]
-struct BaseChannel(Option<Arc<RawChannel>>);
+struct BaseChannel(Arc<RawChannel>);
 
 /// A writer for logging messages to an MCAP file.
 ///
@@ -125,7 +125,7 @@ impl BaseChannel {
             .build_raw()
             .map_err(PyFoxgloveError::from)?;
 
-        Ok(BaseChannel(Some(channel)))
+        Ok(BaseChannel(channel))
     }
 
     #[pyo3(signature = (msg, log_time=None, publish_time=None, sequence=None))]
@@ -141,18 +141,12 @@ impl BaseChannel {
             publish_time,
             sequence,
         };
-        if let Some(channel) = &self.0 {
-            channel.log_with_meta(msg, metadata);
-        } else {
-            tracing::debug!(target: "foxglove.channels", "Cannot log() on a closed channel");
-        }
+        self.0.log_with_meta(msg, metadata);
         Ok(())
     }
 
     fn close(&mut self) {
-        if let Some(inner) = self.0.take() {
-            inner.close();
-        }
+        self.0.close();
     }
 }
 
@@ -179,7 +173,7 @@ fn open_mcap(path: PathBuf, allow_overwrite: bool) -> PyResult<PyMcapWriter> {
 #[pyfunction]
 fn get_channel_for_topic(topic: &str) -> PyResult<Option<BaseChannel>> {
     let channel = Context::get_default().get_channel_by_topic(topic);
-    Ok(channel.map(|chan| BaseChannel(Some(chan))))
+    Ok(channel.map(BaseChannel))
 }
 
 // Not public. Re-exported in a wrapping function.

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -96,8 +96,10 @@ impl<T: Encode> Channel<T> {
 
         /// Closes the channel, removing it from the context.
         ///
-        /// Future messages logged to the channel will not be received by any sink. Attempts to log
-        /// on a closed channel will elicit a throttled warning message.
+        /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+        /// channels dynamically, such as the [`WebSocketServer`][crate::WebSocketServer].
+        ///
+        /// Attempts to log on a closed channel will elicit a throttled warning message.
         pub fn close(&self);
     } }
 

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -1,14 +1,22 @@
 //! A raw channel.
 
 use std::collections::BTreeMap;
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tracing::warn;
 
 use super::ChannelId;
 use crate::log_sink_set::LogSinkSet;
 use crate::sink::SmallSinkVec;
+use crate::throttler::Throttler;
 use crate::{nanoseconds_since_epoch, Context, Metadata, PartialMetadata, Schema};
+
+/// Interval for throttled warnings.
+static WARN_THROTTLER_INTERVAL: Duration = Duration::from_secs(10);
 
 /// A log channel that can be used to log binary messages.
 ///
@@ -32,6 +40,8 @@ pub struct RawChannel {
     metadata: BTreeMap<String, String>,
     message_sequence: AtomicU32,
     sinks: LogSinkSet,
+    closed: AtomicBool,
+    warn_throttler: Mutex<Throttler>,
 }
 
 impl RawChannel {
@@ -51,6 +61,8 @@ impl RawChannel {
             metadata,
             message_sequence: AtomicU32::new(1),
             sinks: LogSinkSet::new(),
+            closed: AtomicBool::new(false),
+            warn_throttler: Mutex::new(Throttler::new(WARN_THROTTLER_INTERVAL)),
         })
     }
 
@@ -86,21 +98,40 @@ impl RawChannel {
 
     /// Closes the channel, removing it from the context.
     ///
-    /// Future messages logged to the channel will not be received by any sink.
+    /// Future messages logged to the channel will not be received by any sink. Attempts to log
+    /// on a closed channel will elicit a throttled warning message.
     pub fn close(&self) {
-        if let Some(ctx) = self.context.upgrade() {
-            ctx.remove_channel(self.id);
+        if !self.is_closed() {
+            if let Some(ctx) = self.context.upgrade() {
+                ctx.remove_channel(self.id);
+            }
+        }
+    }
+
+    /// Invoked when the channel is removed from its context.
+    ///
+    /// This can happen either due to an explicit call to [`RawChannel::close`], or due to the
+    /// context being dropped.
+    pub(crate) fn remove_from_context(&self) {
+        self.closed.store(true, Release);
+        self.sinks.clear();
+    }
+
+    /// Returns true if the channel is closed.
+    fn is_closed(&self) -> bool {
+        self.closed.load(Acquire)
+    }
+
+    /// Issues a throttled warning about attempting to log on a closed channel.
+    pub(crate) fn log_warn_if_closed(&self) {
+        if self.is_closed() && self.warn_throttler.lock().try_acquire() {
+            warn!("Cannot log on closed channel for {}", self.topic());
         }
     }
 
     /// Updates the set of sinks that are subscribed to this channel.
     pub(crate) fn update_sinks(&self, sinks: SmallSinkVec) {
         self.sinks.store(sinks);
-    }
-
-    /// Clears the set of subscribed sinks.
-    pub(crate) fn clear_sinks(&self) {
-        self.sinks.clear();
     }
 
     /// Returns true if at least one sink is subscribed to this channel.
@@ -116,15 +147,15 @@ impl RawChannel {
 
     /// Logs a message.
     pub fn log(&self, msg: &[u8]) {
-        if self.has_sinks() {
-            self.log_to_sinks(msg, PartialMetadata::default());
-        }
+        self.log_with_meta(msg, PartialMetadata::default());
     }
 
     /// Logs a message with additional metadata.
     pub fn log_with_meta(&self, msg: &[u8], opts: PartialMetadata) {
         if self.has_sinks() {
             self.log_to_sinks(msg, opts);
+        } else {
+            self.log_warn_if_closed();
         }
     }
 

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -98,8 +98,10 @@ impl RawChannel {
 
     /// Closes the channel, removing it from the context.
     ///
-    /// Future messages logged to the channel will not be received by any sink. Attempts to log
-    /// on a closed channel will elicit a throttled warning message.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+    /// dynamically, such as the [`WebSocketServer`][crate::WebSocketServer].
+    ///
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     pub fn close(&self) {
         if !self.is_closed() {
             if let Some(ctx) = self.context.upgrade() {
@@ -110,14 +112,17 @@ impl RawChannel {
 
     /// Invoked when the channel is removed from its context.
     ///
-    /// This can happen either due to an explicit call to [`RawChannel::close`], or due to the
-    /// context being dropped.
+    /// This can happen either in the context of an explicit call to [`RawChannel::close`], or due
+    /// to the context being dropped.
     pub(crate) fn remove_from_context(&self) {
         self.closed.store(true, Release);
         self.sinks.clear();
     }
 
     /// Returns true if the channel is closed.
+    ///
+    /// A channel may be closed either by an explicit call to [`RawChannel::close`], or due to the
+    /// context being dropped.
     fn is_closed(&self) -> bool {
         self.closed.load(Acquire)
     }

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -69,6 +69,7 @@ impl ChannelBuilder {
     /// Returns [`FoxgloveError::DuplicateChannel`] if a channel with the same topic already exists.
     pub fn build_raw(self) -> Result<Arc<RawChannel>, FoxgloveError> {
         let channel = RawChannel::new(
+            &self.context,
             self.topic,
             self.message_encoding
                 .ok_or_else(|| FoxgloveError::MessageEncodingRequired)?,

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -192,7 +192,7 @@ impl Context {
         self.0.write().add_channel(channel)
     }
 
-    /// Removes the specified channel.
+    /// Removes a channel from the context.
     pub(crate) fn remove_channel(&self, channel_id: ChannelId) -> bool {
         self.0.write().remove_channel(channel_id)
     }

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -188,11 +188,19 @@ impl Context {
     }
 
     /// Adds a channel to the context.
+    ///
+    /// This is deliberately `pub(crate)` to ensure that the channel's context linkage remains
+    /// consistent. Publicly, the only way to add a channel to a context is by constructing it via
+    /// a [`ChannelBuilder`][crate::ChannelBuilder].
     pub(crate) fn add_channel(&self, channel: Arc<RawChannel>) -> Result<(), FoxgloveError> {
         self.0.write().add_channel(channel)
     }
 
     /// Removes a channel from the context.
+    ///
+    /// This is deliberately `pub(crate)` to ensure that the channel's context linkage remains
+    /// consistent. Publicly, the only way to remove a channel from a context is by calling
+    /// [`RawChannel::close`], or by dropping the context entirely.
     pub(crate) fn remove_channel(&self, channel_id: ChannelId) -> bool {
         self.0.write().remove_channel(channel_id)
     }

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -58,8 +58,8 @@ impl ContextInner {
         // Remove subscriptions for this channel.
         self.subs.remove_channel_subscriptions(channel.id());
 
-        // Disconnect channel sinks.
-        channel.clear_sinks();
+        // Close the channel and remove sinks.
+        channel.remove_from_context();
 
         // Notify sinks of removed channel.
         for sink in self.sinks.values() {
@@ -140,7 +140,15 @@ impl ContextInner {
 
     /// Removes all channels and sinks from the context.
     fn clear(&mut self) {
-        self.channels.clear();
+        for (_, channel) in self.channels.drain() {
+            // Close the channel and remove sinks.
+            channel.remove_from_context();
+
+            // Notify sink of removed channel.
+            for sink in self.sinks.values() {
+                sink.remove_channel(&channel);
+            }
+        }
         self.channels_by_topic.clear();
         self.sinks.clear();
         self.subs.clear();

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -48,12 +48,12 @@ impl ContextInner {
         Ok(())
     }
 
-    /// Removes the channel for the specified topic.
-    fn remove_channel_for_topic(&mut self, topic: &str) -> bool {
-        let Some(channel) = self.channels_by_topic.remove(topic) else {
+    /// Removes a channel from the context.
+    fn remove_channel(&mut self, channel_id: ChannelId) -> bool {
+        let Some(channel) = self.channels.remove(&channel_id) else {
             return false;
         };
-        self.channels.remove(&channel.id());
+        self.channels_by_topic.remove(channel.topic());
 
         // Remove subscriptions for this channel.
         self.subs.remove_channel_subscriptions(channel.id());
@@ -180,13 +180,13 @@ impl Context {
     }
 
     /// Adds a channel to the context.
-    pub fn add_channel(&self, channel: Arc<RawChannel>) -> Result<(), FoxgloveError> {
+    pub(crate) fn add_channel(&self, channel: Arc<RawChannel>) -> Result<(), FoxgloveError> {
         self.0.write().add_channel(channel)
     }
 
-    /// Removes the channel for the specified topic.
-    pub fn remove_channel_for_topic(&self, topic: &str) -> bool {
-        self.0.write().remove_channel_for_topic(topic)
+    /// Removes the specified channel.
+    pub(crate) fn remove_channel(&self, channel_id: ChannelId) -> bool {
+        self.0.write().remove_channel(channel_id)
     }
 
     /// Adds a sink to the context.
@@ -197,11 +197,13 @@ impl Context {
     /// present and future channels on the context. Otherwise, the sink is expected to manage its
     /// subscriptions dynamically with [`Context::subscribe_channels`] and
     /// [`Context::unsubscribe_channels`].
+    #[doc(hidden)] // Hidden until Sink is public
     pub fn add_sink(&self, sink: Arc<dyn Sink>) -> bool {
         self.0.write().add_sink(sink)
     }
 
     /// Removes a sink from the context.
+    #[doc(hidden)] // Hidden until Sink is public.
     pub fn remove_sink(&self, sink_id: SinkId) -> bool {
         self.0.write().remove_sink(sink_id)
     }
@@ -209,6 +211,7 @@ impl Context {
     /// Subscribes a sink to the specified channels.
     ///
     /// This method has no effect for sinks that return true from [`Sink::auto_subscribe`].
+    #[doc(hidden)] // Hidden until Sink is public.
     pub fn subscribe_channels(&self, sink_id: SinkId, channel_ids: &[ChannelId]) {
         self.0.write().subscribe_channels(sink_id, channel_ids);
     }
@@ -216,6 +219,7 @@ impl Context {
     /// Unsubscribes a sink from the specified channels.
     ///
     /// This method has no effect for sinks that return true from [`Sink::auto_subscribe`].
+    #[doc(hidden)] // Hidden until Sink is public.
     pub fn unsubscribe_channels(&self, sink_id: SinkId, channel_ids: &[ChannelId]) {
         self.0.write().unsubscribe_channels(sink_id, channel_ids);
     }
@@ -367,8 +371,8 @@ mod tests {
     #[test]
     fn test_remove_channel() {
         let ctx = Context::new();
-        let _ = new_test_channel(&ctx, "topic").unwrap();
-        assert!(ctx.remove_channel_for_topic("topic"));
+        let ch = new_test_channel(&ctx, "topic").unwrap();
+        assert!(ctx.remove_channel(ch.id()));
         assert!(ctx.0.read().channels.is_empty());
     }
 
@@ -388,7 +392,7 @@ mod tests {
         assert!(c2.has_sinks());
 
         // Auto-subscribe to new channels.
-        assert!(ctx.remove_channel_for_topic(c1.topic()));
+        assert!(ctx.remove_channel(c1.id()));
         assert!(!c1.has_sinks());
         assert!(c2.has_sinks());
         ctx.add_channel(c1.clone()).unwrap();
@@ -416,7 +420,7 @@ mod tests {
         assert!(!c2.has_sinks());
 
         // No auto-subscribe to new channels.
-        assert!(ctx.remove_channel_for_topic(c1.topic()));
+        assert!(ctx.remove_channel(c1.id()));
         ctx.add_channel(c1.clone()).unwrap();
         assert!(!c1.has_sinks());
 
@@ -431,7 +435,7 @@ mod tests {
         // If a channel is removed and re-added, its subscriptions are lost. This isn't a workflow
         // we expect to happen. Note that the sink will receive `remove_channel` and `add_channel`
         // callbacks, so it has an opportunity to reinstall subscriptions if it wants to.
-        assert!(ctx.remove_channel_for_topic(c1.topic()));
+        assert!(ctx.remove_channel(c1.id()));
         assert!(!c1.has_sinks());
         assert!(c2.has_sinks());
         ctx.add_channel(c1.clone()).unwrap();
@@ -497,7 +501,7 @@ mod tests {
         assert!(!ch.has_sinks());
 
         // Add channel with existing sink.
-        assert!(ctx.remove_channel_for_topic(ch.topic()));
+        assert!(ctx.remove_channel(ch.id()));
         ctx.add_channel(ch.clone()).unwrap();
         assert!(!ch.has_sinks());
     }

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -178,6 +178,7 @@ mod sink;
 mod tests;
 #[cfg(test)]
 mod testutil;
+mod throttler;
 mod time;
 pub mod websocket;
 mod websocket_server;

--- a/rust/foxglove/src/throttler.rs
+++ b/rust/foxglove/src/throttler.rs
@@ -1,0 +1,46 @@
+use std::time::{Duration, Instant};
+
+/// A time tracker for throttling the frequency of an action.
+#[derive(Debug)]
+pub(crate) struct Throttler {
+    interval: Duration,
+    next_at: Option<Instant>,
+}
+impl Throttler {
+    /// Create a new throttler with the specified duration.
+    pub const fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            next_at: None,
+        }
+    }
+
+    /// Returns true if the action is allowed now, and updates the internal timestamp.
+    pub fn try_acquire(&mut self) -> bool {
+        let now = Instant::now();
+        if self.next_at.is_some_and(|t| now < t) {
+            false
+        } else {
+            self.next_at = Some(now + self.interval);
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_throttler() {
+        let interval = Duration::from_millis(10);
+        let mut throttler = Throttler::new(interval);
+        assert!(throttler.try_acquire());
+        assert!(!throttler.try_acquire());
+        assert!(!throttler.try_acquire());
+        std::thread::sleep(interval);
+        assert!(throttler.try_acquire());
+        assert!(!throttler.try_acquire());
+        assert!(!throttler.try_acquire());
+    }
+}

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -570,11 +570,13 @@ impl ${channelClass} {
     /// Close the channel.
     ///
     /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients. Destroying all references to the channel will also close it.
+    /// visualization clients.
     ///
     /// It is an error to call :py:meth:\`log\` after closing the channel.
     fn close(&mut self) {
-        self.0 = None;
+        if let Some(inner) = self.0.take() {
+            inner.close();
+        }
     }
 
     /// Log a :py:class:\`foxglove.schemas.${schemaClass}\` message to the channel.

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -569,10 +569,10 @@ impl ${channelClass} {
 
     /// Close the channel.
     ///
-    /// You do not need to call this unless you explicitly want to remove advertisements from live
-    /// visualization clients.
+    /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
+    /// channels dynamically, such as the :py:class:\`foxglove.WebSocketServer\`.
     ///
-    /// It is an error to call :py:meth:\`log\` after closing the channel.
+    /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
         self.0.close();
     }


### PR DESCRIPTION
### Changelog
- rust: Add `Channel::close`

### Description
As part of making `Context` public, I realized that we probably don't want to expose `Context::remove_channel_for_topic()`. We should really be removing channels by ID, to avoid TOCTOU errors. We should expose this functionality publicly as `Channel::close()`, to mirror the python `Channel.close`.

While I was doing that, I realized that [my fix for python's `Channel.close`](https://github.com/foxglove/foxglove-sdk/pull/329) should've also removed a lie in the docstrings ("Destroying all references to the channel will also close it") and completely missed updating the generated typed channels. So this change fakes care of those things too.

The python SDK issues a (debug-level) warning when attempting to log on a channel that was explicitly closed. In this change, we move that warning down to rust, so that it's common. With a few changes:
 - The message is now issued at _warning_ level, because we don't want users to miss it.
 - Add a per-channel warning throttler with a 5s interval.
 - Handle the case where a channel is implicitly closed because the context is dropped.
 - Python no longer has to wrap channels in Option<>.

Fixes: FG-11010
Fixes: FG-10877