### PR TITLE
python: fix channel interface to provide ID

### DIFF
--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -42,7 +42,7 @@ class BaseChannel:
         metadata: Optional[List[Tuple[str, str]]] = None,
     ) -> "BaseChannel": ...
     def id(self) -> int:
-        """The id of the channel"""
+        """The unique ID of the channel"""
         ...
 
     def topic(self) -> str:

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -41,6 +41,10 @@ class BaseChannel:
         schema: Optional["Schema"] = None,
         metadata: Optional[List[Tuple[str, str]]] = None,
     ) -> "BaseChannel": ...
+    def id(self) -> int:
+        """The id of the channel"""
+        ...
+
     def topic(self) -> str:
         """The topic name of the channel"""
         ...

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
@@ -41,13 +41,30 @@ class CameraCalibrationChannel:
         cls,
         topic: str,
     ) -> "CameraCalibrationChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "CameraCalibration",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove CameraCalibration message on the channel."""
+        ...
 
 class CircleAnnotationChannel:
     """
@@ -58,13 +75,30 @@ class CircleAnnotationChannel:
         cls,
         topic: str,
     ) -> "CircleAnnotationChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "CircleAnnotation",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove CircleAnnotation message on the channel."""
+        ...
 
 class ColorChannel:
     """
@@ -75,13 +109,30 @@ class ColorChannel:
         cls,
         topic: str,
     ) -> "ColorChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Color",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Color message on the channel."""
+        ...
 
 class CompressedImageChannel:
     """
@@ -92,13 +143,30 @@ class CompressedImageChannel:
         cls,
         topic: str,
     ) -> "CompressedImageChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "CompressedImage",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove CompressedImage message on the channel."""
+        ...
 
 class CompressedVideoChannel:
     """
@@ -109,13 +177,30 @@ class CompressedVideoChannel:
         cls,
         topic: str,
     ) -> "CompressedVideoChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "CompressedVideo",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove CompressedVideo message on the channel."""
+        ...
 
 class FrameTransformChannel:
     """
@@ -126,13 +211,30 @@ class FrameTransformChannel:
         cls,
         topic: str,
     ) -> "FrameTransformChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "FrameTransform",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove FrameTransform message on the channel."""
+        ...
 
 class FrameTransformsChannel:
     """
@@ -143,13 +245,30 @@ class FrameTransformsChannel:
         cls,
         topic: str,
     ) -> "FrameTransformsChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "FrameTransforms",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove FrameTransforms message on the channel."""
+        ...
 
 class GeoJsonChannel:
     """
@@ -160,13 +279,30 @@ class GeoJsonChannel:
         cls,
         topic: str,
     ) -> "GeoJsonChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "GeoJson",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove GeoJson message on the channel."""
+        ...
 
 class GridChannel:
     """
@@ -177,13 +313,30 @@ class GridChannel:
         cls,
         topic: str,
     ) -> "GridChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Grid",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Grid message on the channel."""
+        ...
 
 class ImageAnnotationsChannel:
     """
@@ -194,13 +347,30 @@ class ImageAnnotationsChannel:
         cls,
         topic: str,
     ) -> "ImageAnnotationsChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "ImageAnnotations",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove ImageAnnotations message on the channel."""
+        ...
 
 class KeyValuePairChannel:
     """
@@ -211,13 +381,30 @@ class KeyValuePairChannel:
         cls,
         topic: str,
     ) -> "KeyValuePairChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "KeyValuePair",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove KeyValuePair message on the channel."""
+        ...
 
 class LaserScanChannel:
     """
@@ -228,13 +415,30 @@ class LaserScanChannel:
         cls,
         topic: str,
     ) -> "LaserScanChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "LaserScan",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove LaserScan message on the channel."""
+        ...
 
 class LocationFixChannel:
     """
@@ -245,13 +449,30 @@ class LocationFixChannel:
         cls,
         topic: str,
     ) -> "LocationFixChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "LocationFix",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove LocationFix message on the channel."""
