### PR TITLE
Add readability-identifier-naming rules

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -27,11 +27,11 @@ CheckOptions:
   readability-identifier-naming.AbstractClassCase: CamelCase
   readability-identifier-naming.ClassCase: CamelCase
   readability-identifier-naming.ClassConstantCase: CamelCase
-  readability-identifier-naming.ClassMemberCase: CamelCase
+  readability-identifier-naming.ClassMemberCase: lower_case
   readability-identifier-naming.ClassMethodCase: camelBack
   readability-identifier-naming.ConceptCase: CamelCase
-  readability-identifier-naming.ConstantCase: CamelCase
-  readability-identifier-naming.ConstantMemberCase: CamelCase
+  readability-identifier-naming.ConstantCase: lower_case
+  readability-identifier-naming.ConstantMemberCase: lower_case
   readability-identifier-naming.ConstantParameterCase: lower_case
   readability-identifier-naming.ConstantPointerParameterCase: lower_case
   readability-identifier-naming.ConstexprMethodCase: camelBack

--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -23,3 +23,31 @@ Checks:
 CheckOptions:
   # See discussion at https://stackoverflow.com/a/58845898/23649 & https://stackoverflow.com/a/78343833/23649
   hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: true
+  # Naming
+  readability-identifier-naming.AbstractClassCase: CamelCase
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.ClassConstantCase: CamelCase
+  readability-identifier-naming.ClassMemberCase: CamelCase
+  readability-identifier-naming.ClassMethodCase: camelBack
+  readability-identifier-naming.ConceptCase: CamelCase
+  readability-identifier-naming.ConstantCase: CamelCase
+  readability-identifier-naming.ConstantMemberCase: CamelCase
+  readability-identifier-naming.ConstantParameterCase: lower_case
+  readability-identifier-naming.ConstantPointerParameterCase: lower_case
+  readability-identifier-naming.ConstexprMethodCase: camelBack
+  readability-identifier-naming.ConstexprVariableCase: lower_case
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumConstantCase: CamelCase
+  readability-identifier-naming.FunctionCase: camelBack
+  readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
+  readability-identifier-naming.MemberCase: lower_case
+  readability-identifier-naming.MethodCase: camelBack
+  readability-identifier-naming.NamespaceCase: lower_case
+  readability-identifier-naming.ParameterCase: lower_case
+  readability-identifier-naming.PrivateMemberSuffix: _
+  readability-identifier-naming.StaticConstantCase: CamelCase
+  readability-identifier-naming.StaticVariableCase: lower_case
+  readability-identifier-naming.StructCase: lower_case
+  readability-identifier-naming.TypeAliasCase: CamelCase
+  readability-identifier-naming.TypedefCase: CamelCase
+  readability-identifier-naming.VariableCase: lower_case

--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -1,6 +1,8 @@
 ---
 WarningsAsErrors: "*"
 UseColor: true
+HeaderFilterRegex: "\\/include\\/foxglove\\/"
+ExcludeHeaderFilterRegex: "expected\\.hpp"
 Checks:
   - -*
   - clang-analyzer-*
@@ -24,7 +26,6 @@ CheckOptions:
   # See discussion at https://stackoverflow.com/a/58845898/23649 & https://stackoverflow.com/a/78343833/23649
   hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: true
   # Naming
-  readability-identifier-naming.AbstractClassCase: CamelCase
   readability-identifier-naming.ClassCase: CamelCase
   readability-identifier-naming.ClassConstantCase: CamelCase
   readability-identifier-naming.ClassMemberCase: lower_case
@@ -37,17 +38,19 @@ CheckOptions:
   readability-identifier-naming.ConstexprMethodCase: camelBack
   readability-identifier-naming.ConstexprVariableCase: lower_case
   readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumIgnoredRegexp: foxglove_error
   readability-identifier-naming.EnumConstantCase: CamelCase
   readability-identifier-naming.FunctionCase: camelBack
   readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
   readability-identifier-naming.MemberCase: lower_case
+  readability-identifier-naming.MemberIgnoredRegexp: "^on[A-Z].*" # std::function members of callback struct
   readability-identifier-naming.MethodCase: camelBack
   readability-identifier-naming.NamespaceCase: lower_case
   readability-identifier-naming.ParameterCase: lower_case
   readability-identifier-naming.PrivateMemberSuffix: _
   readability-identifier-naming.StaticConstantCase: CamelCase
   readability-identifier-naming.StaticVariableCase: lower_case
-  readability-identifier-naming.StructCase: lower_case
+  readability-identifier-naming.StructCase: CamelCase
   readability-identifier-naming.TypeAliasCase: CamelCase
   readability-identifier-naming.TypedefCase: CamelCase
   readability-identifier-naming.VariableCase: lower_case

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -14,6 +14,12 @@ lint:
 		grep -v 'foxglove/expected.hpp' |\
 		xargs clang-format --dry-run -Werror --color=1
 
+.PHONY: lint-fix
+lint-fix:
+	find . -path './build*' -prune -name '*.h' -o -name '*.hpp' -o -name '*.cpp' |\
+		grep -v 'foxglove/expected.hpp' |\
+		xargs clang-format -i -Werror --color=1
+
 .PHONY: clean
 clean:
 	rm -rf $(BUILD_DIR)

