### PR TITLE
C/C++: Export compile_commands.json

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -20,6 +20,7 @@ clean:
 build:
 	cmake \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=true \
 		$(if $(SANITIZE),-DSANITIZE=$(SANITIZE)) \
 		$(if $(CLANG_TIDY),-DCLANG_TIDY=$(CLANG_TIDY)) \
 		-B $(BUILD_DIR)


### PR DESCRIPTION
I'm using clangd as an LSP with neovim, and it seems to depend on a `build/compile_commands.json`. This change tells cmake to drop one of those while generating the rest of the build scripts.