### PR TITLE
Call `on_unsubscribe` when client disconnects

### DIFF
--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -41,7 +41,7 @@ class ServerListener(Protocol):
 
     def on_unsubscribe(self, client: Client, channel: ChannelView) -> None:
         """
-        Called by the server when a client unsubscribes from a channel.
+        Called by the server when a client unsubscribes from a channel or disconnects.
 
         :param client: The client (id) that sent the message.
         :type client: :py:class:`Client`

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -235,7 +235,7 @@ pub trait ServerListener: Send + Sync {
     /// Callback invoked when a client subscribes to a channel.
     /// Only invoked if the channel is associated with the server and isn't already subscribed to by the client.
     fn on_subscribe(&self, _client: Client, _channel: ChannelView) {}
-    /// Callback invoked when a client unsubscribes from a channel.
+    /// Callback invoked when a client unsubscribes from a channel or disconnects.
     /// Only invoked for channels that had an active subscription from the client.
     fn on_unsubscribe(&self, _client: Client, _channel: ChannelView) {}
     /// Callback invoked when a client advertises a client channel. Requires [`Capability::ClientPublish`].

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -416,6 +416,12 @@ impl ConnectedClient {
             _ = sender.send(Message::Close(None)).await;
         }
 
+        let channel_ids = {
+            let subscriptions = self.subscriptions.lock();
+            subscriptions.left_values().copied().collect()
+        };
+        self.unsubscribe_channel_ids(channel_ids);
+
         // If we track paramter subscriptions, unsubscribe this clients subscriptions
         // and notify the handler, if necessary
         if !server.capabilities.contains(&Capability::Parameters) || self.server_listener.is_none()
@@ -535,37 +541,7 @@ impl ConnectedClient {
             }
         }
 
-        // Propagate client unsubscriptions to the context.
-        if let Some(context) = self.context.upgrade() {
-            context.unsubscribe_channels(self.sink_id, &unsubscribed_channel_ids);
-        }
-
-        // If we don't have a ServerListener, we're done.
-        let Some(handler) = self.server_listener.as_ref() else {
-            return;
-        };
-
-        // Then gather the actual channel references while holding the channels lock
-        let mut unsubscribed_channels = Vec::with_capacity(unsubscribed_channel_ids.len());
-        {
-            let channels = self.channels.read();
-            for channel_id in unsubscribed_channel_ids {
-                if let Some(channel) = channels.get(&channel_id) {
-                    unsubscribed_channels.push(channel.clone());
-                }
-            }
-        }
-
-        // Finally call the handler for each channel
-        for channel in unsubscribed_channels {
-            handler.on_unsubscribe(
-                Client::new(self),
-                ChannelView {
-                    id: channel.id(),
-                    topic: channel.topic(),
-                },
-            );
-        }
+        self.unsubscribe_channel_ids(unsubscribed_channel_ids);
     }
 
     fn on_subscribe(&self, mut subscriptions: Vec<Subscription>) {
@@ -1032,6 +1008,42 @@ impl ConnectedClient {
                 "Unadvertised channel with id {} to client {}",
                 channel_id,
                 self.addr
+            );
+        }
+    }
+
+    /// Unsubscribes from a list of channel IDs.
+    /// Takes a read lock on the channels map.
+    fn unsubscribe_channel_ids(&self, unsubscribed_channel_ids: Vec<ChannelId>) {
+        // Propagate client unsubscriptions to the context.
+        if let Some(context) = self.context.upgrade() {
+            context.unsubscribe_channels(self.sink_id, &unsubscribed_channel_ids);
+        }
+
+        // If we don't have a ServerListener, we're done.
+        let Some(handler) = self.server_listener.as_ref() else {
+            return;
+        };
+
+        // Then gather the actual channel references while holding the channels lock
+        let mut unsubscribed_channels = Vec::with_capacity(unsubscribed_channel_ids.len());
+        {
+            let channels = self.channels.read();
+            for channel_id in unsubscribed_channel_ids {
+                if let Some(channel) = channels.get(&channel_id) {
+                    unsubscribed_channels.push(channel.clone());
+                }
+            }
+        }
+
+        // Finally call the handler for each channel
+        for channel in unsubscribed_channels {
+            handler.on_unsubscribe(
+                Client::new(self),
+                ChannelView {
+                    id: channel.id(),
+                    topic: channel.topic(),
+                },
             );
         }
     }

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -504,6 +504,62 @@ async fn test_log_only_to_subscribers() {
 
 #[traced_test]
 #[tokio::test]
+async fn test_on_unsubscribe_called_after_disconnect() {
+    let recording_listener = Arc::new(RecordingServerListener::new());
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            listener: Some(recording_listener.clone()),
+            ..Default::default()
+        },
+    );
+
+    let chan = new_channel("/foo", &ctx);
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut client = connect_client(addr).await;
+    client.next().await.expect("No serverInfo sent").unwrap();
+    client.next().await.expect("No advertisement sent").unwrap();
+
+    let subscribe = json!({
+        "op": "subscribe",
+        "subscriptions": [
+            { "id": 1, "channelId": chan.id() }
+        ]
+    });
+    client
+        .send(Message::text(subscribe.to_string()))
+        .await
+        .expect("Failed to send");
+
+    // Allow the server to process the subscriptions
+    assert_eventually(|| dbg!(chan.num_sinks()) == 1).await;
+
+    let subscriptions = recording_listener.take_subscribe();
+    assert_eq!(subscriptions.len(), 1);
+
+    let unsubscriptions = recording_listener.take_unsubscribe();
+    assert_eq!(unsubscriptions.len(), 0);
+
+    // Disconnect the client without unsubscribing explicitly
+    client.close(None).await.unwrap();
+
+    // Allow the server to process the disconnection
+    assert_eventually(|| dbg!(chan.num_sinks()) == 0).await;
+
+    let unsubscriptions = recording_listener.take_unsubscribe();
+    assert_eq!(unsubscriptions.len(), 1);
+
+    server.stop().await;
+}
+
+#[traced_test]
+#[tokio::test]
 async fn test_error_when_client_publish_unsupported() {
     // Server does not support clientPublish capability by default
     let ctx = Context::new();

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -502,7 +502,6 @@ async fn test_log_only_to_subscribers() {
     server.stop().await;
 }
 
-#[traced_test]
 #[tokio::test]
 async fn test_on_unsubscribe_called_after_disconnect() {
     let recording_listener = Arc::new(RecordingServerListener::new());


### PR DESCRIPTION
### Changelog

When a WS client disconnects, a server listener will receive an `on_unsubscribe` event for all subscribed channels.

### Description

A Foxglove (WS) client may disconnect without explicitly unsubscribing; a server listener should be made aware of this via the `on_unsubscribe` callback.