### PR TITLE
TS: move rosmsg-msgs-common back to dependencies, bump to 1.7.1

### DIFF
--- a/typescript/schemas/package.json
+++ b/typescript/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/schemas",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Foxglove-defined message schemas for ROS, Protobuf, FlatBuffers, OMG IDL, and JSON",
   "license": "MIT",
   "author": {
@@ -29,10 +29,10 @@
     "prepack": "yarn clean && yarn build"
   },
   "dependencies": {
+    "@foxglove/rosmsg-msgs-common": "^3.0.0",
     "tslib": "^2"
   },
   "devDependencies": {
-    "@foxglove/rosmsg-msgs-common": "^3.0.0",
     "rimraf": "^6.0.1",
     "typescript": "5.7.3"
   }


### PR DESCRIPTION
### Changelog
TS: fixed missing dependency on `@foxglove/rosmsg-msgs-common`

### Docs

None

### Description

This was moved to devDependencies in https://github.com/foxglove/foxglove-sdk/pull/170, however there are some exported functions whose type definitions depend on it (admittedly they are under `internal`, but we use them for generating docs). The missing dependency caused TS errors downstream.