### PR TITLE
rust: Make Context public, add LazyContext

### DIFF
--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -58,7 +58,6 @@ impl ChannelBuilder {
     }
 
     /// Sets the context for this channel.
-    #[doc(hidden)]
     pub fn context(mut self, ctx: &Arc<Context>) -> Self {
         self.context = ctx.clone();
         self

--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -1,13 +1,18 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::{ChannelId, FoxgloveError, RawChannel, Sink, SinkId};
+use crate::{
+    ChannelBuilder, ChannelId, FoxgloveError, McapWriter, RawChannel, Sink, SinkId, WebSocketServer,
+};
 
+mod lazy_context;
 mod subscriptions;
+
+pub use lazy_context::LazyContext;
 use subscriptions::Subscriptions;
 
 #[derive(Default)]
@@ -155,10 +160,40 @@ impl ContextInner {
     }
 }
 
-/// A context is a collection of channels and sinks.
+/// A context is the binding between channels and sinks.
 ///
-/// To obtain a reference to the default context, use [`Context::get_default`]. To construct a new
-/// context, use [`Context::new`].
+/// Each channel and each sink belongs to exactly one context. Sinks receive advertisements about
+/// channels on the context, and can optionally subscribe to receive logged messages on those
+/// channels.
+///
+/// When the context is dropped, its corresponding channels and sinks will be disconnected from one
+/// another, and logging will stop. Attempts to log on a channel after its context has been dropped
+/// will elicit a throttled warning message.
+///
+/// Since many applications only need a single context, the SDK provides a static default context
+/// for convenience. To obtain a reference to the default context, use [`Context::get_default`].
+///
+/// It is also possible to create explicit contexts:
+///
+/// ```
+/// use foxglove::{Context, FoxgloveError};
+/// use foxglove::schemas::Log;
+///
+/// // Create a channel for the "/log" topic.
+/// let topic = "/topic";
+/// let ctx_a = Context::new();
+/// let chan_a = ctx_a.channel_builder(topic).build().unwrap();
+/// chan_a.log(&Log{ message: "hello a".into(), ..Log::default() });
+///
+/// // Attempting to create another channel with the same topic on the same context will fail.
+/// let err = ctx_a.channel_builder(topic).build::<Log>().unwrap_err();
+/// assert!(matches!(err, FoxgloveError::DuplicateChannel(_)));
+///
+/// // Create a channel for the "/log" topic on a different context.
+/// let ctx_b = Context::new();
+/// let chan_b = ctx_b.channel_builder(topic).build().unwrap();
+/// chan_b.log(&Log{ message: "hello b".into(), ..Log::default() });
+/// ```
 pub struct Context(RwLock<ContextInner>);
 
 impl Debug for Context {
@@ -178,8 +213,22 @@ impl Context {
     ///
     /// If there is no default context, this function instantiates one.
     pub fn get_default() -> Arc<Self> {
-        static DEFAULT_CONTEXT: LazyLock<Arc<Context>> = LazyLock::new(Context::new);
-        DEFAULT_CONTEXT.clone()
+        Arc::clone(LazyContext::get_default())
+    }
+
+    /// Returns a channel builder for a channel in this context.
+    pub fn channel_builder(self: &Arc<Self>, topic: impl Into<String>) -> ChannelBuilder {
+        ChannelBuilder::new(topic).context(self)
+    }
+
+    /// Returns a builder for an MCAP writer in this context.
+    pub fn mcap_writer(self: &Arc<Self>) -> McapWriter {
+        McapWriter::new().context(self)
+    }
+
+    /// Returns a builder for a websocket server in this context.
+    pub fn websocket_server(self: &Arc<Self>) -> WebSocketServer {
+        WebSocketServer::new().context(self)
     }
 
     /// Returns the channel for the specified topic, if there is one.

--- a/rust/foxglove/src/context/lazy_context.rs
+++ b/rust/foxglove/src/context/lazy_context.rs
@@ -1,0 +1,66 @@
+use std::ops::Deref;
+use std::sync::{Arc, LazyLock};
+
+use crate::{Encode, LazyChannel, LazyRawChannel};
+
+use super::Context;
+
+static DEFAULT_CONTEXT: LazyContext = LazyContext::new();
+
+/// A context that is initialized lazily upon first use.
+///
+/// This is intended to be used with [`LazyChannel`][crate::LazyChannel] to create static channels
+/// attached to static contexts.
+///
+/// Refer to the [`Context`] documentation for more information about contexts.
+///
+/// # Example
+/// ```
+/// use foxglove::{LazyChannel, LazyContext, LazyRawChannel};
+/// use foxglove::schemas::Log;
+///
+/// // Create two channels for the same topic, in different contexts.
+/// static TOPIC: &str = "/topic";
+/// static CTX_A: LazyContext = LazyContext::new();
+/// static CTX_B: LazyContext = LazyContext::new();
+/// static LOG_A: LazyChannel<Log> = CTX_A.channel(TOPIC);
+/// static LOG_B: LazyRawChannel = CTX_B.raw_channel(TOPIC, "json");
+/// LOG_A.log(&Log{ message: "hello a".into(), ..Log::default() });
+/// LOG_B.log(br#"{"message": "hello b"}"#);
+/// ```
+pub struct LazyContext(LazyLock<Arc<Context>>);
+
+impl LazyContext {
+    /// Creates a new lazily-initialized channel.
+    #[allow(clippy::new_without_default)] // avoid confusion with LazyContext::get_default()
+    pub const fn new() -> Self {
+        Self(LazyLock::new(Context::new))
+    }
+
+    /// Returns a reference to the lazily-initialized default context.
+    pub const fn get_default() -> &'static Self {
+        &DEFAULT_CONTEXT
+    }
+
+    /// Creates a new lazily-initialized channel in this context.
+    pub const fn channel<T: Encode>(&'static self, topic: &'static str) -> LazyChannel<T> {
+        LazyChannel::new(topic).context(self)
+    }
+
+    /// Creates a new lazily-initialized raw channel in this context.
+    pub const fn raw_channel(
+        &'static self,
+        topic: &'static str,
+        message_encoding: &'static str,
+    ) -> LazyRawChannel {
+        LazyRawChannel::new(topic, message_encoding).context(self)
+    }
+}
+
+impl Deref for LazyContext {
+    type Target = Arc<Context>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -11,32 +11,77 @@
 //!
 //! To record messages, you need at least one sink, and at least one channel. In this example, we
 //! create an MCAP file sink, and a channel for [`Log`](`crate::schemas::Log`) messages on a topic
-//! called `"/log"`. Then we write one log message and close the file.
+//! called `/log`. Then we write one log message and close the file.
 //!
 //! ```no_run
-//! use foxglove::{McapWriter, Channel};
+//! use foxglove::{Channel, McapWriter};
 //! use foxglove::schemas::Log;
 //!
 //! # fn func() -> Result<(), foxglove::FoxgloveError> {
+//! // Create a new MCAP file named 'test.mcap'.
 //! let mcap = McapWriter::new().create_new_buffered_file("test.mcap")?;
 //!
+//! // Create a new channel for the topic "/log" for `Log` messages.
 //! let channel = Channel::new("/log")?;
 //! channel.log(&Log{
 //!     message: "Hello, Foxglove!".to_string(),
 //!     ..Default::default()
 //! });
 //!
+//! // Flush and close the MCAP file.
 //! mcap.close()?;
 //! # Ok(()) }
 //! ```
 //!
 //! # Concepts
 //!
+//! ## Context
+//!
+//! A [`Context`] is the binding between channels and sinks. Each channel and sink belongs to
+//! exactly one context. Sinks receive advertisements about channels on the context, and can
+//! optionally subscribe to receive logged messages on those channels.
+//!
+//! When the context goes out of scope, its corresponding channels and sinks will be disconnected
+//! from one another, and logging will stop. Attempts to log further messages on the channels
+//! will elict throttled warning messages.
+//!
+//! Since many applications only need a single context, the SDK provides a static default context
+//! for convenience. This default sink is the one used in the example above. If we wanted to use an
+//! explicit context instead, we'd write:
+//!
+//! ```no_run
+//! use foxglove::Context;
+//! use foxglove::schemas::Log;
+//!
+//! # fn func() -> Result<(), foxglove::FoxgloveError> {
+//! // Create a new context.
+//! let ctx = Context::new();
+//!
+//! // Create a new MCAP file named 'test.mcap'.
+//! let mcap = ctx.mcap_writer().create_new_buffered_file("test.mcap")?;
+//!
+//! // Create a new channel for the topic "/log" for `Log` messages.
+//! let channel = ctx.channel_builder("/log").build()?;
+//! channel.log(&Log{
+//!     message: "Hello, Foxglove!".to_string(),
+//!     ..Default::default()
+//! });
+//!
+//! // Flush and close the MCAP file.
+//! mcap.close()?;
+//! # Ok(()) }
+//! ```
+//!
 //! ## Channels
 //!
-//! A "channel" gives a way to log related messages which have the same type, or [`Schema`].
+//! A [`Channel`] gives a way to log related messages which have the same type, or [`Schema`].
 //! Each channel is instantiated with a unique "topic", or name, which is typically prefixed by a `/`.
-//! If you're familiar with MCAP, it's the same concept as an [MCAP channel]:
+//! If you're familiar with MCAP, it's the same concept as an [MCAP channel].
+//!
+//! A channel is always associated with exactly one [`Context`] throughout its lifecycle. The
+//! channel remains attached to the context until it is either explicitly closed with
+//! [`Channel::close`], or the context is dropped. Attempting to log a message on a closed channel
+//! will elicit a throttled warning.
 //!
 //! [MCAP channel]: https://mcap.dev/guides/concepts#channel
 //!
@@ -71,21 +116,35 @@
 //!
 //! [jsonschema-trait]: https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html
 //!
-//! ### Static Channels
+//! ### Lazy Channels
 //!
 //! A common pattern is to create the channels once as static variables, and then use them
 //! throughout the application. But because channels do not have a const initializer, they must be
-//! initialized lazily. [`LazyChannel`] provides a convenient way to do this.
+//! initialized lazily. [`LazyChannel`] and [`LazyRawChannel`] provide a convenient way to do this.
 //!
 //! Be careful when using this pattern. The channel will not be advertised to sinks until it is
 //! initialized, which is guaranteed to happen when the channel is first used. If you need to
 //! ensure the channel is initialized _before_ using it, you can use [`LazyChannel::init`].
 //!
+//! In this example, we create two lazy channels on the default context:
+//!
 //! ```
-//! use foxglove::LazyChannel;
+//! use foxglove::{LazyChannel, LazyRawChannel};
 //! use foxglove::schemas::SceneUpdate;
 //!
 //! static BOXES: LazyChannel<SceneUpdate> = LazyChannel::new("/boxes");
+//! static MSG: LazyRawChannel = LazyRawChannel::new("/msg", "json");
+//! ```
+//!
+//! It is also possible to bind lazy channels to an explicit [`LazyContext`]:
+//!
+//! ```
+//! use foxglove::{LazyChannel, LazyContext, LazyRawChannel};
+//! use foxglove::schemas::SceneUpdate;
+//!
+//! static CTX: LazyContext = LazyContext::new();
+//! static BOXES: LazyChannel<SceneUpdate> = CTX.channel("/boxes");
+//! static MSG: LazyRawChannel = CTX.raw_channel("/msg", "json");
 //! ```
 //!
 //! ## Sinks
@@ -94,11 +153,14 @@
 //! will simply be dropped without being recorded. You can configure multiple sinks, and you can
 //! create or destroy them dynamically at runtime.
 //!
+//! A sink is typically associated with exactly one [`Context`] throughout its lifecycle. Details
+//! about the how the sink is registered and unregistered from the context are sink-specific.
+//!
 //! ### MCAP file
 //!
 //! Use [`McapWriter::new()`] to register a new MCAP writer. As long as the handle remains in
-//! scope, events will be logged to the MCAP file. When the handle is closed or dropped, the file
-//! will be finalized and flushed.
+//! scope, events will be logged to the MCAP file. When the handle is closed or dropped, the sink
+//! will be unregistered from the [`Context`], and the file will be finalized and flushed.
 //!
 //! ```no_run
 //! # fn func() -> Result<(), foxglove::FoxgloveError> {
@@ -127,8 +189,11 @@
 //!
 //! Use [`WebSocketServer::new`] to create a new live visualization server. By default, the server
 //! listens on `127.0.0.1:8765`. Once the server is configured, call [`WebSocketServer::start`] to
-//! register the server as a message sink, and begin accepting websocket connections from the
-//! Foxglove app.
+//! start the server, and begin accepting websocket connections from the Foxglove app.
+//!
+//! Each client that connects to the websocket server is its own independent sink. The sink is
+//! dynamically added to the [`Context`] associated with the server when the client connects, and
+//! removed from the context when the client disconnects.
 //!
 //! See the ["Connect" documentation][app-connect] for how to connect the Foxglove app to your running
 //! server.
@@ -192,8 +257,7 @@ mod websocket_server;
 
 pub use channel::{Channel, ChannelId, LazyChannel, LazyRawChannel, RawChannel};
 pub use channel_builder::ChannelBuilder;
-#[doc(hidden)]
-pub use context::Context;
+pub use context::{Context, LazyContext};
 pub use encode::Encode;
 pub use mcap_writer::{McapWriter, McapWriterHandle};
 pub use metadata::{Metadata, PartialMetadata};

--- a/rust/foxglove/src/mcap_writer.rs
+++ b/rust/foxglove/src/mcap_writer.rs
@@ -94,8 +94,8 @@ impl McapWriter {
 
 /// A handle to an MCAP file writer.
 ///
-/// When this handle is dropped, the writer will stop logging events, and flush any buffered data
-/// to the writer.
+/// When this handle is dropped, the writer will unregister from the [`Context`], stop logging
+/// events, and flush any buffered data to the writer.
 #[must_use]
 #[derive(Debug)]
 pub struct McapWriterHandle<W: Write + Seek + Send + 'static> {

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -171,7 +171,6 @@ impl WebSocketServer {
     }
 
     /// Sets the context for this sink.
-    #[doc(hidden)]
     pub fn context(mut self, ctx: &Arc<Context>) -> Self {
         self.context = ctx.clone();
         self


### PR DESCRIPTION
### Changelog
- rust: Add Context and LazyContext

### Description
This change unhides `Context` from the public API. The bulk of the change is:
- Updating documentation to describe contexts.
- Add shortcut methods for building channels & sinks from a context.
- Add a `LazyContext` for use with `LazyChannel`.

Fixes: FG-10885
Fixes: FG-10854