### PR TITLE
python: Add MCAP write options

### DIFF
--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -8,6 +8,7 @@ foxglove
 
 .. automodule:: foxglove
    :members:
+   :exclude-members: MCAPWriter
 
 Schemas
 ^^^^^^^
@@ -83,6 +84,25 @@ disk and return its contents.
 See the Asset Server example for more information.
 
 .. autoclass:: foxglove.AssetHandler
+
+.. py:class:: MCAPCompression
+
+   Deprecated. Use :py:class:`mcap.MCAPCompression` instead.
+
+
+foxglove.mcap
+------------------
+
+.. Enums are excluded and manually documented, since pyo3 only emulates them. (https://github.com/PyO3/pyo3/issues/2887)
+.. Parameter types and values are manually documented since nested classes (values) are not supported by automodule.
+.. automodule:: foxglove.mcap
+   :members:
+   :exclude-members: MCAPCompression
+
+.. py:enum:: MCAPCompression
+
+   .. py:data:: Zstd
+   .. py:data:: Lz4
 
 
 foxglove.websocket

--- a/python/foxglove-sdk/python/docs/conf.py
+++ b/python/foxglove-sdk/python/docs/conf.py
@@ -27,10 +27,11 @@ nitpicky = True
 nitpick_ignore_regex = [
     # Ignore warnings for built-in types from autodoc_typehints
     ("py:data", r"typing.*"),
-    ("py:class", r"collections.abc.Callable"),
+    ("py:class", r"collections\.abc\.Callable"),
+    ("py:class", r"Path"),
     # autodoc_typehints also fails on Capability which is imported in websocket.py, but is
     # manually documented as an enum
-    ("py:class", r"foxglove.Capability"),
+    ("py:class", r"foxglove\.Capability"),
 ]
 
 templates_path = ["_templates"]

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -12,12 +12,11 @@ from typing import List, Optional, Union
 from . import _foxglove_py as _foxglove
 
 # Re-export these imports
-from ._foxglove_py import (
-    MCAPWriter,
-    Schema,
-    open_mcap,
-)
+from ._foxglove_py import Schema, open_mcap
 from .channel import Channel, log
+
+# Deprecated. Use foxglove.mcap.MCAPWriter instead.
+from .mcap import MCAPWriter
 from .websocket import (
     AssetHandler,
     Capability,

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -1,33 +1,8 @@
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
+from .mcap import MCAPWriteOptions, MCAPWriter
 from .websocket import AssetHandler, Capability, Service, WebSocketServer
-
-class MCAPWriter:
-    """
-    A writer for logging messages to an MCAP file.
-
-    Obtain an instance by calling :py:func:`open_mcap`.
-
-    This class may be used as a context manager, in which case the writer will
-    be closed when you exit the context.
-
-    If the writer is not closed by the time it is garbage collected, it will be
-    closed automatically, and any errors will be logged.
-    """
-
-    def __new__(cls) -> "MCAPWriter": ...
-    def __enter__(self) -> "MCAPWriter": ...
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None: ...
-    def close(self) -> None:
-        """
-        Close the writer explicitly.
-
-        You may call this to explicitly close the writer. Note that the writer
-        will be automatically closed when it is garbage-collected, or when
-        exiting the context manager.
-        """
-        ...
 
 class BaseChannel:
     """
@@ -119,12 +94,17 @@ def shutdown() -> None:
     """
     ...
 
-def open_mcap(path: str | Path, allow_overwrite: bool = False) -> MCAPWriter:
+def open_mcap(
+    path: str | Path,
+    allow_overwrite: bool = False,
+    writer_options: Optional[MCAPWriteOptions] = None,
+) -> MCAPWriter:
     """
     Creates a new MCAP file for recording.
 
     :param path: The path to the MCAP file. This file will be created and must not already exist.
     :param allow_overwrite: Set this flag in order to overwrite an existing file at this path.
+    :param writer_options: Options for the MCAP writer.
     :rtype: :py:class:`MCAPWriter`
     """
     ...

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -96,6 +96,7 @@ def shutdown() -> None:
 
 def open_mcap(
     path: str | Path,
+    *,
     allow_overwrite: bool = False,
     writer_options: Optional[MCAPWriteOptions] = None,
 ) -> MCAPWriter:

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
@@ -1,0 +1,84 @@
+from enum import Enum
+from typing import Any, Optional
+
+class MCAPCompression(Enum):
+    """
+    Compression options for content in an MCAP file.
+    """
+
+    Zstd = 0
+    Lz4 = 1
+
+class MCAPWriteOptions:
+    """
+    Options for the MCAP writer.
+
+    :param compression: Specifies the compression that should be used on chunks. Defaults to Zstd.
+        Pass `None` to disable compression.
+    :param profile: Specifies the profile that should be written to the MCAP Header record.
+    :param chunk_size: Specifies the target uncompressed size of each chunk.
+    :param use_chunks: Specifies whether to use chunks for storing messages.
+    :param emit_statistics: Specifies whether to write a statistics record in the summary section.
+    :param emit_summary_offsets: Specifies whether to write summary offset records.
+    :param emit_message_indexes: Specifies whether to write message index records after each chunk.
+    :param emit_chunk_indexes: Specifies whether to write chunk index records in the summary
+        section.
+    :param repeat_channels: Specifies whether to repeat each channel record from the data section
+        in the summary section.
+    :param repeat_schemas: Specifies whether to repeat each schema record from the data section in
+        the summary section.
+    :param calculate_chunk_crcs: Specifies whether to calculate and write CRCs for chunk records.
+    :param calculate_data_section_crc: Specifies whether to calculate and write a data section CRC
+        into the DataEnd record.
+    :param calculate_summary_section_crc: Specifies whether to calculate and write a summary section
+        CRC into the Footer record.
+    """
+
+    def __new__(
+        cls,
+        *,
+        compression: Optional[MCAPCompression] = MCAPCompression.Zstd,
+        profile: Optional[str] = None,
+        chunk_size: Optional[int] = None,
+        use_chunks: bool = False,
+        emit_statistics: bool = True,
+        emit_summary_offsets: bool = True,
+        emit_message_indexes: bool = True,
+        emit_chunk_indexes: bool = True,
+        repeat_channels: bool = True,
+        repeat_schemas: bool = True,
+        calculate_chunk_crcs: bool = True,
+        calculate_data_section_crc: bool = True,
+        calculate_summary_section_crc: bool = True,
+    ) -> "MCAPWriteOptions": ...
+
+class MCAPWriter:
+    """
+    A writer for logging messages to an MCAP file.
+
+    Obtain an instance by calling :py:func:`open_mcap`.
+
+    This class may be used as a context manager, in which case the writer will
+    be closed when you exit the context.
+
+    If the writer is not closed by the time it is garbage collected, it will be
+    closed automatically, and any errors will be logged.
+    """
+
+    def __new__(
+        cls,
+        *,
+        allow_overwrite: Optional[bool] = False,
+        writer_options: Optional[MCAPWriteOptions] = None,
+    ) -> "MCAPWriter": ...
+    def __enter__(self) -> "MCAPWriter": ...
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None: ...
+    def close(self) -> None:
+        """
+        Close the writer explicitly.
+
+        You may call this to explicitly close the writer. Note that the writer
+        will be automatically closed when it is garbage-collected, or when
+        exiting the context manager.
+        """
+        ...

--- a/python/foxglove-sdk/python/foxglove/mcap.py
+++ b/python/foxglove-sdk/python/foxglove/mcap.py
@@ -1,0 +1,12 @@
+# Re-export these imports
+from ._foxglove_py.mcap import (
+    MCAPCompression,
+    MCAPWriteOptions,
+    MCAPWriter,
+)
+
+__all__ = [
+    "MCAPCompression",
+    "MCAPWriter",
+    "MCAPWriteOptions",
+]

--- a/python/foxglove-sdk/python/foxglove/tests/test_mcap.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_mcap.py
@@ -1,21 +1,40 @@
-import os
 from pathlib import Path
-from typing import Generator
+from typing import Callable, Generator, Optional
 
 import pytest
 from foxglove import open_mcap
 from foxglove.channel import Channel
+from foxglove.mcap import MCAPWriteOptions
 
 chan = Channel("test", schema={"type": "object"})
 
 
 @pytest.fixture
-def tmp_mcap(tmpdir: os.PathLike[str]) -> Generator[Path, None, None]:
-    dir = Path(tmpdir)
-    mcap = dir / "test.mcap"
-    yield mcap
-    mcap.unlink()
-    dir.rmdir()
+def make_tmp_mcap(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[Callable[[], Path], None, None]:
+    mcap: Optional[Path] = None
+    dir: Optional[Path] = None
+
+    def _make_tmp_mcap() -> Path:
+        nonlocal dir, mcap
+        dir = tmp_path_factory.mktemp("test", numbered=True)
+        mcap = dir / "test.mcap"
+        return mcap
+
+    yield _make_tmp_mcap
+
+    if mcap is not None and dir is not None:
+        try:
+            mcap.unlink()
+            dir.rmdir()
+        except FileNotFoundError:
+            pass
+
+
+@pytest.fixture
+def tmp_mcap(make_tmp_mcap: Callable[[], Path]) -> Generator[Path, None, None]:
+    yield make_tmp_mcap()
 
 
 def test_open_with_str(tmp_mcap: Path) -> None:
@@ -44,3 +63,29 @@ def test_context_manager(tmp_mcap: Path) -> None:
             chan.log({"foo": ii})
         size_before_close = tmp_mcap.stat().st_size
     assert tmp_mcap.stat().st_size > size_before_close
+
+
+def test_writer_compression(make_tmp_mcap: Callable[[], Path]) -> None:
+    tmp_1 = make_tmp_mcap()
+    tmp_2 = make_tmp_mcap()
+
+    # Compression is enabled by default
+    mcap_1 = open_mcap(tmp_1)
+    mcap_2 = open_mcap(tmp_2, writer_options=MCAPWriteOptions(compression=None))
+
+    for _ in range(20):
+        chan.log({"foo": "bar"})
+
+    mcap_1.close()
+    mcap_2.close()
+
+    assert tmp_1.stat().st_size < tmp_2.stat().st_size
+
+
+def test_writer_custom_profile(tmp_mcap: Path) -> None:
+    options = MCAPWriteOptions(profile="--custom-profile-1--")
+    with open_mcap(tmp_mcap, writer_options=options):
+        chan.log({"foo": "bar"})
+
+    contents = tmp_mcap.read_bytes()
+    assert contents.find(b"--custom-profile-1--") > -1

--- a/python/foxglove-sdk/src/mcap.rs
+++ b/python/foxglove-sdk/src/mcap.rs
@@ -1,0 +1,187 @@
+use crate::errors::PyFoxgloveError;
+use foxglove::{McapCompression, McapWriteOptions, McapWriterHandle};
+use pyo3::prelude::*;
+use std::fs::File;
+use std::io::BufWriter;
+
+/// Compression algorithm to use for MCAP writing.
+#[pyclass(eq, eq_int, name = "MCAPCompression", module = "foxglove.mcap")]
+#[derive(PartialEq, Clone)]
+pub enum PyMcapCompression {
+    Zstd = 0,
+    Lz4 = 1,
+}
+
+impl From<PyMcapCompression> for McapCompression {
+    fn from(value: PyMcapCompression) -> Self {
+        match value {
+            PyMcapCompression::Zstd => McapCompression::Zstd,
+            PyMcapCompression::Lz4 => McapCompression::Lz4,
+        }
+    }
+}
+
+/// Options for the MCAP writer.
+///
+/// All parameters are optional.
+///
+/// :param compression: Specifies the compression that should be used on chunks. Defaults to Zstd.
+///     Pass `None` to disable compression.
+/// :type compression: MCAPCompression
+/// :param profile: Specifies the profile that should be written to the MCAP Header record.
+/// :type profile: str
+/// :param chunk_size: Specifies the target uncompressed size of each chunk.
+/// :type chunk_size: int
+/// :param use_chunks: Specifies whether to use chunks for storing messages.
+/// :type use_chunks: bool
+/// :param emit_statistics: Specifies whether to write a statistics record in the summary section.
+/// :type emit_statistics: bool
+/// :param emit_summary_offsets: Specifies whether to write summary offset records.
+/// :type emit_summary_offsets: bool
+/// :param emit_message_indexes: Specifies whether to write message index records after each chunk.
+/// :type emit_message_indexes: bool
+/// :param emit_chunk_indexes: Specifies whether to write chunk index records in the summary section.
+/// :type emit_chunk_indexes: bool
+/// :param repeat_channels: Specifies whether to repeat each channel record from the data section in the summary section.
+/// :type repeat_channels: bool
+/// :param repeat_schemas: Specifies whether to repeat each schema record from the data section in the summary section.
+/// :type repeat_schemas: bool
+/// :param calculate_chunk_crcs: Specifies whether to calculate and write CRCs for chunk records.
+/// :type calculate_chunk_crcs: bool
+/// :param calculate_data_section_crc: Specifies whether to calculate and write a data section CRC into the DataEnd record.
+/// :type calculate_data_section_crc: bool
+/// :param calculate_summary_section_crc: Specifies whether to calculate and write a summary section CRC into the Footer record.
+/// :type calculate_summary_section_crc: bool
+#[derive(Default, Clone)]
+#[pyclass(name = "MCAPWriteOptions", module = "foxglove.mcap")]
+pub(crate) struct PyMcapWriteOptions(McapWriteOptions);
+
+#[pymethods]
+impl PyMcapWriteOptions {
+    #[new]
+    #[pyo3(signature = (
+        *,
+        compression = None,
+        profile = None,
+        chunk_size = None,
+        use_chunks = false,
+        emit_statistics = true,
+        emit_summary_offsets = true,
+        emit_message_indexes = true,
+        emit_chunk_indexes = true,
+        repeat_channels = true,
+        repeat_schemas = true,
+        calculate_chunk_crcs = true,
+        calculate_data_section_crc = true,
+        calculate_summary_section_crc = true,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        compression: Option<PyMcapCompression>,
+        profile: Option<String>,
+        chunk_size: Option<u64>,
+        use_chunks: Option<bool>,
+        emit_statistics: Option<bool>,
+        emit_summary_offsets: Option<bool>,
+        emit_message_indexes: Option<bool>,
+        emit_chunk_indexes: Option<bool>,
+        repeat_channels: Option<bool>,
+        repeat_schemas: Option<bool>,
+        calculate_chunk_crcs: Option<bool>,
+        calculate_data_section_crc: Option<bool>,
+        calculate_summary_section_crc: Option<bool>,
+    ) -> Self {
+        let compression = compression.or(Some(PyMcapCompression::Zstd));
+        let opts = McapWriteOptions::default()
+            .compression(compression.map(Into::into))
+            .chunk_size(chunk_size)
+            .use_chunks(use_chunks.unwrap_or(false))
+            .emit_statistics(emit_statistics.unwrap_or(true))
+            .emit_summary_offsets(emit_summary_offsets.unwrap_or(true))
+            .emit_message_indexes(emit_message_indexes.unwrap_or(true))
+            .emit_chunk_indexes(emit_chunk_indexes.unwrap_or(true))
+            .repeat_channels(repeat_channels.unwrap_or(true))
+            .repeat_schemas(repeat_schemas.unwrap_or(true))
+            .calculate_chunk_crcs(calculate_chunk_crcs.unwrap_or(true))
+            .calculate_data_section_crc(calculate_data_section_crc.unwrap_or(true))
+            .calculate_summary_section_crc(calculate_summary_section_crc.unwrap_or(true));
+
+        let opts = if let Some(profile) = profile {
+            opts.profile(profile)
+        } else {
+            opts
+        };
+
+        Self(opts)
+    }
+}
+
+impl From<PyMcapWriteOptions> for McapWriteOptions {
+    fn from(value: PyMcapWriteOptions) -> Self {
+        value.0
+    }
+}
+
+/// A writer for logging messages to an MCAP file.
+///
+/// Obtain an instance by calling :py:func:`foxglove.open_mcap`.
+///
+/// This class may be used as a context manager, in which case the writer will
+/// be closed when you exit the context.
+///
+/// If the writer is not closed by the time it is garbage collected, it will be
+/// closed automatically, and any errors will be logged.
+#[pyclass(name = "MCAPWriter", module = "foxglove.mcap")]
+pub(crate) struct PyMcapWriter(pub(crate) Option<McapWriterHandle<BufWriter<File>>>);
+
+impl Drop for PyMcapWriter {
+    fn drop(&mut self) {
+        if let Err(e) = self.close() {
+            log::error!("Failed to close MCAP writer: {e}");
+        }
+    }
+}
+
+#[pymethods]
+impl PyMcapWriter {
+    fn __enter__(slf: PyRef<Self>) -> PyRef<Self> {
+        slf
+    }
+
+    fn __exit__(
+        &mut self,
+        _exc_type: Py<PyAny>,
+        _exc_value: Py<PyAny>,
+        _traceback: Py<PyAny>,
+    ) -> PyResult<()> {
+        self.close()
+    }
+
+    /// Close the MCAP writer.
+    ///
+    /// You may call this to explicitly close the writer. Note that the writer will be automatically
+    /// closed for you when it is garbage collected, or when exiting the context manager.
+    fn close(&mut self) -> PyResult<()> {
+        if let Some(writer) = self.0.take() {
+            writer.close().map_err(PyFoxgloveError::from)?;
+        }
+        Ok(())
+    }
+}
+
+pub fn register_submodule(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let module = PyModule::new(parent_module.py(), "mcap")?;
+
+    module.add_class::<PyMcapCompression>()?;
+    module.add_class::<PyMcapWriter>()?;
+    module.add_class::<PyMcapWriteOptions>()?;
+
+    // Define as a package
+    // https://github.com/PyO3/pyo3/issues/759
+    let py = parent_module.py();
+    py.import("sys")?
+        .getattr("modules")?
+        .set_item("foxglove._foxglove_py.mcap", &module)?;
+
+    parent_module.add_submodule(&module)
+}


### PR DESCRIPTION
### Changelog

python: Add MCAP write options
python: [deprecation] `MCAPWriter` moved to the `foxglove.mcap` module

### Description

This exposes MCAP writer options in the python SDK. I omitted some options which are not useful today: file metadata and attachments are not used; `disable_seek` is only useful if you control the rust writer; `library` is used by the SDK. I think we should consider removing these from C++ and Rust as appropriate.

The options here otherwise match the rust writer options; note that this differs from the python mcap library.

This also introduces a `foxglove.mcap` submodule. MCAPWriter is re-exported from `foxglove` to avoid a breaking change, but is documented as deprecated.
