### PR TITLE
python: Fix library annotations

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: ["*"]
 
-env:
-  FOXGLOVE_SDK_LANGUAGE: python
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -200,6 +200,7 @@ fn shutdown(py: Python<'_>) {
 /// Rust bindings are exported as `_foxglove_py` and should not be imported directly.
 #[pymodule]
 fn _foxglove_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    foxglove::library_version::set_sdk_language("python");
     pyo3_log::init();
     m.add_function(wrap_pyfunction!(enable_logging, m)?)?;
     m.add_function(wrap_pyfunction!(disable_logging, m)?)?;


### PR DESCRIPTION
Setting `FOXGLOVE_SDK_LANGUAGE=python` works locally, but not in CI, because `PyO3/maturin-action` runs the build inside a container, and [cherry-picks env vars](https://github.com/foxglove/foxglove-sdk/actions/runs/14318226568/job/40129192596#step:5:79). We could poke our env var through [using the action's `docker-options` input](https://github.com/PyO3/maturin-action?tab=readme-ov-file#inputs), but I think it's a lot more straightforward to just call `set_sdk_language("python")` from the module entrypoint.

This should also cover the case where someone decides they want to build the python SDK bindings from the sdist.