### PR TITLE
Add encoding_len to ProtobufField

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -69,6 +69,7 @@ enum foxglove_error
   FOXGLOVE_ERROR_CONNECTION_GRAPH_NOT_SUPPORTED,
   FOXGLOVE_ERROR_IO_ERROR,
   FOXGLOVE_ERROR_MCAP_ERROR,
+  FOXGLOVE_ERROR_ENCODE_ERROR,
 };
 #ifndef __cplusplus
 typedef uint8_t foxglove_error;

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -765,6 +765,7 @@ pub enum FoxgloveError {
     ConnectionGraphNotSupported,
     IoError,
     McapError,
+    EncodeError,
 }
 
 impl From<foxglove::FoxgloveError> for FoxgloveError {
@@ -789,6 +790,7 @@ impl From<foxglove::FoxgloveError> for FoxgloveError {
             }
             foxglove::FoxgloveError::IoError(_) => FoxgloveError::IoError,
             foxglove::FoxgloveError::McapError(_) => FoxgloveError::McapError,
+            foxglove::FoxgloveError::EncodeError(_) => FoxgloveError::EncodeError,
             _ => FoxgloveError::Unspecified,
         }
     }
@@ -811,6 +813,7 @@ impl FoxgloveError {
             FoxgloveError::ConnectionGraphNotSupported => c"Connection Graph Not Supported",
             FoxgloveError::IoError => c"IO Error",
             FoxgloveError::McapError => c"MCAP Error",
+            FoxgloveError::EncodeError => c"Encode Error",
             _ => c"Unspecified Error",
         }
     }

--- a/cpp/foxglove/include/foxglove/error.hpp
+++ b/cpp/foxglove/include/foxglove/error.hpp
@@ -41,8 +41,10 @@ enum class FoxgloveError : uint8_t {
   ConnectionGraphNotSupported,
   /// An I/O error.
   IoError,
-  /// An error related to MCAP encoding.
-  McapError
+  /// An error related to MCAP writing.
+  McapError,
+  /// An error related to encoding.
+  EncodeError,
 };
 
 /// @brief A result type for Foxglove operations.

--- a/rust/foxglove-derive/src/lib.rs
+++ b/rust/foxglove-derive/src/lib.rs
@@ -291,8 +291,7 @@ fn derive_struct_impl(input: &DeriveInput, data: &DataStruct) -> TokenStream {
             }
 
             fn encode(&self, buf: &mut impl ::foxglove::bytes::BufMut) -> Result<(), Self::Error> {
-                let total_len = 0 #(+ #field_message_lengths)*;
-                if total_len > buf.remaining_mut() {
+                if self.encoded_len().is_some_and(|len| len > buf.remaining_mut()) {
                     return Err(::foxglove::FoxgloveError::EncodeError(
                         "insufficient buffer".to_string(),
                     ));
@@ -301,6 +300,10 @@ fn derive_struct_impl(input: &DeriveInput, data: &DataStruct) -> TokenStream {
                 // The top level message is encoded without a length prefix
                 #(#field_encoders)*
                 Ok(())
+            }
+
+            fn encoded_len(&self) -> Option<usize> {
+                Some(#tags_encoded_len #(+ #field_message_lengths)*)
             }
         }
     };

--- a/rust/foxglove-derive/src/lib.rs
+++ b/rust/foxglove-derive/src/lib.rs
@@ -78,7 +78,7 @@ fn derive_enum_impl(input: &DeriveInput, data: &DataEnum) -> TokenStream {
             }
 
             fn encoded_len(&self) -> usize {
-                prost::encoding::encoded_len_varint(*self as u64)
+                ::foxglove::protobuf::encoded_len_varint(*self as u64)
             }
         }
     };

