### PR TITLE
c++: Remove usage of CStr

### DIFF
--- a/c/build.rs
+++ b/c/build.rs
@@ -8,5 +8,5 @@ fn main() {
         .write_to_file("include/foxglove-c/foxglove-c.h");
 
     println!("cargo:rerun-if-changed=cbindgen.toml");
-    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=src/");
 }

--- a/c/build.rs
+++ b/c/build.rs
@@ -8,4 +8,5 @@ fn main() {
         .write_to_file("include/foxglove-c/foxglove-c.h");
 
     println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-changed=src/lib.rs");
 }

--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -33,6 +33,7 @@ non_null_attribute = "FOXGLOVE_NONNULL"
 prefix_with_name = true
 
 [export.rename]
+FoxgloveString = "foxglove_string"
 FoxgloveWebSocketServer = "foxglove_websocket_server"
 FoxgloveChannel = "foxglove_channel"
 FoxgloveSchema = "foxglove_schema"

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -103,7 +103,7 @@ typedef struct foxglove_string {
    */
   const char *data;
   /**
-   * Number of characters in the string.
+   * Number of bytes in the string
    */
   size_t len;
 } foxglove_string;

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -101,11 +101,14 @@ typedef uint8_t foxglove_server_capability;
 
 typedef struct foxglove_server_options {
   const char *name;
+  size_t name_len;
   const char *host;
+  size_t host_len;
   uint16_t port;
   const struct foxglove_server_callbacks *callbacks;
   foxglove_server_capability capabilities;
   const char *const *supported_encodings;
+  const size_t *supported_encoding_lengths;
   size_t supported_encodings_count;
 } foxglove_server_options;
 
