### PR TITLE
Update some CMake and lint config

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: clang-format --version
       - run: make lint
         working-directory: cpp
       - run: make CLANG_TIDY=true build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
   "C_Cpp.formatting": "clangFormat",
   // https://github.com/microsoft/vscode-cpptools/issues/722
   "C_Cpp.autoAddFileAssociations": false,
+  "C_Cpp.default.cppStandard": "c++17",
   "rust-analyzer.check.command": "clippy",
   "cmake.sourceDirectory": "/home/eloff/foxglove/sdk/cpp"
 }

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -101,6 +101,8 @@ file(GLOB_RECURSE foxglove_cpp_srcs CONFIGURE_DEPENDS
 
 add_library(foxglove_cpp_obj OBJECT "${foxglove_cpp_srcs}")
 set_property(TARGET foxglove_cpp_obj PROPERTY POSITION_INDEPENDENT_CODE True)
+set_property(TARGET foxglove_cpp_obj PROPERTY CXX_STANDARD 17)
+set_property(TARGET foxglove_cpp_obj PROPERTY CXX_STANDARD_REQUIRED True)
 target_include_directories(foxglove_cpp_obj PUBLIC foxglove/include ${CMAKE_CURRENT_SOURCE_DIR}/../c/include)
 target_compile_options(foxglove_cpp_obj PUBLIC ${SANITIZER_COMPILE_OPTIONS})
 target_link_options(foxglove_cpp_obj PUBLIC ${SANITIZER_LINK_OPTIONS})
@@ -120,6 +122,8 @@ file(GLOB_RECURSE foxglove_test_srcs CONFIGURE_DEPENDS
     "foxglove/tests/*.cpp"
 )
 add_executable(tests "${foxglove_test_srcs}")
+set_property(TARGET tests PROPERTY CXX_STANDARD 17)
+set_property(TARGET tests PROPERTY CXX_STANDARD_REQUIRED True)
 target_compile_definitions(tests PRIVATE ASIO_STANDALONE)
 target_compile_options(tests PUBLIC ${SANITIZER_COMPILE_OPTIONS})
 target_link_options(tests PUBLIC ${SANITIZER_LINK_OPTIONS})
@@ -135,18 +139,22 @@ endif()
 ### Examples
 
 add_executable(example_server examples/ws-server/src/main.cpp)
+set_property(TARGET example_server PROPERTY CXX_STANDARD 17)
+set_property(TARGET example_server PROPERTY CXX_STANDARD_REQUIRED True)
 target_compile_options(example_server PUBLIC ${SANITIZER_COMPILE_OPTIONS})
 target_link_options(example_server PUBLIC ${SANITIZER_LINK_OPTIONS})
 target_link_libraries(example_server foxglove_cpp_static)
 
 add_executable(example_mcap examples/mcap/src/main.cpp)
+set_property(TARGET example_mcap PROPERTY CXX_STANDARD 17)
+set_property(TARGET example_mcap PROPERTY CXX_STANDARD_REQUIRED True)
 target_compile_options(example_mcap PUBLIC ${SANITIZER_COMPILE_OPTIONS})
 target_link_options(example_mcap PUBLIC ${SANITIZER_LINK_OPTIONS})
 target_link_libraries(example_mcap foxglove_cpp_static)
 
 add_executable(example_quickstart examples/quickstart/src/main.cpp)
-target_compile_options(example_quickstart PUBLIC ${SANITIZER_COMPILE_OPTIONS})
-target_link_options(example_quickstart PUBLIC ${SANITIZER_LINK_OPTIONS})
 set_property(TARGET example_quickstart PROPERTY CXX_STANDARD 17)
 set_property(TARGET example_quickstart PROPERTY CXX_STANDARD_REQUIRED True)
+target_compile_options(example_quickstart PUBLIC ${SANITIZER_COMPILE_OPTIONS})
+target_link_options(example_quickstart PUBLIC ${SANITIZER_LINK_OPTIONS})
 target_link_libraries(example_quickstart foxglove_cpp_static)

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -10,7 +10,9 @@ endif
 
 .PHONY: lint
 lint:
-	find . -path './build*' -prune -name '*.h' -o -name '*.hpp' -o -name '*.cpp' | xargs clang-format --dry-run -Werror --color=1
+	find . -path './build*' -prune -name '*.h' -o -name '*.hpp' -o -name '*.cpp' |\
+		grep -v 'foxglove/expected.hpp' |\
+		xargs clang-format --dry-run -Werror --color=1
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This updates some C++ config as follows.

Set CXX_STANDARD 17 on all targets. The [CMAKE variables we have set now](https://github.com/foxglove/foxglove-sdk/blob/7767f4855b75ece70f916db983d63c73db5b59fe/cpp/CMakeLists.txt#L9-L10) only apply to new targets when added (hence quickstart being the only one it applied to).

Add a VSCode-specific setting for cppStandard; I couldn't get it to coordinate with CMake.

Ignore "expected.hpp" from our linter. This was CC0 code added for error handling in #350; newer versions of clang-format report errors on it. (The modified find command was harder to read than piping through grep, in my opinion.)