### PR TITLE
Update quickstart examples

### DIFF
--- a/cpp/examples/quickstart/src/main.cpp
+++ b/cpp/examples/quickstart/src/main.cpp
@@ -11,6 +11,8 @@
 
 using namespace std::chrono_literals;
 
+// This example logs custom data on an "example" topic. Open Foxglove and connect to the running
+// server. Then add a Raw Message panel, and choose the "example" topic.
 int main(int argc, const char* argv[]) {
   static std::function<void()> sigintHandler;
 
@@ -20,6 +22,17 @@ int main(int argc, const char* argv[]) {
     }
   });
 
+  // We'll log to both an MCAP file, and to a running Foxglove app.
+  foxglove::McapWriterOptions mcap_options = {};
+  mcap_options.path = "quickstart-cpp.mcap";
+  auto writerResult = foxglove::McapWriter::create(mcap_options);
+  if (!writerResult.has_value()) {
+    std::cerr << "Failed to create writer: " << foxglove::strerror(writerResult.error()) << '\n';
+    return 1;
+  }
+  auto writer = std::move(writerResult.value());
+
+  // Start a server to communicate with the Foxglove app.
   foxglove::WebSocketServerOptions ws_options;
   ws_options.host = "127.0.0.1";
   ws_options.port = 8765;
@@ -31,20 +44,12 @@ int main(int argc, const char* argv[]) {
   auto server = std::move(serverResult.value());
   std::cerr << "Server listening on port " << server.port() << '\n';
 
-  foxglove::McapWriterOptions mcap_options = {};
-  mcap_options.path = "quickstart-cpp.mcap";
-  auto writerResult = foxglove::McapWriter::create(mcap_options);
-  if (!writerResult.has_value()) {
-    std::cerr << "Failed to create writer: " << foxglove::strerror(writerResult.error()) << '\n';
-    return 1;
-  }
-  auto writer = std::move(writerResult.value());
-
   std::atomic_bool done = false;
   sigintHandler = [&] {
     done = true;
   };
 
+  // Our example logs custom data on an "example" topic, so we'll create a channel for that.
   foxglove::Schema schema;
   schema.encoding = "jsonschema";
   std::string schemaData = R"({
@@ -63,6 +68,8 @@ int main(int argc, const char* argv[]) {
   auto channel = std::move(channelResult.value());
 
   while (!done) {
+    // Log messages on the channel until interrupted. By default, each message
+    // is stamped with the current time.
     std::this_thread::sleep_for(33ms);
     auto now = std::chrono::system_clock::now().time_since_epoch().count();
     std::string msg = "{\"val\": " + std::to_string(now) + "}";

--- a/python/foxglove-sdk-examples/quickstart/main.py
+++ b/python/foxglove-sdk-examples/quickstart/main.py
@@ -15,9 +15,13 @@ from foxglove.schemas import (
 
 foxglove.set_log_level("DEBUG")
 
+# Our example logs data on a couple of different topics, so we'll create a
+# channel for each. We can use a channel like SceneUpdateChannel to log
+# Foxglove schemas, or a generic Channel to log custom data.
 scene_channel = SceneUpdateChannel("/scene")
-json_channel = Channel("/info", message_encoding="json")
+size_channel = Channel("/size", message_encoding="json")
 
+# We'll log to both an MCAP file, and to a running Foxglove app via a server.
 file_name = "quickstart-python.mcap"
 writer = foxglove.open_mcap(file_name)
 server = foxglove.start_server()
@@ -25,7 +29,9 @@ server = foxglove.start_server()
 while True:
     size = abs(math.sin(time.time())) + 1
 
-    json_channel.log(json.dumps({"size": size}).encode("utf-8"))
+    # Log messages on both channels until interrupted. By default, each message
+    # is stamped with the current time.
+    size_channel.log(json.dumps({"size": size}).encode("utf-8"))
     scene_channel.log(
         SceneUpdate(
             entities=[

--- a/rust/examples/quickstart/src/main.rs
+++ b/rust/examples/quickstart/src/main.rs
@@ -1,45 +1,18 @@
 use std::ops::Add;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::SystemTime;
 
-use foxglove::schemas::SceneUpdate;
-use foxglove::{LazyChannel, McapWriter};
+use foxglove::schemas::{Color, CubePrimitive, SceneEntity, SceneUpdate, Vector3};
+use foxglove::{LazyChannel, LazyRawChannel, McapWriter};
 
 const FILE_NAME: &str = "quickstart-rust.mcap";
 
+// Our example logs data on a couple of different topics, so we'll create a
+// channel for each. We can use a channel like SceneUpdateChannel to log
+// Foxglove schemas, or a generic Channel to log custom data.
 static SCENE: LazyChannel<SceneUpdate> = LazyChannel::new("/scene");
-
-fn log_message() {
-    let size = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs_f64()
-        .sin()
-        .abs()
-        .add(1.0);
-
-    SCENE.log(&foxglove::schemas::SceneUpdate {
-        deletions: vec![],
-        entities: vec![foxglove::schemas::SceneEntity {
-            id: "box".to_string(),
-            cubes: vec![foxglove::schemas::CubePrimitive {
-                size: Some(foxglove::schemas::Vector3 {
-                    x: size,
-                    y: size,
-                    z: size,
-                }),
-                color: Some(foxglove::schemas::Color {
-                    r: 1.0,
-                    g: 0.0,
-                    b: 0.0,
-                    a: 1.0,
-                }),
-                ..Default::default()
-            }],
-            ..Default::default()
-        }],
-    });
-}
+static SIZE: LazyRawChannel = LazyRawChannel::new("/size", "json");
 
 fn main() {
     let env = env_logger::Env::default().default_filter_or("debug");
@@ -54,16 +27,50 @@ fn main() {
     })
     .expect("Failed to set SIGINT handler");
 
-    foxglove::WebSocketServer::new()
-        .start_blocking()
-        .expect("Server failed to start");
-
+    // We'll log to both an MCAP file, and to a running Foxglove app via a server.
     let mcap = McapWriter::new()
         .create_new_buffered_file(FILE_NAME)
         .expect("Failed to start mcap writer");
 
+    // Start a server to communicate with the Foxglove app.
+    foxglove::WebSocketServer::new()
+        .start_blocking()
+        .expect("Server failed to start");
+
     while !done.load(Ordering::Relaxed) {
-        log_message();
+        let size = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            .sin()
+            .abs()
+            .add(1.0);
+
+        // Log messages on the channel until interrupted. By default, each message
+        // is stamped with the current time.
+        SIZE.log(format!("{{\"size\": {size}}}").as_bytes());
+        SCENE.log(&SceneUpdate {
+            deletions: vec![],
+            entities: vec![SceneEntity {
+                id: "box".to_string(),
+                cubes: vec![CubePrimitive {
+                    size: Some(Vector3 {
+                        x: size,
+                        y: size,
+                        z: size,
+                    }),
+                    color: Some(Color {
+                        r: 1.0,
+                        g: 0.0,
+                        b: 0.0,
+                        a: 1.0,
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        });
+
         std::thread::sleep(std::time::Duration::from_millis(33));
     }
 


### PR DESCRIPTION
### Changelog
None

### Description

This adds some comments to the quickstart examples, based on documentation feedback.

I also added a "size" channel to the Rust example to illustrate a JSON schema and match python. (We'll update the C++ example once the Foxglove schemas are available there.)