### PR TITLE
Re-export mcap and bytes dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,6 @@ dependencies = [
  "ctrlc",
  "env_logger",
  "foxglove",
- "mcap 0.15.1",
  "schemars",
  "serde",
 ]

--- a/rust/examples/mcap/Cargo.toml
+++ b/rust/examples/mcap/Cargo.toml
@@ -11,6 +11,5 @@ foxglove = { path = "../../foxglove" }
 clap = { version = "4.5", features = ["derive"] }
 ctrlc = "3.4.5"
 env_logger = "0.11.5"
-mcap.workspace = true
 schemars = "0.8.21"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/examples/mcap/src/main.rs
+++ b/rust/examples/mcap/src/main.rs
@@ -3,8 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use clap::{Parser, ValueEnum};
-use foxglove::{LazyChannel, McapWriter};
-use mcap::{Compression, WriteOptions};
+use foxglove::{LazyChannel, McapCompression, McapWriteOptions, McapWriter};
 use std::time::Duration;
 
 #[derive(Debug, Parser)]
@@ -32,11 +31,11 @@ enum CompressionArg {
     Lz4,
     None,
 }
-impl From<CompressionArg> for Option<Compression> {
+impl From<CompressionArg> for Option<McapCompression> {
     fn from(value: CompressionArg) -> Self {
         match value {
-            CompressionArg::Zstd => Some(Compression::Zstd),
-            CompressionArg::Lz4 => Some(Compression::Lz4),
+            CompressionArg::Zstd => Some(McapCompression::Zstd),
+            CompressionArg::Lz4 => Some(McapCompression::Lz4),
             CompressionArg::None => None,
         }
     }
@@ -82,7 +81,7 @@ fn main() {
         std::fs::remove_file(&args.path).expect("Failed to remove file");
     }
 
-    let options = WriteOptions::new()
+    let options = McapWriteOptions::new()
         .chunk_size(Some(args.chunk_size))
         .compression(args.compression.into());
 

--- a/rust/examples/quickstart/Cargo.toml
+++ b/rust/examples/quickstart/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 workspace = true
 
 [dependencies]
-foxglove = { path = "../../foxglove", features = ["unstable"] }
+foxglove = { path = "../../foxglove" }
 ctrlc = "3.4.5"
 env_logger = "0.11.5"

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -72,7 +72,6 @@ mod test {
     use super::*;
     use crate::channel_builder::ChannelBuilder;
     use crate::{Context, Schema};
-    use prost::bytes::BufMut;
     use serde::Serialize;
     use serde_json::{json, Value};
     use tracing_test::traced_test;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -287,7 +287,7 @@ pub use channel::{Channel, ChannelId, LazyChannel, LazyRawChannel, RawChannel};
 pub use channel_builder::ChannelBuilder;
 pub use context::{Context, LazyContext};
 pub use encode::Encode;
-pub use mcap_writer::{McapWriter, McapWriterHandle};
+pub use mcap_writer::{McapCompression, McapWriteOptions, McapWriter, McapWriterHandle};
 pub use metadata::{Metadata, PartialMetadata};
 pub(crate) use runtime::get_runtime_handle;
 pub use runtime::shutdown_runtime;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -283,6 +283,9 @@ mod time;
 pub mod websocket;
 mod websocket_server;
 
+// Re-export bytes crate for convenience when implementing the `Encode` trait
+pub use bytes;
+
 pub use channel::{Channel, ChannelId, LazyChannel, LazyRawChannel, RawChannel};
 pub use channel_builder::ChannelBuilder;
 pub use context::{Context, LazyContext};

--- a/rust/foxglove/src/mcap_writer.rs
+++ b/rust/foxglove/src/mcap_writer.rs
@@ -9,7 +9,9 @@ use std::{fmt::Debug, io::Write};
 use crate::library_version::get_library_version;
 use crate::{Context, FoxgloveError, Sink};
 
+/// Compression options for content in an MCAP file
 pub use mcap::Compression as McapCompression;
+/// Options for use with an [`McapWriter`][crate::McapWriter].
 pub use mcap::WriteOptions as McapWriteOptions;
 
 mod mcap_sink;

--- a/rust/foxglove/src/mcap_writer.rs
+++ b/rust/foxglove/src/mcap_writer.rs
@@ -8,7 +8,9 @@ use std::{fmt::Debug, io::Write};
 
 use crate::library_version::get_library_version;
 use crate::{Context, FoxgloveError, Sink};
-use mcap::WriteOptions;
+
+pub use mcap::Compression as McapCompression;
+pub use mcap::WriteOptions as McapWriteOptions;
 
 mod mcap_sink;
 use mcap_sink::McapSink;
@@ -17,12 +19,12 @@ use mcap_sink::McapSink;
 #[must_use]
 #[derive(Debug, Clone)]
 pub struct McapWriter {
-    options: WriteOptions,
+    options: McapWriteOptions,
     context: Arc<Context>,
 }
 
-impl From<WriteOptions> for McapWriter {
-    fn from(value: WriteOptions) -> Self {
+impl From<McapWriteOptions> for McapWriter {
+    fn from(value: McapWriteOptions) -> Self {
         let options = value.library(get_library_version());
         Self {
             options,
@@ -33,7 +35,7 @@ impl From<WriteOptions> for McapWriter {
 
 impl Default for McapWriter {
     fn default() -> Self {
-        Self::from(WriteOptions::default())
+        Self::from(McapWriteOptions::default())
     }
 }
 
@@ -45,7 +47,7 @@ impl McapWriter {
 
     /// Instantiates a new MCAP writer with the provided options.
     /// The library option is ignored.
-    pub fn with_options(options: WriteOptions) -> Self {
+    pub fn with_options(options: McapWriteOptions) -> Self {
         options.into()
     }
 


### PR DESCRIPTION
### Changelog

Rust: SDK now re-exports the `bytes` crate (for implementing the `Encode` trait) and MCAP options for writing

