### PR TITLE
rust: Rework websocket responder payload types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,6 @@ dependencies = [
 name = "example-ws-server-fetch-asset"
 version = "0.0.0"
 dependencies = [
- "bytes",
  "clap",
  "env_logger",
  "foxglove",

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -1,6 +1,5 @@
 use crate::{errors::PyFoxgloveError, PySchema};
 use base64::prelude::*;
-use bytes::Bytes;
 use foxglove::websocket::{
     AssetHandler, ChannelView, Client, ClientChannel, ServerListener, Status, StatusLevel,
 };
@@ -347,9 +346,7 @@ impl foxglove::websocket::service::Handler for ServiceHandler {
                     .bind(py)
                     .call((request,), None)
                     .and_then(|data| data.extract::<Vec<u8>>())
-            })
-            .map(Bytes::from)
-            .map_err(|e| e.to_string());
+            });
             responder.respond(result);
         });
     }
@@ -628,9 +625,7 @@ impl AssetHandler for CallbackAssetHandler {
                         data.extract::<Vec<u8>>()
                     }
                 })
-            })
-            .map(Bytes::from)
-            .map_err(|e| e.to_string());
+            });
             responder.respond(result);
         });
     }

--- a/rust/examples/ws-server-fetch-asset/Cargo.toml
+++ b/rust/examples/ws-server-fetch-asset/Cargo.toml
@@ -8,4 +8,3 @@ foxglove = { path = "../../foxglove" }
 tokio = { version = "1.43", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"
-bytes = "1.10.0"

--- a/rust/examples/ws-server-fetch-asset/src/main.rs
+++ b/rust/examples/ws-server-fetch-asset/src/main.rs
@@ -1,19 +1,17 @@
-use bytes::Bytes;
 use clap::Parser;
 
 use foxglove::websocket::{AssetHandler, AssetResponder};
 use std::collections::HashMap;
 
 struct AssetServer {
-    assets: HashMap<String, Bytes>,
+    assets: HashMap<String, &'static [u8]>,
 }
 
 impl AssetServer {
     fn new() -> Self {
-        let mut assets = HashMap::new();
-        assets.insert("/test/one".to_string(), Bytes::from_static(b"one"));
-        assets.insert("/test/two".to_string(), Bytes::from_static(b"two"));
-
+        let mut assets: HashMap<_, &'static [u8]> = HashMap::new();
+        assets.insert("/test/one".to_string(), b"one");
+        assets.insert("/test/two".to_string(), b"two");
         Self { assets }
     }
 }
@@ -23,8 +21,8 @@ impl AssetHandler for AssetServer {
         match self.assets.get(&uri) {
             // A real implementation might use std::fs::read to read a file into a Vec<u8>
             // The ws-protocol doesn't currently support streaming for a single asset.
-            Some(asset) => responder.respond(Ok(asset.clone())),
-            None => responder.respond(Err(format!("Asset {} not found", uri))),
+            Some(asset) => responder.respond_ok(asset),
+            None => responder.respond_err(format!("Asset {} not found", uri)),
         }
     }
 }

--- a/rust/foxglove/src/websocket/client.rs
+++ b/rust/foxglove/src/websocket/client.rs
@@ -2,8 +2,6 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Weak;
 
-use bytes::Bytes;
-
 use super::connected_client::ConnectedClient;
 use super::Status;
 
@@ -60,11 +58,11 @@ impl Client {
     }
 
     /// Send a fetch asset response to the client. Does nothing if client is disconnected.
