### PR TITLE
rust: Enable derive feature by default

### DIFF
--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -15,7 +15,11 @@ workspace = true
 base64 = "0.22.1"
 bitflags = "2.9.0"
 env_logger = "0.11.5"
-foxglove = { path = "../rust/foxglove", features = ["unstable"] }
+foxglove = { path = "../rust/foxglove", default-features = false, features = [
+  "live_visualization",
+  "lz4",
+  "zstd",
+] }
 log.workspace = true
 mcap.workspace = true
 tracing.workspace = true

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -14,7 +14,11 @@ workspace = true
 [dependencies]
 base64 = "0.22.1"
 bytes.workspace = true
-foxglove = { path = "../../rust/foxglove" }
+foxglove = { path = "../../rust/foxglove", default-features = false, features = [
+  "live_visualization",
+  "lz4",
+  "zstd",
+]}
 log.workspace = true
 prost-types = "0.13"
 pyo3 = "0.24.1"

--- a/rust/examples/ws_server/Cargo.toml
+++ b/rust/examples/ws_server/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 workspace = true
 
 [dependencies]
-foxglove = { path = "../../foxglove", features = ["derive", "schemars"] }
+foxglove = { path = "../../foxglove", features = ["schemars"] }
 tokio = { version = "1.43", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"

--- a/rust/examples/ws_server_blocking/Cargo.toml
+++ b/rust/examples/ws_server_blocking/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 workspace = true
 
 [dependencies]
-foxglove = { path = "../../foxglove", features = ["derive"] }
+foxglove = { path = "../../foxglove" }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"
 ctrlc = "3.4.5"

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-default = ["live_visualization", "lz4", "zstd"]
+default = ["derive", "live_visualization", "lz4", "zstd"]
 chrono = ["dep:chrono"]
 derive = ["dep:foxglove_derive"]
 live_visualization = [

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -263,7 +263,7 @@
 //! - `chrono`: enables [chrono] conversions for [`Duration`][crate::schemas::Duration] and
 //!   [`Timestamp`][crate::schemas::Timestamp].
 //! - `derive`: enables the use of `#[derive(Encode)]` to derive the [`Encode`] trait for logging
-//!   custom structs.
+//!   custom structs. Enabled by default.
 //! - `live_visualization`: enables the live visualization server and client, and adds dependencies
 //!   on [tokio]. Enabled by default.
 //! - `lz4`: enables support for the LZ4 compression algorithm for mcap files. Enabled by default.


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
As @defunctzombie points out, the `derive` feature is a core component of the SDK. Let's enable it by default.