### PR TITLE
Add docs about thread-safety to C++ API

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2734,6 +2734,8 @@ void foxglove_fetch_asset_respond_error(struct foxglove_fetch_asset_responder *r
  *
  * Log styles (colors) may be configured with the FOXGLOVE_LOG_STYLE environment variable "never",
  * "always", or "auto" (default).
+ *
+ * This is thread-safe, but only the first call to this function will have an effect.
  */
 void foxglove_set_log_level(foxglove_logging_level level);
 

--- a/c/src/logging.rs
+++ b/c/src/logging.rs
@@ -25,6 +25,8 @@ pub enum FoxgloveLoggingLevel {
 ///
 /// Log styles (colors) may be configured with the FOXGLOVE_LOG_STYLE environment variable "never",
 /// "always", or "auto" (default).
+///
+/// This is thread-safe, but only the first call to this function will have an effect.
 #[unsafe(no_mangle)]
 pub extern "C" fn foxglove_set_log_level(level: FoxgloveLoggingLevel) {
     static INIT: Once = Once::new();

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -35,6 +35,8 @@ struct Schema {
 };
 
 /// @brief A channel for messages logged to a topic.
+///
+/// @note Creating channels and logging on them is thread-safe.
 class RawChannel final {
 public:
   /// @brief Create a new channel.
@@ -51,6 +53,9 @@ public:
   );
 
   /// @brief Log a message to the channel.
+  ///
+  /// @note Logging is thread-safe. The data will be logged atomically
+  /// before or after data logged from other threads.
   ///
   /// @param data The message data.
   /// @param data_len The length of the message data, in bytes.

--- a/cpp/foxglove/include/foxglove/context.hpp
+++ b/cpp/foxglove/include/foxglove/context.hpp
@@ -22,6 +22,8 @@ namespace foxglove {
 ///
 /// Since many applications only need a single context, the SDK provides a static default context
 /// for convenience.
+///
+/// @note Context is thread safe.
 class Context final {
 public:
   /// The default global context

--- a/cpp/foxglove/include/foxglove/foxglove.hpp
+++ b/cpp/foxglove/include/foxglove/foxglove.hpp
@@ -24,7 +24,7 @@ enum class LogLevel : uint8_t {
 /// logged. Note that this does not affect logging of messages to MCAP or Foxglove.
 ///
 /// This function should be called before other Foxglove initialization to capture output from all
-/// components. Subsequent calls will have no effect.
+/// components.
 ///
 /// As long as you initialize one logging sink (WebSocket server or MCAP), log level may instead be
 /// configured via a `FOXGLOVE_LOG_LEVEL` environment variable, with one of the values "debug",
@@ -38,6 +38,8 @@ enum class LogLevel : uint8_t {
 /// disabled.
 ///
 /// @param level The severity level for stderr logging from the SDK.
+///
+/// @note This is thread-safe, but only the first call to this function will have an effect.
 void setLogLevel(LogLevel level);
 
 }  // namespace foxglove

--- a/cpp/foxglove/include/foxglove/mcap.hpp
+++ b/cpp/foxglove/include/foxglove/mcap.hpp
@@ -68,6 +68,10 @@ struct McapWriterOptions {
 class McapWriter final {
 public:
   /// @brief Create a new MCAP writer.
+  ///
+  /// @note Calls to create from multiple threads is safe,
+  /// unless the same file path is given.
+  ///
   /// @param options The options for the MCAP writer.
   /// @return A new MCAP writer.
   static FoxgloveResult<McapWriter> create(const McapWriterOptions& options);

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -89,6 +89,9 @@ inline WebSocketServerCapabilities operator&(
 ///
 /// These methods are invoked from the client's main poll loop and must be as low-latency as
 /// possible.
+///
+/// @note These callbacks may be invoked concurrently from multiple threads.
+/// You must synchronize access to your mutable internal state or shared resources.
 struct WebSocketServerCallbacks {
   /// @brief Callback invoked when a client subscribes to a channel.
   ///
@@ -201,6 +204,8 @@ struct WebSocketServerOptions {
 /// [Connecting to data].
 ///
 /// [Connecting to data]: https://docs.foxglove.dev/docs/connecting-to-data/introduction
+///
+/// @note WebSocketServer is thread-safe.
 class WebSocketServer final {
 public:
   /// @brief Create a new WebSocket server with the given options.

--- a/typescript/schemas/src/internal/generateSdkCpp.ts
+++ b/typescript/schemas/src/internal/generateSdkCpp.ts
@@ -170,6 +170,10 @@ export function generateHppSchemas(
 
   const channelClasses = schemas.filter(hasChannelType).map(
     (schema) => `/// @brief A channel for logging ${schema.name} messages to a topic.
+      ///
+      /// @note Creating channels and logging on them is thread-safe,
+      /// but the ${schema.name} struct is not thread-safe, do not
+      /// modify it concurrently or during the call to log.
       class ${schema.name}Channel {
       public:
         /// @brief Create a new channel.


### PR DESCRIPTION
What it says on the tin.

I think we're also going to need thread-safety docs for Rust and Python.