### PR TITLE
Fix up python docs

### DIFF
--- a/python/foxglove-sdk/poetry.lock
+++ b/python/foxglove-sdk/poetry.lock
@@ -1529,4 +1529,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "f582c9ee771bdc0fd045f8d5fc17582e1d7dc6007bd2a1d76a6d310a9ecea55b"
+content-hash = "827bf413bf82581fbdd2afabf721179b455dc3f178526147a00071db20beb72e"

--- a/python/foxglove-sdk/pyproject.toml
+++ b/python/foxglove-sdk/pyproject.toml
@@ -36,6 +36,7 @@ mypy = "^1.13.0"
 pytest = "^8.3.4"
 pytest-benchmark = "^5.1.0"
 sphinx = "^7.0.0"
+sphinx-autodoc-typehints = "^2.0.0"
 
 [tool.mypy]
 python_version = "3.9"

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -4,48 +4,8 @@ API Reference
 foxglove
 --------
 
-.. Enums are excluded and manually documented, since pyo3 only emulates them. (https://github.com/PyO3/pyo3/issues/2887)
-.. Parameter types and values are manually documented since nested classes (values) are not supported by automodule.
 .. automodule:: foxglove
    :members:
-
-Enums
-^^^^^
-
-.. py:enum:: Capability
-
-   An enumeration of capabilities that you may choose to support for live visualization.
-
-   Specify the capabilities you support when calling :py:func:`start_server`. These will be
-   advertised to the Foxglove app when connected as a WebSocket client.
-
-   .. py:data:: ClientPublish
-
-      Allow clients to advertise channels to send data messages to the server.
-
-   .. py:data:: Parameters
-
-      Allow clients to get & set parameters.
-
-   .. py:data:: Services
-
-      Allow clients to call services.
-
-   .. py:data:: Time
-
-      Inform clients about the latest server time.
-
-      This allows accelerated, slowed, or stepped control over the progress of time. If the
-      server publishes time data, then timestamps of published messages must originate from the
-      same time source.
-
-.. py:enum:: StatusLevel
-
-   A level for :py:meth:`WebSocketServer.publish_status`.
-
-   .. py:data:: Info
-   .. py:data:: Warning
-   .. py:data:: Error
 
 Schemas
 ^^^^^^^
@@ -67,7 +27,7 @@ Channels
 Parameters
 ^^^^^^^^^^
 
-Used with the parameter service during live visualization. Requires the :py:data:`Capability.Parameters` capability.
+Used with the parameter service during live visualization. Requires the :py:data:`websocket.Capability.Parameters` capability.
 
 .. autoclass:: foxglove.websocket.ParameterType
 
@@ -126,6 +86,47 @@ See the Asset Server example for more information.
 foxglove.websocket
 ------------------
 
+.. Enums are excluded and manually documented, since pyo3 only emulates them. (https://github.com/PyO3/pyo3/issues/2887)
+.. Parameter types and values are manually documented since nested classes (values) are not supported by automodule.
 .. automodule:: foxglove.websocket
    :members:
    :exclude-members: Capability, ParameterType, ParameterValue, StatusLevel
+
+
+Enums
+^^^^^
+
+.. py:enum:: Capability
+
+   An enumeration of capabilities that you may choose to support for live visualization.
+
+   Specify the capabilities you support when calling :py:func:`foxglove.start_server`. These will be
+   advertised to the Foxglove app when connected as a WebSocket client.
+
+   .. py:data:: ClientPublish
+
+      Allow clients to advertise channels to send data messages to the server.
+
+   .. py:data:: Parameters
+
+      Allow clients to get & set parameters.
+
+   .. py:data:: Services
+
+      Allow clients to call services.
+
+   .. py:data:: Time
+
+      Inform clients about the latest server time.
+
+      This allows accelerated, slowed, or stepped control over the progress of time. If the
+      server publishes time data, then timestamps of published messages must originate from the
+      same time source.
+
+.. py:enum:: StatusLevel
+
+   A level for :py:meth:`WebSocketServer.publish_status`.
+
+   .. py:data:: Info
+   .. py:data:: Warning
+   .. py:data:: Error

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -1,6 +1,8 @@
 API Reference
 =============
 
+Version: |release|
+
 foxglove
 --------
 

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -8,8 +8,6 @@ foxglove
 .. Parameter types and values are manually documented since nested classes (values) are not supported by automodule.
 .. automodule:: foxglove
    :members:
-   :exclude-members: Capability, ParameterType, ParameterValue, StatusLevel
-
 
 Enums
 ^^^^^
@@ -123,3 +121,11 @@ disk and return its contents.
 See the Asset Server example for more information.
 
 .. autoclass:: foxglove.AssetHandler
+
+
+foxglove.websocket
+------------------
+
+.. automodule:: foxglove.websocket
+   :members:
+   :exclude-members: Capability, ParameterType, ParameterValue, StatusLevel

--- a/python/foxglove-sdk/python/docs/conf.py
+++ b/python/foxglove-sdk/python/docs/conf.py
@@ -24,6 +24,15 @@ extensions: list[str] = [
 ]
 
 nitpicky = True
+nitpick_ignore_regex = [
+    # Ignore warnings for built-in types from autodoc_typehints
+    ("py:data", r"typing.*"),
+    ("py:class", r"collections.abc.Callable"),
+    # autodoc_typehints also fails on Capability which is imported in websocket.py, but is
+    # manually documented as an enum
+    ("py:class", r"foxglove.Capability"),
+]
+
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/python/foxglove-sdk/python/docs/conf.py
+++ b/python/foxglove-sdk/python/docs/conf.py
@@ -2,24 +2,34 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+from datetime import date
+
+from docs.version import SDK_VERSION
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Foxglove SDK"
-copyright = "2025, Foxglove"
+copyright = f"{date.today().year}, Foxglove"
 author = "Foxglove"
+release = SDK_VERSION
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions: list[str] = [
     "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
     "enum_tools.autoenum",
 ]
 
+nitpicky = True
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# Config for sphinx_autodoc_typehints
+# https://pypi.org/project/sphinx-autodoc-typehints/
+typehints_defaults = "braces"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/python/foxglove-sdk/python/docs/index.rst
+++ b/python/foxglove-sdk/python/docs/index.rst
@@ -5,6 +5,8 @@
 Foxglove SDK documentation
 ==========================
 
+Version: |release|
+
 The official `Foxglove <https://docs.foxglove.dev/docs>`_ SDK for Python.
 
 This package provides support for integrating with the Foxglove platform. It can be used to log

--- a/python/foxglove-sdk/python/docs/version.py
+++ b/python/foxglove-sdk/python/docs/version.py
@@ -1,0 +1,1 @@
+SDK_VERSION = "0.4.1"

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -44,22 +44,15 @@ def start_server(
     Start a websocket server for live visualization.
 
     :param name: The name of the server.
-    :type name: Optional[str]
     :param host: The host to bind to.
-    :type host: Optional[str] = "127.0.0.1"
     :param port: The port to bind to.
-    :type port: Optional[int] = 8765
     :param capabilities: A list of capabilities to advertise to clients.
-    :type capabilities: Optional[List[Capability]] = None
-    :param server_listener: A Python object that implements the :py:class:`ServerListener` protocol.
-    :type server_listener: Optional[ServerListener] = None
+    :param server_listener: A Python object that implements the :py:class:`websocket.ServerListener`
+        protocol.
     :param supported_encodings: A list of encodings to advertise to clients.
-    :type supported_encodings: Optional[List[str]] = None
     :param services: A list of services to advertise to clients.
-    :type services: Optional[List[Service]] = None
     :param asset_handler: A callback function that returns the asset for a given URI, or None if
         it doesn't exist.
-    :type asset_handler: Optional[:py:class:`AssetHandler`] = None
     """
     return _foxglove.start_server(
         name=name,

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
@@ -23,8 +23,6 @@ class Duration:
         Raises `OverflowError` if the duration cannot be represented.
 
         :param secs: Seconds
-        :type secs: float
-        :rtype: :py:class:`Duration`
         """
         ...
 
@@ -36,8 +34,6 @@ class Duration:
         Raises `OverflowError` if the duration cannot be represented.
 
         :param td: Timedelta
-        :type td: :py:class:`datetime.timedelta`
-        :rtype: :py:class:`Duration`
         """
         ...
 
@@ -59,14 +55,12 @@ class Timestamp:
     def from_epoch_secs(timestamp: float) -> "Timestamp":
         """
         Creates a :py:class:`Timestamp` from an epoch timestamp, such as is
-        returned by :py:func:`time.time` or
+        returned by :py:meth:`time.time` or
         :py:func:`datetime.datetime.timestamp`.
 
         Raises `OverflowError` if the timestamp cannot be represented.
 
         :param timestamp: Seconds since epoch
-        :type timestamp: float
-        :rtype: :py:class:`Timestamp`
         """
         ...
 
@@ -80,7 +74,5 @@ class Timestamp:
         Raises `OverflowError` if the timestamp cannot be represented.
 
         :param dt: Datetime
-        :type dt: :py:class:`datetime.datetime`
-        :rtype: :py:class:`Timestamp`
         """
         ...

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
@@ -55,8 +55,7 @@ class Timestamp:
     def from_epoch_secs(timestamp: float) -> "Timestamp":
         """
         Creates a :py:class:`Timestamp` from an epoch timestamp, such as is
-        returned by :py:meth:`time.time` or
-        :py:func:`datetime.datetime.timestamp`.
+        returned by :py:func:`time.time` or :py:func:`datetime.datetime.timestamp`.
 
         Raises `OverflowError` if the timestamp cannot be represented.
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -61,6 +61,9 @@ class ConnectionGraph:
         """
         Set a published topic and its associated publisher ids. Overwrites any existing topic with
         the same name.
+
+        :param topic: The topic name.
+        :param publisher_ids: The set of publisher ids.
         """
         ...
 
@@ -68,6 +71,9 @@ class ConnectionGraph:
         """
         Set a subscribed topic and its associated subscriber ids. Overwrites any existing topic with
         the same name.
+
+        :param topic: The topic name.
+        :param subscriber_ids: The set of subscriber ids.
         """
         ...
 
@@ -75,6 +81,9 @@ class ConnectionGraph:
         """
         Set an advertised service and its associated provider ids Overwrites any existing service
         with the same name.
+
+        :param service: The service name.
+        :param provider_ids: The set of provider ids.
         """
         ...
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from enum import Enum
 from typing import List, Optional, Union
 
-from . import Schema
+import foxglove
 
 class Capability(Enum):
     """
@@ -67,13 +67,13 @@ class MessageSchema:
     """
 
     encoding: str
-    schema: "Schema"
+    schema: "foxglove.Schema"
 
     def __new__(
         cls,
         *,
         encoding: str,
-        schema: "Schema",
+        schema: "foxglove.Schema",
     ) -> "MessageSchema": ...
 
 class Parameter:

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -57,9 +57,26 @@ class ConnectionGraph:
     """
 
     def __new__(cls) -> "ConnectionGraph": ...
-    def set_published_topic(self, topic: str, publisher_ids: List[str]) -> None: ...
-    def set_subscribed_topic(self, topic: str, subscriber_ids: List[str]) -> None: ...
-    def set_advertised_service(self, service: str, provider_ids: List[str]) -> None: ...
+    def set_published_topic(self, topic: str, publisher_ids: List[str]) -> None:
+        """
+        Set a published topic and its associated publisher ids. Overwrites any existing topic with
+        the same name.
+        """
+        ...
+
+    def set_subscribed_topic(self, topic: str, subscriber_ids: List[str]) -> None:
+        """
+        Set a subscribed topic and its associated subscriber ids. Overwrites any existing topic with
+        the same name.
+        """
+        ...
+
+    def set_advertised_service(self, service: str, provider_ids: List[str]) -> None:
+        """
+        Set an advertised service and its associated provider ids Overwrites any existing service
+        with the same name.
+        """
+        ...
 
 class MessageSchema:
     """
@@ -199,6 +216,8 @@ class ServiceSchema:
     ) -> "ServiceSchema": ...
 
 class StatusLevel(Enum):
+    """A level for `WebSocketServer.publish_status`"""
+
     Info = ...
     Warning = ...
     Error = ...
@@ -210,15 +229,60 @@ class WebSocketServer:
 
     def __new__(cls) -> "WebSocketServer": ...
     @property
-    def port(self) -> int: ...
-    def stop(self) -> None: ...
-    def clear_session(self, session_id: Optional[str] = None) -> None: ...
-    def broadcast_time(self, timestamp_nanos: int) -> None: ...
-    def publish_parameter_values(self, parameters: List["Parameter"]) -> None: ...
+    def port(self) -> int:
+        """Get the port on which the server is listening."""
+        ...
+
+    def stop(self) -> None:
+        """Explicitly stop the server."""
+        ...
+
+    def clear_session(self, session_id: Optional[str] = None) -> None:
+        """
+        Sets a new session ID and notifies all clients, causing them to reset their state.
+        If no session ID is provided, generates a new one based on the current timestamp.
+        If the server has been stopped, this has no effect.
+        """
+        ...
+
+    def broadcast_time(self, timestamp_nanos: int) -> None:
+        """
+        Publishes the current server timestamp to all clients.
+        If the server has been stopped, this has no effect.
+        """
+        ...
+
+    def publish_parameter_values(self, parameters: List["Parameter"]) -> None:
+        """Publishes parameter values to all subscribed clients."""
+        ...
+
     def publish_status(
         self, message: str, level: "StatusLevel", id: Optional[str] = None
-    ) -> None: ...
-    def remove_status(self, ids: list[str]) -> None: ...
-    def add_services(self, services: list["Service"]) -> None: ...
-    def remove_services(self, names: list[str]) -> None: ...
-    def publish_connection_graph(self, graph: "ConnectionGraph") -> None: ...
+    ) -> None:
+        """
+        Send a status message to all clients. If the server has been stopped, this has no effect.
+        """
+        ...
+
+    def remove_status(self, ids: list[str]) -> None:
+        """
+        Remove status messages by id from all clients. If the server has been stopped, this has no
+        effect.
+        """
+        ...
+
+    def add_services(self, services: list["Service"]) -> None:
+        """Add services to the server."""
+        ...
+
+    def remove_services(self, names: list[str]) -> None:
+        """Removes services that were previously advertised."""
+        ...
+
+    def publish_connection_graph(self, graph: "ConnectionGraph") -> None:
+        """
+        Publishes a connection graph update to all subscribed clients. An update is published to
+        clients as a difference from the current graph to the replacement graph. When a client first
+        subscribes to connection graph updates, it receives the current graph.
+        """
+        ...

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -84,7 +84,7 @@ class Channel:
         Close the channel.
 
         You can use this to explicitly unadvertise the channel to sinks that subscribe to
-        channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+        channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
 
         Attempts to log on a closed channel will elicit a throttled warning message.
         """

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -33,9 +33,7 @@ class ServerListener(Protocol):
         Called by the server when a client subscribes to a channel.
 
         :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
         :param channel: The channel (id, topic) that the message was sent on.
-        :type channel: :py:class:`ChannelView`
         """
         return None
 
@@ -44,9 +42,7 @@ class ServerListener(Protocol):
         Called by the server when a client unsubscribes from a channel.
 
         :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
         :param channel: The channel (id, topic) that the message was sent on.
-        :type channel: :py:class:`ChannelView`
         """
         return None
 
@@ -55,9 +51,7 @@ class ServerListener(Protocol):
         Called by the server when a client advertises a channel.
 
         :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
         :param channel: The client channel that is being advertised.
-        :type channel: :py:class:`ClientChannel`
         """
         return None
 
@@ -66,9 +60,7 @@ class ServerListener(Protocol):
         Called by the server when a client unadvertises a channel.
 
         :param client: The client (id) that is unadvertising the channel.
-        :type client: :py:class:`Client`
         :param client_channel_id: The client channel id that is being unadvertised.
-        :type client_channel_id: int
         """
         return None
 
@@ -79,11 +71,8 @@ class ServerListener(Protocol):
         Called by the server when a message is received from a client.
 
         :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
         :param client_channel_id: The client channel id that the message was sent on.
-        :type client_channel_id: int
         :param data: The message data.
-        :type data: bytes
         """
         return None
 
@@ -99,11 +88,8 @@ class ServerListener(Protocol):
         Requires :py:data:`Capability.Parameters`.
 
         :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
         :param param_names: The names of the parameters to get.
-        :type param_names: list[str]
         :param request_id: An optional request id.
-        :type request_id: Optional[str]
         """
         return []
 
@@ -121,11 +107,8 @@ class ServerListener(Protocol):
         Requires :py:data:`Capability.Parameters`.
 
         :param client: The client (id) that sent the message.
-        :type client: :py:class:`Client`
         :param parameters: The parameters to set.
-        :type parameters: list[:py:class:`Parameter`]
         :param request_id: An optional request id.
-        :type request_id: Optional[str]
         """
         return parameters
 
@@ -139,7 +122,6 @@ class ServerListener(Protocol):
         Requires :py:data:`Capability.Parameters`.
 
         :param param_names: The names of the parameters to subscribe to.
-        :type param_names: list[str]
         """
         return None
 
@@ -154,7 +136,6 @@ class ServerListener(Protocol):
         Requires :py:data:`Capability.Parameters`.
 
         :param param_names: The names of the parameters to unsubscribe from.
-        :type param_names: list[str]
         """
         return None
 

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -68,7 +68,7 @@ impl CameraCalibrationChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -125,7 +125,7 @@ impl CircleAnnotationChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -182,7 +182,7 @@ impl ColorChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -239,7 +239,7 @@ impl CompressedImageChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -296,7 +296,7 @@ impl CompressedVideoChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -353,7 +353,7 @@ impl FrameTransformChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -410,7 +410,7 @@ impl FrameTransformsChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -467,7 +467,7 @@ impl GeoJsonChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -524,7 +524,7 @@ impl GridChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -581,7 +581,7 @@ impl ImageAnnotationsChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -638,7 +638,7 @@ impl KeyValuePairChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -695,7 +695,7 @@ impl LaserScanChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -752,7 +752,7 @@ impl LocationFixChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -809,7 +809,7 @@ impl LogChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -866,7 +866,7 @@ impl SceneEntityDeletionChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -923,7 +923,7 @@ impl SceneEntityChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -980,7 +980,7 @@ impl SceneUpdateChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1037,7 +1037,7 @@ impl PackedElementFieldChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1094,7 +1094,7 @@ impl Point2Channel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1151,7 +1151,7 @@ impl Point3Channel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1208,7 +1208,7 @@ impl PointCloudChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1265,7 +1265,7 @@ impl PointsAnnotationChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1322,7 +1322,7 @@ impl PoseChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1379,7 +1379,7 @@ impl PoseInFrameChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1436,7 +1436,7 @@ impl PosesInFrameChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1493,7 +1493,7 @@ impl QuaternionChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1550,7 +1550,7 @@ impl RawImageChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1607,7 +1607,7 @@ impl TextAnnotationChannel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1664,7 +1664,7 @@ impl Vector2Channel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {
@@ -1721,7 +1721,7 @@ impl Vector3Channel {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:`foxglove.WebSocketServer`.
+    /// channels dynamically, such as the :py:class:`foxglove.websocket.WebSocketServer`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {

--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -7,7 +7,7 @@ use pyo3::types::{timezone_utc, PyDateTime};
 /// A timestamp in seconds and nanoseconds
 ///
 /// :param sec: The number of seconds since a user-defined epoch.
-/// :param nsec: The number of nanoseconds since the :py:attr:\`sec\` value.
+/// :param nsec: The number of nanoseconds since the sec value.
 #[pyclass(module = "foxglove.schemas", eq)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct Timestamp(foxglove::schemas::Timestamp);
@@ -41,6 +41,7 @@ impl Timestamp {
     /// Creates a :py:class:`Timestamp` from the current system time.
     ///
     /// Raises `OverflowError` if the timestamp cannot be represented.
+    ///
     /// :rtype: :py:class:`Timestamp`
     #[staticmethod]
     #[pyo3(signature = ())]
@@ -52,12 +53,11 @@ impl Timestamp {
     }
 
     /// Creates a :py:class:`Timestamp` from an epoch timestamp, such as is returned by
-    /// :py:func:`time.time` or :py:func:`datetime.datetime.timestamp`.
+    /// :py:func:`!time.time` or :py:func:`!datetime.datetime.timestamp`.
     ///
     /// Raises `OverflowError` if the timestamp cannot be represented.
     ///
     /// :param timestamp: Seconds since epoch
-    /// :type timestamp: float
     /// :rtype: :py:class:`Timestamp`
     #[staticmethod]
     #[pyo3(signature = (timestamp))]
@@ -74,7 +74,6 @@ impl Timestamp {
     /// Raises `OverflowError` if the timestamp cannot be represented.
     ///
     /// :param dt: Datetime
-    /// :type dt: :py:class:`datetime.datetime`
     /// :rtype: :py:class:`Timestamp`
     #[staticmethod]
     #[pyo3(signature = (dt))]
@@ -159,7 +158,6 @@ impl Duration {
     /// Raises `OverflowError` if the duration cannot be represented.
     ///
     /// :param secs: Seconds
-    /// :type secs: float
     /// :rtype: :py:class:`Duration`
     #[staticmethod]
     #[pyo3(signature = (secs))]
@@ -174,7 +172,6 @@ impl Duration {
     /// Raises `OverflowError` if the duration cannot be represented.
     ///
     /// :param td: Timedelta
-    /// :type td: :py:class:`datetime.timedelta`
     /// :rtype: :py:class:`Duration`
     #[staticmethod]
     #[pyo3(signature = (td))]

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -935,9 +935,7 @@ impl PyConnectionGraph {
     /// Overwrites any existing topic with the same name.
     ///
     /// :param topic: The topic name.
-    /// :type topic: str
     /// :param publisher_ids: The set of publisher ids.
-    /// :type publisher_ids: list[str]
     pub fn set_published_topic(&mut self, topic: &str, publisher_ids: Vec<String>) {
         self.0.set_published_topic(topic, publisher_ids);
     }
@@ -946,9 +944,7 @@ impl PyConnectionGraph {
     /// Overwrites any existing topic with the same name.
     ///
     /// :param topic: The topic name.
-    /// :type topic: str
     /// :param subscriber_ids: The set of subscriber ids.
-    /// :type subscriber_ids: list[str]
     pub fn set_subscribed_topic(&mut self, topic: &str, subscriber_ids: Vec<String>) {
         self.0.set_subscribed_topic(topic, subscriber_ids);
     }
@@ -957,9 +953,7 @@ impl PyConnectionGraph {
     /// Overwrites any existing service with the same name.
     ///
     /// :param service: The service name.
-    /// :type service: str
     /// :param provider_ids: The set of provider ids.
-    /// :type provider_ids: list[str]
     pub fn set_advertised_service(&mut self, service: &str, provider_ids: Vec<String>) {
         self.0.set_advertised_service(service, provider_ids);
     }

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -447,7 +447,6 @@ impl PyWebSocketServer {
     /// If the server has been stopped, this has no effect.
     ///
     /// :param session_id: An optional session ID.
-    /// :type session_id: Optional[str]
     #[pyo3(signature = (session_id=None))]
     pub fn clear_session(&self, session_id: Option<String>) {
         if let Some(server) = &self.0 {
@@ -459,7 +458,6 @@ impl PyWebSocketServer {
     /// If the server has been stopped, this has no effect.
     ///
     /// :param timestamp_nanos: The timestamp to broadcast, in nanoseconds.
-    /// :type timestamp_nanos: int
     #[pyo3(signature = (timestamp_nanos))]
     pub fn broadcast_time(&self, timestamp_nanos: u64) {
         if let Some(server) = &self.0 {
@@ -471,11 +469,8 @@ impl PyWebSocketServer {
     /// If the server has been stopped, this has no effect.
     ///
     /// :param message: The message to send.
-    /// :type message: str
     /// :param level: The level of the status message.
-    /// :type level: :py:enum:`StatusLevel`
     /// :param id: An optional id for the status message.
-    /// :type id: Optional[str]
     #[pyo3(signature = (message, level, id=None))]
     pub fn publish_status(&self, message: String, level: &PyStatusLevel, id: Option<String>) {
         let Some(server) = &self.0 else {
@@ -517,7 +512,6 @@ impl PyWebSocketServer {
     /// This method will fail if the server was not configured with :py:attr:`Capability.Services`.
     ///
     /// :param services: Services to add.
-    /// :type services: list[:py:class:`Service`]
     pub fn add_services(&self, py: Python<'_>, services: Vec<PyService>) -> PyResult<()> {
         if let Some(server) = &self.0 {
             py.allow_threads(move || {
@@ -532,7 +526,6 @@ impl PyWebSocketServer {
     /// Removes services that were previously advertised.
     ///
     /// :param names: Names of services to remove.
-    /// :type names: list[str]
     pub fn remove_services(&self, py: Python<'_>, names: Vec<String>) {
         if let Some(server) = &self.0 {
             py.allow_threads(move || server.remove_services(names));
@@ -544,7 +537,6 @@ impl PyWebSocketServer {
     /// subscribes to connection graph updates, it receives the current graph.
     ///
     /// :param graph: The connection graph to publish.
-    /// :type graph: :py:class:`foxglove.websocket.ConnectionGraph`
     pub fn publish_connection_graph(&self, graph: Bound<'_, PyConnectionGraph>) -> PyResult<()> {
         let Some(server) = &self.0 else {
             return Ok(());

--- a/scripts/bumpSdkVersion.ts
+++ b/scripts/bumpSdkVersion.ts
@@ -81,6 +81,23 @@ async function main() {
     process.exit(status);
   }
 
+  // update version in Python SDK docs
+  console.log("\nUpdating python docs version...");
+  const pythonVersionModule = path.join(
+    workspaceRoot,
+    "python/foxglove-sdk/python/docs/version.py",
+  );
+  const content = await readFile(pythonVersionModule, "utf8");
+  const updatedContent = content.replace(
+    /SDK_VERSION\s*=\s*"([^"]*)"/m,
+    `SDK_VERSION = "${newVersion}"`,
+  );
+  if (!updatedContent.includes(newVersion)) {
+    console.error(`❌ Failed to update python docs version`);
+    process.exit(1);
+  }
+  await writeFile(pythonVersionModule, updatedContent);
+
   console.log("\n✅ Success!");
 
   // github action outputs

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -570,7 +570,7 @@ impl ${channelClass} {
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
-    /// channels dynamically, such as the :py:class:\`foxglove.WebSocketServer\`.
+    /// channels dynamically, such as the :py:class:\`foxglove.websocket.WebSocketServer\`.
     ///
     /// Attempts to log on a closed channel will elicit a throttled warning message.
     fn close(&mut self) {


### PR DESCRIPTION
### Changelog
None

### Description

This updates and fixes python documentation, and improves the sphinx configuration for better cross-reference validation.

- Restore the `websocket` submodule documentation, as automodule is not recursive
- Add the "sphinx-autodoc-typehints" extension so types can typically be inferred from type definitions rather than needing to include `:type` docs
- Configure sphinx with "nitpicky", which warns on various issues including broken cross-references. (CI is configured to fail on warnings)
- Add a version to the published documentation; `release` is included in page titles automatically.
