### PR TITLE
python: Improved websocket parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
 name = "foxglove-sdk-python"
 version = "0.6.2"
 dependencies = [
+ "base64",
  "bytes",
  "env_logger",
  "foxglove",

--- a/python/foxglove-sdk-examples/ws-param-server/main.py
+++ b/python/foxglove-sdk-examples/ws-param-server/main.py
@@ -10,13 +10,7 @@ import time
 from typing import List, Optional
 
 import foxglove
-from foxglove.websocket import (
-    Capability,
-    Client,
-    Parameter,
-    ParameterType,
-    ParameterValue,
-)
+from foxglove.websocket import Capability, Client, Parameter
 
 
 class ParameterStore(foxglove.websocket.ServerListener):
@@ -72,21 +66,21 @@ def main() -> None:
     foxglove.set_log_level(logging.DEBUG)
 
     initial_values: list[Parameter] = [
+        Parameter("p0"),
         Parameter(
-            "param1",
-            value=ParameterValue.Dict(
-                {
-                    "a": ParameterValue.Number(1),
-                    "b": ParameterValue.Bool(True),
-                    "c": ParameterValue.String("hello"),
-                    "arr": ParameterValue.Array(
-                        [ParameterValue.Number(1), ParameterValue.Bool(True)]
-                    ),
-                }
-            ),
+            "p1",
+            value={
+                "a": 1,
+                "b": True,
+                "c": "hello",
+                "arr": [1, True],
+            },
         ),
-        Parameter("param2"),
-        Parameter("p3", value=ParameterValue.Number(0.124), type=ParameterType.Float64),
+        Parameter("p2", value=True),
+        Parameter("p3", value=0.124),
+        Parameter("p4", value=[1, 1, 2, 3, 5]),
+        Parameter("p5", value=b"data"),
+        Parameter("p6", value="hello"),
     ]
 
     store = ParameterStore(initial_values)

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -12,13 +12,14 @@ crate-type = ["cdylib"]
 workspace = true
 
 [dependencies]
+base64 = "0.22.1"
 bytes.workspace = true
 env_logger = "0.11.5"
+foxglove = { path = "../../rust/foxglove", features = ["unstable"] }
 log = "0.4.22"
 prost-types = "0.13"
 pyo3 = "0.24.1"
 pyo3-log = "0.12.3"
-foxglove = { path = "../../rust/foxglove", features = ["unstable"] }
 thiserror.workspace = true
 tokio-tungstenite.workspace = true
 tokio-util.workspace = true

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -104,7 +104,12 @@ class MessageSchema:
 
 class Parameter:
     """
-    A parameter.
+    A parameter which can be sent to a client.
+
+    :param name: The parameter name.
+    :type name: str
+    :param value: Optional value, represented as a native python object.
+    :type value: AnyNativeParameterValue
     """
 
     name: str
@@ -123,8 +128,22 @@ class Parameter:
         *,
         type: Optional["ParameterType"],
         value: Optional["AnyParameterValue"],
-    ) -> "Parameter": ...
-    def get_value(self) -> "AnyNativeParameterValue": ...
+    ) -> "Parameter":
+        """
+        Constructs a parameter from raw parts
+
+        :param name: The parameter name.
+        :type name: str
+        :param type: Optional type.
+        :type type: ParameterType
+        :param value: Optional value, represented as a raw parameter value.
+        :type value: ParameterValue
+        """
+        ...
+
+    def get_value(self) -> "AnyNativeParameterValue":
+        """Returns the parameter value as a native python object."""
+        ...
 
 class ParameterType(Enum):
     """
@@ -142,7 +161,7 @@ class ParameterType(Enum):
 
 class ParameterValue:
     """
-    The value of a parameter, as it is represented on the wire.
+    The raw value of a parameter, as it is represented on the wire.
     """
 
     class Bool:

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -108,8 +108,11 @@ class Parameter:
 
     :param name: The parameter name.
     :type name: str
-    :param value: Optional value, represented as a native python object.
-    :type value: AnyNativeParameterValue
+    :param value: Optional value, represented as a native python object, or a ParameterValue.
+    :type value: None|bool|float|str|bytes|list|dict|ParameterValue
+    :param type: Optional parameter type. This is automatically derived when passing a native
+                 python object as the value.
+    :type type: ParameterType|None
     """
 
     name: str
@@ -121,27 +124,9 @@ class Parameter:
         name: str,
         *,
         value: Optional["AnyNativeParameterValue"] = None,
+        type: Optional["ParameterType"] = None,
     ) -> None: ...
