### PR TITLE
C/C++: Add artifacts to release assets

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -141,8 +141,8 @@ jobs:
       - name: Zip libraries for artifact (Windows)
         if: runner.os == 'Windows'
         run: |
-          7z a -tzip target/${{ matrix.target }}.zip \
-            target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} \
+          7z a -tzip target/${{ matrix.target }}.zip `
+            target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} `
             target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
 
       - name: Upload static & shared library to artifacts

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -8,9 +8,9 @@ on:
   # workflow may be called by draft-release to publish artifacts
   workflow_call:
     outputs:
-      artifact_prefix:
-        description: "prefix pattern for all uploaded artifacts"
-        value: ${{ jobs.build.outputs.artifact_prefix }}
+      artifact_pattern:
+        description: "pattern to match all uploaded artifact names"
+        value: ${{ jobs.build.outputs.artifact_pattern }}
 
 jobs:
   lint:
@@ -106,7 +106,7 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
 
     outputs:
-      artifact_prefix: target/*
+      artifact_pattern: "*foxglove*"
 
     steps:
       - uses: actions/checkout@v4
@@ -137,12 +137,14 @@ jobs:
         with:
           name: ${{ matrix.staticlib_artifact_name }}
           path: target/${{ matrix.target }}/release/${{ matrix.staticlib_name }}
+          if-no-files-found: error
 
       - name: Upload shared library to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.cdylib_artifact_name }}
           path: target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
+          if-no-files-found: error
 
   test-asan-ubsan:
     runs-on: ubuntu-latest

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -137,18 +137,11 @@ jobs:
             target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} \
             target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
 
-      - name: Upload static library to artifacts
+      - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.staticlib_artifact_name }}
-          path: target/${{ matrix.target }}-${{ matrix.staticlib_name }}.zip
-          if-no-files-found: error
-
-      - name: Upload shared library to artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.cdylib_artifact_name }}
-          path: target/${{ matrix.target }}-${{ matrix.cdylib_name }}.zip
+          path: target/${{ matrix.target }}.zip
           if-no-files-found: error
 
   test-asan-ubsan:

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     tags: ["**"]
   pull_request: {}
+  # workflow may be called by draft-release to publish artifacts
+  workflow_call:
+    outputs:
+      artifact_prefix:
+        description: "prefix pattern for all uploaded artifacts"
+        value: ${{ jobs.build.outputs.artifact_prefix }}
 
 jobs:
   lint:
@@ -98,6 +104,9 @@ jobs:
 
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
+
+    outputs:
+      artifact_prefix: target/*
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.staticlib_artifact_name }}
+          name: ${{ matrix.target }}.zip
           path: target/${{ matrix.target }}.zip
           if-no-files-found: error
 

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -150,7 +150,7 @@ jobs:
         working-directory: artifacts
         run: |
           zip -r \
-            ${{ matrix.target }}.zip \
+            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip \
             foxglove/
 
       - name: Zip libraries for artifact (Windows)
@@ -158,14 +158,14 @@ jobs:
         working-directory: artifacts
         run: |
           7z a -tzip -sse `
-            ${{ matrix.target }}.zip `
+            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip `
             foxglove/
 
       - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip
-          path: artifacts/${{ matrix.target }}.zip
+          path: artifacts/foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip
           if-no-files-found: error
 
   test-asan-ubsan:

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -6,6 +6,11 @@ on:
     tags: ["**"]
   pull_request: {}
   workflow_call:
+    inputs:
+      sdk-version:
+        required: false
+        type: string
+        default: ${{ github.sha }}
     outputs:
       artifact_pattern:
         description: "pattern to match all uploaded artifact names"
@@ -131,20 +136,26 @@ jobs:
         run: make test
         working-directory: cpp
 
+      - name: Organize artifacts for zip
+        run: |
+          mkdir target/foxglove
+          mkdir target/foxglove/lib
+          mv target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} target/foxglove/lib/
+          mv target/${{ matrix.target }}/release/${{ matrix.cdylib_name }} target/foxglove/lib/
+
       - name: Zip libraries for artifact
         if: runner.os != 'Windows'
         run: |
-          zip --must-match --junk-paths target/${{ matrix.target }}.zip \
-            target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} \
-            target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
+          zip -r \
+            target/foxglove-${{inputs.sdk-version}}-cpp-${{ matrix.target }}.zip \
+            target/foxglove
 
       - name: Zip libraries for artifact (Windows)
         if: runner.os == 'Windows'
-        working-directory: target/${{ matrix.target }}/release
         run: |
-          7z a -tzip -sse ../../${{ matrix.target }}.zip `
-            ${{ matrix.staticlib_name }} `
-            ${{ matrix.cdylib_name }}
+          7z a -tzip -sse `
+            target/foxglove-${{inputs.sdk-version}}-cpp-${{ matrix.target }}.zip `
+            target/foxglove
 
       - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -5,12 +5,6 @@ on:
     branches: [main]
     tags: ["**"]
   pull_request: {}
-  # workflow may be called by draft-release to publish artifacts
-  workflow_call:
-    outputs:
-      artifact_pattern:
-        description: "pattern to match all uploaded artifact names"
-        value: ${{ jobs.build.outputs.artifact_pattern }}
 
 jobs:
   lint:
@@ -105,9 +99,6 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
 
-    outputs:
-      artifact_pattern: "*foxglove*"
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -132,18 +123,24 @@ jobs:
         run: make test
         working-directory: cpp
 
+      - name: Zip libraries for artifact
+        run: |
+          zip target/${{ matrix.target }}.zip \
+            target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} \
+            target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
+
       - name: Upload static library to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.staticlib_artifact_name }}
-          path: target/${{ matrix.target }}/release/${{ matrix.staticlib_name }}
+          path: target/${{ matrix.target }}-${{ matrix.staticlib_name }}.zip
           if-no-files-found: error
 
       - name: Upload shared library to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.cdylib_artifact_name }}
-          path: target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
+          path: target/${{ matrix.target }}-${{ matrix.cdylib_name }}.zip
           if-no-files-found: error
 
   test-asan-ubsan:

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
     tags: ["**"]
   pull_request: {}
+  workflow_call:
+    outputs:
+      artifact_pattern:
+        description: "pattern to match all uploaded artifact names"
+        value: ${{ jobs.build.outputs.artifact_pattern }}
 
 jobs:
   lint:
@@ -98,6 +103,9 @@ jobs:
 
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
+
+    outputs:
+      artifact_pattern: "*.zip"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -8,9 +8,8 @@ on:
   workflow_call:
     inputs:
       sdk-version:
-        required: false
+        required: true
         type: string
-        default: ${{ github.sha }}
     outputs:
       artifact_pattern:
         description: "pattern to match all uploaded artifact names"
@@ -137,31 +136,36 @@ jobs:
         working-directory: cpp
 
       - name: Organize artifacts for zip
+        shell: bash
         run: |
-          mkdir target/foxglove
-          mkdir target/foxglove/lib
-          mv target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} target/foxglove/lib/
-          mv target/${{ matrix.target }}/release/${{ matrix.cdylib_name }} target/foxglove/lib/
+          mkdir -p artifacts/foxglove/lib
+          mkdir -p artifacts/foxglove/include
+          mv target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} artifacts/foxglove/lib/
+          mv target/${{ matrix.target }}/release/${{ matrix.cdylib_name }} artifacts/foxglove/lib/
+          cp -R cpp/foxglove/include/foxglove artifacts/foxglove/include/
+          cp -R c/include/foxglove-c artifacts/foxglove/include/
 
       - name: Zip libraries for artifact
         if: runner.os != 'Windows'
+        working-directory: artifacts
         run: |
           zip -r \
-            target/foxglove-${{inputs.sdk-version}}-cpp-${{ matrix.target }}.zip \
-            target/foxglove
+            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip \
+            foxglove/
 
       - name: Zip libraries for artifact (Windows)
         if: runner.os == 'Windows'
+        working-directory: artifacts
         run: |
           7z a -tzip -sse `
-            target/foxglove-${{inputs.sdk-version}}-cpp-${{ matrix.target }}.zip `
-            target/foxglove
+            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip `
+            foxglove/
 
       - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}.zip
-          path: target/${{ matrix.target }}.zip
+          path: artifacts/foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip
           if-no-files-found: error
 
   test-asan-ubsan:

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -134,16 +134,17 @@ jobs:
       - name: Zip libraries for artifact
         if: runner.os != 'Windows'
         run: |
-          zip target/${{ matrix.target }}.zip \
+          zip --must-match --junk-paths target/${{ matrix.target }}.zip \
             target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} \
             target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
 
       - name: Zip libraries for artifact (Windows)
         if: runner.os == 'Windows'
+        working-directory: target/${{ matrix.target }}/release
         run: |
-          7z a -tzip target/${{ matrix.target }}.zip `
-            target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} `
-            target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
+          7z a -tzip -sse ../../${{ matrix.target }}.zip `
+            ${{ matrix.staticlib_name }} `
+            ${{ matrix.cdylib_name }}
 
       - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -150,7 +150,7 @@ jobs:
         working-directory: artifacts
         run: |
           zip -r \
-            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip \
+            ${{ matrix.target }}.zip \
             foxglove/
 
       - name: Zip libraries for artifact (Windows)
@@ -158,14 +158,14 @@ jobs:
         working-directory: artifacts
         run: |
           7z a -tzip -sse `
-            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip `
+            ${{ matrix.target }}.zip `
             foxglove/
 
       - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}.zip
-          path: artifacts/foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip
+          name: foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip
+          path: artifacts/${{ matrix.target }}.zip
           if-no-files-found: error
 
   test-asan-ubsan:

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -132,8 +132,16 @@ jobs:
         working-directory: cpp
 
       - name: Zip libraries for artifact
+        if: runner.os != 'Windows'
         run: |
           zip target/${{ matrix.target }}.zip \
+            target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} \
+            target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
+
+      - name: Zip libraries for artifact (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          7z a -tzip target/${{ matrix.target }}.zip \
             target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} \
             target/${{ matrix.target }}/release/${{ matrix.cdylib_name }}
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   build-artifacts:
     uses: ./.github/workflows/c_cpp.yml
+    with:
+      sdk-version: ${{ github.event.inputs.version }}
 
   draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -61,21 +61,12 @@ jobs:
       - name: Download C/C++ artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ needs.build-artifacts.outputs.artifact_pattern }}
+          pattern: "*foxglove*.zip"
           path: ci_artifacts/
-          merge-multiple: false
-
-      - name: Record downloaded artifacts
-        # "{path}#{label}" format used by `gh release create`. Use the artifact name as the label.
-        run: find ./ci_artifacts -type f -exec python -c 'print("{}#" + "{}".split("/")[-2])' \; > ci_artifacts.txt
+          merge-multiple: true
 
       - name: List artifacts
-        run: cat ci_artifacts.txt
-
-      - name: List args
-        run: |
-          <ci_artifacts.txt xargs \
-            echo
+        run: ls -l ./ci_artifacts
 
       # - name: Create draft release
       #   env:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -13,8 +13,12 @@ env:
   SDK_BRANCH: release/sdk/${{ github.event.inputs.version }}
 
 jobs:
+  build-artifacts:
+    uses: ./.github/workflows/c_cpp.yml
+
   draft:
     runs-on: ubuntu-latest
+    needs: build-artifacts
     permissions:
       contents: write
     steps:
@@ -50,6 +54,16 @@ jobs:
           git commit -m "Release '${{ env.SDK_TAG }}'"
           git push -f origin "${{ env.SDK_BRANCH }}"
 
+      - name: Download C/C++ artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: c_artifacts
+          path: ${{ needs.build-artifacts.outputs.artifact_prefix }}
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -l ./c_artifacts
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -59,4 +73,5 @@ jobs:
             --target "${{ env.SDK_BRANCH }}" \
             --generate-notes \
             --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
-            --draft
+            --draft \
+            ./c_artifacts/*

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -68,14 +68,14 @@ jobs:
       - name: List artifacts
         run: ls -l ./ci_artifacts
 
-      # - name: Create draft release
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
-      #   run: |
-      #     <ci_artifacts.txt xargs \
-      #       gh release create "${{ env.SDK_TAG }}" \
-      #       --title "${{ env.SDK_TAG }}" \
-      #       --target "${{ env.SDK_BRANCH }}" \
-      #       --generate-notes \
-      #       --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
-      #       --draft
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ env.SDK_TAG }}" \
+            ./ci_artifacts/* \
+            --title "${{ env.SDK_TAG }}" \
+            --target "${{ env.SDK_BRANCH }}" \
+            --generate-notes \
+            --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
+            --draft

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,9 +59,9 @@ jobs:
         with:
           pattern: "*foxglove*"
           path: ${{ needs.build-artifacts.outputs.artifact_prefix }}
-          merge-multiple: true
+          merge-multiple: false
 
-      - name: List artifacts
+      - name: List downloaded artifacts
         run: ls -l ${{ needs.build-artifacts.outputs.artifact_prefix }}
 
       - name: Create draft release
@@ -69,9 +69,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ env.SDK_TAG }}" \
+            '${{ needs.build-artifacts.outputs.artifact_prefix }}' \
             --title "${{ env.SDK_TAG }}" \
             --target "${{ env.SDK_BRANCH }}" \
             --generate-notes \
             --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
-            --draft \
-            ${{ needs.build-artifacts.outputs.artifact_prefix }}
+            --draft

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -68,7 +68,7 @@ jobs:
           merge-multiple: true
 
       - name: List artifacts
-        run: ls -l ./ci_artifacts
+        run: find ./ci_artifacts -type f
 
       - name: Create draft release
         env:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -61,22 +61,20 @@ jobs:
       - name: Download C/C++ artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "*foxglove*"
-          path: ${{ needs.build-artifacts.outputs.artifact_prefix }}
+          pattern: ${{ needs.build-artifacts.outputs.artifact_pattern }}
+          path: ci_artifacts/
           merge-multiple: false
 
-      - name: List downloaded artifacts
-        run: ls -l ${{ needs.build-artifacts.outputs.artifact_prefix }}
-
-      - name: Debug version
-        run: gh --version
+      - name: Record downloaded artifacts
+        # "{path}#{label}" format used by `gh release create`. Use the artifact name as the label.
+        run: find ./ci_artifacts -type f -exec python -c 'print("{}#" + "{}".split("/")[-2])' \; > ci_artifacts.txt
 
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ env.SDK_TAG }}" \
-            '${{ needs.build-artifacts.outputs.artifact_prefix }}' \
+          <ci_artifacts.txt xargs\
+            gh release create "${{ env.SDK_TAG }}" \
             --title "${{ env.SDK_TAG }}" \
             --target "${{ env.SDK_BRANCH }}" \
             --generate-notes \

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Download C/C++ artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "*foxglove*.zip"
+          pattern: ${{ needs.build-artifacts.outputs.artifact_pattern }}
           path: ci_artifacts/
           merge-multiple: true
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -69,14 +69,22 @@ jobs:
         # "{path}#{label}" format used by `gh release create`. Use the artifact name as the label.
         run: find ./ci_artifacts -type f -exec python -c 'print("{}#" + "{}".split("/")[-2])' \; > ci_artifacts.txt
 
-      - name: Create draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: List artifacts
+        run: cat ci_artifacts.txt
+
+      - name: List args
         run: |
-          <ci_artifacts.txt xargs\
-            gh release create "${{ env.SDK_TAG }}" \
-            --title "${{ env.SDK_TAG }}" \
-            --target "${{ env.SDK_BRANCH }}" \
-            --generate-notes \
-            --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
-            --draft
+          <ci_artifacts.txt xargs \
+            echo
+
+      # - name: Create draft release
+      #   env:
+      #     GH_TOKEN: ${{ github.token }}
+      #   run: |
+      #     <ci_artifacts.txt xargs \
+      #       gh release create "${{ env.SDK_TAG }}" \
+      #       --title "${{ env.SDK_TAG }}" \
+      #       --target "${{ env.SDK_BRANCH }}" \
+      #       --generate-notes \
+      #       --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
+      #       --draft

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Download C/C++ artifacts
         uses: actions/download-artifact@v4
         with:
-          name: c_artifacts
+          pattern: "*foxglove*"
           path: ${{ needs.build-artifacts.outputs.artifact_prefix }}
           merge-multiple: true
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -12,6 +12,10 @@ env:
   SDK_TAG: sdk/${{ github.event.inputs.version }}
   SDK_BRANCH: release/sdk/${{ github.event.inputs.version }}
 
+concurrency:
+  group: "draft-release-${{ github.event.inputs.version }}"
+  cancel-in-progress: false
+
 jobs:
   build-artifacts:
     uses: ./.github/workflows/c_cpp.yml
@@ -63,6 +67,9 @@ jobs:
 
       - name: List downloaded artifacts
         run: ls -l ${{ needs.build-artifacts.outputs.artifact_prefix }}
+
+      - name: Debug version
+        run: gh --version
 
       - name: Create draft release
         env:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -62,7 +62,7 @@ jobs:
           merge-multiple: true
 
       - name: List artifacts
-        run: ls -l ./c_artifacts
+        run: ls -l ${{ needs.build-artifacts.outputs.artifact_prefix }}
 
       - name: Create draft release
         env:
@@ -74,4 +74,4 @@ jobs:
             --generate-notes \
             --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
             --draft \
-            ./c_artifacts/*
+            ${{ needs.build-artifacts.outputs.artifact_prefix }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,14 @@ For more details, refer to the [Python SDK contributing guide](python/foxglove-s
 
 Releases are published via GitHub Actions.
 
-### Rust & Python
+### Rust, Python, and C/C++
 
 All SDK languages are versioned and released together.
 
 1. Manually trigger the "Draft Release" workflow in GitHub Actions, specifying the new version number.
-2. Check the release notes, and hit publish on the new release.
-3. Ensure the post-release and tag workflows complete successfully.
+2. Ensure that the draft release workflow completes successfully.
+3. Check the release notes, and hit publish on the new release.
+4. Ensure the post-release and tag workflows complete successfully.
 
 ### TypeScript
 


### PR DESCRIPTION
This makes the release artifacts from the C/C++ CI workflow available on a draft release.

A draft release can't have assets with duplicate file names, so I zipped the artifacts prior to uploading, which will preserve the original library filenames once extracted. I put the shared & static libraries in the same zip because it seemed a little easier to find what you're looking for, but of course it increases the download size (particularly for shared); we could produce a zip for each.

These changes produced [this v0.6.0 draft](https://github.com/foxglove/foxglove-sdk/releases/tag/untagged-29e1bf6fd156a0a64220).