### PR TITLE
Don't use default values from schemas for C++

### DIFF
--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -29,13 +29,13 @@ typedef std::unique_ptr<const foxglove_channel, ChannelDeleter> ChannelUniquePtr
 /// @brief A vector in 3D space that represents a direction only
 struct Vector3 {
   /// @brief x coordinate length
-  double x = 1;
+  double x = 0;
 
   /// @brief y coordinate length
-  double y = 1;
+  double y = 0;
 
   /// @brief z coordinate length
-  double z = 1;
+  double z = 0;
 };
 
 /// @brief A [quaternion](https://eater.net/quaternions) representing a rotation in 3D space
@@ -50,7 +50,7 @@ struct Quaternion {
   double z = 0;
 
   /// @brief w value
-  double w = 1;
+  double w = 0;
 };
 
 /// @brief A position and orientation for an object or reference frame in 3D space
@@ -65,16 +65,16 @@ struct Pose {
 /// @brief A color in RGBA format
 struct Color {
   /// @brief Red value between 0 and 1
-  double r = 1;
+  double r = 0;
 
   /// @brief Green value between 0 and 1
-  double g = 1;
+  double g = 0;
 
   /// @brief Blue value between 0 and 1
-  double b = 1;
+  double b = 0;
 
   /// @brief Alpha value between 0 and 1
-  double a = 1;
+  double a = 0;
 };
 
 /// @brief A primitive representing an arrow
@@ -360,10 +360,10 @@ struct GeoJSON {
 /// @brief A vector in 2D space that represents a direction only
 struct Vector2 {
   /// @brief x coordinate length
-  double x = 1;
+  double x = 0;
 
   /// @brief y coordinate length
-  double y = 1;
+  double y = 0;
 };
 
 /// @brief A field present within each element in a byte array of packed elements.
@@ -485,7 +485,7 @@ struct TextAnnotation {
   std::string text;
 
   /// @brief Font size in pixels
-  double font_size = 12;
+  double font_size = 0;
 
   /// @brief Text color
   std::optional<Color> text_color;

--- a/typescript/schemas/src/internal/generateSdkCpp.ts
+++ b/typescript/schemas/src/internal/generateSdkCpp.ts
@@ -146,9 +146,7 @@ export function generateHppSchemas(
               break;
             case "primitive": {
               const defaultValue =
-                field.array != undefined
-                  ? undefined
-                  : (field.defaultValue ?? primitiveDefaultValue(field.type.name));
+                field.array != undefined ? undefined : primitiveDefaultValue(field.type.name);
               defaultStr = defaultValue != undefined ? ` = ${defaultValue.toString()}` : "";
               fieldType = primitiveToCpp(field.type.name);
               break;


### PR DESCRIPTION
This removes the non-zero default values for C++ schemas to match Rust and Python.

The reasoning:

There weren't many fields with a non-zero default value, and while w=1.0 makes sense for quarternion, the values make less sense for vectors and colors.

Rust has default of 0 as defined by prost protobuf library, and we can't change that, so if we use non-zero defaults elsewhere it won't be consistent across the sdk.

Having everything default to 0, but a couple exceptions could be surprising to developers.

We didn't document the defaults: https://docs.foxglove.dev/docs/visualization/message-schemas/quaternion

Slack discussion: https://foxglove.slack.com/archives/C07RB3SSJE5/p1747846188213449