### PR TITLE
C++: Catch callback exceptions

### DIFF
--- a/cpp/foxglove/include/foxglove/error.hpp
+++ b/cpp/foxglove/include/foxglove/error.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <iostream>
+#include <sstream>
 
 #include "expected.hpp"
 
@@ -28,5 +30,49 @@ template<typename T>
 using FoxgloveResult = expected<T, FoxgloveError>;
 
 const char* strerror(FoxgloveError error);
+
+class WarnStream {
+public:
+  WarnStream() = default;
+  WarnStream(const WarnStream&) = delete;
+  WarnStream(WarnStream&&) = delete;
+  WarnStream& operator=(const WarnStream&) = delete;
+  WarnStream& operator=(WarnStream&&) = delete;
+
+  template<typename T>
+  WarnStream& operator<<(const T& value) {
+#ifndef FOXGLOVE_DISABLE_CPP_WARNINGS
+    // If T is an array type, we need special handling to avoid
+    // cppcoreguidelines-pro-bounds-array-to-pointer-decay.
+    if constexpr (std::is_array_v<T>) {
+      // Determine the underlying element type of the array. If it's a char
+      // array, treat it as a C-style string. Otherwise, it's just a pointer.
+      using ElementType = std::remove_cv_t<std::remove_all_extents_t<T>>;
+      if constexpr (std::is_same_v<ElementType, char>) {
+        buffer_ << static_cast<const char*>(value);
+      } else {
+        buffer_ << static_cast<const void*>(value);
+      }
+    } else {
+      buffer_ << value;
+    }
+#endif
+    return *this;
+  }
+
+  ~WarnStream() {
+#ifndef FOXGLOVE_DISABLE_CPP_WARNINGS
+    auto msg = buffer_.str();
+    std::cerr << "[foxglove] " << msg << "\n";
+#endif
+  }
+
+private:
+  std::ostringstream buffer_;
+};
+
+inline WarnStream warn() {
+  return WarnStream{};
+}
 
 }  // namespace foxglove

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -4,7 +4,6 @@
 #include <foxglove/server.hpp>
 #include <foxglove/server/connection_graph.hpp>
 
-#include <iostream>
 #include <type_traits>
 
 namespace foxglove {
@@ -32,7 +31,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
         try {
           (static_cast<const WebSocketServerCallbacks*>(context))->onSubscribe(channel_id);
         } catch (const std::exception& exc) {
-          std::cerr << "onSubscribe callback failed: " << exc.what() << "\n";
+          warn() << "onSubscribe callback failed: " << exc.what();
         }
       };
     }
@@ -41,7 +40,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
         try {
           (static_cast<const WebSocketServerCallbacks*>(context))->onUnsubscribe(channel_id);
         } catch (const std::exception& exc) {
-          std::cerr << "onUnsubscribe callback failed: " << exc.what() << "\n";
+          warn() << "onUnsubscribe callback failed: " << exc.what();
         }
       };
     }
@@ -61,7 +60,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
             (static_cast<const WebSocketServerCallbacks*>(context))
               ->onClientAdvertise(client_id, cpp_channel);
           } catch (const std::exception& exc) {
-            std::cerr << "onClientAdvertise callback failed: " << exc.what() << "\n";
+            warn() << "onClientAdvertise callback failed: " << exc.what();
           }
         };
     }
@@ -80,7 +79,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
               client_id, client_channel_id, reinterpret_cast<const std::byte*>(payload), payload_len
             );
         } catch (const std::exception& exc) {
-          std::cerr << "onMessageData callback failed: " << exc.what() << "\n";
+          warn() << "onMessageData callback failed: " << exc.what();
         }
       };
     }
@@ -92,7 +91,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
             (static_cast<const WebSocketServerCallbacks*>(context))
               ->onClientUnadvertise(client_id, client_channel_id);
           } catch (const std::exception& exc) {
-            std::cerr << "onClientUnadvertise callback failed: " << exc.what() << "\n";
+            warn() << "onClientUnadvertise callback failed: " << exc.what();
           }
         };
     }
@@ -101,7 +100,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
         try {
           (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphSubscribe();
         } catch (const std::exception& exc) {
-          std::cerr << "onConnectionGraphSubscribe callback failed: " << exc.what() << "\n";
+          warn() << "onConnectionGraphSubscribe callback failed: " << exc.what();
         }
       };
     }
