### PR TITLE
Enable sccache again now that issue has been fixed upstream

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -123,7 +123,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "false"
+          sccache: "true"
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -155,7 +155,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "false"
+          sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -184,7 +184,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "false"
+          sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -211,7 +211,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "false"
+          sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -123,7 +123,8 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          # Add a comment so there is a diff
+          sccache: "false"
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -155,7 +156,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          sccache: "false"
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -184,7 +185,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          sccache: "false"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -211,7 +212,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
           args: --release --out dist --find-interpreter
-          sccache: "true"
+          sccache: "false"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Now that sccache 0.10.0 is published to pip, we can enable the cache again