+        ...
 
 class LogChannel:
     """
@@ -262,13 +483,30 @@ class LogChannel:
         cls,
         topic: str,
     ) -> "LogChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Log",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Log message on the channel."""
+        ...
 
 class PackedElementFieldChannel:
     """
@@ -279,13 +517,30 @@ class PackedElementFieldChannel:
         cls,
         topic: str,
     ) -> "PackedElementFieldChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "PackedElementField",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove PackedElementField message on the channel."""
+        ...
 
 class Point2Channel:
     """
@@ -296,13 +551,30 @@ class Point2Channel:
         cls,
         topic: str,
     ) -> "Point2Channel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Point2",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Point2 message on the channel."""
+        ...
 
 class Point3Channel:
     """
@@ -313,13 +585,30 @@ class Point3Channel:
         cls,
         topic: str,
     ) -> "Point3Channel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Point3",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Point3 message on the channel."""
+        ...
 
 class PointCloudChannel:
     """
@@ -330,13 +619,30 @@ class PointCloudChannel:
         cls,
         topic: str,
     ) -> "PointCloudChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "PointCloud",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove PointCloud message on the channel."""
+        ...
 
 class PointsAnnotationChannel:
     """
@@ -347,13 +653,30 @@ class PointsAnnotationChannel:
         cls,
         topic: str,
     ) -> "PointsAnnotationChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "PointsAnnotation",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove PointsAnnotation message on the channel."""
+        ...
 
 class PoseChannel:
     """
@@ -364,13 +687,30 @@ class PoseChannel:
         cls,
         topic: str,
     ) -> "PoseChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Pose",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Pose message on the channel."""
+        ...
 
 class PoseInFrameChannel:
     """
@@ -381,13 +721,30 @@ class PoseInFrameChannel:
         cls,
         topic: str,
     ) -> "PoseInFrameChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "PoseInFrame",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove PoseInFrame message on the channel."""
+        ...
 
 class PosesInFrameChannel:
     """
@@ -398,13 +755,30 @@ class PosesInFrameChannel:
         cls,
         topic: str,
     ) -> "PosesInFrameChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "PosesInFrame",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove PosesInFrame message on the channel."""
+        ...
 
 class QuaternionChannel:
     """
@@ -415,13 +789,30 @@ class QuaternionChannel:
         cls,
         topic: str,
     ) -> "QuaternionChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Quaternion",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Quaternion message on the channel."""
+        ...
 
 class RawImageChannel:
     """
@@ -432,13 +823,30 @@ class RawImageChannel:
         cls,
         topic: str,
     ) -> "RawImageChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "RawImage",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove RawImage message on the channel."""
+        ...
 
 class SceneEntityChannel:
     """
@@ -449,13 +857,30 @@ class SceneEntityChannel:
         cls,
         topic: str,
     ) -> "SceneEntityChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "SceneEntity",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove SceneEntity message on the channel."""
+        ...
 
 class SceneEntityDeletionChannel:
     """
@@ -466,13 +891,30 @@ class SceneEntityDeletionChannel:
         cls,
         topic: str,
     ) -> "SceneEntityDeletionChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "SceneEntityDeletion",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove SceneEntityDeletion message on the channel."""
+        ...
 
 class SceneUpdateChannel:
     """
@@ -483,13 +925,30 @@ class SceneUpdateChannel:
         cls,
         topic: str,
     ) -> "SceneUpdateChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "SceneUpdate",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove SceneUpdate message on the channel."""
+        ...
 
 class TextAnnotationChannel:
     """
@@ -500,13 +959,30 @@ class TextAnnotationChannel:
         cls,
         topic: str,
     ) -> "TextAnnotationChannel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "TextAnnotation",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove TextAnnotation message on the channel."""
+        ...
 
 class Vector2Channel:
     """
@@ -517,13 +993,30 @@ class Vector2Channel:
         cls,
         topic: str,
     ) -> "Vector2Channel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Vector2",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Vector2 message on the channel."""
