### PR TITLE
Batch websocket channel advertisements

### DIFF
--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use smallvec::SmallVec;
 
 use crate::metadata::Metadata;
-use crate::{FoxgloveError, RawChannel};
+use crate::{ChannelId, FoxgloveError, RawChannel};
 
 /// Uniquely identifies a [`Sink`] in the context of this program.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -43,7 +43,7 @@ pub trait Sink: Send + Sync {
         metadata: &Metadata,
     ) -> Result<(), FoxgloveError>;
 
-    /// Called when a new channel is made available within the [`Context`][ctx].
+    /// Called when new channels are made available within the [`Context`][ctx].
     ///
     /// Sinks can track channels seen, and do new channel-related things the first time they see a
     /// channel, rather than in this method. The choice is up to the implementor.
@@ -52,18 +52,26 @@ pub trait Sink: Send + Sync {
     /// with each of the channels registered to that context.
     ///
     /// For sinks that manage their channel subscriptions dynamically, note that it is NOT safe to
-    /// call [`Context::subscribe_channels`][sub] from the context of this callback. The
-    /// implementation may return true to immediately subscribe to the channel, or it may return
-    /// false and subscribe later by calling [`Context::subscribe_channels`][sub] at some later
-    /// time.
+    /// call [`Context::subscribe_channels`][sub] from the context of this callback. If the sink
+    /// wants to subscribe to channels immediately, it may return a list of corresponding channel
+    /// IDs.
     ///
     /// For sinks that [auto-subscribe][Sink::auto_subscribe] to all channels, the return value of
     /// this method is ignored.
     ///
     /// [ctx]: crate::Context
     /// [sub]: crate::Context::subscribe_channels
-    fn add_channel(&self, _channel: &Arc<RawChannel>) -> bool {
-        false
+    fn add_channels(&self, _channel: &[&Arc<RawChannel>]) -> Option<Vec<ChannelId>> {
+        None
+    }
+
+    /// Called when a new channel is made available within the [`Context`][crate::Context].
+    ///
+    /// See [`Sink::add_channels`] for more details.
+    #[doc(hidden)]
+    fn add_channel(&self, channel: &Arc<RawChannel>) -> bool {
+        self.add_channels(&[channel])
+            .is_some_and(|ids| ids.contains(&channel.id()))
     }
 
     /// Called when a channel is unregistered from the [`Context`][ctx].

--- a/rust/foxglove/src/sink.rs
+++ b/rust/foxglove/src/sink.rs
@@ -67,7 +67,10 @@ pub trait Sink: Send + Sync {
 
     /// Called when a new channel is made available within the [`Context`][crate::Context].
     ///
-    /// See [`Sink::add_channels`] for more details.
+    /// See [`Sink::add_channels`] for additional details.
+    ///
+    /// For sinks that manage their channel subscriptions dynamically, this function may return
+    /// true to immediately subscribe to the channel.
     #[doc(hidden)]
     fn add_channel(&self, channel: &Arc<RawChannel>) -> bool {
         self.add_channels(&[channel])

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -351,10 +351,15 @@ async fn test_log_only_to_subscribers() {
     expect_recv!(client3, ServerMessage::ServerInfo);
 
     // Read the channel advertisement from each client for all 3 channels
-    for _ in 0..3 {
-        expect_recv!(client1, ServerMessage::Advertise);
-        expect_recv!(client2, ServerMessage::Advertise);
-        expect_recv!(client3, ServerMessage::Advertise);
+    let expect_ch_ids: Vec<_> = [&ch1, &ch2, &ch3]
+        .iter()
+        .map(|c| u64::from(c.id()))
+        .collect();
+    for client in [&mut client1, &mut client2, &mut client3] {
+        let msg = expect_recv!(client, ServerMessage::Advertise);
+        let mut ch_ids: Vec<_> = msg.channels.iter().map(|c| c.id).collect();
+        ch_ids.sort_unstable();
+        assert_eq!(&ch_ids, &expect_ch_ids);
     }
 
     client1


### PR DESCRIPTION
When a websocket is established, we can advertise channels in batches, rather than one at a time.