### PR TITLE
ci: Build rust examples individually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,18 @@ jobs:
 
       - run: cargo fmt --all --check
       - run: cargo build --verbose
-      # Validate that we can build without live visualization
+      # Validate that we can build each example individually.
+      - name: Build examples individually
+        run: |
+          set -euo pipefail
+          cargo metadata --no-deps --format-version 1 \
+            | jq -r ".packages[].name" \
+            | grep example \
+            | while read package; do
+            echo "Building $package"
+            cargo build -p "$package"
+          done
+      # Validate that we can build without default features.
       - run: cargo build -p foxglove --verbose --no-default-features
       # Validate that we can build against the MSRV (minimum specified rust version).
       - run: cargo +1.83.0 build -p foxglove --verbose


### PR DESCRIPTION
I noticed with #415 breaks the `example-mcap` build, but it isn't caught in CI, because we're building the entire workspace all at once, which means we're building dependencies with the union of all features specified by all target packages.

This change adds a step to CI to build each example individually, to ensure that we don't break them when we introduce new feature flags. We only need to do this for examples, because we already build the other targets individually.