-    pub(crate) fn send_asset_response(&self, result: Result<Bytes, String>, request_id: u32) {
+    pub(crate) fn send_asset_response(&self, result: Result<&[u8], &str>, request_id: u32) {
         if let Some(client) = self.client.upgrade() {
             match result {
-                Ok(asset) => client.send_asset_response(&asset, request_id),
-                Err(err) => client.send_asset_error(&err.to_string(), request_id),
+                Ok(asset) => client.send_asset_response(asset, request_id),
+                Err(err) => client.send_asset_error(err, request_id),
             }
         }
     }

--- a/rust/foxglove/src/websocket/service/handler.rs
+++ b/rust/foxglove/src/websocket/service/handler.rs
@@ -1,6 +1,6 @@
-use std::{fmt::Display, future::Future, sync::Arc};
-
-use bytes::Bytes;
+use std::fmt::Display;
+use std::future::Future;
+use std::sync::Arc;
 
 use crate::websocket::service::{Request, Responder};
 
@@ -28,76 +28,86 @@ pub trait SyncHandler: Send + Sync {
     /// The error type returned for service calls.
     type Error: Display;
 
+    /// Response payload type.
+    type Response: AsRef<[u8]> + 'static;
+
     /// Synchronously handles a service call request from a client and returns a result.
     ///
     /// This method is invoked from the client's main poll loop and must not block. If blocking or
     /// long-running behavior is required, use [`Handler`] instead.
-    fn call(&self, request: Request) -> Result<Bytes, Self::Error>;
+    fn call(&self, request: Request) -> Result<Self::Response, Self::Error>;
 }
 
 impl<T: SyncHandler> Handler for T {
     fn call(&self, request: Request, responder: Responder) {
         let result = SyncHandler::call(self, request);
-        responder.respond(result.map_err(|e| e.to_string()));
+        responder.respond(result);
     }
 }
 
 /// A wrapper around a function that serves as a service call handler.
-pub(crate) struct HandlerFn<F, E>(pub F)
+pub(crate) struct HandlerFn<F, T, E>(pub F)
 where
-    F: Fn(Request) -> Result<Bytes, E> + Send + Sync,
+    F: Fn(Request) -> Result<T, E> + Send + Sync,
+    T: AsRef<[u8]> + 'static,
     E: Display;
 
-impl<F, E> SyncHandler for HandlerFn<F, E>
+impl<F, T, E> SyncHandler for HandlerFn<F, T, E>
 where
-    F: Fn(Request) -> Result<Bytes, E> + Send + Sync,
+    F: Fn(Request) -> Result<T, E> + Send + Sync,
+    T: AsRef<[u8]> + 'static,
     E: Display,
 {
     type Error = E;
+    type Response = T;
 
-    fn call(&self, request: Request) -> Result<Bytes, Self::Error> {
+    fn call(&self, request: Request) -> Result<Self::Response, Self::Error> {
         self.0(request)
     }
 }
 
 /// A wrapper around a blocking function that serves as a service call handler.
-pub(crate) struct BlockingHandlerFn<F, E>(pub Arc<F>)
+pub(crate) struct BlockingHandlerFn<F, T, E>(pub Arc<F>)
 where
-    F: Fn(Request) -> Result<Bytes, E> + Send + Sync + 'static,
+    F: Fn(Request) -> Result<T, E> + Send + Sync + 'static,
+    T: AsRef<[u8]> + 'static,
     E: Display;
 
-impl<F, E> Handler for BlockingHandlerFn<F, E>
+impl<F, T, E> Handler for BlockingHandlerFn<F, T, E>
 where
-    F: Fn(Request) -> Result<Bytes, E> + Send + Sync + 'static,
+    F: Fn(Request) -> Result<T, E> + Send + Sync + 'static,
+    T: AsRef<[u8]> + 'static,
     E: Display,
 {
     fn call(&self, request: Request, responder: Responder) {
         let func = self.0.clone();
         tokio::task::spawn_blocking(move || {
             let result = (func)(request);
-            responder.respond(result.map_err(|e| e.to_string()));
+            responder.respond(result);
         });
     }
 }
 
 /// A wrapper around a async function that serves as a service call handler.
-pub(crate) struct AsyncHandlerFn<F, Fut, E>(pub Arc<F>)
+pub(crate) struct AsyncHandlerFn<F, Fut, T, E>(pub Arc<F>)
 where
     F: Fn(Request) -> Fut + Send + Sync,
-    Fut: Future<Output = Result<Bytes, E>> + Send + 'static,
+    Fut: Future<Output = Result<T, E>> + Send + 'static,
+    T: AsRef<[u8]> + 'static,
     E: Display;
 
-impl<F, Fut, E> Handler for AsyncHandlerFn<F, Fut, E>
+impl<F, Fut, T, E> Handler for AsyncHandlerFn<F, Fut, T, E>
 where
     F: Fn(Request) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<Bytes, E>> + Send,
+    Fut: Future<Output = Result<T, E>> + Send,
+    T: AsRef<[u8]> + 'static,
     E: Display + Send,
 {
     fn call(&self, request: Request, responder: Responder) {
         let func = self.0.clone();
         tokio::task::spawn(async move {
             let result = (func)(request).await;
-            responder.respond(result.map_err(|e| e.to_string()));
+            responder.respond(result);
         });
     }
 }

--- a/rust/foxglove/src/websocket/service/tests.rs
+++ b/rust/foxglove/src/websocket/service/tests.rs
@@ -3,7 +3,7 @@ use super::{Service, ServiceId, ServiceMap, ServiceSchema};
 fn make_service(name: &str, id: u32) -> Service {
     Service::builder(name, ServiceSchema::new("schema"))
         .with_id(ServiceId::new(id))
-        .handler_fn(|_| Err(""))
+        .handler_fn(|_| Err::<&[u8], _>(""))
 }
 
 #[test]


### PR DESCRIPTION
### Changelog
- rust: Breaking: Changed websocket FetchAsset and Service handler types

### Description
I originally proposed we use `bytes::Bytes` for websocket responders, which works fine for callback wrappers that need to return an owned/static value, but it's too restrictive for the underlying responder methods, which would be perfectly happy with any `T: AsRef<[u8]>`.

And so, the core of this change is updating [`service::Responder::respond`](https://github.com/foxglove/foxglove-sdk/pull/395/files#diff-0dc13b18578dee88e4a12ad6685a031c1b807dbe8ced9cb5151cc6253e93c9d4R52-R55) and [`AssetResponder::respond`](https://github.com/foxglove/foxglove-sdk/pull/395/files#diff-48005a706a82df3099ed9cd1dd2586acb02efc3d24d32abfd702dabc4173528dR80-R84) to accept a `T: AsRef<[u8]>`.

Since that change breaks compatibility (albeit in a mild way), we might as well go a bit further:
- If we accept an `E: Display`, we can simplify several callers.
- Callback wrappers can return a `T: AsRef<[u8]>`.