@@ -135,7 +138,9 @@ typedef struct foxglove_mcap_options {
 
 typedef struct foxglove_schema {
   const char *name;
+  size_t name_len;
   const char *encoding;
+  size_t encoding_len;
   const uint8_t *data;
   size_t data_len;
 } foxglove_schema;
@@ -150,7 +155,15 @@ extern "C" {
  * `port` may be 0, in which case an available port will be automatically selected.
  *
  * # Safety
- * `name` and `host` must be null-terminated strings with valid UTF8.
+ * If `name` is supplied in options, it must be valid UTF8, and `name_len` must be the length of
+ * `name`.
+ * If `host` is supplied in options, it must be valid UTF8, and `host_len` must be the length of
+ * `host`.
+ * If `supported_encodings` is supplied in options, all `supported_encodings` must be valid UTF8;
+ * `supported_encoding_lengths` must define the length of each encoding in `supported_encodings`;
+ * and both `supported_encodings` and `supported_encoding_lengths` must have the same length, equal
+ * to `supported_encodings_count`.
+ * "Length" here refers to the number of characters in the string.
  */
 struct foxglove_websocket_server *foxglove_server_start(const struct foxglove_server_options *FOXGLOVE_NONNULL options);
 
@@ -199,12 +212,15 @@ void foxglove_server_stop(struct foxglove_websocket_server *server);
  * Create a new channel. The channel must later be freed with `foxglove_channel_free`.
  *
  * # Safety
- * `topic` and `message_encoding` must be null-terminated strings with valid UTF8. `schema` is an
- * optional pointer to a schema. The schema and the data it points to need only remain alive for
- * the duration of this function call (they will be copied).
+ * `topic` and `message_encoding` must contain valid UTF8. `topic_len` and `message_encoding_len`
+ * must define the lengths (number of characters) of `topic` and `message_encoding` respectively.
+ * `schema` is an optional pointer to a schema. The schema and the data it points to need only
+ * remain alive for the duration of this function call (they will be copied).
  */
 foxglove_channel *foxglove_channel_create(const char *topic,
+                                          size_t topic_len,
                                           const char *message_encoding,
+                                          size_t message_encoding_len,
                                           const struct foxglove_schema *schema);
 
 /**

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -162,10 +162,10 @@ extern "C" {
  * `port` may be 0, in which case an available port will be automatically selected.
  *
  * # Safety
- * If `name` is supplied in options, it must be valid UTF8.
- * If `host` is supplied in options, it must be valid UTF8.
- * If `supported_encodings` is supplied in options, all `supported_encodings` must be valid UTF8,
- * and `supported_encodings` must have length equal to `supported_encodings_count`.
+ * If `name` is supplied in options, it must contain valid UTF8.
+ * If `host` is supplied in options, it must contain valid UTF8.
+ * If `supported_encodings` is supplied in options, all `supported_encodings` must contain valid
+ * UTF8, and `supported_encodings` must have length equal to `supported_encodings_count`.
  */
 struct foxglove_websocket_server *foxglove_server_start(const struct foxglove_server_options *FOXGLOVE_NONNULL options);
 
@@ -173,7 +173,7 @@ struct foxglove_websocket_server *foxglove_server_start(const struct foxglove_se
  * Create or open an MCAP file for writing. Must later be freed with `foxglove_mcap_free`.
  *
  * # Safety
- * `path`, `profile`, and `library` must be valid UTF8.
+ * `path` and `profile` must contain valid UTF8.
  */
 struct foxglove_mcap_writer *foxglove_mcap_open(const struct foxglove_mcap_options *FOXGLOVE_NONNULL options);
 

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -119,8 +119,7 @@ typedef struct foxglove_server_options {
   uint16_t port;
   const struct foxglove_server_callbacks *callbacks;
   foxglove_server_capability capabilities;
-  const char *const *supported_encodings;
-  const size_t *supported_encoding_lengths;
+  const struct FoxgloveString *supported_encodings;
   size_t supported_encodings_count;
 } foxglove_server_options;
 
@@ -165,11 +164,8 @@ extern "C" {
  * # Safety
  * If `name` is supplied in options, it must be valid UTF8.
  * If `host` is supplied in options, it must be valid UTF8.
- * If `supported_encodings` is supplied in options, all `supported_encodings` must be valid UTF8;
- * `supported_encoding_lengths` must define the length of each encoding in `supported_encodings`;
- * and both `supported_encodings` and `supported_encoding_lengths` must have the same length, equal
- * to `supported_encodings_count`.
- * "Length" here refers to the number of characters in the string.
+ * If `supported_encodings` is supplied in options, all `supported_encodings` must be valid UTF8,
+ * and `supported_encodings` must have length equal to `supported_encodings_count`.
  */
 struct foxglove_websocket_server *foxglove_server_start(const struct foxglove_server_options *FOXGLOVE_NONNULL options);
 

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -69,6 +69,20 @@ typedef struct foxglove_mcap_writer foxglove_mcap_writer;
 
 typedef struct foxglove_websocket_server foxglove_websocket_server;
 
+/**
+ * A string with associated length.
+ */
+typedef struct FoxgloveString {
+  /**
+   * Pointer to valid UTF-8 data
+   */
+  const char *data;
+  /**
+   * Number of characters in the string.
+   */
+  size_t len;
+} FoxgloveString;
+
 typedef struct foxglove_client_channel {
   uint32_t id;
   const char *topic;
@@ -100,10 +114,8 @@ typedef struct foxglove_server_callbacks {
 typedef uint8_t foxglove_server_capability;
 
 typedef struct foxglove_server_options {
-  const char *name;
-  size_t name_len;
-  const char *host;
-  size_t host_len;
+  struct FoxgloveString name;
+  struct FoxgloveString host;
   uint16_t port;
   const struct foxglove_server_callbacks *callbacks;
   foxglove_server_capability capabilities;
@@ -113,13 +125,11 @@ typedef struct foxglove_server_options {
 } foxglove_server_options;
 
 typedef struct foxglove_mcap_options {
-  const char *path;
-  size_t path_len;
+  struct FoxgloveString path;
   bool create;
   bool truncate;
   FoxgloveMcapCompression compression;
-  const char *profile;
-  size_t profile_len;
+  struct FoxgloveString profile;
   /**
    * chunk_size of 0 is treated as if it was omitted (None)
    */
@@ -137,10 +147,8 @@ typedef struct foxglove_mcap_options {
 } foxglove_mcap_options;
 
 typedef struct foxglove_schema {
-  const char *name;
-  size_t name_len;
-  const char *encoding;
-  size_t encoding_len;
+  struct FoxgloveString name;
+  struct FoxgloveString encoding;
   const uint8_t *data;
   size_t data_len;
 } foxglove_schema;
@@ -155,10 +163,8 @@ extern "C" {
  * `port` may be 0, in which case an available port will be automatically selected.
  *
  * # Safety
- * If `name` is supplied in options, it must be valid UTF8, and `name_len` must be the length of
- * `name`.
- * If `host` is supplied in options, it must be valid UTF8, and `host_len` must be the length of
- * `host`.
+ * If `name` is supplied in options, it must be valid UTF8.
+ * If `host` is supplied in options, it must be valid UTF8.
  * If `supported_encodings` is supplied in options, all `supported_encodings` must be valid UTF8;
  * `supported_encoding_lengths` must define the length of each encoding in `supported_encodings`;
  * and both `supported_encodings` and `supported_encoding_lengths` must have the same length, equal
@@ -212,15 +218,12 @@ void foxglove_server_stop(struct foxglove_websocket_server *server);
  * Create a new channel. The channel must later be freed with `foxglove_channel_free`.
  *
  * # Safety
- * `topic` and `message_encoding` must contain valid UTF8. `topic_len` and `message_encoding_len`
- * must define the lengths (number of characters) of `topic` and `message_encoding` respectively.
- * `schema` is an optional pointer to a schema. The schema and the data it points to need only
- * remain alive for the duration of this function call (they will be copied).
+ * `topic` and `message_encoding` must contain valid UTF8. `schema` is an optional pointer to a
+ * schema. The schema and the data it points to need only remain alive for the duration of this
+ * function call (they will be copied).
  */
-foxglove_channel *foxglove_channel_create(const char *topic,
-                                          size_t topic_len,
-                                          const char *message_encoding,
-                                          size_t message_encoding_len,
+foxglove_channel *foxglove_channel_create(struct FoxgloveString topic,
+                                          struct FoxgloveString message_encoding,
                                           const struct foxglove_schema *schema);
 
 /**

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -72,7 +72,7 @@ typedef struct foxglove_websocket_server foxglove_websocket_server;
 /**
  * A string with associated length.
  */
-typedef struct FoxgloveString {
+typedef struct foxglove_string {
   /**
    * Pointer to valid UTF-8 data
    */
@@ -81,7 +81,7 @@ typedef struct FoxgloveString {
    * Number of characters in the string.
    */
   size_t len;
-} FoxgloveString;
+} foxglove_string;
 
 typedef struct foxglove_client_channel {
   uint32_t id;
@@ -114,21 +114,21 @@ typedef struct foxglove_server_callbacks {
 typedef uint8_t foxglove_server_capability;
 
 typedef struct foxglove_server_options {
-  struct FoxgloveString name;
-  struct FoxgloveString host;
+  struct foxglove_string name;
+  struct foxglove_string host;
   uint16_t port;
   const struct foxglove_server_callbacks *callbacks;
   foxglove_server_capability capabilities;
-  const struct FoxgloveString *supported_encodings;
+  const struct foxglove_string *supported_encodings;
   size_t supported_encodings_count;
 } foxglove_server_options;
 
 typedef struct foxglove_mcap_options {
-  struct FoxgloveString path;
+  struct foxglove_string path;
   bool create;
   bool truncate;
   FoxgloveMcapCompression compression;
-  struct FoxgloveString profile;
+  struct foxglove_string profile;
   /**
    * chunk_size of 0 is treated as if it was omitted (None)
    */
@@ -146,8 +146,8 @@ typedef struct foxglove_mcap_options {
 } foxglove_mcap_options;
 
 typedef struct foxglove_schema {
-  struct FoxgloveString name;
-  struct FoxgloveString encoding;
+  struct foxglove_string name;
+  struct foxglove_string encoding;
   const uint8_t *data;
   size_t data_len;
 } foxglove_schema;
@@ -218,8 +218,8 @@ void foxglove_server_stop(struct foxglove_websocket_server *server);
  * schema. The schema and the data it points to need only remain alive for the duration of this
  * function call (they will be copied).
  */
-foxglove_channel *foxglove_channel_create(struct FoxgloveString topic,
-                                          struct FoxgloveString message_encoding,
+foxglove_channel *foxglove_channel_create(struct foxglove_string topic,
+                                          struct foxglove_string message_encoding,
                                           const struct foxglove_schema *schema);
 
 /**

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -14,9 +14,9 @@ use std::sync::Arc;
 #[repr(C)]
 pub struct FoxgloveString {
     /// Pointer to valid UTF-8 data
-    pub data: *const c_char,
+    data: *const c_char,
     /// Number of characters in the string.
-    pub len: usize,
+    len: usize,
 }
 
 impl FoxgloveString {

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -25,7 +25,6 @@ impl FoxgloveString {
     /// # Safety
     ///
     /// The [`self::data`] must be valid UTF-8, and have a length equal to [`FoxgloveString.len`].
-    #[unsafe(no_mangle)]
     unsafe fn as_utf8_str(&self) -> Result<&str, std::str::Utf8Error> {
         std::str::from_utf8(unsafe { std::slice::from_raw_parts(self.data as *const u8, self.len) })
     }

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -167,10 +167,10 @@ pub struct FoxgloveSchema {
 /// `port` may be 0, in which case an available port will be automatically selected.
 ///
 /// # Safety
-/// If `name` is supplied in options, it must be valid UTF8.
-/// If `host` is supplied in options, it must be valid UTF8.
-/// If `supported_encodings` is supplied in options, all `supported_encodings` must be valid UTF8,
-/// and `supported_encodings` must have length equal to `supported_encodings_count`.
+/// If `name` is supplied in options, it must contain valid UTF8.
+/// If `host` is supplied in options, it must contain valid UTF8.
+/// If `supported_encodings` is supplied in options, all `supported_encodings` must contain valid
+/// UTF8, and `supported_encodings` must have length equal to `supported_encodings_count`.
 #[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn foxglove_server_start(
@@ -274,15 +274,13 @@ pub struct FoxgloveMcapWriter(Option<foxglove::McapWriterHandle<BufWriter<File>>
 /// Create or open an MCAP file for writing. Must later be freed with `foxglove_mcap_free`.
 ///
 /// # Safety
-/// `path`, `profile`, and `library` must be valid UTF8.
+/// `path` and `profile` must contain valid UTF8.
 #[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn foxglove_mcap_open(
     options: &FoxgloveMcapOptions,
 ) -> *mut FoxgloveMcapWriter {
     let path = unsafe { options.path.as_utf8_str().expect("path is invalid") };
-
-    // Safety: this is safe if the options struct contains valid strings
     let mcap_options = unsafe { options.to_write_options() };
 
     let file = File::options()

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -202,18 +202,10 @@ pub unsafe extern "C" fn foxglove_server_start(
 unsafe fn do_foxglove_server_start(
     options: &FoxgloveServerOptions,
 ) -> Result<*mut FoxgloveWebSocketServer, foxglove::FoxgloveError> {
-    let name = unsafe {
-        options
-            .name
-            .as_utf8_str()
-            .map_err(|e| foxglove::FoxgloveError::Utf8Error(format!("name is invalid: {}", e)))?
-    };
-    let host = unsafe {
-        options
-            .host
-            .as_utf8_str()
-            .map_err(|e| foxglove::FoxgloveError::Utf8Error(format!("host is invalid: {}", e)))?
-    };
+    let name = unsafe { options.name.as_utf8_str() }
+        .map_err(|e| foxglove::FoxgloveError::Utf8Error(format!("name is invalid: {}", e)))?;
+    let host = unsafe { options.host.as_utf8_str() }
+        .map_err(|e| foxglove::FoxgloveError::Utf8Error(format!("host is invalid: {}", e)))?;
 
     let mut server = foxglove::WebSocketServer::new()
         .name(name)

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub struct FoxgloveString {
     /// Pointer to valid UTF-8 data
     data: *const c_char,
-    /// Number of characters in the string.
+    /// Number of bytes in the string
     len: usize,
 }
 
@@ -741,4 +741,26 @@ unsafe fn result_to_c<T>(
 #[unsafe(no_mangle)]
 pub extern "C" fn foxglove_error_to_cstr(error: FoxgloveError) -> *const c_char {
     error.to_cstr().as_ptr() as *const _
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foxglove_string_as_utf8_str() {
+        let string = FoxgloveString {
+            data: c"test".as_ptr(),
+            len: 4,
+        };
+        let utf8_str = unsafe { string.as_utf8_str() };
+        assert_eq!(utf8_str, Ok("test"));
+
+        let string = FoxgloveString {
+            data: c"💖".as_ptr(),
+            len: 4,
+        };
+        let utf8_str = unsafe { string.as_utf8_str() };
+        assert_eq!(utf8_str, Ok("💖"));
+    }
 }

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -20,11 +20,11 @@ pub struct FoxgloveString {
 }
 
 impl FoxgloveString {
-    /// Wrapper around [`std::str::from_utf8`] that is unsafe to call.
+    /// Wrapper around [`std::str::from_utf8`].
     ///
     /// # Safety
     ///
-    /// The [`self::data`] must be valid UTF-8, and have a length equal to [`FoxgloveString.len`].
+    /// The [`data`] field must be valid UTF-8, and have a length equal to [`FoxgloveString.len`].
     unsafe fn as_utf8_str(&self) -> Result<&str, std::str::Utf8Error> {
         std::str::from_utf8(unsafe { std::slice::from_raw_parts(self.data as *const u8, self.len) })
     }

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -9,16 +9,14 @@ Channel::Channel(
     : _impl(nullptr, foxglove_channel_free) {
   foxglove_schema cSchema = {};
   if (schema) {
-    cSchema.name = schema->name.data();
-    cSchema.encoding = schema->encoding.data();
+    cSchema.name = {schema->name.data(), schema->name.length()};
+    cSchema.encoding = {schema->encoding.data(), schema->encoding.length()};
     cSchema.data = reinterpret_cast<const uint8_t*>(schema->data);
     cSchema.data_len = schema->dataLen;
   }
   _impl.reset(foxglove_channel_create(
-    topic.data(),
-    topic.length(),
-    messageEncoding.data(),
-    messageEncoding.length(),
+    {topic.data(), topic.length()},
+    {messageEncoding.data(), messageEncoding.length()},
     schema ? &cSchema : nullptr
   ));
 }

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -14,9 +14,13 @@ Channel::Channel(
     cSchema.data = reinterpret_cast<const uint8_t*>(schema->data);
     cSchema.data_len = schema->dataLen;
   }
-  _impl.reset(
-    foxglove_channel_create(topic.data(), messageEncoding.data(), schema ? &cSchema : nullptr)
-  );
+  _impl.reset(foxglove_channel_create(
+    topic.data(),
+    topic.length(),
+    messageEncoding.data(),
+    messageEncoding.length(),
+    schema ? &cSchema : nullptr
+  ));
 }
 
 uint64_t Channel::id() const {

--- a/cpp/foxglove/src/mcap.cpp
+++ b/cpp/foxglove/src/mcap.cpp
@@ -19,10 +19,8 @@ McapWriter::McapWriter(McapWriterOptions options)
   foxglove_internal_register_cpp_wrapper();
 
   foxglove_mcap_options cOptions = {};
-  cOptions.path = options.path.data();
-  cOptions.path_len = options.path.length();
-  cOptions.profile = options.profile.data();
-  cOptions.profile_len = options.profile.length();
+  cOptions.path = {options.path.data(), options.path.length()};
+  cOptions.profile = {options.profile.data(), options.profile.length()};
   cOptions.compression = toFoxgloveMcapCompression(options.compression);
   cOptions.chunk_size = options.chunkSize;
   cOptions.use_chunks = options.useChunks;

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -69,10 +69,8 @@ WebSocketServer::WebSocketServer(const WebSocketServerOptions& options)
   }
 
   foxglove_server_options cOptions = {};
-  cOptions.name = options.name.c_str();
-  cOptions.name_len = options.name.length();
-  cOptions.host = options.host.c_str();
-  cOptions.host_len = options.host.length();
+  cOptions.name = {options.name.c_str(), options.name.length()};
+  cOptions.host = {options.host.c_str(), options.host.length()};
   cOptions.port = options.port;
   cOptions.callbacks = hasAnyCallbacks ? &cCallbacks : nullptr;
   cOptions.capabilities =

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -75,17 +75,12 @@ WebSocketServer::WebSocketServer(const WebSocketServerOptions& options)
   cOptions.callbacks = hasAnyCallbacks ? &cCallbacks : nullptr;
   cOptions.capabilities =
     static_cast<std::underlying_type_t<decltype(options.capabilities)>>(options.capabilities);
-  std::vector<const char*> supportedEncodings;
+  std::vector<FoxgloveString> supportedEncodings;
   supportedEncodings.reserve(options.supportedEncodings.size());
-
-  std::vector<size_t> supportedEncodingLengths;
-  supportedEncodingLengths.reserve(options.supportedEncodings.size());
   for (const auto& encoding : options.supportedEncodings) {
-    supportedEncodings.push_back(encoding.c_str());
-    supportedEncodingLengths.push_back(encoding.length());
+    supportedEncodings.push_back({encoding.c_str(), encoding.length()});
   }
   cOptions.supported_encodings = supportedEncodings.data();
-  cOptions.supported_encoding_lengths = supportedEncodingLengths.data();
   cOptions.supported_encodings_count = supportedEncodings.size();
   _impl.reset(foxglove_server_start(&cOptions));
 }

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -70,17 +70,24 @@ WebSocketServer::WebSocketServer(const WebSocketServerOptions& options)
 
   foxglove_server_options cOptions = {};
   cOptions.name = options.name.c_str();
+  cOptions.name_len = options.name.length();
   cOptions.host = options.host.c_str();
+  cOptions.host_len = options.host.length();
   cOptions.port = options.port;
   cOptions.callbacks = hasAnyCallbacks ? &cCallbacks : nullptr;
   cOptions.capabilities =
     static_cast<std::underlying_type_t<decltype(options.capabilities)>>(options.capabilities);
   std::vector<const char*> supportedEncodings;
   supportedEncodings.reserve(options.supportedEncodings.size());
+
+  std::vector<size_t> supportedEncodingLengths;
+  supportedEncodingLengths.reserve(options.supportedEncodings.size());
   for (const auto& encoding : options.supportedEncodings) {
     supportedEncodings.push_back(encoding.c_str());
+    supportedEncodingLengths.push_back(encoding.length());
   }
   cOptions.supported_encodings = supportedEncodings.data();
+  cOptions.supported_encoding_lengths = supportedEncodingLengths.data();
   cOptions.supported_encodings_count = supportedEncodings.size();
   _impl.reset(foxglove_server_start(&cOptions));
 }

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -75,7 +75,7 @@ WebSocketServer::WebSocketServer(const WebSocketServerOptions& options)
   cOptions.callbacks = hasAnyCallbacks ? &cCallbacks : nullptr;
   cOptions.capabilities =
     static_cast<std::underlying_type_t<decltype(options.capabilities)>>(options.capabilities);
-  std::vector<FoxgloveString> supportedEncodings;
+  std::vector<foxglove_string> supportedEncodings;
   supportedEncodings.reserve(options.supportedEncodings.size());
   for (const auto& encoding : options.supportedEncodings) {
     supportedEncodings.push_back({encoding.c_str(), encoding.length()});

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -167,6 +167,7 @@ TEST_CASE("Client advertise/publish callbacks") {
   options.host = "127.0.0.1";
   options.port = 0;
   options.capabilities = foxglove::WebSocketServerCapabilities::ClientPublish;
+  options.supportedEncodings = {"schema encoding", "another"};
   options.callbacks.onClientAdvertise =
     [&](uint32_t clientId, const foxglove::ClientChannel& channel) {
       std::scoped_lock lock{mutex};


### PR DESCRIPTION
### Changelog
None

### Description

This replaces usage of `CStr` with a `FoxgloveString` type having an associated length, per https://github.com/foxglove/foxglove-sdk/pull/295#discussion_r2002095320. I also updated the MCAP options which used separate length parameters.