### PR TITLE
C/C++: Add support for websocket parameter subscriptions

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -374,9 +374,9 @@ typedef struct foxglove_server_callbacks {
    *
    * Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
    *
-   * The `params` argument is guaranteed to be non-NULL. This argument points to buffers that
-   * are valid and immutable for the duration of the call. If the callback wishes to store these
-   * values, they must be copied out.
+   * The `param_names` argument is guaranteed to be non-NULL. This argument points to buffers
+   * that are valid and immutable for the duration of the call. If the callback wishes to store
+   * these values, they must be copied out.
    */
   void (*on_parameters_subscribe)(const void *context,
                                   const struct foxglove_string *param_names,
@@ -386,9 +386,9 @@ typedef struct foxglove_server_callbacks {
    *
    * Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
    *
-   * The `params` argument is guaranteed to be non-NULL. This argument points to buffers that
-   * are valid and immutable for the duration of the call. If the callback wishes to store these
-   * values, they must be copied out.
+   * The `param_names` argument is guaranteed to be non-NULL. This argument points to buffers
+   * that are valid and immutable for the duration of the call. If the callback wishes to store
+   * these values, they must be copied out.
    */
   void (*on_parameters_unsubscribe)(const void *context,
                                     const struct foxglove_string *param_names,

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -369,11 +369,29 @@ typedef struct foxglove_server_callbacks {
                                                         uint32_t client_id,
                                                         const struct foxglove_string *request_id,
                                                         const struct foxglove_parameter_array *params);
+  /**
+   * Callback invoked when a client subscribes to the named parameters for the first time.
+   *
+   * Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
+   *
+   * The `params` argument is guaranteed to be non-NULL. This argument points to buffers that
+   * are valid and immutable for the duration of the call. If the callback wishes to store these
+   * values, they must be copied out.
+   */
   void (*on_parameters_subscribe)(const void *context,
-                                  const char *const *param_names,
+                                  const struct foxglove_string *param_names,
                                   size_t param_names_len);
+  /**
+   * Callback invoked when the last client unsubscribes from the named parameters.
+   *
+   * Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
+   *
+   * The `params` argument is guaranteed to be non-NULL. This argument points to buffers that
+   * are valid and immutable for the duration of the call. If the callback wishes to store these
+   * values, they must be copied out.
+   */
   void (*on_parameters_unsubscribe)(const void *context,
-                                    const char *const *param_names,
+                                    const struct foxglove_string *param_names,
                                     size_t param_names_len);
   void (*on_connection_graph_subscribe)(const void *context);
   void (*on_connection_graph_unsubscribe)(const void *context);

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -369,6 +369,12 @@ typedef struct foxglove_server_callbacks {
                                                         uint32_t client_id,
                                                         const struct foxglove_string *request_id,
                                                         const struct foxglove_parameter_array *params);
+  void (*on_parameters_subscribe)(const void *context,
+                                  const char *const *param_names,
+                                  size_t param_names_len);
+  void (*on_parameters_unsubscribe)(const void *context,
+                                    const char *const *param_names,
+                                    size_t param_names_len);
   void (*on_connection_graph_subscribe)(const void *context);
   void (*on_connection_graph_unsubscribe)(const void *context);
 } foxglove_server_callbacks;
@@ -468,6 +474,16 @@ uint16_t foxglove_server_get_port(struct foxglove_websocket_server *server);
  * Stop and shut down `server` and free the resources associated with it.
  */
 foxglove_error foxglove_server_stop(struct foxglove_websocket_server *server);
+
+/**
+ * Publish parameter values to all subscribed clients.
+ *
+ * # Safety
+ * - `params` must be a valid parameter to a value allocated by `foxglove_parameter_array_create`.
+ *   This value is moved into this function, and must not be accessed afterwards.
+ */
+foxglove_error foxglove_server_publish_parameter_values(struct foxglove_websocket_server *server,
+                                                        struct foxglove_parameter_array *params);
 
 /**
  * Publish a connection graph to the server.

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -284,9 +284,9 @@ pub struct FoxgloveServerCallbacks {
     ///
     /// Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
     ///
-    /// The `params` argument is guaranteed to be non-NULL. This argument points to buffers that
-    /// are valid and immutable for the duration of the call. If the callback wishes to store these
-    /// values, they must be copied out.
+    /// The `param_names` argument is guaranteed to be non-NULL. This argument points to buffers
+    /// that are valid and immutable for the duration of the call. If the callback wishes to store
+    /// these values, they must be copied out.
     pub on_parameters_subscribe: Option<
         unsafe extern "C" fn(
             context: *const c_void,
@@ -298,9 +298,9 @@ pub struct FoxgloveServerCallbacks {
     ///
     /// Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
     ///
-    /// The `params` argument is guaranteed to be non-NULL. This argument points to buffers that
-    /// are valid and immutable for the duration of the call. If the callback wishes to store these
-    /// values, they must be copied out.
+    /// The `param_names` argument is guaranteed to be non-NULL. This argument points to buffers
+    /// that are valid and immutable for the duration of the call. If the callback wishes to store
+    /// these values, they must be copied out.
     pub on_parameters_unsubscribe: Option<
         unsafe extern "C" fn(
             context: *const c_void,

--- a/cpp/examples/param-server/src/main.cpp
+++ b/cpp/examples/param-server/src/main.cpp
@@ -104,6 +104,18 @@ int main(int argc, const char* argv[]) {
     }
     return result;
   };
+  options.callbacks.onParametersSubscribe = [](const std::vector<std::string>& names) {
+    std::cerr << "onParametersSubscribe called for parameters:\n";
+    for (const auto& name : names) {
+      std::cerr << " - " << name << "\n";
+    }
+  };
+  options.callbacks.onParametersUnsubscribe = [](const std::vector<std::string>& names) {
+    std::cerr << "onParametersUnsubscribe called for parameters:\n";
+    for (const auto& name : names) {
+      std::cerr << " - " << name << "\n";
+    }
+  };
 
   auto server_result = foxglove::WebSocketServer::create(std::move(options));
   if (!server_result.has_value()) {
@@ -127,7 +139,11 @@ int main(int argc, const char* argv[]) {
     // Update elapsed time
     auto now = std::chrono::steady_clock::now();
     auto elapsed = std::chrono::duration<double>(now - start_time).count();
-    param_store.insert_or_assign("elapsed", foxglove::Parameter("elapsed", elapsed));
+    auto param = foxglove::Parameter("elapsed", elapsed);
+    param_store.insert_or_assign("elapsed", param.clone());
+    std::vector<foxglove::Parameter> params;
+    params.emplace_back(std::move(param));
+    server.publishParameterValues(std::move(params));
   }
 
   std::cerr << "Done\n";

--- a/cpp/examples/param-server/src/main.cpp
+++ b/cpp/examples/param-server/src/main.cpp
@@ -104,13 +104,13 @@ int main(int argc, const char* argv[]) {
     }
     return result;
   };
-  options.callbacks.onParametersSubscribe = [](const std::vector<std::string>& names) {
+  options.callbacks.onParametersSubscribe = [](const std::vector<std::string_view>& names) {
     std::cerr << "onParametersSubscribe called for parameters:\n";
     for (const auto& name : names) {
       std::cerr << " - " << name << "\n";
     }
   };
-  options.callbacks.onParametersUnsubscribe = [](const std::vector<std::string>& names) {
+  options.callbacks.onParametersUnsubscribe = [](const std::vector<std::string_view>& names) {
     std::cerr << "onParametersUnsubscribe called for parameters:\n";
     for (const auto& name : names) {
       std::cerr << " - " << name << "\n";

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -130,8 +130,8 @@ struct WebSocketServerCallbacks {
   )>
     onSetParameters;
 
-  std::function<void(const std::vector<std::string>& param_names)> onParametersSubscribe;
-  std::function<void(const std::vector<std::string>& param_names)> onParametersUnsubscribe;
+  std::function<void(const std::vector<std::string_view>& param_names)> onParametersSubscribe;
+  std::function<void(const std::vector<std::string_view>& param_names)> onParametersUnsubscribe;
 
   /// @brief Callback invoked when a client requests connection graph updates.
   ///

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -130,7 +130,16 @@ struct WebSocketServerCallbacks {
   )>
     onSetParameters;
 
+  /// Callback invoked when a client subscribes to the named parameters for the
+  /// first time.
+  ///
+  /// Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
   std::function<void(const std::vector<std::string_view>& param_names)> onParametersSubscribe;
+
+  /// Callback invoked when the last client unsubscribes from the named
+  /// parameters.
+  ///
+  /// Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
   std::function<void(const std::vector<std::string_view>& param_names)> onParametersUnsubscribe;
 
   /// @brief Callback invoked when a client requests connection graph updates.

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -130,6 +130,9 @@ struct WebSocketServerCallbacks {
   )>
     onSetParameters;
 
+  std::function<void(const std::vector<std::string>& param_names)> onParametersSubscribe;
+  std::function<void(const std::vector<std::string>& param_names)> onParametersUnsubscribe;
+
   /// @brief Callback invoked when a client requests connection graph updates.
   ///
   /// Requires the capability WebSocketServerCapabilities::ConnectionGraph
@@ -177,6 +180,8 @@ public:
 
   /// @brief Gracefully shut down the websocket server.
   FoxgloveError stop();
+
+  void publishParameterValues(std::vector<Parameter>&& params);
 
   /// @brief Publish a connection graph to all subscribed clients.
   ///

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -130,16 +130,20 @@ struct WebSocketServerCallbacks {
   )>
     onSetParameters;
 
-  /// Callback invoked when a client subscribes to the named parameters for the
-  /// first time.
+  /// @brief Callback invoked when a client subscribes to the named parameters
+  /// for the first time.
   ///
-  /// Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
+  /// Requires the capability WebSocketServerCapabilities::Parameters.
+  ///
+  /// @param param_names A list of parameter names.
   std::function<void(const std::vector<std::string_view>& param_names)> onParametersSubscribe;
 
-  /// Callback invoked when the last client unsubscribes from the named
+  /// @brief Callback invoked when the last client unsubscribes from the named
   /// parameters.
   ///
-  /// Requires `FOXGLOVE_CAPABILITY_PARAMETERS`.
+  /// Requires the capability WebSocketServerCapabilities::Parameters.
+  ///
+  /// @param param_names A list of parameter names.
   std::function<void(const std::vector<std::string_view>& param_names)> onParametersUnsubscribe;
 
   /// @brief Callback invoked when a client requests connection graph updates.
@@ -190,6 +194,11 @@ public:
   /// @brief Gracefully shut down the websocket server.
   FoxgloveError stop();
 
+  /// @brief Publishes parameter values to all subscribed clients.
+  ///
+  /// Requires the capability WebSocketServerCapabilities::Parameters.
+  ///
+  /// @param params Updated parameters.
   void publishParameterValues(std::vector<Parameter>&& params);
 
   /// @brief Publish a connection graph to all subscribed clients.

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -166,7 +166,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
           try {
             (static_cast<const WebSocketServerCallbacks*>(context))->onParametersSubscribe(names);
           } catch (const std::exception& exc) {
-            std::cerr << "onParametersSubscribe callback failed: " << exc.what() << "\n";
+            warn() << "onParametersSubscribe callback failed: " << exc.what();
           }
         };
     }
@@ -181,7 +181,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
           try {
             (static_cast<const WebSocketServerCallbacks*>(context))->onParametersUnsubscribe(names);
           } catch (const std::exception& exc) {
-            std::cerr << "onParametersUnsubscribe callback failed: " << exc.what() << "\n";
+            warn() << "onParametersUnsubscribe callback failed: " << exc.what();
           }
         };
     }

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -163,7 +163,11 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
           for (auto i = 0; i < names_len; ++i) {
             names.emplace_back(c_names[i].data, c_names[i].len);
           }
-          (static_cast<const WebSocketServerCallbacks*>(context))->onParametersSubscribe(names);
+          try {
+            (static_cast<const WebSocketServerCallbacks*>(context))->onParametersSubscribe(names);
+          } catch (const std::exception& exc) {
+            std::cerr << "onParametersSubscribe callback failed: " << exc.what() << "\n";
+          }
         };
     }
     if (callbacks->onParametersUnsubscribe) {
@@ -174,7 +178,11 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
           for (auto i = 0; i < names_len; ++i) {
             names.emplace_back(c_names[i].data, c_names[i].len);
           }
-          (static_cast<const WebSocketServerCallbacks*>(context))->onParametersUnsubscribe(names);
+          try {
+            (static_cast<const WebSocketServerCallbacks*>(context))->onParametersUnsubscribe(names);
+          } catch (const std::exception& exc) {
+            std::cerr << "onParametersUnsubscribe callback failed: " << exc.what() << "\n";
+          }
         };
     }
     if (callbacks->onConnectionGraphSubscribe) {

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -157,22 +157,22 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
     }
     if (callbacks->onParametersSubscribe) {
       c_callbacks.on_parameters_subscribe =
-        [](const void* context, const char* const* c_names, size_t names_len) {
-          std::vector<std::string> names;
+        [](const void* context, const struct foxglove_string* c_names, size_t names_len) {
+          std::vector<std::string_view> names;
           names.reserve(names_len);
           for (auto i = 0; i < names_len; ++i) {
-            names.emplace_back(c_names[i]);
+            names.emplace_back(c_names[i].data, c_names[i].len);
           }
           (static_cast<const WebSocketServerCallbacks*>(context))->onParametersSubscribe(names);
         };
     }
     if (callbacks->onParametersUnsubscribe) {
       c_callbacks.on_parameters_unsubscribe =
-        [](const void* context, const char* const* c_names, size_t names_len) {
-          std::vector<std::string> names;
+        [](const void* context, const struct foxglove_string* c_names, size_t names_len) {
+          std::vector<std::string_view> names;
           names.reserve(names_len);
           for (auto i = 0; i < names_len; ++i) {
-            names.emplace_back(c_names[i]);
+            names.emplace_back(c_names[i].data, c_names[i].len);
           }
           (static_cast<const WebSocketServerCallbacks*>(context))->onParametersUnsubscribe(names);
         };

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -102,17 +102,36 @@ private:
   bool closed_{};
 };
 
+foxglove::WebSocketServer startServer(foxglove::WebSocketServerOptions&& options) {
+  auto result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(result.has_value());
+  auto server = std::move(result.value());
+  REQUIRE(server.port() != 0);
+  return server;
+}
+
+foxglove::WebSocketServer startServer(
+  foxglove::Context context,
+  foxglove::WebSocketServerCapabilities capabilities = foxglove::WebSocketServerCapabilities(0),
+  foxglove::WebSocketServerCallbacks&& callbacks = {},
+  std::vector<std::string> supported_encodings = {}
+) {
+  return startServer({
+    std::move(context),
+    "unit-test",
+    "127.0.0.1",
+    0,
+    std::move(callbacks),
+    capabilities,
+    std::move(supported_encodings),
+  });
+}
+
 }  // namespace
 
 TEST_CASE("Start and stop server") {
-  foxglove::WebSocketServerOptions options;
-  options.name = "unit-test";
-  options.host = "127.0.0.1";
-  options.port = 0;
-  auto server_result = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(server_result.has_value());
-  auto& server = server_result.value();
-  REQUIRE(server.port() != 0);
+  auto context = foxglove::Context::create();
+  auto server = startServer(context);
   REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }
 
@@ -148,14 +167,7 @@ TEST_CASE("supported encoding is invalid utf-8") {
 
 TEST_CASE("Log a message with and without metadata") {
   auto context = foxglove::Context::create();
-  foxglove::WebSocketServerOptions options{context};
-  options.name = "unit-test";
-  options.host = "127.0.0.1";
-  options.port = 0;
-  auto server_result = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(server_result.has_value());
-  auto& server = server_result.value();
-  REQUIRE(server.port() != 0);
+  auto server = startServer(context);
 
   auto channel_result = foxglove::Channel::create("example", "json", std::nullopt, context);
   REQUIRE(channel_result.has_value());
@@ -182,24 +194,18 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
 
   std::unique_lock lock{mutex};
 
-  foxglove::WebSocketServerOptions options{context};
-  options.name = "unit-test";
-  options.host = "127.0.0.1";
-  options.port = 0;
-  options.callbacks.onSubscribe = [&](uint64_t channel_id) {
+  foxglove::WebSocketServerCallbacks callbacks;
+  callbacks.onSubscribe = [&](uint64_t channel_id) {
     std::scoped_lock lock{mutex};
     subscribe_calls.push_back(channel_id);
     cv.notify_all();
   };
-  options.callbacks.onUnsubscribe = [&](uint64_t channel_id) {
+  callbacks.onUnsubscribe = [&](uint64_t channel_id) {
     std::scoped_lock lock{mutex};
     unsubscribe_calls.push_back(channel_id);
     cv.notify_all();
   };
-  auto server_result = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(server_result.has_value());
-  auto& server = server_result.value();
-  REQUIRE(server.port() != 0);
+  auto server = startServer(context, {}, std::move(callbacks));
 
   foxglove::Schema schema;
   schema.name = "ExampleSchema";
@@ -278,29 +284,23 @@ TEST_CASE("Client advertise/publish callbacks") {
 
   std::unique_lock lock{mutex};
 
-  foxglove::WebSocketServerOptions options{context};
-  options.name = "unit-test";
-  options.host = "127.0.0.1";
-  options.port = 0;
-  options.capabilities = foxglove::WebSocketServerCapabilities::ClientPublish;
-  options.supported_encodings = {"schema encoding", "another"};
-  options.callbacks.onClientAdvertise =
-    [&](uint32_t client_id, const foxglove::ClientChannel& channel) {
-      std::scoped_lock lock{mutex};
-      advertised = true;
-      REQUIRE(client_id == 1);
-      REQUIRE(channel.id == 100);
-      REQUIRE(channel.topic == "topic");
-      REQUIRE(channel.encoding == "encoding");
-      REQUIRE(channel.schema_name == "schema name");
-      REQUIRE(channel.schema_encoding == "schema encoding");
-      REQUIRE(
-        std::string_view(reinterpret_cast<const char*>(channel.schema), channel.schema_len) ==
-        "schema data"
-      );
-      cv.notify_all();
-    };
-  options.callbacks.onMessageData =
+  foxglove::WebSocketServerCallbacks callbacks;
+  callbacks.onClientAdvertise = [&](uint32_t client_id, const foxglove::ClientChannel& channel) {
+    std::scoped_lock lock{mutex};
+    advertised = true;
+    REQUIRE(client_id == 1);
+    REQUIRE(channel.id == 100);
+    REQUIRE(channel.topic == "topic");
+    REQUIRE(channel.encoding == "encoding");
+    REQUIRE(channel.schema_name == "schema name");
+    REQUIRE(channel.schema_encoding == "schema encoding");
+    REQUIRE(
+      std::string_view(reinterpret_cast<const char*>(channel.schema), channel.schema_len) ==
+      "schema data"
+    );
+    cv.notify_all();
+  };
+  callbacks.onMessageData =
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     [&](uint32_t client_id, uint32_t client_channel_id, const std::byte* data, size_t data_len) {
       std::scoped_lock lock{mutex};
@@ -312,17 +312,19 @@ TEST_CASE("Client advertise/publish callbacks") {
       REQUIRE(char(data[2]) == 'c');
       cv.notify_all();
     };
-  options.callbacks.onClientUnadvertise = [&](uint32_t client_id, uint32_t client_channel_id) {
+  callbacks.onClientUnadvertise = [&](uint32_t client_id, uint32_t client_channel_id) {
     std::scoped_lock lock{mutex};
     advertised = false;
     REQUIRE(client_id == 1);
     REQUIRE(client_channel_id == 100);
     cv.notify_all();
   };
-  auto server_result = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(server_result.has_value());
-  auto& server = server_result.value();
-  REQUIRE(server.port() != 0);
+  auto server = startServer(
+    context,
+    foxglove::WebSocketServerCapabilities::ClientPublish,
+    std::move(callbacks),
+    {"schema encoding", "another"}
+  );
 
   WebSocketClient client;
   client.inner().set_open_handler([&](const auto& hdl) {
@@ -380,17 +382,13 @@ TEST_CASE("Parameter callbacks") {
     server_set_parameters;
   std::queue<std::string> client_rx;
 
-  foxglove::WebSocketServerOptions options;
-  options.name = "unit-test";
-  options.host = "127.0.0.1";
-  options.port = 0;
-  options.capabilities = foxglove::WebSocketServerCapabilities::Parameters;
-  options.callbacks.onGetParameters = [&](
-                                        uint32_t client_id,
-                                        std::optional<std::string_view>
-                                          request_id,
-                                        const std::vector<std::string_view>& param_names
-                                      ) -> std::vector<foxglove::Parameter> {
+  foxglove::WebSocketServerCallbacks callbacks;
+  callbacks.onGetParameters = [&](
+                                uint32_t client_id,
+                                std::optional<std::string_view>
+                                  request_id,
+                                const std::vector<std::string_view>& param_names
+                              ) -> std::vector<foxglove::Parameter> {
     std::scoped_lock lock{mutex};
     std::optional<std::string> owned_request_id;
     if (request_id.has_value()) {
@@ -409,12 +407,12 @@ TEST_CASE("Parameter callbacks") {
     result.emplace_back("baz", 1.234);
     return result;
   };
-  options.callbacks.onSetParameters = [&](
-                                        uint32_t client_id,
-                                        std::optional<std::string_view>
-                                          request_id,
-                                        const std::vector<foxglove::ParameterView>& params
-                                      ) -> std::vector<foxglove::Parameter> {
+  callbacks.onSetParameters = [&](
+                                uint32_t client_id,
+                                std::optional<std::string_view>
+                                  request_id,
+                                const std::vector<foxglove::ParameterView>& params
+                              ) -> std::vector<foxglove::Parameter> {
     std::scoped_lock lock{mutex};
     std::optional<std::string> owned_request_id;
     if (request_id.has_value()) {
@@ -434,10 +432,9 @@ TEST_CASE("Parameter callbacks") {
     result.emplace_back("bytes", data.data(), data.size());
     return result;
   };
-  auto server_result = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(server_result.has_value());
-  auto& server = server_result.value();
-  REQUIRE(server.port() != 0);
+  auto context = foxglove::Context::create();
+  auto server =
+    startServer(context, foxglove::WebSocketServerCapabilities::Parameters, std::move(callbacks));
 
   WebSocketClient client;
   client.inner().set_open_handler([&](const auto& hdl) {
@@ -599,22 +596,122 @@ TEST_CASE("Parameter callbacks") {
   REQUIRE(parsed == expected);
 }
 
-TEST_CASE("Publish a connection graph") {
-  foxglove::WebSocketServerOptions options;
-  options.name = "unit-test";
-  options.host = "127.0.0.1";
-  options.port = 0;
-  options.capabilities = foxglove::WebSocketServerCapabilities::ConnectionGraph;
-  auto server_result = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(server_result.has_value());
-  auto& server = server_result.value();
-  REQUIRE(server.port() != 0);
+TEST_CASE("Parameter subscription callbacks") {
+  std::mutex mutex;
+  std::condition_variable cv;
+  // the following variables are protected by the mutex:
+  bool connection_opened = false;
+  std::optional<std::vector<std::string>> server_sub_names;
+  std::optional<std::vector<std::string>> server_unsub_names;
+  std::queue<std::string> client_rx;
 
+  foxglove::WebSocketServerCallbacks callbacks;
+  callbacks.onParametersSubscribe = [&](const std::vector<std::string>& names) {
+    std::scoped_lock lock{mutex};
+    server_sub_names = names;
+    cv.notify_one();
+  };
+  callbacks.onParametersUnsubscribe = [&](const std::vector<std::string>& names) {
+    std::scoped_lock lock{mutex};
+    server_unsub_names = names;
+    cv.notify_one();
+  };
+  auto context = foxglove::Context::create();
+  auto server =
+    startServer(context, foxglove::WebSocketServerCapabilities::Parameters, std::move(callbacks));
+
+  WebSocketClient client;
+  client.inner().set_open_handler([&](const auto& hdl) {
+    std::scoped_lock lock{mutex};
+    connection_opened = true;
+    cv.notify_one();
+  });
+  client.inner().set_message_handler(
+    [&](const websocketpp::connection_hdl&, const WebSocketMessage& msg) {
+      std::scoped_lock lock{mutex};
+      client_rx.push(msg->get_payload());
+      cv.notify_one();
+    }
+  );
+  client.start(server.port());
+
+  // Wait for the connection to be opened.
+  {
+    std::unique_lock lock{mutex};
+    auto wait_result = cv.wait_for(lock, std::chrono::seconds(1), [&] {
+      return connection_opened;
+    });
+    REQUIRE(wait_result);
+  }
+
+  // Wait for the the serverInfo message.
+  std::string payload;
+  {
+    std::unique_lock lock{mutex};
+    auto wait_result = cv.wait_for(lock, std::chrono::seconds(1), [&] {
+      return !client_rx.empty();
+    });
+    REQUIRE(wait_result);
+    payload = client_rx.front();
+    client_rx.pop();
+  }
+  Json parsed = Json::parse(payload);
+  REQUIRE(parsed.contains("op"));
+  REQUIRE(parsed["op"] == "serverInfo");
+
+  // Send subscribeParameterUpdates.
+  client.send(
+    R"({
+      "op": "subscribeParameterUpdates",
+      "parameterNames": ["foo", "beep"]
+    })"
+  );
+
+  // Wait for the server to process the callback.
+  {
+    std::unique_lock lock{mutex};
+    auto wait_result = cv.wait_for(lock, std::chrono::seconds(1), [&] {
+      if (server_sub_names.has_value()) {
+        auto names = *server_sub_names;
+        REQUIRE_THAT(names, Equals(std::vector<std::string>{"foo", "beep"}));
+        return true;
+      }
+      return false;
+    });
+    REQUIRE(wait_result);
+  }
+
+  // Send a parameter update from the server, including some parameters that we
+  // expect to be filtered out, since they aren't subscribed.
+  std::vector<foxglove::Parameter> params;
+  params.emplace_back("baz", 1.234);
+  params.emplace_back("beep", "boop");
+  server.publishParameterValues(std::move(params));
+
+  // Wait for the server to send the parameterValues message and validate it.
+  {
+    std::unique_lock lock{mutex};
+    auto wait_result = cv.wait_for(lock, std::chrono::seconds(1), [&] {
+      return !client_rx.empty();
+    });
+    REQUIRE(wait_result);
+    payload = client_rx.front();
+    client_rx.pop();
+  }
+  parsed = Json::parse(payload);
+  auto expected = Json::parse(R"({
+      "op": "parameterValues",
+      "parameters": [{ "name": "beep", "value": "boop" }]
+    })");
+  REQUIRE(parsed == expected);
+}
+
+TEST_CASE("Publish a connection graph") {
+  auto context = foxglove::Context::create();
+  auto server = startServer(context, foxglove::WebSocketServerCapabilities::ConnectionGraph);
   foxglove::ConnectionGraph graph;
   graph.setPublishedTopic("topic", {"publisher1", "publisher2"});
   graph.setSubscribedTopic("topic", {"subscriber1", "subscriber2"});
   graph.setAdvertisedService("service", {"provider1", "provider2"});
   server.publishConnectionGraph(graph);
-
-  REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -249,6 +249,8 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
     return !unsubscribe_calls.empty();
   });
   REQUIRE_THAT(unsubscribe_calls, Equals(std::vector<uint64_t>{1}));
+
+  REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }
 
 TEST_CASE("Capability enums") {
@@ -369,6 +371,8 @@ TEST_CASE("Client advertise/publish callbacks") {
   cv.wait(lock, [&] {
     return !advertised;
   });
+
+  REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }
 
 TEST_CASE("Parameter callbacks") {
@@ -594,6 +598,8 @@ TEST_CASE("Parameter callbacks") {
       ]
     })");
   REQUIRE(parsed == expected);
+
+  REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }
 
 TEST_CASE("Parameter subscription callbacks") {
@@ -712,6 +718,8 @@ TEST_CASE("Parameter subscription callbacks") {
       "parameters": [{ "name": "beep", "value": "boop" }]
     })");
   REQUIRE(parsed == expected);
+
+  REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }
 
 TEST_CASE("Publish a connection graph") {

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -606,14 +606,22 @@ TEST_CASE("Parameter subscription callbacks") {
   std::queue<std::string> client_rx;
 
   foxglove::WebSocketServerCallbacks callbacks;
-  callbacks.onParametersSubscribe = [&](const std::vector<std::string>& names) {
+  callbacks.onParametersSubscribe = [&](const std::vector<std::string_view>& names) {
     std::scoped_lock lock{mutex};
-    server_sub_names = names;
+    server_sub_names.emplace();
+    server_sub_names->reserve(names.size());
+    for (const auto& name : names) {
+      server_sub_names->emplace_back(name);
+    }
     cv.notify_one();
   };
-  callbacks.onParametersUnsubscribe = [&](const std::vector<std::string>& names) {
+  callbacks.onParametersUnsubscribe = [&](const std::vector<std::string_view>& names) {
     std::scoped_lock lock{mutex};
-    server_unsub_names = names;
+    server_unsub_names.emplace();
+    server_unsub_names->reserve(names.size());
+    for (const auto& name : names) {
+      server_unsub_names->emplace_back(name);
+    }
     cv.notify_one();
   };
   auto context = foxglove::Context::create();


### PR DESCRIPTION
### Changelog
- C/C++: Add support for websocket parameters

### Description
This change is a follow-up on #383, to finish adding support for websocket parameter subscriptions and publishing.

I tried to remove a little boilerplate for the server setup in our tests. While I was doing that, I noticed that the C++ WebSocketServer is RAII - it shuts down the server when it is dropped. So I got rid of some explicit `server.stop()` calls too.