### PR TITLE
rust: make toplevel example snippet pastable into any function

### DIFF
--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -17,7 +17,6 @@
 //! use foxglove::{McapWriter, log};
 //! use foxglove::schemas::Log;
 //!
-//! # fn func() {
 //! // Create a new MCAP file named 'test.mcap'.
 //! let mcap = McapWriter::new().create_new_buffered_file("test.mcap").expect("create failed");
 //!
@@ -27,8 +26,7 @@
 //! });
 //!
 //! // Flush and close the MCAP file.
-//! mcap.close().expect("finish failed");
-//! # }
+//! mcap.close().expect("close failed");
 //! ```
 //!
 //! # Concepts
@@ -51,12 +49,11 @@
 //! use foxglove::Context;
 //! use foxglove::schemas::Log;
 //!
-//! # fn func() -> Result<(), foxglove::FoxgloveError> {
 //! // Create a new context.
 //! let ctx = Context::new();
 //!
 //! // Create a new MCAP file named 'test.mcap'.
-//! let mcap = ctx.mcap_writer().create_new_buffered_file("test.mcap")?;
+//! let mcap = ctx.mcap_writer().create_new_buffered_file("test.mcap").expect("create failed");
 //!
 //! // Create a new channel for the topic "/log" for `Log` messages.
 //! let channel = ctx.channel_builder("/log").build();
@@ -66,8 +63,7 @@
 //! });
 //!
 //! // Flush and close the MCAP file.
-//! mcap.close()?;
-//! # Ok(()) }
+//! mcap.close().expect("close failed");
 //! ```
 //!
 //! ## Channels
@@ -90,9 +86,8 @@
 //! use foxglove::{Channel, McapWriter};
 //! use foxglove::schemas::Log;
 //!
-//! # fn func() -> Result<(), foxglove::FoxgloveError> {
 //! // Create a new MCAP file named 'test.mcap'.
-//! let mcap = McapWriter::new().create_new_buffered_file("test.mcap")?;
+//! let mcap = McapWriter::new().create_new_buffered_file("test.mcap").expect("create failed");
 //!
 //! // Create a new channel for the topic "/log" for `Log` messages.
 //! let channel = Channel::new("/log");
@@ -102,8 +97,7 @@
 //! });
 //!
 //! // Flush and close the MCAP file.
-//! mcap.close()?;
-//! # Ok(()) }
+//! mcap.close().expect("close failed");
 //! ```
 //!
 //! `log!` can be mixed and matched with manually created channels in the default [`Context`], as
@@ -129,13 +123,11 @@
 //!     count: u32,
 //! }
 //!
-//! # fn func() -> Result<(), foxglove::FoxgloveError> {
 //! let channel = foxglove::Channel::new("/custom");
 //! channel.log(&Custom{
 //!     msg: "custom",
 //!     count: 42
 //! });
-//! # Ok(()) }
 //! ```
 //!
 //! [jsonschema-trait]: https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html
@@ -187,24 +179,20 @@
 //! unregistered from the [`Context`], and the file will be finalized and flushed.
 //!
 //! ```no_run
-//! # fn func() -> Result<(), foxglove::FoxgloveError> {
 //! let mcap = foxglove::McapWriter::new()
-//!     .create_new_buffered_file("test.mcap")?;
-//! # Ok(()) }
+//!     .create_new_buffered_file("test.mcap").expect("create failed");
 //! ```
 //!
 //! You can override the MCAP writer's configuration using [`McapWriter::with_options`]. See
 //! [`WriteOptions`](`mcap::WriteOptions`) for more detail about these parameters:
 //!
 //! ```no_run
-//! # fn func() -> Result<(), foxglove::FoxgloveError> {
 //! let options = mcap::WriteOptions::default()
 //!     .chunk_size(Some(1024*1024))
 //!     .compression(Some(mcap::Compression::Lz4));
 //!
 //! let mcap = foxglove::McapWriter::with_options(options)
-//!     .create_new_buffered_file("test.mcap")?;
-//! # Ok(()) }
+//!     .create_new_buffered_file("test.mcap").expect("create failed");
 //! ```
 //!
 //! ### Live visualization server

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -17,9 +17,9 @@
 //! use foxglove::{McapWriter, log};
 //! use foxglove::schemas::Log;
 //!
-//! # fn func() -> Result<(), foxglove::FoxgloveError> {
+//! # fn func() {
 //! // Create a new MCAP file named 'test.mcap'.
-//! let mcap = McapWriter::new().create_new_buffered_file("test.mcap")?;
+//! let mcap = McapWriter::new().create_new_buffered_file("test.mcap").expect("create failed");
 //!
 //! log!("/log", Log{
 //!     message: "Hello, Foxglove!".to_string(),
@@ -27,8 +27,8 @@
 //! });
 //!
 //! // Flush and close the MCAP file.
-//! mcap.close()?;
-//! # Ok(()) }
+//! mcap.close().expect("finish failed");
+//! # }
 //! ```
 //!
 //! # Concepts


### PR DESCRIPTION
### Changelog
None.
### Docs

Is a docs PR.
### Description

Today there is a code snippet showing the user how to use the foxglove SDK, but to use it they must wrap it in a function that returns `Result<T, E> where E: From<FoxgloveError>`. This means they'd need to write non-trivial extra code to use this code as written. This PR updates the example to use `expect`, which allows a user to get started immediately from `cargo init .; cargo add foxglove`.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