+        ...
 
 class Vector3Channel:
     """
@@ -534,10 +1027,27 @@ class Vector3Channel:
         cls,
         topic: str,
     ) -> "Vector3Channel": ...
-    def close(self) -> None: ...
+    def id(self) -> int:
+        """The unique ID of the channel."""
+        ...
+
+    def topic(self) -> str:
+        """The topic name of the channel."""
+        ...
+
+    def schema_name(self) -> str | None:
+        """The name of the schema for the channel."""
+        ...
+
+    def close(self) -> None:
+        """Close the channel."""
+        ...
+
     def log(
         self,
         message: "Vector3",
         *,
         log_time: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Log a Foxglove Vector3 message on the channel."""
+        ...

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -59,9 +59,11 @@ class Channel:
         _channels_by_topic[topic] = self
 
     def __repr__(self) -> str:
-        return (
-            f"Channel(topic='{self.base.topic()}', schema='{self.base.schema_name()}')"
-        )
+        return f"Channel(id='{self.id()}', topic='{self.topic()}', schema='{self.schema_name()}')"
+
+    def id(self) -> int:
+        """The id of the channel"""
+        return self.base.id()
 
     def topic(self) -> str:
         """The topic name of the channel"""

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -59,10 +59,10 @@ class Channel:
         _channels_by_topic[topic] = self
 
     def __repr__(self) -> str:
-        return f"Channel(id='{self.id()}', topic='{self.topic()}', schema='{self.schema_name()}')"
+        return f"Channel(id={self.id()}, topic='{self.topic()}', schema='{self.schema_name()}')"
 
     def id(self) -> int:
-        """The id of the channel"""
+        """The unique ID of the channel"""
         return self.base.id()
 
     def topic(self) -> str:

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -130,3 +130,13 @@ def test_generates_names_for_schemas(new_topic: str) -> None:
 
     assert ch_1.schema_name() != ch_2.schema_name()
     assert ch_2.schema_name() == ch_3.schema_name()
