### PR TITLE
Deploy initial (empty) foxglove-derive crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,33 @@ jobs:
       - run: cargo +nightly rustdoc -p foxglove --all-features -- -D warnings --cfg docsrs
       - run: cargo test --features unstable --verbose
         timeout-minutes: 10
-      - run: cargo publish --package foxglove --dry-run
-      - run: cargo publish --package foxglove
-        if: startsWith(github.ref, 'refs/tags/sdk/v')
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      # - run: cargo publish --package foxglove --dry-run
+      # - run: cargo publish --package foxglove
+      #   if: startsWith(github.ref, 'refs/tags/sdk/v')
+      #   env:
+      #     CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  bootstrap-derive-crate:
+    runs-on: ubuntu-latest
+    needs: rust
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install common dependencies
+        uses: ./.github/actions/common-deps
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # The last-specified toolchain is the default.
+          toolchain: 1.83.0,nightly,stable
+      - name: test version string
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="'foxglove-derive'").version')
+          echo "version=$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - run: cargo publish --package foxglove-derive
+      - name: Wait for foxglove-derive to be published
+        run: until cargo info --registry=crates-io foxglove-derive@0.7.1; do sleep 10; done
 
   typescript:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "foxglove-derive"
+version = "0.7.1"
+dependencies = [
+ "bytes",
+ "foxglove",
+ "proc-macro2",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "quote",
+ "syn 2.0.96",
+ "tracing",
+ "tracing-test",
+]
+
+[[package]]
 name = "foxglove-proto-gen"
 version = "0.0.0"
 dependencies = [
@@ -1465,6 +1481,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+dependencies = [
+ "once_cell",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "c",
   "rust/foxglove",
+  "rust/foxglove-derive",
   "rust/foxglove-proto-gen",
   "rust/examples/*",
   "python/foxglove-sdk",
@@ -21,6 +22,7 @@ tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "signal", "
 tokio-tungstenite = "0.26"
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { version = "0.1", features = ["log"] }
+tracing-test = "0.2.5"
 
 [workspace.lints.clippy]
 assigning_clones = "warn"

--- a/rust/foxglove-derive/Cargo.toml
+++ b/rust/foxglove-derive/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "foxglove-derive"
+description = "Foxglove SDK derive macros"
+version = "0.7.1"
+edition = "2021"
+rust-version = "1.83.0"
+repository = "https://github.com/foxglove/foxglove-sdk"
+license = "MIT"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full", "extra-traits"] }
+prost-types.workspace = true
+
+[dev-dependencies]
+bytes = "1.4"
+foxglove = { path = "../foxglove" }
+prost.workspace = true
+prost-reflect = "0.14.7"
+tracing.workspace = true
+tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/rust/foxglove-derive/README.md
+++ b/rust/foxglove-derive/README.md
@@ -1,0 +1,8 @@
+# foxglove-derive
+
+Derive macros for the Foxglove SDK.
+
+Note: This module is not intended for use on its own and is designed to be used via the [`foxglove`]
+crate.
+
+[`foxglove`]: https://crates.io/crates/foxglove

--- a/rust/foxglove-derive/src/lib.rs
+++ b/rust/foxglove-derive/src/lib.rs
@@ -1,0 +1,1 @@
+// This crate will hold a derive macro for the Foxglove SDK.


### PR DESCRIPTION
This branch contains an 'empty' crate for foxglove-derive. Publishing an initial 0.7.1 version of the crate should allow CI checks to pass and future versions to be published correctly (as of #324).