--- a/rust/foxglove-derive/src/lib.rs
+++ b/rust/foxglove-derive/src/lib.rs
@@ -26,6 +26,14 @@ fn derive_enum_impl(input: &DeriveInput, data: &DataEnum) -> TokenStream {
     let name = &input.ident;
     let variants = &data.variants;
 
+    for variant in variants {
+        if !variant.fields.is_empty() {
+            return TokenStream::from(quote! {
+                compile_error!("Enums with associated data are not supported.");
+            });
+        }
+    }
+
     // Generate variant name and number pairs for enum descriptor
     let variant_descriptors = variants.iter().enumerate().map(|(i, v)| {
         let variant_ident = &v.ident;

--- a/rust/foxglove-derive/tests/scalar_fields_test.rs
+++ b/rust/foxglove-derive/tests/scalar_fields_test.rs
@@ -55,7 +55,7 @@ fn test_primitive_serialization() {
         i64: i64::MIN,
         i32: 42,
         i16: 43,
-        i8: 44,
+        i8: -127,
         f64: -33.5,
         f32: 1234.5678,
         bool: true,
@@ -99,7 +99,7 @@ fn test_primitive_serialization() {
     assert_eq!(field_descriptor.name(), "i64");
     assert_eq!(number_value, i64::MIN);
 
-    let signed_32_types = [("i8", 44), ("i16", 43), ("i32", 42)];
+    let signed_32_types = [("i8", -127), ("i16", 43), ("i32", 42)];
     for (field_name, expected_value) in signed_32_types {
         let field_descriptor = message_descriptor
             .get_field_by_name(field_name)

--- a/rust/foxglove-derive/tests/scalar_fields_test.rs
+++ b/rust/foxglove-derive/tests/scalar_fields_test.rs
@@ -187,13 +187,17 @@ fn test_bytes_serialization() {
 }
 
 #[test]
-#[should_panic(expected = "Failed to write bytes")]
-fn test_insufficient_bytes_buffer_panics() {
+fn test_insufficient_bytes_buffer_errors() {
     let test_struct = TestMessageBytes {
         bytes: bytes::Bytes::from_static(&[1, 2, 3, 4]),
     };
     let mut buf = FixedSizeBuffer::with_capacity(3);
-    test_struct.encode(&mut buf).expect("Failed to encode");
+    let result = test_struct.encode(&mut buf);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Encoding error: insufficient buffer"
+    );
 }
 
 #[test]

--- a/rust/foxglove-derive/tests/string_fields_test.rs
+++ b/rust/foxglove-derive/tests/string_fields_test.rs
@@ -80,23 +80,31 @@ fn test_single_str_field_serialization() {
 }
 
 #[test]
-#[should_panic(expected = "Failed to write string")]
-fn test_insufficient_string_buffer_panics() {
+fn test_insufficient_string_buffer_errors() {
     let mut buf = FixedSizeBuffer::with_capacity(1);
     let test_struct = TestMessage {
         field: "Hello, world!".to_string(),
     };
-    test_struct.encode(&mut buf).expect("Failed to encode");
+    let result = test_struct.encode(&mut buf);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Encoding error: insufficient buffer"
+    );
 }
 
 #[test]
-#[should_panic(expected = "Failed to write str")]
-fn test_insufficient_str_buffer_panics() {
+fn test_insufficient_str_buffer_errors() {
     let mut buf = FixedSizeBuffer::with_capacity(1);
     let test_struct = TestMessageWithLifetime {
         field_ref: "Hello, world!",
     };
-    test_struct.encode(&mut buf).expect("Failed to encode");
+    let result = test_struct.encode(&mut buf);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Encoding error: insufficient buffer"
+    );
 }
 
 fn get_message_descriptor(schema: &Schema) -> MessageDescriptor {

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -10,6 +10,13 @@ use crate::Schema;
 ///
 /// Implementing this trait for your type `T` enables the use of [`Channel<T>`][crate::Channel],
 /// which offers a type-checked `log` method.
+///
+/// This trait may be derived for structs and unit-only enums using the [`derive(Encode)]`
+/// attribute. Today, this will serialize messages using [protobuf]. This means there are some
+/// limitations on the data that you can encode. Notably, enum variants should have a field with a
+/// 0-value, which indicates the default variant.
+///
+/// [protobuf]: https://protobuf.dev/
 pub trait Encode {
     /// The error type returned by methods in this trait.
     type Error: std::error::Error;

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -35,12 +35,12 @@ pub trait Encode {
     /// Encodes message data to the provided buffer.
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error>;
 
-    /// Optional. Returns an estimated encoded length for the message data. For serialization
+    /// Optional. Returns an estimated encoded length for the message data.
+    ///
+    /// Used as a hint when allocating the buffer for [`Encode::encode`]. For serialization
     /// performance, it's important to provide an accurate estimate, but err on the side of
     /// overestimating. If insufficient buffer space is available based on this estimate,
     /// [`Encode::encode`] will result in an error.
-    ///
-    /// Used as a hint when allocating the buffer for [`Encode::encode`].
     fn encoded_len(&self) -> Option<usize> {
         None
     }

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -35,7 +35,10 @@ pub trait Encode {
     /// Encodes message data to the provided buffer.
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error>;
 
-    /// Optional. Returns an estimated encoded length for the message data.
+    /// Optional. Returns an estimated encoded length for the message data. For serialization
+    /// performance, it's important to provide an accurate estimate, but err on the side of
+    /// overestimating. If insufficient buffer space is available based on this estimate,
+    /// [`Encode::encode`] will result in an error.
     ///
     /// Used as a hint when allocating the buffer for [`Encode::encode`].
     fn encoded_len(&self) -> Option<usize> {

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -374,9 +374,12 @@ pub enum FoxgloveError {
     /// An I/O error.
     #[error(transparent)]
     IoError(#[from] std::io::Error),
-    /// An error related to MCAP encoding.
+    /// An error related to MCAP writing.
     #[error("MCAP error: {0}")]
     McapError(#[from] mcap::McapError),
+    /// An error occurred while encoding a message.
+    #[error("Encoding error: {0}")]
+    EncodeError(String),
 }
 
 impl From<convert::RangeError> for FoxgloveError {

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -120,7 +120,7 @@
 //! You can also define your own custom data types by implementing the [`Encode`] trait.
 //!
 //! The easiest way to do this is to derive the [`Encode`] trait, which will generate a schema
-//! and allow you to log your struct to a channel. This currently uses protobuf encoding.
+//! and allow you to log your struct to a channel.
 //!
 //! ```no_run
 //! #[derive(foxglove::Encode)]

--- a/rust/foxglove/src/protobuf.rs
+++ b/rust/foxglove/src/protobuf.rs
@@ -30,6 +30,12 @@ pub fn encode_varint(value: u64, buf: &mut impl bytes::BufMut) {
     prost::encoding::encode_varint(value, buf);
 }
 
+/// Returns the encoded length of a value to be written with [encode_varint].
+#[doc(hidden)]
+pub fn encoded_len_varint(value: u64) -> usize {
+    prost::encoding::encoded_len_varint(value)
+}
+
 /// The `ProtobufField` trait defines the interface for types that can be serialized to Protocol
 /// Buffer format.
 ///

--- a/rust/foxglove/src/protobuf.rs
+++ b/rust/foxglove/src/protobuf.rs
@@ -284,7 +284,7 @@ impl ProtobufField for bool {
     }
 
     fn encoded_len(&self) -> usize {
-        prost::encoding::encoded_len_varint(*self as u64)
+        1
     }
 }
 
@@ -439,5 +439,27 @@ where
         let delim_len = prost::encoding::length_delimiter_len(self.len());
         let data_len: usize = self.iter().map(|value| value.encoded_len()).sum();
         delim_len + data_len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u8_encoded_len() {
+        assert_eq!(ProstFieldType::Uint32, u8::field_type());
+        assert_eq!(1, u8::encoded_len(&127u8));
+        assert_eq!(2, u8::encoded_len(&128u8));
+    }
+
+    #[test]
+    fn test_i8_encoded_len() {
+        // Zig-zag encoding
+        assert_eq!(ProstFieldType::Sint32, i8::field_type());
+        assert_eq!(1, (-1i8).encoded_len());
+        assert_eq!(1, 1i8.encoded_len());
+        assert_eq!(10, i8::MIN.encoded_len());
+        assert_eq!(10, i8::MAX.encoded_len());
     }
 }


### PR DESCRIPTION
This builds on #324, and is a follow-up to #396.

The primary change is to add a required `encoded_len` method to the ProtobufField trait. This provides the length of encoded data to `Encode::encode`, which will now return an error if the remaining buffer is too short to hold the written data.

This also adds a compiler check for unit-only enums; any variant with fields will now provide a nicer error message.

This also updates the documentation, and notes the protobuf limitation around enum values.

This also fixes the encoding of tags, which were previously written as a single byte. I capped the derived field numbers to 2047, which makes it a little easier to think about encoded_len and avoids thinking about reserved ranges or other limits.