### PR TITLE
python: allow logging on schemaless channels

### DIFF
--- a/python/foxglove-sdk-examples/live-visualization/main.py
+++ b/python/foxglove-sdk-examples/live-visualization/main.py
@@ -144,6 +144,7 @@ def main() -> None:
     )
 
     # If you want to use JSON encoding, you can also specify the schema and log messages as dicts.
+    # Dicts can also be logged without specifying a schema.
     json_chan = Channel(topic="/json", schema=plot_schema)
 
     img_chan = RawImageChannel(topic="/image")

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -36,6 +36,9 @@ class Channel:
             for full control. If a dictionary is passed, it will be treated as a
             JSON schema.
 
+        If both message_encoding and schema are None, then the channel will use JSON encoding, and
+        allow any dict to be logged.
+
         :raises KeyError: if a channel already exists for the given topic.
         """
         if topic in _channels_by_topic:
@@ -150,11 +153,17 @@ def _normalize_schema(
     message_encoding: Optional[str],
     schema: Union[JsonSchema, _foxglove.Schema, None] = None,
 ) -> tuple[str, Optional[_foxglove.Schema]]:
-    if isinstance(schema, _foxglove.Schema) or schema is None:
+    if isinstance(schema, _foxglove.Schema):
         if message_encoding is None:
             raise ValueError("message encoding is required")
         return message_encoding, schema
-    elif isinstance(schema, dict):
+
+    if schema is None and message_encoding is None:
+        # Schemaless support via JSON encoding; same as specifying an empty dict schema
+        schema = {}
+        message_encoding = "json"
+
+    if isinstance(schema, dict):
         # Dicts default to json encoding. An empty dict is equivalent to the empty schema (b"")
         if message_encoding and message_encoding != "json":
             raise ValueError("message_encoding must be 'json' when schema is a dict")
@@ -168,5 +177,5 @@ def _normalize_schema(
                 data=json.dumps(schema).encode("utf-8") if schema else b"",
             ),
         )
-    else:
-        raise TypeError(f"Invalid schema type: {type(schema)}")
+
+    raise TypeError(f"Invalid schema type: {type(schema)}")

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -155,14 +155,17 @@ def _normalize_schema(
             raise ValueError("message encoding is required")
         return message_encoding, schema
     elif isinstance(schema, dict):
-        if schema.get("type") != "object":
+        # Dicts default to json encoding. An empty dict is equivalent to the empty schema (b"")
+        if message_encoding and message_encoding != "json":
+            raise ValueError("message_encoding must be 'json' when schema is a dict")
+        if schema and schema.get("type") != "object":
             raise ValueError("Only object schemas are supported")
         return (
-            message_encoding or "json",
+            "json",
             _foxglove.Schema(
                 name=schema.get("title", "json_schema"),
                 encoding="jsonschema",
-                data=json.dumps(schema).encode("utf-8"),
+                data=json.dumps(schema).encode("utf-8") if schema else b"",
             ),
         )
     else:

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -36,6 +36,20 @@ def test_log_dict_on_json_channel(new_topic: str) -> None:
     channel.log({"test": "test"})
 
 
+def test_log_dict_on_schemaless_channel(new_topic: str) -> None:
+    channel = Channel(new_topic)
+    assert channel.message_encoding == "json"
+
+    channel.log({"test": "test"})
+
+
+def test_log_dict_with_empty_schema(new_topic: str) -> None:
+    channel = Channel(new_topic, schema={})
+    assert channel.message_encoding == "json"
+
+    channel.log({"test": "test"})
+
+
 def test_log_must_serialize_on_protobuf_channel(new_topic: str) -> None:
     channel = Channel(
         new_topic,


### PR DESCRIPTION
### Changelog
Python: 'schema' and 'message_encoding' are now both optional when defining a channel.

### Description

One stated use case for the SDK is that a user should be able to log messages for custom schemas without needing to care about the underlying encoding or serialization. This enables faster development for exploratory use cases, and makes it easier to test out ideas in the app.

In the Rust SDK, we support this use case by providing the `Encode` trait for custom structs that implement [JsonSchema](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html), which can be used with typed channels. We've discussed doing something similar in the Python SDK; perhaps annotations that allow us to dynamically produce schemas with minimal effort from the user. However, this feels less pythonic to me than allowing users to log dicts and taking care of the encoding for them. We took a similar stance with the "high-level" API — a user logs their data to [untyped] channels. The SDK is already partway there; we support this behavior on channels if you explicitly choose "json" encoding, or provide an "any object" schema. And the app supports generally schemaless logging using JSON.

If we move forward with some Rust solution that allows logging of custom schemas with binary protocols (#318), then we can consider something like that for other languages as well.