--- a/cpp/examples/connection-graph/src/main.cpp
+++ b/cpp/examples/connection-graph/src/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, const char* argv[]) {
   uint32_t i = 0;
   while (!done) {
     std::this_thread::sleep_for(1s);
-    server.publish_connection_graph(graph);
+    server.publishConnectionGraph(graph);
 
     ++i;
   }

--- a/cpp/examples/connection-graph/src/main.cpp
+++ b/cpp/examples/connection-graph/src/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, const char* argv[]) {
   uint32_t i = 0;
   while (!done) {
     std::this_thread::sleep_for(1s);
-    server.publishConnectionGraph(graph);
+    server.publish_connection_graph(graph);
 
     ++i;
   }

--- a/cpp/examples/connection-graph/src/main.cpp
+++ b/cpp/examples/connection-graph/src/main.cpp
@@ -17,13 +17,13 @@ using namespace std::chrono_literals;
  */
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static std::function<void()> sigintHandler;
+static std::function<void()> sigint_handler;
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, const char* argv[]) {
   std::signal(SIGINT, [](int) {
-    if (sigintHandler) {
-      sigintHandler();
+    if (sigint_handler) {
+      sigint_handler();
     }
   });
 
@@ -39,24 +39,24 @@ int main(int argc, const char* argv[]) {
     std::cerr << "Connection graph unsubscribed\n";
   };
 
-  auto connectionGraph = foxglove::ConnectionGraph();
-  auto err = connectionGraph.setPublishedTopic("/example-topic", {"1", "2"});
+  auto graph = foxglove::ConnectionGraph();
+  auto err = graph.setPublishedTopic("/example-topic", {"1", "2"});
   if (err != foxglove::FoxgloveError::Ok) {
     std::cerr << "Failed to set published topic: " << foxglove::strerror(err) << '\n';
   }
-  connectionGraph.setSubscribedTopic("/subscribed-topic", {"3", "4"});
-  connectionGraph.setAdvertisedService("example-service", {"5", "6"});
+  graph.setSubscribedTopic("/subscribed-topic", {"3", "4"});
+  graph.setAdvertisedService("example-service", {"5", "6"});
 
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  if (!serverResult.has_value()) {
-    std::cerr << "Failed to create server: " << foxglove::strerror(serverResult.error()) << '\n';
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  if (!server_result.has_value()) {
+    std::cerr << "Failed to create server: " << foxglove::strerror(server_result.error()) << '\n';
     return 1;
   }
-  auto server = std::move(serverResult.value());
+  auto server = std::move(server_result.value());
   std::cerr << "Server listening on port " << server.port() << '\n';
 
   std::atomic_bool done = false;
-  sigintHandler = [&] {
+  sigint_handler = [&] {
     std::cerr << "Shutting down...\n";
     server.stop();
     done = true;
@@ -65,7 +65,7 @@ int main(int argc, const char* argv[]) {
   uint32_t i = 0;
   while (!done) {
     std::this_thread::sleep_for(1s);
-    server.publishConnectionGraph(connectionGraph);
+    server.publishConnectionGraph(graph);
 
     ++i;
   }

--- a/cpp/examples/mcap/src/main.cpp
+++ b/cpp/examples/mcap/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, const char* argv[]) {
   foxglove::McapWriterOptions options = {};
   options.path = "test.mcap";

--- a/cpp/examples/mcap/src/main.cpp
+++ b/cpp/examples/mcap/src/main.cpp
@@ -7,30 +7,30 @@ int main(int argc, const char* argv[]) {
   foxglove::McapWriterOptions options = {};
   options.path = "test.mcap";
   options.truncate = true;
-  auto writerResult = foxglove::McapWriter::create(options);
-  if (!writerResult.has_value()) {
-    std::cerr << "Failed to create writer: " << foxglove::strerror(writerResult.error()) << '\n';
+  auto writer_result = foxglove::McapWriter::create(options);
+  if (!writer_result.has_value()) {
+    std::cerr << "Failed to create writer: " << foxglove::strerror(writer_result.error()) << '\n';
     return 1;
   }
-  auto writer = std::move(writerResult.value());
+  auto writer = std::move(writer_result.value());
 
   foxglove::Schema schema;
   schema.name = "Test";
   schema.encoding = "jsonschema";
-  std::string schemaData = R"({
+  std::string schema_data = R"({
     "type": "object",
     "properties": {
         "val": { "type": "number" }
     }
     })";
-  schema.data = reinterpret_cast<const std::byte*>(schemaData.data());
-  schema.dataLen = schemaData.size();
-  auto channelResult = foxglove::Channel::create("example", "json", std::move(schema));
-  if (!channelResult.has_value()) {
-    std::cerr << "Failed to create channel: " << foxglove::strerror(channelResult.error()) << '\n';
+  schema.data = reinterpret_cast<const std::byte*>(schema_data.data());
+  schema.data_len = schema_data.size();
+  auto channel_result = foxglove::Channel::create("example", "json", std::move(schema));
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create channel: " << foxglove::strerror(channel_result.error()) << '\n';
     return 1;
   }
-  auto channel = std::move(channelResult.value());
+  auto channel = std::move(channel_result.value());
 
   for (int i = 0; i < 100; ++i) {
     std::string msg = "{\"val\": " + std::to_string(i) + "}";

--- a/cpp/examples/quickstart/src/main.cpp
+++ b/cpp/examples/quickstart/src/main.cpp
@@ -14,58 +14,58 @@ using namespace std::chrono_literals;
 // This example logs custom data on an "example" topic. Open Foxglove and connect to the running
 // server. Then add a Raw Message panel, and choose the "example" topic.
 int main(int argc, const char* argv[]) {
-  static std::function<void()> sigintHandler;
+  static std::function<void()> sigint_handler;
 
   std::signal(SIGINT, [](int) {
-    if (sigintHandler) {
-      sigintHandler();
+    if (sigint_handler) {
+      sigint_handler();
     }
   });
 
   // We'll log to both an MCAP file, and to a running Foxglove app.
   foxglove::McapWriterOptions mcap_options = {};
   mcap_options.path = "quickstart-cpp.mcap";
-  auto writerResult = foxglove::McapWriter::create(mcap_options);
-  if (!writerResult.has_value()) {
-    std::cerr << "Failed to create writer: " << foxglove::strerror(writerResult.error()) << '\n';
+  auto writer_result = foxglove::McapWriter::create(mcap_options);
+  if (!writer_result.has_value()) {
+    std::cerr << "Failed to create writer: " << foxglove::strerror(writer_result.error()) << '\n';
     return 1;
   }
-  auto writer = std::move(writerResult.value());
+  auto writer = std::move(writer_result.value());
 
   // Start a server to communicate with the Foxglove app.
   foxglove::WebSocketServerOptions ws_options;
   ws_options.host = "127.0.0.1";
   ws_options.port = 8765;
-  auto serverResult = foxglove::WebSocketServer::create(std::move(ws_options));
-  if (!serverResult.has_value()) {
-    std::cerr << "Failed to create server: " << foxglove::strerror(serverResult.error()) << '\n';
+  auto server_result = foxglove::WebSocketServer::create(std::move(ws_options));
+  if (!server_result.has_value()) {
+    std::cerr << "Failed to create server: " << foxglove::strerror(server_result.error()) << '\n';
     return 1;
   }
-  auto server = std::move(serverResult.value());
+  auto server = std::move(server_result.value());
   std::cerr << "Server listening on port " << server.port() << '\n';
 
   std::atomic_bool done = false;
-  sigintHandler = [&] {
+  sigint_handler = [&] {
     done = true;
   };
 
   // Our example logs custom data on an "example" topic, so we'll create a channel for that.
   foxglove::Schema schema;
   schema.encoding = "jsonschema";
-  std::string schemaData = R"({
+  std::string schema_data = R"({
     "type": "object",
     "properties": {
       "val": { "type": "number" }
     }
   })";
-  schema.data = reinterpret_cast<const std::byte*>(schemaData.data());
-  schema.dataLen = schemaData.size();
-  auto channelResult = foxglove::Channel::create("example", "json", std::move(schema));
-  if (!channelResult.has_value()) {
-    std::cerr << "Failed to create channel: " << foxglove::strerror(channelResult.error()) << '\n';
+  schema.data = reinterpret_cast<const std::byte*>(schema_data.data());
+  schema.data_len = schema_data.size();
+  auto channel_result = foxglove::Channel::create("example", "json", std::move(schema));
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create channel: " << foxglove::strerror(channel_result.error()) << '\n';
     return 1;
   }
-  auto channel = std::move(channelResult.value());
+  auto channel = std::move(channel_result.value());
 
   while (!done) {
     // Log messages on the channel until interrupted. By default, each message

--- a/cpp/examples/quickstart/src/main.cpp
+++ b/cpp/examples/quickstart/src/main.cpp
@@ -13,6 +13,8 @@ using namespace std::chrono_literals;
 
 // This example logs custom data on an "example" topic. Open Foxglove and connect to the running
 // server. Then add a Raw Message panel, and choose the "example" topic.
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, const char* argv[]) {
   static std::function<void()> sigint_handler;
 

--- a/cpp/examples/ws-server/src/main.cpp
+++ b/cpp/examples/ws-server/src/main.cpp
@@ -12,13 +12,13 @@
 using namespace std::chrono_literals;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static std::function<void()> sigintHandler;
+static std::function<void()> sigint_handler;
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, const char* argv[]) {
   std::signal(SIGINT, [](int) {
-    if (sigintHandler) {
-      sigintHandler();
+    if (sigint_handler) {
+      sigint_handler();
     }
   });
 
@@ -35,9 +35,9 @@ int main(int argc, const char* argv[]) {
     std::cerr << "Unsubscribed from channel " << channel_id << '\n';
   };
   options.callbacks.onClientAdvertise = [](
-                                          uint32_t clientId, const foxglove::ClientChannel& channel
+                                          uint32_t client_id, const foxglove::ClientChannel& channel
                                         ) {
-    std::cerr << "Client " << clientId << " advertised channel " << channel.id << ":\n";
+    std::cerr << "Client " << client_id << " advertised channel " << channel.id << ":\n";
     std::cerr << "  Topic: " << channel.topic << '\n';
     std::cerr << "  Encoding: " << channel.encoding << '\n';
     std::cerr << "  Schema name: " << channel.schemaName << '\n';
@@ -50,23 +50,23 @@ int main(int argc, const char* argv[]) {
               << '\n';
   };
   options.callbacks.onMessageData =
-    [](uint32_t clientId, uint32_t clientChannelId, const std::byte* data, size_t dataLen) {
-      std::cerr << "Client " << clientId << " published on channel " << clientChannelId << ": "
-                << std::string(reinterpret_cast<const char*>(data), dataLen) << '\n';
+    [](uint32_t client_id, uint32_t client_channel_id, const std::byte* data, size_t data_len) {
+      std::cerr << "Client " << client_id << " published on channel " << client_channel_id << ": "
+                << std::string(reinterpret_cast<const char*>(data), data_len) << '\n';
     };
-  options.callbacks.onClientUnadvertise = [](uint32_t clientId, uint32_t clientChannelId) {
-    std::cerr << "Client " << clientId << " unadvertised channel " << clientChannelId << '\n';
+  options.callbacks.onClientUnadvertise = [](uint32_t client_id, uint32_t client_channel_id) {
+    std::cerr << "Client " << client_id << " unadvertised channel " << client_channel_id << '\n';
   };
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  if (!serverResult.has_value()) {
-    std::cerr << "Failed to create server: " << foxglove::strerror(serverResult.error()) << '\n';
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  if (!server_result.has_value()) {
+    std::cerr << "Failed to create server: " << foxglove::strerror(server_result.error()) << '\n';
     return 1;
   }
-  auto server = std::move(serverResult.value());
+  auto server = std::move(server_result.value());
   std::cerr << "Server listening on port " << server.port() << '\n';
 
   std::atomic_bool done = false;
-  sigintHandler = [&] {
+  sigint_handler = [&] {
     std::cerr << "Shutting down...\n";
     server.stop();
     done = true;
@@ -75,20 +75,20 @@ int main(int argc, const char* argv[]) {
   foxglove::Schema schema;
   schema.name = "Test";
   schema.encoding = "jsonschema";
-  std::string schemaData = R"({
+  std::string schema_data = R"({
     "type": "object",
     "properties": {
       "val": { "type": "number" }
     }
   })";
-  schema.data = reinterpret_cast<const std::byte*>(schemaData.data());
-  schema.dataLen = schemaData.size();
-  auto channelResult = foxglove::Channel::create("example", "json", std::move(schema));
-  if (!channelResult.has_value()) {
-    std::cerr << "Failed to create channel: " << foxglove::strerror(channelResult.error()) << '\n';
+  schema.data = reinterpret_cast<const std::byte*>(schema_data.data());
+  schema.data_len = schema_data.size();
+  auto channel_result = foxglove::Channel::create("example", "json", std::move(schema));
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create channel: " << foxglove::strerror(channel_result.error()) << '\n';
     return 1;
   }
-  auto channel = std::move(channelResult.value());
+  auto channel = std::move(channel_result.value());
 
   uint32_t i = 0;
   while (!done) {

--- a/cpp/examples/ws-server/src/main.cpp
+++ b/cpp/examples/ws-server/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, const char* argv[]) {
   options.host = "127.0.0.1";
   options.port = 8765;
   options.capabilities = foxglove::WebSocketServerCapabilities::ClientPublish;
-  options.supportedEncodings = {"json"};
+  options.supported_encodings = {"json"};
   options.callbacks.onSubscribe = [](uint64_t channel_id) {
     std::cerr << "Subscribed to channel " << channel_id << '\n';
   };
@@ -40,12 +40,12 @@ int main(int argc, const char* argv[]) {
     std::cerr << "Client " << client_id << " advertised channel " << channel.id << ":\n";
     std::cerr << "  Topic: " << channel.topic << '\n';
     std::cerr << "  Encoding: " << channel.encoding << '\n';
-    std::cerr << "  Schema name: " << channel.schemaName << '\n';
+    std::cerr << "  Schema name: " << channel.schema_name << '\n';
     std::cerr << "  Schema encoding: "
-              << (!channel.schemaEncoding.empty() ? channel.schemaEncoding : "(none)") << '\n';
+              << (!channel.schema_encoding.empty() ? channel.schema_encoding : "(none)") << '\n';
     std::cerr << "  Schema: "
               << (channel.schema != nullptr
-                    ? std::string(reinterpret_cast<const char*>(channel.schema), channel.schemaLen)
+                    ? std::string(reinterpret_cast<const char*>(channel.schema), channel.schema_len)
                     : "(none)")
               << '\n';
   };

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -17,19 +17,21 @@ struct Schema {
   std::string name;
   std::string encoding;
   const std::byte* data = nullptr;
-  size_t dataLen = 0;
+  size_t data_len = 0;
 };
 
 class Channel final {
 public:
   static FoxgloveResult<Channel> create(
-    const std::string& topic, const std::string& messageEncoding,
+    const std::string& topic, const std::string& message_encoding,
     std::optional<Schema> schema = std::nullopt, const Context& context = Context()
   );
 
   FoxgloveError log(
-    const std::byte* data, size_t dataLen, std::optional<uint64_t> logTime = std::nullopt
+    const std::byte* data, size_t data_len, std::optional<uint64_t> log_time = std::nullopt
   );
+
+  uint64_t test_ID() const;
 
   uint64_t id() const;
 

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -31,19 +31,22 @@ public:
     const std::byte* data, size_t data_len, std::optional<uint64_t> log_time = std::nullopt
   );
 
-  uint64_t test_ID() const;
+  [[nodiscard]] uint64_t testId() const;
 
-  uint64_t id() const;
+  [[nodiscard]] uint64_t id() const;
 
   Channel(const Channel&) = delete;
   Channel& operator=(const Channel&) = delete;
 
   Channel(Channel&& other) noexcept = default;
+  Channel& operator=(Channel&& other) noexcept = default;
+
+  ~Channel() = default;
 
 private:
   explicit Channel(const foxglove_channel* channel);
 
-  std::unique_ptr<const foxglove_channel, void (*const)(const foxglove_channel*)> _impl;
+  std::unique_ptr<const foxglove_channel, void (*const)(const foxglove_channel*)> impl_;
 };
 
 }  // namespace foxglove

--- a/cpp/foxglove/include/foxglove/context.hpp
+++ b/cpp/foxglove/include/foxglove/context.hpp
@@ -24,11 +24,11 @@ public:
 private:
   explicit Context(const foxglove_context* context);
 
-  const foxglove_context* get_inner() const {
-    return _impl.get();
+  [[nodiscard]] const foxglove_context* getInner() const {
+    return impl_.get();
   }
 
-  std::shared_ptr<const foxglove_context> _impl;
+  std::shared_ptr<const foxglove_context> impl_;
 };
 
 }  // namespace foxglove

--- a/cpp/foxglove/include/foxglove/mcap.hpp
+++ b/cpp/foxglove/include/foxglove/mcap.hpp
@@ -25,18 +25,18 @@ struct McapWriterOptions {
   Context context;
   std::string_view path;
   std::string_view profile;
-  uint64_t chunkSize = 1024 * 768;
+  uint64_t chunk_size = static_cast<uint64_t>(1024 * 768);
   McapCompression compression = McapCompression::Zstd;
-  bool useChunks = true;
-  bool disableSeeking = false;
-  bool emitStatistics = true;
-  bool emitSummaryOffsets = true;
-  bool emitMessageIndexes = true;
-  bool emitChunkIndexes = true;
-  bool emitAttachmentIndexes = true;
-  bool emitMetadataIndexes = true;
-  bool repeatChannels = true;
-  bool repeatSchemas = true;
+  bool use_chunks = true;
+  bool disable_seeking = false;
+  bool emit_statistics = true;
+  bool emit_summary_offsets = true;
+  bool emit_message_indexes = true;
+  bool emit_chunk_indexes = true;
+  bool emit_attachment_indexes = true;
+  bool emit_metadata_indexes = true;
+  bool repeat_channels = true;
+  bool repeat_schemas = true;
   bool truncate = false;
 
   McapWriterOptions() = default;
@@ -47,12 +47,18 @@ public:
   static FoxgloveResult<McapWriter> create(const McapWriterOptions& options);
 
   FoxgloveError close();
+
+  // Default destructor & move, disable copy.
   McapWriter(McapWriter&&) = default;
+  ~McapWriter() = default;
+  McapWriter& operator=(McapWriter&&) = default;
+  McapWriter(const McapWriter&) = delete;
+  McapWriter& operator=(const McapWriter&) = delete;
 
 private:
   explicit McapWriter(foxglove_mcap_writer* writer);
 
-  std::unique_ptr<foxglove_mcap_writer, foxglove_error (*)(foxglove_mcap_writer*)> _impl;
+  std::unique_ptr<foxglove_mcap_writer, foxglove_error (*)(foxglove_mcap_writer*)> impl_;
 };
 
 }  // namespace foxglove

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -21,10 +21,10 @@ struct ClientChannel {
   uint32_t id;
   std::string_view topic;
   std::string_view encoding;
-  std::string_view schemaName;
-  std::string_view schemaEncoding;
+  std::string_view schema_name;
+  std::string_view schema_encoding;
   const std::byte* schema;
-  size_t schemaLen;
+  size_t schema_len;
 };
 
 enum class WebSocketServerCapabilities : uint8_t {
@@ -77,7 +77,7 @@ struct WebSocketServerOptions {
   uint16_t port = 8765;  // default foxglove WebSocket port
   WebSocketServerCallbacks callbacks;
   WebSocketServerCapabilities capabilities = WebSocketServerCapabilities(0);
-  std::vector<std::string> supportedEncodings;
+  std::vector<std::string> supported_encodings;
 };
 
 class WebSocketServer final {
@@ -85,7 +85,7 @@ public:
   static FoxgloveResult<WebSocketServer> create(WebSocketServerOptions&& options);
 
   // Get the port on which the server is listening.
-  uint16_t port() const;
+  [[nodiscard]] uint16_t port() const;
 
   FoxgloveError stop();
 
@@ -96,8 +96,8 @@ private:
     foxglove_websocket_server* server, std::unique_ptr<WebSocketServerCallbacks> callbacks
   );
 
-  std::unique_ptr<WebSocketServerCallbacks> _callbacks;
-  std::unique_ptr<foxglove_websocket_server, foxglove_error (*)(foxglove_websocket_server*)> _impl;
+  std::unique_ptr<WebSocketServerCallbacks> callbacks_;
+  std::unique_ptr<foxglove_websocket_server, foxglove_error (*)(foxglove_websocket_server*)> impl_;
 };
 
 }  // namespace foxglove

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -89,7 +89,7 @@ public:
 
   FoxgloveError stop();
 
-  void publish_connection_graph(ConnectionGraph& graph);
+  void publishConnectionGraph(ConnectionGraph& graph);
 
 private:
   WebSocketServer(

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -89,7 +89,7 @@ public:
 
   FoxgloveError stop();
 
-  void publishConnectionGraph(ConnectionGraph& graph);
+  void publish_connection_graph(ConnectionGraph& graph);
 
 private:
   WebSocketServer(

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -57,13 +57,13 @@ inline WebSocketServerCapabilities operator&(
 }
 
 struct WebSocketServerCallbacks {
-  std::function<void(uint64_t channelId)> onSubscribe;
-  std::function<void(uint64_t channelId)> onUnsubscribe;
-  std::function<void(uint32_t clientId, const ClientChannel& channel)> onClientAdvertise;
+  std::function<void(uint64_t channel_id)> onSubscribe;
+  std::function<void(uint64_t channel_id)> onUnsubscribe;
+  std::function<void(uint32_t client_id, const ClientChannel& channel)> onClientAdvertise;
   std::function<
-    void(uint32_t clientId, uint32_t clientChannelId, const std::byte* data, size_t dataLen)>
+    void(uint32_t client_id, uint32_t client_channel_id, const std::byte* data, size_t data_len)>
     onMessageData;
-  std::function<void(uint32_t clientId, uint32_t clientChannelId)> onClientUnadvertise;
+  std::function<void(uint32_t client_id, uint32_t client_channel_id)> onClientUnadvertise;
   std::function<void()> onConnectionGraphSubscribe;
   std::function<void()> onConnectionGraphUnsubscribe;
 };

--- a/cpp/foxglove/include/foxglove/server/connection_graph.hpp
+++ b/cpp/foxglove/include/foxglove/server/connection_graph.hpp
@@ -27,7 +27,7 @@ public:
   );
 
 private:
-  std::unique_ptr<foxglove_connection_graph, void (*)(foxglove_connection_graph*)> _impl;
+  std::unique_ptr<foxglove_connection_graph, void (*)(foxglove_connection_graph*)> impl_;
 };
 
 }  // namespace foxglove

--- a/cpp/foxglove/include/foxglove/server/connection_graph.hpp
+++ b/cpp/foxglove/include/foxglove/server/connection_graph.hpp
@@ -17,13 +17,13 @@ public:
   ConnectionGraph();
 
   FoxgloveError setPublishedTopic(
-    std::string_view topic, const std::vector<std::string>& publisherIds
+    std::string_view topic, const std::vector<std::string>& publisher_ids
   );
   FoxgloveError setSubscribedTopic(
-    std::string_view topic, const std::vector<std::string>& subscriberIds
+    std::string_view topic, const std::vector<std::string>& subscriber_ids
   );
   FoxgloveError setAdvertisedService(
-    std::string_view service, const std::vector<std::string>& providerIds
+    std::string_view service, const std::vector<std::string>& provider_ids
   );
 
 private:

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -6,23 +6,20 @@
 namespace foxglove {
 
 FoxgloveResult<Channel> Channel::create(
-  const std::string& topic, const std::string& messageEncoding, std::optional<Schema> schema,
+  const std::string& topic, const std::string& message_encoding, std::optional<Schema> schema,
   const Context& context
 ) {
-  foxglove_schema cSchema = {};
+  foxglove_schema c_schema = {};
   if (schema) {
-    cSchema.name = {schema->name.data(), schema->name.length()};
-    cSchema.encoding = {schema->encoding.data(), schema->encoding.length()};
-    cSchema.data = reinterpret_cast<const uint8_t*>(schema->data);
-    cSchema.data_len = schema->dataLen;
+    c_schema.name = {schema->name.data(), schema->name.length()};
+    c_schema.encoding = {schema->encoding.data(), schema->encoding.length()};
+    c_schema.data = reinterpret_cast<const uint8_t*>(schema->data);
+    c_schema.data_len = schema->data_len;
   }
   const foxglove_channel* channel = nullptr;
   foxglove_error error = foxglove_channel_create(
-    {topic.data(), topic.length()},
-    {messageEncoding.data(), messageEncoding.length()},
-    schema ? &cSchema : nullptr,
-    context.get_inner(),
-    &channel
+    {topic.data(), topic.length()}, {message_encoding.data(), message_encoding.length()},
+    schema ? &c_schema : nullptr, context.get_inner(), &channel
   );
   if (error != foxglove_error::FOXGLOVE_ERROR_OK || channel == nullptr) {
     return foxglove::unexpected(FoxgloveError(error));
@@ -37,9 +34,15 @@ uint64_t Channel::id() const {
   return foxglove_channel_get_id(_impl.get());
 }
 
-FoxgloveError Channel::log(const std::byte* data, size_t dataLen, std::optional<uint64_t> logTime) {
+uint64_t Channel::test_ID() const {
+  return foxglove_channel_get_id(_impl.get());
+}
+
+FoxgloveError Channel::log(
+  const std::byte* data, size_t data_len, std::optional<uint64_t> log_time
+) {
   foxglove_error error = foxglove_channel_log(
-    _impl.get(), reinterpret_cast<const uint8_t*>(data), dataLen, logTime ? &*logTime : nullptr
+    _impl.get(), reinterpret_cast<const uint8_t*>(data), data_len, log_time ? &*log_time : nullptr
   );
   return FoxgloveError(error);
 }

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -21,7 +21,7 @@ FoxgloveResult<Channel> Channel::create(
     {topic.data(), topic.length()},
     {message_encoding.data(), message_encoding.length()},
     schema ? &c_schema : nullptr,
-    context.get_inner(),
+    context.getInner(),
     &channel
   );
   if (error != foxglove_error::FOXGLOVE_ERROR_OK || channel == nullptr) {
@@ -31,21 +31,21 @@ FoxgloveResult<Channel> Channel::create(
 }
 
 Channel::Channel(const foxglove_channel* channel)
-    : _impl(channel, foxglove_channel_free) {}
+    : impl_(channel, foxglove_channel_free) {}
 
 uint64_t Channel::id() const {
-  return foxglove_channel_get_id(_impl.get());
+  return foxglove_channel_get_id(impl_.get());
 }
 
-uint64_t Channel::test_ID() const {
-  return foxglove_channel_get_id(_impl.get());
+uint64_t Channel::testId() const {
+  return foxglove_channel_get_id(impl_.get());
 }
 
 FoxgloveError Channel::log(
   const std::byte* data, size_t data_len, std::optional<uint64_t> log_time
 ) {
   foxglove_error error = foxglove_channel_log(
-    _impl.get(), reinterpret_cast<const uint8_t*>(data), data_len, log_time ? &*log_time : nullptr
+    impl_.get(), reinterpret_cast<const uint8_t*>(data), data_len, log_time ? &*log_time : nullptr
   );
   return FoxgloveError(error);
 }

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -18,8 +18,11 @@ FoxgloveResult<Channel> Channel::create(
   }
   const foxglove_channel* channel = nullptr;
   foxglove_error error = foxglove_channel_create(
-    {topic.data(), topic.length()}, {message_encoding.data(), message_encoding.length()},
-    schema ? &c_schema : nullptr, context.get_inner(), &channel
+    {topic.data(), topic.length()},
+    {message_encoding.data(), message_encoding.length()},
+    schema ? &c_schema : nullptr,
+    context.get_inner(),
+    &channel
   );
   if (error != foxglove_error::FOXGLOVE_ERROR_OK || channel == nullptr) {
     return foxglove::unexpected(FoxgloveError(error));

--- a/cpp/foxglove/src/context.cpp
+++ b/cpp/foxglove/src/context.cpp
@@ -4,7 +4,7 @@
 namespace foxglove {
 
 Context::Context(const foxglove_context* context)
-    : _impl(context, foxglove_context_free) {}
+    : impl_(context, foxglove_context_free) {}
 
 Context Context::create() {
   return Context(foxglove_context_new());

--- a/cpp/foxglove/src/mcap.cpp
+++ b/cpp/foxglove/src/mcap.cpp
@@ -9,23 +9,23 @@ FoxgloveResult<McapWriter> McapWriter::create(const McapWriterOptions& options) 
   foxglove_internal_register_cpp_wrapper();
 
   foxglove_mcap_options c_options = {};
-  c_options.context = options.context.get_inner();
+  c_options.context = options.context.getInner();
   c_options.path = {options.path.data(), options.path.length()};
   c_options.profile = {options.profile.data(), options.profile.length()};
   // TODO FG-11215: generate the enum for C++ from the C enum
   // so this is guaranteed to never get out of sync
   c_options.compression = static_cast<foxglove_mcap_compression>(options.compression);
-  c_options.chunk_size = options.chunkSize;
-  c_options.use_chunks = options.useChunks;
-  c_options.disable_seeking = options.disableSeeking;
-  c_options.emit_statistics = options.emitStatistics;
-  c_options.emit_summary_offsets = options.emitSummaryOffsets;
-  c_options.emit_message_indexes = options.emitMessageIndexes;
-  c_options.emit_chunk_indexes = options.emitChunkIndexes;
-  c_options.emit_attachment_indexes = options.emitAttachmentIndexes;
-  c_options.emit_metadata_indexes = options.emitMetadataIndexes;
-  c_options.repeat_channels = options.repeatChannels;
-  c_options.repeat_schemas = options.repeatSchemas;
+  c_options.chunk_size = options.chunk_size;
+  c_options.use_chunks = options.use_chunks;
+  c_options.disable_seeking = options.disable_seeking;
+  c_options.emit_statistics = options.emit_statistics;
+  c_options.emit_summary_offsets = options.emit_summary_offsets;
+  c_options.emit_message_indexes = options.emit_message_indexes;
+  c_options.emit_chunk_indexes = options.emit_chunk_indexes;
+  c_options.emit_attachment_indexes = options.emit_attachment_indexes;
+  c_options.emit_metadata_indexes = options.emit_metadata_indexes;
+  c_options.repeat_channels = options.repeat_channels;
+  c_options.repeat_schemas = options.repeat_schemas;
   c_options.truncate = options.truncate;
 
   foxglove_mcap_writer* writer = nullptr;
@@ -38,10 +38,10 @@ FoxgloveResult<McapWriter> McapWriter::create(const McapWriterOptions& options) 
 }
 
 McapWriter::McapWriter(foxglove_mcap_writer* writer)
-    : _impl(writer, foxglove_mcap_close) {}
+    : impl_(writer, foxglove_mcap_close) {}
 
 FoxgloveError McapWriter::close() {
-  foxglove_error error = foxglove_mcap_close(_impl.release());
+  foxglove_error error = foxglove_mcap_close(impl_.release());
   return FoxgloveError(error);
 }
 

--- a/cpp/foxglove/src/mcap.cpp
+++ b/cpp/foxglove/src/mcap.cpp
@@ -8,28 +8,28 @@ namespace foxglove {
 FoxgloveResult<McapWriter> McapWriter::create(const McapWriterOptions& options) {
   foxglove_internal_register_cpp_wrapper();
 
-  foxglove_mcap_options cOptions = {};
-  cOptions.context = options.context.get_inner();
-  cOptions.path = {options.path.data(), options.path.length()};
-  cOptions.profile = {options.profile.data(), options.profile.length()};
+  foxglove_mcap_options c_options = {};
+  c_options.context = options.context.get_inner();
+  c_options.path = {options.path.data(), options.path.length()};
+  c_options.profile = {options.profile.data(), options.profile.length()};
   // TODO FG-11215: generate the enum for C++ from the C enum
   // so this is guaranteed to never get out of sync
-  cOptions.compression = static_cast<foxglove_mcap_compression>(options.compression);
-  cOptions.chunk_size = options.chunkSize;
-  cOptions.use_chunks = options.useChunks;
-  cOptions.disable_seeking = options.disableSeeking;
-  cOptions.emit_statistics = options.emitStatistics;
-  cOptions.emit_summary_offsets = options.emitSummaryOffsets;
-  cOptions.emit_message_indexes = options.emitMessageIndexes;
-  cOptions.emit_chunk_indexes = options.emitChunkIndexes;
-  cOptions.emit_attachment_indexes = options.emitAttachmentIndexes;
-  cOptions.emit_metadata_indexes = options.emitMetadataIndexes;
-  cOptions.repeat_channels = options.repeatChannels;
-  cOptions.repeat_schemas = options.repeatSchemas;
-  cOptions.truncate = options.truncate;
+  c_options.compression = static_cast<foxglove_mcap_compression>(options.compression);
+  c_options.chunk_size = options.chunkSize;
+  c_options.use_chunks = options.useChunks;
+  c_options.disable_seeking = options.disableSeeking;
+  c_options.emit_statistics = options.emitStatistics;
+  c_options.emit_summary_offsets = options.emitSummaryOffsets;
+  c_options.emit_message_indexes = options.emitMessageIndexes;
+  c_options.emit_chunk_indexes = options.emitChunkIndexes;
+  c_options.emit_attachment_indexes = options.emitAttachmentIndexes;
+  c_options.emit_metadata_indexes = options.emitMetadataIndexes;
+  c_options.repeat_channels = options.repeatChannels;
+  c_options.repeat_schemas = options.repeatSchemas;
+  c_options.truncate = options.truncate;
 
   foxglove_mcap_writer* writer = nullptr;
-  foxglove_error error = foxglove_mcap_open(&cOptions, &writer);
+  foxglove_error error = foxglove_mcap_open(&c_options, &writer);
   if (error != foxglove_error::FOXGLOVE_ERROR_OK || writer == nullptr) {
     return foxglove::unexpected(static_cast<FoxgloveError>(error));
   }

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -128,7 +128,7 @@ uint16_t WebSocketServer::port() const {
   return foxglove_server_get_port(_impl.get());
 }
 
-void WebSocketServer::publishConnectionGraph(ConnectionGraph& graph) {
+void WebSocketServer::publish_connection_graph(ConnectionGraph& graph) {
   foxglove_server_publish_connection_graph(_impl.get(), graph._impl.get());
 }
 

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -14,33 +14,33 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
 ) {
   foxglove_internal_register_cpp_wrapper();
 
-  bool hasAnyCallbacks = options.callbacks.onSubscribe || options.callbacks.onUnsubscribe ||
-                         options.callbacks.onClientAdvertise || options.callbacks.onMessageData ||
-                         options.callbacks.onClientUnadvertise ||
-                         options.callbacks.onConnectionGraphSubscribe ||
-                         options.callbacks.onConnectionGraphUnsubscribe;
+  bool has_any_callbacks = options.callbacks.onSubscribe || options.callbacks.onUnsubscribe ||
+                           options.callbacks.onClientAdvertise || options.callbacks.onMessageData ||
+                           options.callbacks.onClientUnadvertise ||
+                           options.callbacks.onConnectionGraphSubscribe ||
+                           options.callbacks.onConnectionGraphUnsubscribe;
 
   std::unique_ptr<WebSocketServerCallbacks> callbacks;
 
-  foxglove_server_callbacks cCallbacks = {};
+  foxglove_server_callbacks c_callbacks = {};
 
-  if (hasAnyCallbacks) {
+  if (has_any_callbacks) {
     callbacks = std::make_unique<WebSocketServerCallbacks>(std::move(options.callbacks));
-    cCallbacks.context = callbacks.get();
+    c_callbacks.context = callbacks.get();
     if (callbacks->onSubscribe) {
-      cCallbacks.on_subscribe = [](uint64_t channel_id, const void* context) {
+      c_callbacks.on_subscribe = [](uint64_t channel_id, const void* context) {
         (static_cast<const WebSocketServerCallbacks*>(context))->onSubscribe(channel_id);
       };
     }
     if (callbacks->onUnsubscribe) {
-      cCallbacks.on_unsubscribe = [](uint64_t channel_id, const void* context) {
+      c_callbacks.on_unsubscribe = [](uint64_t channel_id, const void* context) {
         (static_cast<const WebSocketServerCallbacks*>(context))->onUnsubscribe(channel_id);
       };
     }
     if (callbacks->onClientAdvertise) {
-      cCallbacks.on_client_advertise =
+      c_callbacks.on_client_advertise =
         [](uint32_t client_id, const foxglove_client_channel* channel, const void* context) {
-          ClientChannel cppChannel = {
+          ClientChannel cpp_channel = {
             channel->id,
             channel->topic,
             channel->encoding,
@@ -50,18 +50,16 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
             channel->schema_len
           };
           (static_cast<const WebSocketServerCallbacks*>(context))
-            ->onClientAdvertise(client_id, cppChannel);
+            ->onClientAdvertise(client_id, cpp_channel);
         };
     }
     if (callbacks->onMessageData) {
-      cCallbacks.on_message_data = [](
-                                     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-                                     uint32_t client_id,
-                                     uint32_t client_channel_id,
-                                     const uint8_t* payload,
-                                     size_t payload_len,
-                                     const void* context
-                                   ) {
+      c_callbacks.on_message_data = [](
+                                      // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+                                      uint32_t client_id, uint32_t client_channel_id,
+                                      const uint8_t* payload, size_t payload_len,
+                                      const void* context
+                                    ) {
         (static_cast<const WebSocketServerCallbacks*>(context))
           ->onMessageData(
             client_id, client_channel_id, reinterpret_cast<const std::byte*>(payload), payload_len
@@ -69,7 +67,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
       };
     }
     if (callbacks->onClientUnadvertise) {
-      cCallbacks.on_client_unadvertise =
+      c_callbacks.on_client_unadvertise =
         // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
         [](uint32_t client_id, uint32_t client_channel_id, const void* context) {
           (static_cast<const WebSocketServerCallbacks*>(context))
@@ -77,35 +75,35 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
         };
     }
     if (callbacks->onConnectionGraphSubscribe) {
-      cCallbacks.on_connection_graph_subscribe = [](const void* context) {
+      c_callbacks.on_connection_graph_subscribe = [](const void* context) {
         (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphSubscribe();
       };
     }
     if (callbacks->onConnectionGraphUnsubscribe) {
-      cCallbacks.on_connection_graph_unsubscribe = [](const void* context) {
+      c_callbacks.on_connection_graph_unsubscribe = [](const void* context) {
         (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphUnsubscribe();
       };
     }
   }
 
-  foxglove_server_options cOptions = {};
-  cOptions.context = options.context.get_inner();
-  cOptions.name = {options.name.c_str(), options.name.length()};
-  cOptions.host = {options.host.c_str(), options.host.length()};
-  cOptions.port = options.port;
-  cOptions.callbacks = hasAnyCallbacks ? &cCallbacks : nullptr;
-  cOptions.capabilities =
+  foxglove_server_options c_cptions = {};
+  c_cptions.context = options.context.get_inner();
+  c_cptions.name = {options.name.c_str(), options.name.length()};
+  c_cptions.host = {options.host.c_str(), options.host.length()};
+  c_cptions.port = options.port;
+  c_cptions.callbacks = has_any_callbacks ? &c_callbacks : nullptr;
+  c_cptions.capabilities =
     static_cast<std::underlying_type_t<decltype(options.capabilities)>>(options.capabilities);
-  std::vector<foxglove_string> supportedEncodings;
-  supportedEncodings.reserve(options.supportedEncodings.size());
+  std::vector<foxglove_string> supported_encodings;
+  supported_encodings.reserve(options.supportedEncodings.size());
   for (const auto& encoding : options.supportedEncodings) {
-    supportedEncodings.push_back({encoding.c_str(), encoding.length()});
+    supported_encodings.push_back({encoding.c_str(), encoding.length()});
   }
-  cOptions.supported_encodings = supportedEncodings.data();
-  cOptions.supported_encodings_count = supportedEncodings.size();
+  c_cptions.supported_encodings = supported_encodings.data();
+  c_cptions.supported_encodings_count = supported_encodings.size();
 
   foxglove_websocket_server* server = nullptr;
-  foxglove_error error = foxglove_server_start(&cOptions, &server);
+  foxglove_error error = foxglove_server_start(&c_cptions, &server);
   if (error != foxglove_error::FOXGLOVE_ERROR_OK || server == nullptr) {
     return foxglove::unexpected(static_cast<FoxgloveError>(error));
   }

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -56,8 +56,10 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
     if (callbacks->onMessageData) {
       c_callbacks.on_message_data = [](
                                       // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-                                      uint32_t client_id, uint32_t client_channel_id,
-                                      const uint8_t* payload, size_t payload_len,
+                                      uint32_t client_id,
+                                      uint32_t client_channel_id,
+                                      const uint8_t* payload,
+                                      size_t payload_len,
                                       const void* context
                                     ) {
         (static_cast<const WebSocketServerCallbacks*>(context))

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -89,7 +89,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
   }
 
   foxglove_server_options c_cptions = {};
-  c_cptions.context = options.context.get_inner();
+  c_cptions.context = options.context.getInner();
   c_cptions.name = {options.name.c_str(), options.name.length()};
   c_cptions.host = {options.host.c_str(), options.host.length()};
   c_cptions.port = options.port;
@@ -97,8 +97,8 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
   c_cptions.capabilities =
     static_cast<std::underlying_type_t<decltype(options.capabilities)>>(options.capabilities);
   std::vector<foxglove_string> supported_encodings;
-  supported_encodings.reserve(options.supportedEncodings.size());
-  for (const auto& encoding : options.supportedEncodings) {
+  supported_encodings.reserve(options.supported_encodings.size());
+  for (const auto& encoding : options.supported_encodings) {
     supported_encodings.push_back({encoding.c_str(), encoding.length()});
   }
   c_cptions.supported_encodings = supported_encodings.data();
@@ -116,20 +116,20 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
 WebSocketServer::WebSocketServer(
   foxglove_websocket_server* server, std::unique_ptr<WebSocketServerCallbacks> callbacks
 )
-    : _impl(server, foxglove_server_stop)
-    , _callbacks(std::move(callbacks)) {}
+    : impl_(server, foxglove_server_stop)
+    , callbacks_(std::move(callbacks)) {}
 
 FoxgloveError WebSocketServer::stop() {
-  foxglove_error error = foxglove_server_stop(_impl.release());
+  foxglove_error error = foxglove_server_stop(impl_.release());
   return FoxgloveError(error);
 }
 
 uint16_t WebSocketServer::port() const {
-  return foxglove_server_get_port(_impl.get());
+  return foxglove_server_get_port(impl_.get());
 }
 
 void WebSocketServer::publishConnectionGraph(ConnectionGraph& graph) {
-  foxglove_server_publish_connection_graph(_impl.get(), graph._impl.get());
+  foxglove_server_publish_connection_graph(impl_.get(), graph.impl_.get());
 }
 
 }  // namespace foxglove

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -128,7 +128,7 @@ uint16_t WebSocketServer::port() const {
   return foxglove_server_get_port(_impl.get());
 }
 
-void WebSocketServer::publish_connection_graph(ConnectionGraph& graph) {
+void WebSocketServer::publishConnectionGraph(ConnectionGraph& graph) {
   foxglove_server_publish_connection_graph(_impl.get(), graph._impl.get());
 }
 

--- a/cpp/foxglove/src/server/connection_graph.cpp
+++ b/cpp/foxglove/src/server/connection_graph.cpp
@@ -4,10 +4,10 @@
 namespace foxglove {
 
 ConnectionGraph::ConnectionGraph()
-    : _impl(nullptr, foxglove_connection_graph_free) {
+    : impl_(nullptr, foxglove_connection_graph_free) {
   foxglove_connection_graph* impl = nullptr;
   foxglove_connection_graph_create(&impl);
-  _impl = std::unique_ptr<foxglove_connection_graph, void (*)(foxglove_connection_graph*)>(
+  impl_ = std::unique_ptr<foxglove_connection_graph, void (*)(foxglove_connection_graph*)>(
     impl, foxglove_connection_graph_free
   );
 }
@@ -21,7 +21,7 @@ FoxgloveError ConnectionGraph::setPublishedTopic(
     ids.push_back({id.c_str(), id.length()});
   }
   auto err = foxglove_connection_graph_set_published_topic(
-    _impl.get(), {topic.data(), topic.length()}, ids.data(), ids.size()
+    impl_.get(), {topic.data(), topic.length()}, ids.data(), ids.size()
   );
   return FoxgloveError(err);
 }
@@ -36,7 +36,7 @@ FoxgloveError ConnectionGraph::setSubscribedTopic(
   }
 
   auto err = foxglove_connection_graph_set_subscribed_topic(
-    _impl.get(), {topic.data(), topic.length()}, ids.data(), ids.size()
+    impl_.get(), {topic.data(), topic.length()}, ids.data(), ids.size()
   );
   return FoxgloveError(err);
 }
@@ -51,7 +51,7 @@ FoxgloveError ConnectionGraph::setAdvertisedService(
   }
 
   auto err = foxglove_connection_graph_set_advertised_service(
-    _impl.get(), {service.data(), service.length()}, ids.data(), ids.size()
+    impl_.get(), {service.data(), service.length()}, ids.data(), ids.size()
   );
   return FoxgloveError(err);
 }

--- a/cpp/foxglove/src/server/connection_graph.cpp
+++ b/cpp/foxglove/src/server/connection_graph.cpp
@@ -13,11 +13,11 @@ ConnectionGraph::ConnectionGraph()
 }
 
 FoxgloveError ConnectionGraph::setPublishedTopic(
-  std::string_view topic, const std::vector<std::string>& publisherIds
+  std::string_view topic, const std::vector<std::string>& publisher_ids
 ) {
   std::vector<foxglove_string> ids;
-  ids.reserve(publisherIds.size());
-  for (const auto& id : publisherIds) {
+  ids.reserve(publisher_ids.size());
+  for (const auto& id : publisher_ids) {
     ids.push_back({id.c_str(), id.length()});
   }
   auto err = foxglove_connection_graph_set_published_topic(
@@ -27,11 +27,11 @@ FoxgloveError ConnectionGraph::setPublishedTopic(
 }
 
 FoxgloveError ConnectionGraph::setSubscribedTopic(
-  std::string_view topic, const std::vector<std::string>& subscriberIds
+  std::string_view topic, const std::vector<std::string>& subscriber_ids
 ) {
   std::vector<foxglove_string> ids;
-  ids.reserve(subscriberIds.size());
-  for (const auto& id : subscriberIds) {
+  ids.reserve(subscriber_ids.size());
+  for (const auto& id : subscriber_ids) {
     ids.push_back({id.c_str(), id.length()});
   }
 
@@ -42,11 +42,11 @@ FoxgloveError ConnectionGraph::setSubscribedTopic(
 }
 
 FoxgloveError ConnectionGraph::setAdvertisedService(
-  std::string_view service, const std::vector<std::string>& providerIds
+  std::string_view service, const std::vector<std::string>& provider_ids
 ) {
   std::vector<foxglove_string> ids;
-  ids.reserve(providerIds.size());
-  for (const auto& id : providerIds) {
+  ids.reserve(provider_ids.size());
+  for (const auto& id : provider_ids) {
     ids.push_back({id.c_str(), id.length()});
   }
 

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -17,19 +17,19 @@ using Catch::Matchers::Equals;
 class FileCleanup {
 public:
   explicit FileCleanup(std::string&& path)
-      : _path(std::move(path)) {}
+      : path_(std::move(path)) {}
   FileCleanup(const FileCleanup&) = delete;
   FileCleanup& operator=(const FileCleanup&) = delete;
   FileCleanup(FileCleanup&&) = delete;
   FileCleanup& operator=(FileCleanup&&) = delete;
   ~FileCleanup() {
-    if (std::filesystem::exists(_path)) {
-      std::filesystem::remove(_path);
+    if (std::filesystem::exists(path_)) {
+      std::filesystem::remove(path_);
     }
   }
 
 private:
-  std::string _path;
+  std::string path_;
 };
 
 TEST_CASE("Open new file and close mcap writer") {
@@ -139,9 +139,9 @@ TEST_CASE("different contexts") {
   // Log on context2 (should not be output to the file)
   foxglove::Schema schema;
   schema.name = "ExampleSchema";
-  auto channelResult = foxglove::Channel::create("example1", "json", schema, context2);
-  REQUIRE(channelResult.has_value());
-  auto channel = std::move(channelResult.value());
+  auto channel_result = foxglove::Channel::create("example1", "json", schema, context2);
+  REQUIRE(channel_result.has_value());
+  auto channel = std::move(channel_result.value());
   std::string data = "Hello, world!";
   channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size());
 
@@ -168,9 +168,9 @@ TEST_CASE("specify profile") {
   // Write message
   foxglove::Schema schema;
   schema.name = "ExampleSchema";
-  auto channelResult = foxglove::Channel::create("example1", "json", schema, context);
-  REQUIRE(channelResult.has_value());
-  auto& channel = channelResult.value();
+  auto channel_result = foxglove::Channel::create("example1", "json", schema, context);
+  REQUIRE(channel_result.has_value());
+  auto& channel = channel_result.value();
   std::string data = "Hello, world!";
   channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size());
 
@@ -199,9 +199,9 @@ TEST_CASE("zstd compression") {
   // Write message
   foxglove::Schema schema;
   schema.name = "ExampleSchema";
-  auto channelResult = foxglove::Channel::create("example2", "json", schema, context);
-  REQUIRE(channelResult.has_value());
-  auto channel = std::move(channelResult.value());
+  auto channel_result = foxglove::Channel::create("example2", "json", schema, context);
+  REQUIRE(channel_result.has_value());
+  auto channel = std::move(channel_result.value());
   std::string data = "Hello, world!";
   channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size());
 
@@ -230,9 +230,9 @@ TEST_CASE("lz4 compression") {
   // Write message
   foxglove::Schema schema;
   schema.name = "ExampleSchema";
-  auto channelResult = foxglove::Channel::create("example3", "json", schema, context);
-  REQUIRE(channelResult.has_value());
-  auto& channel = channelResult.value();
+  auto channel_result = foxglove::Channel::create("example3", "json", schema, context);
+  REQUIRE(channel_result.has_value());
+  auto& channel = channel_result.value();
   std::string data = "Hello, world!";
   channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size());
 
@@ -264,7 +264,7 @@ TEST_CASE("Channel can outlive Schema") {
     schema.encoding = "unknown";
     std::string data = "FAKESCHEMA";
     schema.data = reinterpret_cast<const std::byte*>(data.data());
-    schema.dataLen = data.size();
+    schema.data_len = data.size();
     auto result = foxglove::Channel::create("example", "json", schema, context);
     REQUIRE(result.has_value());
     // Channel should copy the schema, so this modification has no effect on the output

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -191,8 +191,8 @@ TEST_CASE("zstd compression") {
   foxglove::McapWriterOptions options{context};
   options.path = "test.mcap";
   options.compression = foxglove::McapCompression::Zstd;
-  options.chunkSize = 10000;
-  options.useChunks = true;
+  options.chunk_size = 10000;
+  options.use_chunks = true;
   auto writer = foxglove::McapWriter::create(options);
   REQUIRE(writer.has_value());
 
@@ -222,8 +222,8 @@ TEST_CASE("lz4 compression") {
   foxglove::McapWriterOptions options{context};
   options.path = "test.mcap";
   options.compression = foxglove::McapCompression::Lz4;
-  options.chunkSize = 10000;
-  options.useChunks = true;
+  options.chunk_size = 10000;
+  options.use_chunks = true;
   auto writer = foxglove::McapWriter::create(options);
   REQUIRE(writer.has_value());
 

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -355,7 +355,7 @@ TEST_CASE("Publish a connection graph") {
   graph.setPublishedTopic("topic", {"publisher1", "publisher2"});
   graph.setSubscribedTopic("topic", {"subscriber1", "subscriber2"});
   graph.setAdvertisedService("service", {"provider1", "provider2"});
-  server.publishConnectionGraph(graph);
+  server.publish_connection_graph(graph);
 
   REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -355,7 +355,7 @@ TEST_CASE("Publish a connection graph") {
   graph.setPublishedTopic("topic", {"publisher1", "publisher2"});
   graph.setSubscribedTopic("topic", {"subscriber1", "subscriber2"});
   graph.setAdvertisedService("service", {"provider1", "provider2"});
-  server.publish_connection_graph(graph);
+  server.publishConnectionGraph(graph);
 
   REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -297,8 +297,8 @@ TEST_CASE("Client advertise/publish callbacks") {
           "id": 100,
           "topic": "topic",
           "encoding": "encoding",
-          "schema_name": "schema name",
-          "schema_encoding": "schema encoding",
+          "schemaName": "schema name",
+          "schemaEncoding": "schema encoding",
           "schema": "schema data"
         }
       ]

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -61,7 +61,7 @@ TEST_CASE("supported encoding is invalid utf-8") {
   options.name = "unit-test";
   options.host = "127.0.0.1";
   options.port = 0;
-  options.supportedEncodings.emplace_back("\x80\x80\x80\x80");
+  options.supported_encodings.emplace_back("\x80\x80\x80\x80");
   auto server_result = foxglove::WebSocketServer::create(std::move(options));
   REQUIRE(!server_result.has_value());
   REQUIRE(server_result.error() == foxglove::FoxgloveError::Utf8Error);
@@ -227,7 +227,7 @@ TEST_CASE("Client advertise/publish callbacks") {
   options.host = "127.0.0.1";
   options.port = 0;
   options.capabilities = foxglove::WebSocketServerCapabilities::ClientPublish;
-  options.supportedEncodings = {"schema encoding", "another"};
+  options.supported_encodings = {"schema encoding", "another"};
   options.callbacks.onClientAdvertise =
     [&](uint32_t client_id, const foxglove::ClientChannel& channel) {
       std::scoped_lock lock{mutex};
@@ -236,10 +236,10 @@ TEST_CASE("Client advertise/publish callbacks") {
       REQUIRE(channel.id == 100);
       REQUIRE(channel.topic == "topic");
       REQUIRE(channel.encoding == "encoding");
-      REQUIRE(channel.schemaName == "schema name");
-      REQUIRE(channel.schemaEncoding == "schema encoding");
+      REQUIRE(channel.schema_name == "schema name");
+      REQUIRE(channel.schema_encoding == "schema encoding");
       REQUIRE(
-        std::string_view(reinterpret_cast<const char*>(channel.schema), channel.schemaLen) ==
+        std::string_view(reinterpret_cast<const char*>(channel.schema), channel.schema_len) ==
         "schema data"
       );
       cv.notify_all();
@@ -297,8 +297,8 @@ TEST_CASE("Client advertise/publish callbacks") {
           "id": 100,
           "topic": "topic",
           "encoding": "encoding",
-          "schemaName": "schema name",
-          "schemaEncoding": "schema encoding",
+          "schema_name": "schema name",
+          "schema_encoding": "schema encoding",
           "schema": "schema data"
         }
       ]

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -20,7 +20,7 @@ using WebSocketClient = websocketpp::client<websocketpp::config::asio_client>;
 namespace {
 
 template<class T>
-constexpr std::underlying_type_t<T> to_underlying(T e) noexcept {
+constexpr std::underlying_type_t<T> toUnderlying(T e) noexcept {
   return static_cast<std::underlying_type_t<T>>(e);
 }
 
@@ -31,9 +31,9 @@ TEST_CASE("Start and stop server") {
   options.name = "unit-test";
   options.host = "127.0.0.1";
   options.port = 0;
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(serverResult.has_value());
-  auto& server = serverResult.value();
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(server_result.has_value());
+  auto& server = server_result.value();
   REQUIRE(server.port() != 0);
   REQUIRE(server.stop() == foxglove::FoxgloveError::Ok);
 }
@@ -41,19 +41,19 @@ TEST_CASE("Start and stop server") {
 TEST_CASE("name is not valid utf-8") {
   foxglove::WebSocketServerOptions options;
   options.name = "\x80\x80\x80\x80";
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(!serverResult.has_value());
-  REQUIRE(serverResult.error() == foxglove::FoxgloveError::Utf8Error);
-  REQUIRE(foxglove::strerror(serverResult.error()) == std::string("UTF-8 Error"));
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(!server_result.has_value());
+  REQUIRE(server_result.error() == foxglove::FoxgloveError::Utf8Error);
+  REQUIRE(foxglove::strerror(server_result.error()) == std::string("UTF-8 Error"));
 }
 
 TEST_CASE("we can't bind host") {
   foxglove::WebSocketServerOptions options;
   options.name = "unit-test";
   options.host = "invalidhost";
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(!serverResult.has_value());
-  REQUIRE(serverResult.error() == foxglove::FoxgloveError::Bind);
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(!server_result.has_value());
+  REQUIRE(server_result.error() == foxglove::FoxgloveError::Bind);
 }
 
 TEST_CASE("supported encoding is invalid utf-8") {
@@ -62,10 +62,10 @@ TEST_CASE("supported encoding is invalid utf-8") {
   options.host = "127.0.0.1";
   options.port = 0;
   options.supportedEncodings.emplace_back("\x80\x80\x80\x80");
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(!serverResult.has_value());
-  REQUIRE(serverResult.error() == foxglove::FoxgloveError::Utf8Error);
-  REQUIRE(foxglove::strerror(serverResult.error()) == std::string("UTF-8 Error"));
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(!server_result.has_value());
+  REQUIRE(server_result.error() == foxglove::FoxgloveError::Utf8Error);
+  REQUIRE(foxglove::strerror(server_result.error()) == std::string("UTF-8 Error"));
 }
 
 TEST_CASE("Log a message with and without metadata") {
@@ -74,14 +74,14 @@ TEST_CASE("Log a message with and without metadata") {
   options.name = "unit-test";
   options.host = "127.0.0.1";
   options.port = 0;
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(serverResult.has_value());
-  auto& server = serverResult.value();
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(server_result.has_value());
+  auto& server = server_result.value();
   REQUIRE(server.port() != 0);
 
-  auto channelResult = foxglove::Channel::create("example", "json", std::nullopt, context);
-  REQUIRE(channelResult.has_value());
-  auto channel = std::move(channelResult.value());
+  auto channel_result = foxglove::Channel::create("example", "json", std::nullopt, context);
+  REQUIRE(channel_result.has_value());
+  auto channel = std::move(channel_result.value());
   const std::array<uint8_t, 3> data = {1, 2, 3};
   REQUIRE(
     channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size()) ==
@@ -98,9 +98,9 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
   std::mutex mutex;
   std::condition_variable cv;
   // the following variables are protected by the mutex:
-  bool connectionOpened = false;
-  std::vector<uint64_t> subscribeCalls;
-  std::vector<uint64_t> unsubscribeCalls;
+  bool connection_opened = false;
+  std::vector<uint64_t> subscribe_calls;
+  std::vector<uint64_t> unsubscribe_calls;
 
   std::unique_lock lock{mutex};
 
@@ -110,31 +110,31 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
   options.port = 0;
   options.callbacks.onSubscribe = [&](uint64_t channel_id) {
     std::scoped_lock lock{mutex};
-    subscribeCalls.push_back(channel_id);
+    subscribe_calls.push_back(channel_id);
     cv.notify_all();
   };
   options.callbacks.onUnsubscribe = [&](uint64_t channel_id) {
     std::scoped_lock lock{mutex};
-    unsubscribeCalls.push_back(channel_id);
+    unsubscribe_calls.push_back(channel_id);
     cv.notify_all();
   };
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(serverResult.has_value());
-  auto& server = serverResult.value();
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(server_result.has_value());
+  auto& server = server_result.value();
   REQUIRE(server.port() != 0);
 
   foxglove::Schema schema;
   schema.name = "ExampleSchema";
-  auto channelResult = foxglove::Channel::create("example", "json", schema, context);
-  REQUIRE(channelResult.has_value());
-  auto channel = std::move(channelResult.value());
+  auto channel_result = foxglove::Channel::create("example", "json", schema, context);
+  REQUIRE(channel_result.has_value());
+  auto channel = std::move(channel_result.value());
 
   WebSocketClient client;
   client.clear_access_channels(websocketpp::log::alevel::all);
   client.clear_error_channels(websocketpp::log::elevel::all);
   client.set_open_handler([&](const auto& hdl) {
     std::scoped_lock lock{mutex};
-    connectionOpened = true;
+    connection_opened = true;
     cv.notify_all();
   });
   client.init_asio();
@@ -144,10 +144,10 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
   client.connect(connection);
-  std::thread clientThread{&WebSocketClient::run, std::ref(client)};
+  std::thread client_thread{&WebSocketClient::run, std::ref(client)};
 
   cv.wait(lock, [&] {
-    return connectionOpened;
+    return connection_opened;
   });
   client.send(
     connection,
@@ -159,15 +159,14 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
       std::to_string(channel.id()) + R"( }
       ]
     })",
-    websocketpp::frame::opcode::text,
-    ec
+    websocketpp::frame::opcode::text, ec
   );
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
   cv.wait_for(lock, std::chrono::seconds(1), [&] {
-    return !subscribeCalls.empty();
+    return !subscribe_calls.empty();
   });
-  REQUIRE_THAT(subscribeCalls, Equals(std::vector<uint64_t>{1}));
+  REQUIRE_THAT(subscribe_calls, Equals(std::vector<uint64_t>{1}));
 
   client.send(
     connection,
@@ -175,38 +174,37 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
       "op": "unsubscribe",
       "subscriptionIds": [100]
     })",
-    websocketpp::frame::opcode::text,
-    ec
+    websocketpp::frame::opcode::text, ec
   );
   cv.wait_for(lock, std::chrono::seconds(1), [&] {
-    return !unsubscribeCalls.empty();
+    return !unsubscribe_calls.empty();
   });
-  REQUIRE_THAT(unsubscribeCalls, Equals(std::vector<uint64_t>{1}));
+  REQUIRE_THAT(unsubscribe_calls, Equals(std::vector<uint64_t>{1}));
 
   client.close(connection, websocketpp::close::status::normal, "", ec);
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
-  clientThread.join();
+  client_thread.join();
 }
 
 TEST_CASE("Capability enums") {
   REQUIRE(
-    to_underlying(foxglove::WebSocketServerCapabilities::ClientPublish) ==
+    toUnderlying(foxglove::WebSocketServerCapabilities::ClientPublish) ==
     (FOXGLOVE_SERVER_CAPABILITY_CLIENT_PUBLISH)
   );
   REQUIRE(
-    to_underlying(foxglove::WebSocketServerCapabilities::ConnectionGraph) ==
+    toUnderlying(foxglove::WebSocketServerCapabilities::ConnectionGraph) ==
     (FOXGLOVE_SERVER_CAPABILITY_CONNECTION_GRAPH)
   );
   REQUIRE(
-    to_underlying(foxglove::WebSocketServerCapabilities::Parameters) ==
+    toUnderlying(foxglove::WebSocketServerCapabilities::Parameters) ==
     (FOXGLOVE_SERVER_CAPABILITY_PARAMETERS)
   );
   REQUIRE(
-    to_underlying(foxglove::WebSocketServerCapabilities::Time) == (FOXGLOVE_SERVER_CAPABILITY_TIME)
+    toUnderlying(foxglove::WebSocketServerCapabilities::Time) == (FOXGLOVE_SERVER_CAPABILITY_TIME)
   );
   REQUIRE(
-    to_underlying(foxglove::WebSocketServerCapabilities::Services) ==
+    toUnderlying(foxglove::WebSocketServerCapabilities::Services) ==
     (FOXGLOVE_SERVER_CAPABILITY_SERVICES)
   );
 }
@@ -216,9 +214,9 @@ TEST_CASE("Client advertise/publish callbacks") {
   std::mutex mutex;
   std::condition_variable cv;
   // the following variables are protected by the mutex:
-  bool connectionOpened = false;
+  bool connection_opened = false;
   bool advertised = false;
-  bool receivedMessage = false;
+  bool received_message = false;
 
   std::unique_lock lock{mutex};
 
@@ -229,10 +227,10 @@ TEST_CASE("Client advertise/publish callbacks") {
   options.capabilities = foxglove::WebSocketServerCapabilities::ClientPublish;
   options.supportedEncodings = {"schema encoding", "another"};
   options.callbacks.onClientAdvertise =
-    [&](uint32_t clientId, const foxglove::ClientChannel& channel) {
+    [&](uint32_t client_id, const foxglove::ClientChannel& channel) {
       std::scoped_lock lock{mutex};
       advertised = true;
-      REQUIRE(clientId == 1);
+      REQUIRE(client_id == 1);
       REQUIRE(channel.id == 100);
       REQUIRE(channel.topic == "topic");
       REQUIRE(channel.encoding == "encoding");
@@ -246,26 +244,26 @@ TEST_CASE("Client advertise/publish callbacks") {
     };
   options.callbacks.onMessageData =
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    [&](uint32_t clientId, uint32_t clientChannelId, const std::byte* data, size_t dataLen) {
+    [&](uint32_t client_id, uint32_t client_channel_id, const std::byte* data, size_t data_len) {
       std::scoped_lock lock{mutex};
-      receivedMessage = true;
-      REQUIRE(clientId == 1);
-      REQUIRE(dataLen == 3);
+      received_message = true;
+      REQUIRE(client_id == 1);
+      REQUIRE(data_len == 3);
       REQUIRE(char(data[0]) == 'a');
       REQUIRE(char(data[1]) == 'b');
       REQUIRE(char(data[2]) == 'c');
       cv.notify_all();
     };
-  options.callbacks.onClientUnadvertise = [&](uint32_t clientId, uint32_t clientChannelId) {
+  options.callbacks.onClientUnadvertise = [&](uint32_t client_id, uint32_t client_channel_id) {
     std::scoped_lock lock{mutex};
     advertised = false;
-    REQUIRE(clientId == 1);
-    REQUIRE(clientChannelId == 100);
+    REQUIRE(client_id == 1);
+    REQUIRE(client_channel_id == 100);
     cv.notify_all();
   };
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(serverResult.has_value());
-  auto& server = serverResult.value();
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(server_result.has_value());
+  auto& server = server_result.value();
   REQUIRE(server.port() != 0);
 
   WebSocketClient client;
@@ -273,7 +271,7 @@ TEST_CASE("Client advertise/publish callbacks") {
   client.clear_error_channels(websocketpp::log::elevel::all);
   client.set_open_handler([&](const auto& hdl) {
     std::scoped_lock lock{mutex};
-    connectionOpened = true;
+    connection_opened = true;
     cv.notify_all();
   });
   client.init_asio();
@@ -283,10 +281,10 @@ TEST_CASE("Client advertise/publish callbacks") {
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
   client.connect(connection);
-  std::thread clientThread{&WebSocketClient::run, std::ref(client)};
+  std::thread client_thread{&WebSocketClient::run, std::ref(client)};
 
   cv.wait(lock, [&] {
-    return connectionOpened;
+    return connection_opened;
   });
   client.send(
     connection,
@@ -303,23 +301,22 @@ TEST_CASE("Client advertise/publish callbacks") {
         }
       ]
     })",
-    websocketpp::frame::opcode::text,
-    ec
+    websocketpp::frame::opcode::text, ec
   );
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
-  auto advertisedResult = cv.wait_for(lock, std::chrono::seconds(1), [&] {
+  auto advertised_result = cv.wait_for(lock, std::chrono::seconds(1), [&] {
     return advertised;
   });
-  REQUIRE(advertisedResult);
+  REQUIRE(advertised_result);
 
   // send ClientMessageData message
   std::array<char, 8> msg = {1, 100, 0, 0, 0, 'a', 'b', 'c'};
   client.send(connection, msg.data(), msg.size(), websocketpp::frame::opcode::binary, ec);
-  auto receivedResult = cv.wait_for(lock, std::chrono::seconds(1), [&] {
-    return receivedMessage;
+  auto received_result = cv.wait_for(lock, std::chrono::seconds(1), [&] {
+    return received_message;
   });
-  REQUIRE(receivedResult);
+  REQUIRE(received_result);
 
   client.send(
     connection,
@@ -327,8 +324,7 @@ TEST_CASE("Client advertise/publish callbacks") {
       "op": "unadvertise",
       "channelIds": [100]
     })",
-    websocketpp::frame::opcode::text,
-    ec
+    websocketpp::frame::opcode::text, ec
   );
   cv.wait(lock, [&] {
     return !advertised;
@@ -337,7 +333,7 @@ TEST_CASE("Client advertise/publish callbacks") {
   client.close(connection, websocketpp::close::status::normal, "", ec);
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
-  clientThread.join();
+  client_thread.join();
 }
 
 TEST_CASE("Publish a connection graph") {
@@ -346,9 +342,9 @@ TEST_CASE("Publish a connection graph") {
   options.host = "127.0.0.1";
   options.port = 0;
   options.capabilities = foxglove::WebSocketServerCapabilities::ConnectionGraph;
-  auto serverResult = foxglove::WebSocketServer::create(std::move(options));
-  REQUIRE(serverResult.has_value());
-  auto& server = serverResult.value();
+  auto server_result = foxglove::WebSocketServer::create(std::move(options));
+  REQUIRE(server_result.has_value());
+  auto& server = server_result.value();
   REQUIRE(server.port() != 0);
 
   foxglove::ConnectionGraph graph;

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -159,7 +159,8 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
       std::to_string(channel.id()) + R"( }
       ]
     })",
-    websocketpp::frame::opcode::text, ec
+    websocketpp::frame::opcode::text,
+    ec
   );
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
@@ -174,7 +175,8 @@ TEST_CASE("Subscribe and unsubscribe callbacks") {
       "op": "unsubscribe",
       "subscriptionIds": [100]
     })",
-    websocketpp::frame::opcode::text, ec
+    websocketpp::frame::opcode::text,
+    ec
   );
   cv.wait_for(lock, std::chrono::seconds(1), [&] {
     return !unsubscribe_calls.empty();
@@ -301,7 +303,8 @@ TEST_CASE("Client advertise/publish callbacks") {
         }
       ]
     })",
-    websocketpp::frame::opcode::text, ec
+    websocketpp::frame::opcode::text,
+    ec
   );
   UNSCOPED_INFO(ec.message());
   REQUIRE(!ec);
@@ -324,7 +327,8 @@ TEST_CASE("Client advertise/publish callbacks") {
       "op": "unadvertise",
       "channelIds": [100]
     })",
-    websocketpp::frame::opcode::text, ec
+    websocketpp::frame::opcode::text,
+    ec
   );
   cv.wait(lock, [&] {
     return !advertised;


### PR DESCRIPTION
### Changelog
c++: Breaking: parameters such as mcap writer options are now snake_case

### Description

This fixes clang-tidy settings to include our C++ header files as well, and fixes some of the resulting warnings.

This also adds `readability-identifier-naming` casing options to clang-tidy, which accounts for most of the changes here.

The settings generally Google's style guide but use `camelBack` for methods rather than initial caps. That's what we've favored so far; the main change here, then, is to use snake_case for variables, etc. The other change I added was to trailing underscore for private members; since there are some specific restrictions related to leading underscores, it seemed easier to enforce the latter.

The casing changes here do involve some breaking changes, and are up for debate.

I omitted global options, since I don't see a reason for us to include any.