-    @staticmethod
-    def raw(
-        name: str,
-        *,
-        type: Optional["ParameterType"],
-        value: Optional["AnyParameterValue"],
-    ) -> "Parameter":
-        """
-        Constructs a parameter from raw parts
-
-        :param name: The parameter name.
-        :type name: str
-        :param type: Optional type.
-        :type type: ParameterType
-        :param value: Optional value, represented as a raw parameter value.
-        :type value: ParameterValue
-        """
-        ...
-
-    def get_value(self) -> "AnyNativeParameterValue":
+    def get_value(self) -> Optional["AnyNativeParameterValue"]:
         """Returns the parameter value as a native python object."""
         ...
 
@@ -161,7 +146,7 @@ class ParameterType(Enum):
 
 class ParameterValue:
     """
-    The raw value of a parameter, as it is represented on the wire.
+    A parameter value.
     """
 
     class Bool:
@@ -206,21 +191,18 @@ AnyParameterValue = Union[
     ParameterValue.Dict,
 ]
 
-AnyNativeParameterValue = Union[
+AnyInnerParameterValue = Union[
+    AnyParameterValue,
     bool,
     float,
     str,
-    bytes,
     List["AnyInnerParameterValue"],
     Dict[str, "AnyInnerParameterValue"],
 ]
 
-AnyInnerParameterValue = Union[
-    bool,
-    float,
-    str,
-    List["AnyInnerParameterValue"],
-    Dict[str, "AnyInnerParameterValue"],
+AnyNativeParameterValue = Union[
+    AnyInnerParameterValue,
+    bytes,
 ]
 
 AssetHandler = Callable[[str], Optional[bytes]]

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import foxglove
 
@@ -115,9 +115,16 @@ class Parameter:
         self,
         name: str,
         *,
-        type: Optional["ParameterType"] = None,
-        value: Optional["AnyParameterValue"] = None,
+        value: Optional["AnyNativeParameterValue"] = None,
     ) -> None: ...
+    @staticmethod
+    def raw(
+        name: str,
+        *,
+        type: Optional["ParameterType"],
+        value: Optional["AnyParameterValue"],
+    ) -> "Parameter": ...
+    def get_value(self) -> "AnyNativeParameterValue": ...
 
 class ParameterType(Enum):
     """
@@ -135,7 +142,7 @@ class ParameterType(Enum):
 
 class ParameterValue:
     """
-    The value of a parameter.
+    The value of a parameter, as it is represented on the wire.
     """
 
     class Bool:
@@ -178,6 +185,23 @@ AnyParameterValue = Union[
     ParameterValue.String,
     ParameterValue.Array,
     ParameterValue.Dict,
+]
+
+AnyNativeParameterValue = Union[
+    bool,
+    float,
+    str,
+    bytes,
+    List["AnyInnerParameterValue"],
+    Dict[str, "AnyInnerParameterValue"],
+]
+
+AnyInnerParameterValue = Union[
+    bool,
+    float,
+    str,
+    List["AnyInnerParameterValue"],
+    Dict[str, "AnyInnerParameterValue"],
 ]
 
 AssetHandler = Callable[[str], Optional[bytes]]

--- a/python/foxglove-sdk/python/foxglove/tests/test_parameters.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_parameters.py
@@ -1,0 +1,111 @@
+from foxglove.websocket import (
+    AnyNativeParameterValue,
+    Parameter,
+    ParameterType,
+    ParameterValue,
+)
+
+
+def test_empty() -> None:
+    p = Parameter("empty")
+    assert p.name == "empty"
+    assert p.type is None
+    assert p.value is None
+    assert p.get_value() is None
+
+
+def test_float() -> None:
+    p = Parameter("float", value=1.234)
+    assert p.name == "float"
+    assert p.type == ParameterType.Float64
+    assert p.value == ParameterValue.Number(1.234)
+    assert p.get_value() == 1.234
+
+
+def test_int() -> None:
+    p = Parameter("int", value=1)
+    assert p.name == "int"
+    assert p.type == ParameterType.Float64
+    assert p.value == ParameterValue.Number(1)
+    assert type(p.get_value()) is float
+    assert p.get_value() == 1
+
+
+def test_float_array() -> None:
+    v: AnyNativeParameterValue = [1, 2, 3]
+    p = Parameter("float_array", value=v)
+    assert p.name == "float_array"
+    assert p.type == ParameterType.Float64Array
+    assert p.value == ParameterValue.Array(
+        [
+            ParameterValue.Number(1),
+            ParameterValue.Number(2),
+            ParameterValue.Number(3),
+        ]
+    )
+    assert p.get_value() == v
+
+
+def test_heterogeneous_array() -> None:
+    v: AnyNativeParameterValue = ["a", 2, False]
+    p = Parameter("heterogeneous_array", value=v)
+    assert p.name == "heterogeneous_array"
+    assert p.type is None
+    assert p.value == ParameterValue.Array(
+        [
+            ParameterValue.String("a"),
+            ParameterValue.Number(2),
+            ParameterValue.Bool(False),
+        ]
+    )
+    assert p.get_value() == v
+
+
+def test_string() -> None:
+    p = Parameter("string", value="hello")
+    assert p.name == "string"
+    assert p.type is None
+    assert p.value == ParameterValue.String("hello")
+    assert p.get_value() == "hello"
+
+
+def test_bytes() -> None:
+    p = Parameter("bytes", value=b"hello")
+    assert p.name == "bytes"
+    assert p.type == ParameterType.ByteArray
+    assert p.value == ParameterValue.String("aGVsbG8=")
+    assert p.get_value() == b"hello"
+
+
+def test_dict() -> None:
+    v: AnyNativeParameterValue = {
+        "a": True,
+        "b": 2,
+        "c": "C",
+        "d": {"inner": [1, 2, 3]},
+    }
+    p = Parameter(
+        "dict",
+        value=v,
+    )
+    assert p.name == "dict"
+    assert p.type is None
+    assert p.value == ParameterValue.Dict(
+        {
+            "a": ParameterValue.Bool(True),
+            "b": ParameterValue.Number(2),
+            "c": ParameterValue.String("C"),
+            "d": ParameterValue.Dict(
+                {
+                    "inner": ParameterValue.Array(
+                        [
+                            ParameterValue.Number(1),
+                            ParameterValue.Number(2),
+                            ParameterValue.Number(3),
+                        ]
+                    )
+                }
+            ),
+        }
+    )
+    assert p.get_value() == v

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -28,20 +28,18 @@ AnyParameterValue = Union[
     ParameterValue.Array,
     ParameterValue.Dict,
 ]
-AnyNativeParameterValue = Union[
+AnyInnerParameterValue = Union[
+    AnyParameterValue,
     bool,
     float,
     str,
-    bytes,
     List["AnyInnerParameterValue"],
     Dict[str, "AnyInnerParameterValue"],
 ]
-AnyInnerParameterValue = Union[
-    bool,
-    float,
-    str,
-    List["AnyInnerParameterValue"],
-    Dict[str, "AnyInnerParameterValue"],
+
+AnyNativeParameterValue = Union[
+    AnyInnerParameterValue,
+    bytes,
 ]
 
 

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import List, Optional, Protocol
+from typing import Dict, List, Optional, Protocol, Union
 
 from ._foxglove_py.websocket import (
     Capability,
@@ -21,6 +21,28 @@ from ._foxglove_py.websocket import (
 # Redefine types from the stub interface so they're available for documentation.
 ServiceHandler = Callable[["ServiceRequest"], bytes]
 AssetHandler = Callable[[str], Optional[bytes]]
+AnyParameterValue = Union[
+    ParameterValue.Bool,
+    ParameterValue.Number,
+    ParameterValue.String,
+    ParameterValue.Array,
+    ParameterValue.Dict,
+]
+AnyNativeParameterValue = Union[
+    bool,
+    float,
+    str,
+    bytes,
+    List["AnyInnerParameterValue"],
+    Dict[str, "AnyInnerParameterValue"],
+]
+AnyInnerParameterValue = Union[
+    bool,
+    float,
+    str,
+    List["AnyInnerParameterValue"],
+    Dict[str, "AnyInnerParameterValue"],
+]
 
 
 class ServerListener(Protocol):
@@ -153,6 +175,9 @@ class ServerListener(Protocol):
 
 
 __all__ = [
+    "AnyInnerParameterValue",
+    "AnyNativeParameterValue",
+    "AnyParameterValue",
     "Capability",
     "ChannelView",
     "Client",

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -818,7 +818,7 @@ impl From<foxglove::websocket::ParameterType> for PyParameterType {
     }
 }
 
-/// A parameter value.
+/// The raw value of a parameter, as it is represented on the wire.
 #[pyclass(name = "ParameterValue", module = "foxglove", eq)]
 #[derive(Clone, PartialEq)]
 pub enum PyParameterValue {
@@ -871,6 +871,11 @@ impl From<foxglove::websocket::ParameterValue> for PyParameterValue {
 }
 
 /// A parameter which can be sent to a client.
+///
+/// :param name: The parameter name.
+/// :type name: str
+/// :param value: Optional value, represented as a native python object.
+/// :type value: None|bool|float|str|bytes|list|dict
 #[pyclass(name = "Parameter", module = "foxglove")]
 #[derive(Clone)]
 pub struct PyParameter {
@@ -880,7 +885,7 @@ pub struct PyParameter {
     /// The parameter type.
     #[pyo3(get)]
     pub r#type: Option<PyParameterType>,
-    /// The parameter value.
+    /// The raw parameter value.
     #[pyo3(get)]
     pub value: Option<PyParameterValue>,
 }
@@ -897,6 +902,14 @@ impl PyParameter {
         )
     }
 
+    /// Constructs a parameter from raw parts.
+    ///
+    /// :param name: The parameter name.
+    /// :type name: str
+    /// :param type: The parameter type.
+    /// :type type: ParameterType|None
+    /// :param value: The raw parameter value.
+    /// :type value: ParameterValue|None
     #[staticmethod]
     #[pyo3(signature = (name, *, r#type=None, value=None))]
     pub fn raw(
@@ -911,11 +924,13 @@ impl PyParameter {
         }
     }
 
-    pub fn get_value(&self, py: Python) -> PyResult<Option<Py<PyAny>>> {
+    /// Returns the parameter value as a native python object.
+    ///
+    /// :rtype: None|bool|float|str|bytes|list|dict
+    pub fn get_value(&self) -> Option<ParameterTypeValueConverter> {
         self.value
             .clone()
-            .map(|v| ParameterTypeValueConverter(self.r#type, v).into_py_any(py))
-            .transpose()
+            .map(|v| ParameterTypeValueConverter(self.r#type, v))
     }
 }
 

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -1,9 +1,13 @@
 use crate::{errors::PyFoxgloveError, PySchema};
+use base64::prelude::*;
 use bytes::Bytes;
 use foxglove::websocket::{
     AssetHandler, ChannelView, Client, ClientChannel, ServerListener, Status, StatusLevel,
 };
 use foxglove::{WebSocketServer, WebSocketServerHandle};
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::types::{PyDict, PyList};
+use pyo3::IntoPyObjectExt;
 use pyo3::{
     exceptions::PyIOError,
     prelude::*,
@@ -784,7 +788,7 @@ impl PyMessageSchema {
 
 /// A parameter type.
 #[pyclass(name = "ParameterType", module = "foxglove", eq, eq_int)]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyParameterType {
     /// A byte array.
     ByteArray,
@@ -815,8 +819,8 @@ impl From<foxglove::websocket::ParameterType> for PyParameterType {
 }
 
 /// A parameter value.
-#[pyclass(name = "ParameterValue", module = "foxglove")]
-#[derive(Clone)]
+#[pyclass(name = "ParameterValue", module = "foxglove", eq)]
+#[derive(Clone, PartialEq)]
 pub enum PyParameterValue {
     /// A decimal or integer value.
     Number(f64),
@@ -884,8 +888,18 @@ pub struct PyParameter {
 #[pymethods]
 impl PyParameter {
     #[new]
+    #[pyo3(signature = (name, *, value=None))]
+    pub fn new(name: String, value: Option<ParameterTypeValueConverter>) -> Self {
+        Self::raw(
+            name,
+            value.as_ref().and_then(|tv| tv.0),
+            value.map(|tv| tv.1),
+        )
+    }
+
+    #[staticmethod]
     #[pyo3(signature = (name, *, r#type=None, value=None))]
-    pub fn new(
+    pub fn raw(
         name: String,
         r#type: Option<PyParameterType>,
         value: Option<PyParameterValue>,
@@ -895,6 +909,13 @@ impl PyParameter {
             r#type,
             value,
         }
+    }
+
+    pub fn get_value(&self, py: Python) -> PyResult<Option<Py<PyAny>>> {
+        self.value
+            .clone()
+            .map(|v| ParameterTypeValueConverter(self.r#type, v).into_py_any(py))
+            .transpose()
     }
 }
 
@@ -914,6 +935,121 @@ impl From<foxglove::websocket::Parameter> for PyParameter {
             name: value.name,
             r#type: value.r#type.map(Into::into),
             value: value.value.map(Into::into),
+        }
+    }
+}
+
+/// A shim type for converting between PyParameterValue and native python types.
+///
+/// Note that we can't implement this on PyParameterValue directly, because it has its own
+/// implementation by virtue of being exposed as a `#[pyclass]` enum.
+pub struct ParameterValueConverter(PyParameterValue);
+
+impl<'py> IntoPyObject<'py> for ParameterValueConverter {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self.0 {
+            PyParameterValue::Number(v) => v.into_bound_py_any(py),
+            PyParameterValue::Bool(v) => v.into_bound_py_any(py),
+            PyParameterValue::String(v) => v.into_bound_py_any(py),
+            PyParameterValue::Array(values) => {
+                let elems = values.into_iter().map(ParameterValueConverter);
+                PyList::new(py, elems)?.into_bound_py_any(py)
+            }
+            PyParameterValue::Dict(values) => {
+                let dict = PyDict::new(py);
+                for (k, v) in values {
+                    dict.set_item(k, ParameterValueConverter(v))?;
+                }
+                dict.into_bound_py_any(py)
+            }
+        }
+    }
+}
+
+impl<'py> FromPyObject<'py> for ParameterValueConverter {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(val) = obj.extract::<PyParameterValue>() {
+            Ok(Self(val))
+        } else if let Ok(val) = obj.extract::<bool>() {
+            Ok(Self(PyParameterValue::Bool(val)))
+        } else if let Ok(val) = obj.extract::<f64>() {
+            Ok(Self(PyParameterValue::Number(val)))
+        } else if let Ok(val) = obj.extract::<String>() {
+            Ok(Self(PyParameterValue::String(val)))
+        } else if let Ok(list) = obj.downcast::<PyList>() {
+            let mut values = Vec::with_capacity(list.len());
+            for item in list.iter() {
+                let value: ParameterValueConverter = item.extract()?;
+                values.push(value.0);
+            }
+            return Ok(Self(PyParameterValue::Array(values)));
+        } else if let Ok(dict) = obj.downcast::<PyDict>() {
+            let mut values = HashMap::new();
+            for (key, value) in dict {
+                let key: String = key.extract()?;
+                let value: ParameterValueConverter = value.extract()?;
+                values.insert(key, value.0);
+            }
+            Ok(Self(PyParameterValue::Dict(values)))
+        } else {
+            Err(PyErr::new::<PyTypeError, _>(format!(
+                "Unsupported type for ParamaterValue: {}",
+                obj.get_type().name()?
+            )))
+        }
+    }
+}
+
+/// A shim type for converting between (PyParameterType, PyParameterValue) and native python types.
+pub struct ParameterTypeValueConverter(Option<PyParameterType>, PyParameterValue);
+
+impl<'py> IntoPyObject<'py> for ParameterTypeValueConverter {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match (self.0, self.1) {
+            (Some(PyParameterType::ByteArray), PyParameterValue::String(v)) => {
+                let data = BASE64_STANDARD
+                    .decode(v)
+                    .map_err(|e| PyValueError::new_err(format!("Failed to decode base64: {e}")))?;
+                PyBytes::new(py, &data).into_bound_py_any(py)
+            }
+            (_, v) => ParameterValueConverter(v).into_bound_py_any(py),
+        }
+    }
+}
+
+impl<'py> FromPyObject<'py> for ParameterTypeValueConverter {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(val) = obj.extract::<ParameterValueConverter>() {
+            let val = val.0;
+            let (typ, val) = match val {
+                PyParameterValue::Number(_) => (Some(PyParameterType::Float64), val),
+                PyParameterValue::Array(ref vec)
+                    if vec.iter().all(|v| matches!(v, PyParameterValue::Number(_))) =>
+                {
+                    (Some(PyParameterType::Float64Array), val)
+                }
+                _ => (None, val),
+            };
+            Ok(Self(typ, val))
+        } else if let Ok(val) = obj.extract::<Vec<u8>>() {
+            let b64 = BASE64_STANDARD.encode(val);
+            Ok(Self(
+                Some(PyParameterType::ByteArray),
+                PyParameterValue::String(b64),
+            ))
+        } else {
+            Err(PyErr::new::<PyTypeError, _>(format!(
+                "Unsupported type for ParamaterValue: {}",
+                obj.get_type().name()?
+            )))
         }
     }
 }


### PR DESCRIPTION
### Changelog
- python: Improved websocket parameters

### Description
The purpose of this change is to make websocket parameters more ergonomic in python, by implementing conversions to and from native python types.

The basic idea is that we can infer the (type, value) from the type information on a python object, so that the caller doesn't need to specify it explicitly. Likewise, we can convert (type, value) back to a single native python object using a `get_value()` method.

The implementation gets just a tiny bit hairy, because we need to introduce some shim types to accomplish the conversions, but generally, pyo3's trait system works in our favor.