@@ -110,7 +109,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
         try {
           (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphUnsubscribe();
         } catch (const std::exception& exc) {
-          std::cerr << "onConnectionGraphUnsubscribe callback failed: " << exc.what() << "\n";
+          warn() << "onConnectionGraphUnsubscribe callback failed: " << exc.what();
         }
       };
     }

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -29,12 +29,20 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
     c_callbacks.context = callbacks.get();
     if (callbacks->onSubscribe) {
       c_callbacks.on_subscribe = [](uint64_t channel_id, const void* context) {
-        (static_cast<const WebSocketServerCallbacks*>(context))->onSubscribe(channel_id);
+        try {
+          (static_cast<const WebSocketServerCallbacks*>(context))->onSubscribe(channel_id);
+        } catch (const std::exception& exc) {
+          std::cerr << "onSubscribe callback failed: " << exc.what() << "\n";
+        }
       };
     }
     if (callbacks->onUnsubscribe) {
       c_callbacks.on_unsubscribe = [](uint64_t channel_id, const void* context) {
-        (static_cast<const WebSocketServerCallbacks*>(context))->onUnsubscribe(channel_id);
+        try {
+          (static_cast<const WebSocketServerCallbacks*>(context))->onUnsubscribe(channel_id);
+        } catch (const std::exception& exc) {
+          std::cerr << "onUnsubscribe callback failed: " << exc.what() << "\n";
+        }
       };
     }
     if (callbacks->onClientAdvertise) {
@@ -49,8 +57,12 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
             reinterpret_cast<const std::byte*>(channel->schema),
             channel->schema_len
           };
-          (static_cast<const WebSocketServerCallbacks*>(context))
-            ->onClientAdvertise(client_id, cpp_channel);
+          try {
+            (static_cast<const WebSocketServerCallbacks*>(context))
+              ->onClientAdvertise(client_id, cpp_channel);
+          } catch (const std::exception& exc) {
+            std::cerr << "onClientAdvertise callback failed: " << exc.what() << "\n";
+          }
         };
     }
     if (callbacks->onMessageData) {
@@ -62,28 +74,44 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
                                       size_t payload_len,
                                       const void* context
                                     ) {
-        (static_cast<const WebSocketServerCallbacks*>(context))
-          ->onMessageData(
-            client_id, client_channel_id, reinterpret_cast<const std::byte*>(payload), payload_len
-          );
+        try {
+          (static_cast<const WebSocketServerCallbacks*>(context))
+            ->onMessageData(
+              client_id, client_channel_id, reinterpret_cast<const std::byte*>(payload), payload_len
+            );
+        } catch (const std::exception& exc) {
+          std::cerr << "onMessageData callback failed: " << exc.what() << "\n";
+        }
       };
     }
     if (callbacks->onClientUnadvertise) {
       c_callbacks.on_client_unadvertise =
         // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
         [](uint32_t client_id, uint32_t client_channel_id, const void* context) {
-          (static_cast<const WebSocketServerCallbacks*>(context))
-            ->onClientUnadvertise(client_id, client_channel_id);
+          try {
+            (static_cast<const WebSocketServerCallbacks*>(context))
+              ->onClientUnadvertise(client_id, client_channel_id);
+          } catch (const std::exception& exc) {
+            std::cerr << "onClientUnadvertise callback failed: " << exc.what() << "\n";
+          }
         };
     }
     if (callbacks->onConnectionGraphSubscribe) {
       c_callbacks.on_connection_graph_subscribe = [](const void* context) {
-        (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphSubscribe();
+        try {
+          (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphSubscribe();
+        } catch (const std::exception& exc) {
+          std::cerr << "onConnectionGraphSubscribe callback failed: " << exc.what() << "\n";
+        }
       };
     }
     if (callbacks->onConnectionGraphUnsubscribe) {
       c_callbacks.on_connection_graph_unsubscribe = [](const void* context) {
-        (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphUnsubscribe();
+        try {
+          (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphUnsubscribe();
+        } catch (const std::exception& exc) {
+          std::cerr << "onConnectionGraphUnsubscribe callback failed: " << exc.what() << "\n";
+        }
       };
     }
   }


### PR DESCRIPTION
If a user-provided callback in C++ raises an exception, that currently causes an inscrutable panic in rust followed by a SIGABRT. Instead, we should catch exceptions, log a message to stderr, and move on.