### PR TITLE
Generate C++ documentation in CI

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -26,6 +26,16 @@ jobs:
       - run: make CLANG_TIDY=true build
         working-directory: cpp
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ssciwr/doxygen-install@v1
+        with:
+          version: "1.13.2"
+      - run: make docs
+        working-directory: cpp
+
   build:
     strategy:
       fail-fast: false

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -35,6 +35,15 @@ jobs:
           version: "1.13.2"
       - run: make docs
         working-directory: cpp
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        # if: startsWith(github.ref, 'refs/tags/sdk/v')
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: cpp/build/html/
+          destination_dir: cpp/
+          force_orphan: true
 
   build:
     strategy:

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -35,15 +35,6 @@ jobs:
           version: "1.13.2"
       - run: make docs
         working-directory: cpp
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        # if: startsWith(github.ref, 'refs/tags/sdk/v')
-        with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: cpp/build/html/
-          destination_dir: cpp/
-          force_orphan: true
 
   build:
     strategy:

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,3 +1,2 @@
 build
 build-*
-docs

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -136,6 +136,15 @@ if(MSVC)
   target_compile_options(tests PRIVATE /Zc:__cplusplus)
 endif()
 
+### Docs
+
+# file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/docs)
+
+add_custom_target(docs
+  COMMAND doxygen Doxyfile
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 ### Examples
 
 add_executable(example_server examples/ws-server/src/main.cpp)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -138,8 +138,6 @@ endif()
 
 ### Docs
 
-# file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/docs)
-
 add_custom_target(docs
   COMMAND doxygen Doxyfile
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/cpp/Doxyfile
+++ b/cpp/Doxyfile
@@ -74,7 +74,7 @@ PROJECT_ICON           =
 # entered, it will be relative to the location where Doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       = build/docs
 
 # If the CREATE_SUBDIRS tag is set to YES then Doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -37,3 +37,13 @@ build:
 .PHONY: test
 test: build
 	cd $(BUILD_DIR) && ctest --verbose
+
+.PHONY: docs
+docs: $(BUILD_DIR)/docs/html
+
+.PHONY: clean-docs
+clean-docs:
+	rm -rf $(BUILD_DIR)/docs
+
+$(BUILD_DIR)/docs/html:
+	cmake --build $(BUILD_DIR) --target docs

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -46,4 +46,5 @@ clean-docs:
 	rm -rf $(BUILD_DIR)/docs
 
 $(BUILD_DIR)/docs/html:
+	cmake -B $(BUILD_DIR)
 	cmake --build $(BUILD_DIR) --target docs

--- a/cpp/foxglove/include/foxglove/error.hpp
+++ b/cpp/foxglove/include/foxglove/error.hpp
@@ -63,6 +63,8 @@ using FoxgloveResult = expected<T, FoxgloveError>;
 /// @return A C string representation of the error.
 const char* strerror(FoxgloveError error);
 
+/// A stream for emitting warnings to stderr, with default formatting.
+/// @cond foxglove_internal
 class WarnStream {
 public:
   WarnStream() = default;
@@ -106,5 +108,6 @@ private:
 inline WarnStream warn() {
   return WarnStream{};
 }
+/// @endcond
 
 }  // namespace foxglove


### PR DESCRIPTION
This adds Doxygen generation to the  C++ CI workflow. We may build documentation around this rather than using the HTML output directly, but it will fail CI if we're missing any public documentation.

Supports FG-11290.