### PR TITLE
rust: Parameter::string() should not produce a byte array

### DIFF
--- a/rust/examples/param-server/src/main.rs
+++ b/rust/examples/param-server/src/main.rs
@@ -119,37 +119,13 @@ async fn main() {
 
     // Initialize the parameter store with some example parameters
     {
+        let params = [
+            Parameter::string("read_only_str_param", "can't change me"),
+            Parameter::float64("elapsed", 0.0),
+            Parameter::float64_array("float_array_param", [1.0, 2.0, 3.0]),
+        ];
         let mut param_store = listener.param_store.lock().unwrap();
-        param_store.insert(
-            "read_only_str_param".to_string(),
-            Parameter {
-                name: "read_only_str_param".to_string(),
-                value: Some(ParameterValue::String(
-                    "can't change me".as_bytes().to_vec(),
-                )),
-                r#type: None,
-            },
-        );
-        param_store.insert(
-            "elapsed".to_string(),
-            Parameter {
-                name: "elapsed".to_string(),
-                value: Some(ParameterValue::Number(0.0)),
-                r#type: None,
-            },
-        );
-        param_store.insert(
-            "float_array_param".to_string(),
-            Parameter {
-                name: "float_array_param".to_string(),
-                value: Some(ParameterValue::Array(vec![
-                    ParameterValue::Number(1.0),
-                    ParameterValue::Number(2.0),
-                    ParameterValue::Number(3.0),
-                ])),
-                r#type: Some(ParameterType::Float64Array),
-            },
-        );
+        param_store.extend(params.into_iter().map(|p| (p.name.clone(), p)));
     }
 
     let server = WebSocketServer::new()

--- a/rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
@@ -46,7 +46,7 @@ mod tests {
         SetParameters::new([
             Parameter::empty("empty"),
             Parameter::float64("f64", 1.23),
-            Parameter::float64_array("f64[]", vec![1.23, 4.56]),
+            Parameter::float64_array("f64[]", [1.23, 4.56]),
             Parameter::byte_array("byte[]", [0x10, 0x20, 0x30]),
             Parameter::bool("bool", true),
         ])

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -68,7 +68,7 @@ impl Parameter {
     }
 
     /// Creates a new parameter with a float64 array value.
-    pub fn float64_array(name: impl Into<String>, values: Vec<f64>) -> Self {
+    pub fn float64_array(name: impl Into<String>, values: impl IntoIterator<Item = f64>) -> Self {
         Self {
             name: name.into(),
             r#type: Some(ParameterType::Float64Array),
@@ -80,7 +80,11 @@ impl Parameter {
 
     /// Creates a new parameter with a string value.
     pub fn string(name: impl Into<String>, value: impl Into<String>) -> Self {
-        Self::byte_array(name, value.into().into_bytes())
+        Self {
+            name: name.into(),
+            r#type: None,
+            value: Some(ParameterValue::String(value.into().into_bytes())),
+        }
     }
 
     /// Creates a new parameter with a byte array value.
@@ -127,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_float_array() {
-        insta::assert_json_snapshot!(Parameter::float64_array("f64[]", vec![1.23, 4.56]));
+        insta::assert_json_snapshot!(Parameter::float64_array("f64[]", [1.23, 4.56]));
     }
 
     #[test]

--- a/rust/foxglove/src/websocket/ws_protocol/server/parameter_values.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/server/parameter_values.rs
@@ -45,7 +45,7 @@ mod tests {
         ParameterValues::new([
             Parameter::empty("empty"),
             Parameter::float64("f64", 1.23),
-            Parameter::float64_array("f64[]", vec![1.23, 4.56]),
+            Parameter::float64_array("f64[]", [1.23, 4.56]),
             Parameter::byte_array("byte[]", [0x10, 0x20, 0x30]),
             Parameter::bool("bool", true),
         ])

--- a/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__string.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__string.snap
@@ -4,6 +4,5 @@ expression: "Parameter::string(\"string\", \"howdy\")"
 ---
 {
   "name": "string",
-  "type": "byte_array",
   "value": "aG93ZHk="
 }


### PR DESCRIPTION
### Changelog
- rust: Fixed Parameter::string() constructor, which was producing a byte array

### Description
The `Parameter::string()` constructor was mistakenly returning a byte array, when it should've been returning a string.

This change also updates `Parameter::float64_array()` to accept an `impl IntoIterator<Item = f64>` and updates the rust `param-server` example.