### PR TITLE
rust: Document buffering behavior

### DIFF
--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -107,11 +107,17 @@ impl<T: Encode> Channel<T> {
     } }
 
     /// Encodes the message and logs it on the channel.
+    ///
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log(&self, msg: &T) {
         self.log_with_meta(msg, PartialMetadata::default());
     }
 
     /// Encodes the message and logs it on the channel with additional metadata.
+    ///
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log_with_meta(&self, msg: &T, metadata: PartialMetadata) {
         if self.has_sinks() {
             self.log_to_sinks(msg, metadata);

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -108,7 +108,7 @@ impl<T: Encode> Channel<T> {
 
     /// Encodes the message and logs it on the channel.
     ///
-    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log(&self, msg: &T) {
         self.log_with_meta(msg, PartialMetadata::default());
@@ -116,7 +116,7 @@ impl<T: Encode> Channel<T> {
 
     /// Encodes the message and logs it on the channel with additional metadata.
     ///
-    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log_with_meta(&self, msg: &T, metadata: PartialMetadata) {
         if self.has_sinks() {

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -151,11 +151,17 @@ impl RawChannel {
     }
 
     /// Logs a message.
+    ///
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log(&self, msg: &[u8]) {
         self.log_with_meta(msg, PartialMetadata::default());
     }
 
     /// Logs a message with additional metadata.
+    ///
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log_with_meta(&self, msg: &[u8], opts: PartialMetadata) {
         if self.has_sinks() {
             self.log_to_sinks(msg, opts);

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -152,7 +152,7 @@ impl RawChannel {
 
     /// Logs a message.
     ///
-    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log(&self, msg: &[u8]) {
         self.log_with_meta(msg, PartialMetadata::default());
@@ -160,7 +160,7 @@ impl RawChannel {
 
     /// Logs a message with additional metadata.
     ///
-    /// The buffering behavior depends on the log sink; see [`McapWriter`][`crate::McapWriter`] and
+    /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
     pub fn log_with_meta(&self, msg: &[u8], opts: PartialMetadata) {
         if self.has_sinks() {

--- a/rust/foxglove/src/mcap_writer.rs
+++ b/rust/foxglove/src/mcap_writer.rs
@@ -14,6 +14,11 @@ mod mcap_sink;
 use mcap_sink::McapSink;
 
 /// An MCAP writer for logging events.
+///
+/// ### Buffering
+///
+/// Logged messages are buffered in a [`BufWriter`]. When the writer is dropped, the buffered
+/// messages are flushed to the writer and the writer is closed.
 #[must_use]
 #[derive(Debug, Clone)]
 pub struct McapWriter {

--- a/rust/foxglove/src/metadata.rs
+++ b/rust/foxglove/src/metadata.rs
@@ -28,13 +28,11 @@ pub struct PartialMetadata {
 pub struct Metadata {
     /// The sequence number is unique per channel,
     /// and allows for ordering of messages as well as detecting missing messages.
-    /// If omitted, a monotonically increasing sequence number unique to the channel is used.
     pub sequence: u32,
     /// The log time is the time, as nanoseconds from the unix epoch, that the message was recorded.
     /// Usually this is the time log() is called. If omitted, the current time is used.
     pub log_time: u64,
     /// The publish_time is the time at which the message was published.
     /// e.g. the timestamp at which the sensor reading was taken.
-    /// If omitted, log time is used.
     pub publish_time: u64,
 }

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -15,6 +15,17 @@ use tokio::runtime::Handle;
 use tracing::warn;
 
 /// A websocket server for live visualization.
+///
+/// ### Buffering
+///
+/// Logged messages are queued in a channel for each client and delivered in a background task. If a
+/// queue fills, perhaps because of a slow client, then the oldest messages will be dropped. The
+/// queue size is configurable with [`WebSocketServer::message_backlog_size`] when creating the
+/// server.
+///
+/// Other protocol messages, including status updates, are delivered from a separate "control"
+/// queue, using the same configured queue size. If the control queue fills, then the slow client is
+/// dropped.
 #[must_use]
 #[derive(Debug)]
 pub struct WebSocketServer {


### PR DESCRIPTION
This updates the rust documentation in a few places.

Resolves FG-10856: remove 'omitted' comments from required fields
Resolves FG-10907: document buffering behavior of log sinks