+
+
+def test_exposes_unique_channel_ids(new_topic: str) -> None:
+    ch_1 = Channel(new_topic + "-1")
+    ch_2 = Channel(new_topic + "-2")
+    ch_3 = LogChannel(new_topic + "-3")
+
+    assert ch_1.id() > 0
+    assert ch_1.id() < ch_2.id()
+    assert ch_2.id() < ch_3.id()

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -65,6 +65,21 @@ impl CameraCalibrationChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -105,6 +120,21 @@ impl CircleAnnotationChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -149,6 +179,21 @@ impl ColorChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -189,6 +234,21 @@ impl CompressedImageChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -233,6 +293,21 @@ impl CompressedVideoChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -273,6 +348,21 @@ impl FrameTransformChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -317,6 +407,21 @@ impl FrameTransformsChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -357,6 +462,21 @@ impl GeoJsonChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -401,6 +521,21 @@ impl GridChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -441,6 +576,21 @@ impl ImageAnnotationsChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -485,6 +635,21 @@ impl KeyValuePairChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -525,6 +690,21 @@ impl LaserScanChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -569,6 +749,21 @@ impl LocationFixChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -609,6 +804,21 @@ impl LogChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -653,6 +863,21 @@ impl SceneEntityDeletionChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -693,6 +918,21 @@ impl SceneEntityChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -737,6 +977,21 @@ impl SceneUpdateChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -777,6 +1032,21 @@ impl PackedElementFieldChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -821,6 +1091,21 @@ impl Point2Channel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -861,6 +1146,21 @@ impl Point3Channel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -905,6 +1205,21 @@ impl PointCloudChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -945,6 +1260,21 @@ impl PointsAnnotationChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -989,6 +1319,21 @@ impl PoseChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -1029,6 +1374,21 @@ impl PoseInFrameChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -1073,6 +1433,21 @@ impl PosesInFrameChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -1113,6 +1488,21 @@ impl QuaternionChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -1157,6 +1547,21 @@ impl RawImageChannel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -1197,6 +1602,21 @@ impl TextAnnotationChannel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.
@@ -1241,6 +1661,21 @@ impl Vector2Channel {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -1281,6 +1716,21 @@ impl Vector3Channel {
     fn new(topic: &str) -> PyResult<Self> {
         let base = Channel::new(topic).map_err(PyFoxgloveError::from)?;
         Ok(Self(base))
+    }
+
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
     }
 
     /// Close the channel.

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -103,7 +103,12 @@ impl CameraCalibrationChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("CameraCalibrationChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "CameraCalibrationChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -160,7 +165,12 @@ impl CircleAnnotationChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("CircleAnnotationChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "CircleAnnotationChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -217,7 +227,7 @@ impl ColorChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("ColorChannel(topic='{}')", self.0.topic()).to_string()
+        format!("ColorChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -274,7 +284,12 @@ impl CompressedImageChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("CompressedImageChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "CompressedImageChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -331,7 +346,12 @@ impl CompressedVideoChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("CompressedVideoChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "CompressedVideoChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -388,7 +408,12 @@ impl FrameTransformChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("FrameTransformChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "FrameTransformChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -445,7 +470,12 @@ impl FrameTransformsChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("FrameTransformsChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "FrameTransformsChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -502,7 +532,12 @@ impl GeoJsonChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("GeoJsonChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "GeoJsonChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -559,7 +594,7 @@ impl GridChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("GridChannel(topic='{}')", self.0.topic()).to_string()
+        format!("GridChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -616,7 +651,12 @@ impl ImageAnnotationsChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("ImageAnnotationsChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "ImageAnnotationsChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -673,7 +713,12 @@ impl KeyValuePairChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("KeyValuePairChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "KeyValuePairChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -730,7 +775,12 @@ impl LaserScanChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("LaserScanChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "LaserScanChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -787,7 +837,12 @@ impl LocationFixChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("LocationFixChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "LocationFixChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -844,7 +899,7 @@ impl LogChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("LogChannel(topic='{}')", self.0.topic()).to_string()
+        format!("LogChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -901,7 +956,12 @@ impl SceneEntityDeletionChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("SceneEntityDeletionChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "SceneEntityDeletionChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -958,7 +1018,12 @@ impl SceneEntityChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("SceneEntityChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "SceneEntityChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1015,7 +1080,12 @@ impl SceneUpdateChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("SceneUpdateChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "SceneUpdateChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1072,7 +1142,12 @@ impl PackedElementFieldChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("PackedElementFieldChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "PackedElementFieldChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1129,7 +1204,7 @@ impl Point2Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!("Point2Channel(topic='{}')", self.0.topic()).to_string()
+        format!("Point2Channel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -1186,7 +1261,7 @@ impl Point3Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!("Point3Channel(topic='{}')", self.0.topic()).to_string()
+        format!("Point3Channel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -1243,7 +1318,12 @@ impl PointCloudChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("PointCloudChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "PointCloudChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1300,7 +1380,12 @@ impl PointsAnnotationChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("PointsAnnotationChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "PointsAnnotationChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1357,7 +1442,7 @@ impl PoseChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("PoseChannel(topic='{}')", self.0.topic()).to_string()
+        format!("PoseChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -1414,7 +1499,12 @@ impl PoseInFrameChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("PoseInFrameChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "PoseInFrameChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1471,7 +1561,12 @@ impl PosesInFrameChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("PosesInFrameChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "PosesInFrameChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1528,7 +1623,12 @@ impl QuaternionChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("QuaternionChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "QuaternionChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1585,7 +1685,12 @@ impl RawImageChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("RawImageChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "RawImageChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1642,7 +1747,12 @@ impl TextAnnotationChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("TextAnnotationChannel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "TextAnnotationChannel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1699,7 +1809,12 @@ impl Vector2Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!("Vector2Channel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "Vector2Channel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }
 
@@ -1756,6 +1871,11 @@ impl Vector3Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!("Vector3Channel(topic='{}')", self.0.topic()).to_string()
+        format!(
+            "Vector3Channel(id='{}',topic='{}')",
+            self.id(),
+            self.topic()
+        )
+        .to_string()
     }
 }

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -104,7 +104,7 @@ impl CameraCalibrationChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "CameraCalibrationChannel(id='{}',topic='{}')",
+            "CameraCalibrationChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -166,7 +166,7 @@ impl CircleAnnotationChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "CircleAnnotationChannel(id='{}',topic='{}')",
+            "CircleAnnotationChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -227,7 +227,7 @@ impl ColorChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("ColorChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
+        format!("ColorChannel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -285,7 +285,7 @@ impl CompressedImageChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "CompressedImageChannel(id='{}',topic='{}')",
+            "CompressedImageChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -347,7 +347,7 @@ impl CompressedVideoChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "CompressedVideoChannel(id='{}',topic='{}')",
+            "CompressedVideoChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -409,7 +409,7 @@ impl FrameTransformChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "FrameTransformChannel(id='{}',topic='{}')",
+            "FrameTransformChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -471,7 +471,7 @@ impl FrameTransformsChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "FrameTransformsChannel(id='{}',topic='{}')",
+            "FrameTransformsChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -532,12 +532,7 @@ impl GeoJsonChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!(
-            "GeoJsonChannel(id='{}',topic='{}')",
-            self.id(),
-            self.topic()
-        )
-        .to_string()
+        format!("GeoJsonChannel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -594,7 +589,7 @@ impl GridChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("GridChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
+        format!("GridChannel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -652,7 +647,7 @@ impl ImageAnnotationsChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "ImageAnnotationsChannel(id='{}',topic='{}')",
+            "ImageAnnotationsChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -714,7 +709,7 @@ impl KeyValuePairChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "KeyValuePairChannel(id='{}',topic='{}')",
+            "KeyValuePairChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -776,7 +771,7 @@ impl LaserScanChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "LaserScanChannel(id='{}',topic='{}')",
+            "LaserScanChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -838,7 +833,7 @@ impl LocationFixChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "LocationFixChannel(id='{}',topic='{}')",
+            "LocationFixChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -899,7 +894,7 @@ impl LogChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("LogChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
+        format!("LogChannel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -957,7 +952,7 @@ impl SceneEntityDeletionChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "SceneEntityDeletionChannel(id='{}',topic='{}')",
+            "SceneEntityDeletionChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1019,7 +1014,7 @@ impl SceneEntityChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "SceneEntityChannel(id='{}',topic='{}')",
+            "SceneEntityChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1081,7 +1076,7 @@ impl SceneUpdateChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "SceneUpdateChannel(id='{}',topic='{}')",
+            "SceneUpdateChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1143,7 +1138,7 @@ impl PackedElementFieldChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "PackedElementFieldChannel(id='{}',topic='{}')",
+            "PackedElementFieldChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1204,7 +1199,7 @@ impl Point2Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!("Point2Channel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
+        format!("Point2Channel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -1261,7 +1256,7 @@ impl Point3Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!("Point3Channel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
+        format!("Point3Channel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -1319,7 +1314,7 @@ impl PointCloudChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "PointCloudChannel(id='{}',topic='{}')",
+            "PointCloudChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1381,7 +1376,7 @@ impl PointsAnnotationChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "PointsAnnotationChannel(id='{}',topic='{}')",
+            "PointsAnnotationChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1442,7 +1437,7 @@ impl PoseChannel {
     }
 
     fn __repr__(&self) -> String {
-        format!("PoseChannel(id='{}',topic='{}')", self.id(), self.topic()).to_string()
+        format!("PoseChannel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -1500,7 +1495,7 @@ impl PoseInFrameChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "PoseInFrameChannel(id='{}',topic='{}')",
+            "PoseInFrameChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1562,7 +1557,7 @@ impl PosesInFrameChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "PosesInFrameChannel(id='{}',topic='{}')",
+            "PosesInFrameChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1624,7 +1619,7 @@ impl QuaternionChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "QuaternionChannel(id='{}',topic='{}')",
+            "QuaternionChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1686,7 +1681,7 @@ impl RawImageChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "RawImageChannel(id='{}',topic='{}')",
+            "RawImageChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1748,7 +1743,7 @@ impl TextAnnotationChannel {
 
     fn __repr__(&self) -> String {
         format!(
-            "TextAnnotationChannel(id='{}',topic='{}')",
+            "TextAnnotationChannel(id={}, topic='{}')",
             self.id(),
             self.topic()
         )
@@ -1809,12 +1804,7 @@ impl Vector2Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!(
-            "Vector2Channel(id='{}',topic='{}')",
-            self.id(),
-            self.topic()
-        )
-        .to_string()
+        format!("Vector2Channel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 
@@ -1871,11 +1861,6 @@ impl Vector3Channel {
     }
 
     fn __repr__(&self) -> String {
-        format!(
-            "Vector3Channel(id='{}',topic='{}')",
-            self.id(),
-            self.topic()
-        )
-        .to_string()
+        format!("Vector3Channel(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -135,6 +135,10 @@ impl BaseChannel {
         Ok(())
     }
 
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
     fn topic(&self) -> &str {
         self.0.topic()
     }

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -144,7 +144,7 @@ impl BaseChannel {
     }
 
     fn schema_name(&self) -> Option<&str> {
-        self.0.schema().map(|s| s.name.as_str())
+        Some(self.0.schema()?.name.as_str())
     }
 
     fn close(&mut self) {

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -609,7 +609,7 @@ impl ${channelClass} {
     }
 
     fn __repr__(&self) -> String {
-        format!("${channelClass}(topic='{}')", self.0.topic()).to_string()
+        format!("${channelClass}(id='{}',topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 `;

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -567,6 +567,21 @@ impl ${channelClass} {
         Ok(Self(base))
     }
 
+    /// The unique ID of the channel.
+    fn id(&self) -> u64 {
+        self.0.id().into()
+    }
+
+    /// The topic name of the channel.
+    fn topic(&self) -> &str {
+        self.0.topic()
+    }
+
+    /// The name of the schema for the channel.
+    fn schema_name(&self) -> Option<&str> {
+        Some(self.0.schema()?.name.as_str())
+    }
+
     /// Close the channel.
     ///
     /// You can use this to explicitly unadvertise the channel to sinks that subscribe to
@@ -628,13 +643,26 @@ export function generatePyChannelStub(messageSchemas: FoxgloveMessageSchema[]): 
         `        cls,`,
         `        topic: str,`,
         `    ) -> "${channelClass}": ...\n`,
-        `    def close(self) -> None: ...`,
+        `    def id(self) -> int:`,
+        `        """The unique ID of the channel."""`,
+        `        ...`,
+        `    def topic(self) -> str:`,
+        `        """The topic name of the channel."""`,
+        `        ...`,
+        `    def schema_name(self) -> str | None:`,
+        `        """The name of the schema for the channel."""`,
+        `        ...`,
+        `    def close(self) -> None:`,
+        `        """Close the channel."""`,
+        `        ...`,
         `    def log(`,
         `        self,`,
         `        message: "${schemaClass}",`,
         `        *,`,
         `        log_time: int | None = None,`,
-        `    ) -> None: ...\n`,
+        `    ) -> None:`,
+        `        """Log a Foxglove ${schemaClass} message on the channel."""`,
+        `        ...`,
       ].join("\n"),
     };
   });

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -609,7 +609,7 @@ impl ${channelClass} {
     }
 
     fn __repr__(&self) -> String {
-        format!("${channelClass}(id='{}',topic='{}')", self.id(), self.topic()).to_string()
+        format!("${channelClass}(id={}, topic='{}')", self.id(), self.topic()).to_string()
     }
 }
 `;


### PR DESCRIPTION
This adds `id()` to the Python channel interface. We publish subscription notifications on the server callback interface with these IDs, but they were not meaningful until now.

This also updates the typed channel interface with public getters for schema and topic name to match the raw channel getters added in #368.