### PR TITLE
String parameters must not be base64-encoded

### DIFF
--- a/python/foxglove-sdk-examples/ws-param-server/main.py
+++ b/python/foxglove-sdk-examples/ws-param-server/main.py
@@ -19,7 +19,7 @@ from foxglove.websocket import (
 )
 
 
-class ParameterStore(foxglove.ServerListener):
+class ParameterStore(foxglove.websocket.ServerListener):
     def __init__(self, parameters: list[Parameter]) -> None:
         # In this example our parameters are unique by name
         self.parameters = {param.name: param for param in parameters}
@@ -78,7 +78,7 @@ def main() -> None:
                 {
                     "a": ParameterValue.Number(1),
                     "b": ParameterValue.Bool(True),
-                    "c": ParameterValue.Bytes(b"hello"),
+                    "c": ParameterValue.String("hello"),
                     "arr": ParameterValue.Array(
                         [ParameterValue.Number(1), ParameterValue.Bool(True)]
                     ),

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -56,9 +56,12 @@ Used with the parameter service during live visualization. Requires the :py:data
 
       A boolean value.
 
-   .. py:class:: Bytes(value: bytes)
+   .. py:class:: String(value: str)
 
-      A byte array.
+      A string value.
+
+      For parameters of type :py:attr:`ParameterType.ByteArray`, this is a
+      base64 encoding of the byte array.
 
    .. py:class:: Array(value: list[ParameterValue])
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -148,10 +148,15 @@ class ParameterValue:
 
         def __new__(cls, value: float) -> "ParameterValue.Number": ...
 
-    class Bytes:
-        """A byte array."""
+    class String:
+        """
+        A string value.
 
-        def __new__(cls, value: bytes) -> "ParameterValue.Bytes": ...
+        For parameters of type :py:attr:ParameterType.ByteArray, this is a
+        base64 encoding of the byte array.
+        """
+
+        def __new__(cls, value: str) -> "ParameterValue.String": ...
 
     class Array:
         """An array of parameter values."""
@@ -170,7 +175,7 @@ class ParameterValue:
 AnyParameterValue = Union[
     ParameterValue.Bool,
     ParameterValue.Number,
-    ParameterValue.Bytes,
+    ParameterValue.String,
     ParameterValue.Array,
     ParameterValue.Dict,
 ]

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -822,8 +822,10 @@ pub enum PyParameterValue {
     Number(f64),
     /// A boolean value.
     Bool(bool),
-    /// A byte array, which will be encoded as a base64-encoded string.
-    Bytes(Vec<u8>),
+    /// A string value.
+    ///
+    /// For parameters of type ByteArray, this is a base64-encoding of the byte array.
+    String(String),
     /// An array of parameter values.
     Array(Vec<PyParameterValue>),
     /// An associative map of parameter values.
@@ -835,7 +837,7 @@ impl From<PyParameterValue> for foxglove::websocket::ParameterValue {
         match value {
             PyParameterValue::Number(n) => foxglove::websocket::ParameterValue::Number(n),
             PyParameterValue::Bool(b) => foxglove::websocket::ParameterValue::Bool(b),
-            PyParameterValue::Bytes(items) => foxglove::websocket::ParameterValue::String(items),
+            PyParameterValue::String(s) => foxglove::websocket::ParameterValue::String(s),
             PyParameterValue::Array(py_parameter_values) => {
                 foxglove::websocket::ParameterValue::Array(
                     py_parameter_values.into_iter().map(Into::into).collect(),
@@ -853,7 +855,7 @@ impl From<foxglove::websocket::ParameterValue> for PyParameterValue {
         match value {
             foxglove::websocket::ParameterValue::Number(n) => PyParameterValue::Number(n),
             foxglove::websocket::ParameterValue::Bool(b) => PyParameterValue::Bool(b),
-            foxglove::websocket::ParameterValue::String(items) => PyParameterValue::Bytes(items),
+            foxglove::websocket::ParameterValue::String(s) => PyParameterValue::String(s),
             foxglove::websocket::ParameterValue::Array(parameter_values) => {
                 PyParameterValue::Array(parameter_values.into_iter().map(Into::into).collect())
             }

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -30,5 +30,7 @@ pub use fetch_asset::{AssetHandler, AssetResponder};
 pub(crate) use fetch_asset::{AsyncAssetHandlerFn, BlockingAssetHandlerFn};
 pub(crate) use server::{create_server, Server, ServerOptions};
 pub use server_listener::ServerListener;
-pub use ws_protocol::parameter::{Parameter, ParameterType, ParameterValue};
+pub use ws_protocol::parameter::{
+    DecodeError as ParameterDecodeError, Parameter, ParameterType, ParameterValue,
+};
 pub use ws_protocol::server::status::{Level as StatusLevel, Status};

--- a/rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
@@ -47,7 +47,8 @@ mod tests {
             Parameter::empty("empty"),
             Parameter::float64("f64", 1.23),
             Parameter::float64_array("f64[]", [1.23, 4.56]),
-            Parameter::byte_array("byte[]", [0x10, 0x20, 0x30]),
+            Parameter::string("str", "hello"),
+            Parameter::byte_array("byte[]", &[0x10, 0x20, 0x30]),
             Parameter::bool("bool", true),
         ])
     }

--- a/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode.snap
@@ -22,6 +22,10 @@ expression: message()
       ]
     },
     {
+      "name": "str",
+      "value": "hello"
+    },
+    {
       "name": "byte[]",
       "type": "byte_array",
       "value": "ECAw"

--- a/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode_with_id.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode_with_id.snap
@@ -22,6 +22,10 @@ expression: message_with_id()
       ]
     },
     {
+      "name": "str",
+      "value": "hello"
+    },
+    {
       "name": "byte[]",
       "type": "byte_array",
       "value": "ECAw"

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -2,9 +2,20 @@
 
 use std::collections::BTreeMap;
 
+use base64::prelude::*;
 use serde::{Deserialize, Serialize};
-use serde_with::base64::Base64;
 use serde_with::serde_as;
+
+/// Error encountered while trying to decide a base64-encoded byte array parameter value.
+#[derive(Debug, thiserror::Error)]
+pub enum DecodeError {
+    /// Parameter is not a byte-array.
+    #[error("Parameter is not a byte array")]
+    WrongType,
+    /// Invalid base64.
+    #[error(transparent)]
+    Base64(#[from] base64::DecodeError),
+}
 
 /// A parameter type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,8 +38,11 @@ pub enum ParameterValue {
     Number(f64),
     /// A boolean value.
     Bool(bool),
-    /// A byte array, encoded as a base64-encoded string.
-    String(#[serde_as(as = "Base64")] Vec<u8>),
+    /// A string value.
+    ///
+    /// For parameters of type [`ParameterType::ByteArray`], this is a base64 encoding of the byte
+    /// array.
+    String(String),
     /// An array of parameter values.
     Array(Vec<ParameterValue>),
     /// An associative map of parameter values.
@@ -83,16 +97,17 @@ impl Parameter {
         Self {
             name: name.into(),
             r#type: None,
-            value: Some(ParameterValue::String(value.into().into_bytes())),
+            value: Some(ParameterValue::String(value.into())),
         }
     }
 
     /// Creates a new parameter with a byte array value.
-    pub fn byte_array(name: impl Into<String>, data: impl Into<Vec<u8>>) -> Self {
+    pub fn byte_array(name: impl Into<String>, data: &[u8]) -> Self {
+        let value = BASE64_STANDARD.encode(data);
         Self {
             name: name.into(),
             r#type: Some(ParameterType::ByteArray),
-            value: Some(ParameterValue::String(data.into())),
+            value: Some(ParameterValue::String(value)),
         }
     }
 
@@ -113,10 +128,26 @@ impl Parameter {
             value: Some(ParameterValue::Dict(value)),
         }
     }
+
+    /// Decodes a byte array parameter.
+    ///
+    /// Returns None if the parameter is unset/empty. Returns an error if the parameter value is
+    /// not a byte array, or if it is not a valid base64 encoding.
+    pub fn decode_byte_array(&self) -> Result<Option<Vec<u8>>, DecodeError> {
+        match (self.r#type, self.value.as_ref()) {
+            (Some(ParameterType::ByteArray), Some(ParameterValue::String(s))) => {
+                Some(BASE64_STANDARD.decode(s).map_err(DecodeError::Base64)).transpose()
+            }
+            (_, None) => Ok(None),
+            _ => Err(DecodeError::WrongType),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
+
     use super::*;
 
     #[test]
@@ -141,7 +172,46 @@ mod tests {
 
     #[test]
     fn test_byte_array() {
-        insta::assert_json_snapshot!(Parameter::byte_array("byte[]", [0x10, 0x20, 0x30]));
+        insta::assert_json_snapshot!(Parameter::byte_array("byte[]", &[0x10, 0x20, 0x30]));
+    }
+
+    #[test]
+    fn test_decode_byte_array() {
+        let param = Parameter::byte_array("bytes", b"123");
+        let decoded = param.decode_byte_array().unwrap().unwrap();
+        assert_eq!(decoded, b"123".to_vec());
+
+        // invalid base64 value
+        let param = Parameter {
+            name: "invalid".into(),
+            r#type: Some(ParameterType::ByteArray),
+            value: Some(ParameterValue::String("!!".into())),
+        };
+        let result = param.decode_byte_array();
+        assert_matches!(result, Err(DecodeError::Base64(_)));
+
+        // it's a string, not a byte array
+        let param = Parameter::string("string", "eHl6enk=");
+        let result = param.decode_byte_array();
+        assert_matches!(result, Err(DecodeError::WrongType));
+
+        // unset
+        let param = Parameter {
+            name: "unset".into(),
+            r#type: Some(ParameterType::ByteArray),
+            value: None,
+        };
+        let result = param.decode_byte_array();
+        assert_matches!(result, Ok(None));
+
+        // unset of a different type
+        let param = Parameter {
+            name: "unset".into(),
+            r#type: None,
+            value: None,
+        };
+        let result = param.decode_byte_array();
+        assert_matches!(result, Ok(None));
     }
 
     #[test]

--- a/rust/foxglove/src/websocket/ws_protocol/server/parameter_values.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/server/parameter_values.rs
@@ -46,7 +46,8 @@ mod tests {
             Parameter::empty("empty"),
             Parameter::float64("f64", 1.23),
             Parameter::float64_array("f64[]", [1.23, 4.56]),
-            Parameter::byte_array("byte[]", [0x10, 0x20, 0x30]),
+            Parameter::string("str", "hello"),
+            Parameter::byte_array("byte[]", &[0x10, 0x20, 0x30]),
             Parameter::bool("bool", true),
         ])
     }

--- a/rust/foxglove/src/websocket/ws_protocol/server/snapshots/foxglove__websocket__ws_protocol__server__parameter_values__tests__encode.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/server/snapshots/foxglove__websocket__ws_protocol__server__parameter_values__tests__encode.snap
@@ -22,6 +22,10 @@ expression: message()
       ]
     },
     {
+      "name": "str",
+      "value": "hello"
+    },
+    {
       "name": "byte[]",
       "type": "byte_array",
       "value": "ECAw"

--- a/rust/foxglove/src/websocket/ws_protocol/server/snapshots/foxglove__websocket__ws_protocol__server__parameter_values__tests__encode_with_id.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/server/snapshots/foxglove__websocket__ws_protocol__server__parameter_values__tests__encode_with_id.snap
@@ -22,6 +22,10 @@ expression: message_with_id()
       ]
     },
     {
+      "name": "str",
+      "value": "hello"
+    },
+    {
       "name": "byte[]",
       "type": "byte_array",
       "value": "ECAw"

--- a/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__string.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__string.snap
@@ -4,5 +4,5 @@ expression: "Parameter::string(\"string\", \"howdy\")"
 ---
 {
   "name": "string",
-  "value": "aG93ZHk="
+  "value": "howdy"
 }


### PR DESCRIPTION
### Changelog
Breaking changes:
- String websocket parameters are not base64-encoded

### Description
I realized while plumbing C++ parameters that we're not representing string parameter values properly. The [example](https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#example-5) from the ws-protocol spec clearly shows that strings values are only supposed to be encoded when the parameter type is specified as `byte_array`.

This change:
- Replaces `ParameterValue::String(Vec<u8>)` with `ParameterValue::String(String)`.
- Adds `Parameter::decode_byte_array()` helper.
  - I didn't extend this to python yet, because we don't have the encode side either. (cf. FG-11299)
- Replaces python `ParameterValue.Bytes(value: bytes)` with `ParameterValue.String(value: str)`.