### PR TITLE
python: fix default schema names; provide topic and schema getters

### DIFF
--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -41,6 +41,14 @@ class BaseChannel:
         schema: Optional["Schema"] = None,
         metadata: Optional[List[Tuple[str, str]]] = None,
     ) -> "BaseChannel": ...
+    def topic(self) -> str:
+        """The topic name of the channel"""
+        ...
+
+    def schema_name(self) -> Optional[str]:
+        """The name of the schema for the channel"""
+        ...
+
     def log(
         self,
         msg: bytes,

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -111,3 +111,22 @@ def test_typed_channel_requires_kwargs_after_message(new_topic: str) -> None:
         match="takes 1 positional arguments but 2 were given",
     ):
         channel.log(Log(), 0)  # type: ignore
+
+
+def test_generates_names_for_schemas(new_topic: str) -> None:
+    ch_1 = Channel(
+        new_topic + "-1",
+        schema={"type": "object", "properties": {"foo": {"type": "string"}}},
+    )
+    ch_2 = Channel(
+        new_topic + "-2",
+        schema={"type": "object", "additionalProperties": True},
+    )
+    # Same schema will have the same name
+    ch_3 = Channel(
+        new_topic + "-3",
+        schema={"type": "object", "additionalProperties": True},
+    )
+
+    assert ch_1.schema_name() != ch_2.schema_name()
+    assert ch_2.schema_name() == ch_3.schema_name()

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -135,6 +135,14 @@ impl BaseChannel {
         Ok(())
     }
 
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    fn schema_name(&self) -> Option<&str> {
+        self.0.schema().map(|s| s.name.as_str())
+    }
+
     fn close(&mut self) {
         self.0.close();
     }


### PR DESCRIPTION
This improves the handling of schema definitions which aren't given a name. Previously, we defaulted to a hard-coded string. This produces warnings in the app if you create multiple channels with unnamed schemas. Now, we'll generate based on a hash of the schema contents so that differing schemas will have different names, with reasonable probability. I used base64 encoding and prefixed with "schema-" so that labeling within the app is clear to users.

This also exposes `topic` and `schema_name` on the Channel, and improves the serialized representation of the channel class.