### PR TITLE
rust: Ensure feature-flagged items are documented

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           # The last-specified toolchain is the default.
-          toolchain: 1.83.0,stable
+          toolchain: 1.83.0,nightly,stable
 
       - name: Ensure generated protobuf schemas are up to date
         run: cargo run --bin foxglove-proto-gen && git diff --exit-code
@@ -33,7 +33,7 @@ jobs:
       # Validate that we can build against the MSRV (minimum specified rust version).
       - run: cargo +1.83.0 build -p foxglove --verbose
       - run: cargo clippy --no-deps --all-targets --tests -- -D warnings
-      - run: cargo rustdoc -p foxglove -- -D warnings
+      - run: cargo +nightly rustdoc -p foxglove --all-features -- -D warnings --cfg docsrs
       - run: cargo test --features unstable --verbose
         timeout-minutes: 10
       - run: cargo publish --package foxglove --dry-run

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -50,3 +50,7 @@ futures-util = "0.3.31"
 insta = { version = "1.42.2", features = ["json"] }
 tempfile = "3.15.0"
 tracing-test = "0.2.5"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
### Description
Turns out we need to provide docs.rs with [configuration](https://docs.rs/about/metadata), if we want it to build with --all-features so that non-default features get documented. Not so surprising in retrospect.

Docs.rs generates docs with +nightly, which opens up features like [doc_auto_cfg](https://github.com/rust-lang/rust/issues/43781), which is the handy thing that annotates feature-flagged items as "available on crate feature <foo> only". To indicate that we're running in a docsrs-y environment, we pass `--cfg docsrs`. This idea is lifted from [tokio](https://github.com/tokio-rs/tokio/blob/0ec4d0db4d24af74cea40cf0ceed6b7a0a5ff183/tokio/Cargo.toml#L160-L161).

I also updated the CI script to run rustdoc with nightly and `--cfg docsrs` so that we get coverage.