### PR TITLE
Add websocket server method to get app URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-test",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2293,6 +2294,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -272,6 +272,22 @@ class WebSocketServer:
         """Get the port on which the server is listening."""
         ...
 
+    def app_url(
+        self,
+        *,
+        layout_id: Optional[str] = None,
+        open_in_desktop: bool = False,
+    ) -> Optional[str]:
+        """
+        Returns a web app URL to open the websocket as a data source.
+
+        Returns None if the server has been stopped.
+
+        :param layout_id: An optional layout ID to include in the URL.
+        :param open_in_desktop: Opens the foxglove desktop app.
+        """
+        ...
+
     def stop(self) -> None:
         """Explicitly stop the server."""
         ...

--- a/python/foxglove-sdk/python/foxglove/tests/test_server.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_server.py
@@ -21,7 +21,9 @@ def test_server_interface() -> None:
     assert isinstance(server.port, int)
     assert server.port != 0
 
-    url = urlparse(server.app_url() or "")
+    raw_url = server.app_url()
+    assert raw_url is not None
+    url = urlparse(raw_url)
     assert url.scheme == "https"
     assert url.netloc == "app.foxglove.dev"
     assert parse_qs(url.query) == {
@@ -29,7 +31,9 @@ def test_server_interface() -> None:
         "ds.url": [f"ws://127.0.0.1:{server.port}"],
     }
 
-    url = urlparse(server.app_url(layout_id="lay_123", open_in_desktop=True) or "")
+    raw_url = server.app_url(layout_id="lay_123", open_in_desktop=True)
+    assert raw_url is not None
+    url = urlparse(raw_url)
     assert url.scheme == "https"
     assert url.netloc == "app.foxglove.dev"
     assert parse_qs(url.query) == {

--- a/python/foxglove-sdk/python/foxglove/tests/test_server.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_server.py
@@ -1,4 +1,5 @@
 import time
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from foxglove import (
@@ -19,6 +20,25 @@ def test_server_interface() -> None:
     server = start_server(port=0)
     assert isinstance(server.port, int)
     assert server.port != 0
+
+    url = urlparse(server.app_url() or "")
+    assert url.scheme == "https"
+    assert url.netloc == "app.foxglove.dev"
+    assert parse_qs(url.query) == {
+        "ds": ["foxglove-websocket"],
+        "ds.url": [f"ws://127.0.0.1:{server.port}"],
+    }
+
+    url = urlparse(server.app_url(layout_id="lay_123", open_in_desktop=True) or "")
+    assert url.scheme == "https"
+    assert url.netloc == "app.foxglove.dev"
+    assert parse_qs(url.query) == {
+        "ds": ["foxglove-websocket"],
+        "ds.url": [f"ws://127.0.0.1:{server.port}"],
+        "layoutId": ["lay_123"],
+        "openIn": ["desktop"],
+    }
+
     server.publish_status("test message", StatusLevel.Info, "some-id")
     server.broadcast_time(time.time_ns())
     server.remove_status(["some-id"])

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -447,6 +447,26 @@ impl PyWebSocketServer {
         self.0.as_ref().map_or(0, |handle| handle.port())
     }
 
+    /// Returns an app URL to open the websocket as a data source.
+    ///
+    /// Returns None if the server has been stopped.
+    ///
+    /// :param layout_id: An optional layout ID to include in the URL.
+    /// :param open_in_desktop: Opens the foxglove desktop app.
+    #[pyo3(signature = (*, layout_id=None, open_in_desktop=false))]
+    pub fn app_url(&self, layout_id: Option<&str>, open_in_desktop: bool) -> Option<String> {
+        self.0.as_ref().map(|s| {
+            let mut url = s.app_url();
+            if let Some(layout_id) = layout_id {
+                url = url.with_layout_id(layout_id);
+            }
+            if open_in_desktop {
+                url = url.with_open_in_desktop();
+            }
+            url.to_string()
+        })
+    }
+
     /// Sets a new session ID and notifies all clients, causing them to reset their state.
     /// If no session ID is provided, generates a new one based on the current timestamp.
     /// If the server has been stopped, this has no effect.

--- a/rust/examples/ws_server/src/main.rs
+++ b/rust/examples/ws_server/src/main.rs
@@ -113,6 +113,10 @@ async fn main() {
         .await
         .expect("Server failed to start");
 
+    let app_url = server.app_url();
+    println!("View in browser: {app_url}");
+    println!("View in desktop: {}", app_url.with_open_in_desktop());
+
     tokio::task::spawn(log_forever(args.fps));
     tokio::signal::ctrl_c().await.ok();
     server.stop().wait().await;

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -55,6 +55,7 @@ tokio-tungstenite = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 tracing.workspace = true
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/rust/foxglove/src/app_url.rs
+++ b/rust/foxglove/src/app_url.rs
@@ -7,6 +7,7 @@ static BASE_URL: &str = "https://app.foxglove.dev";
 
 #[derive(Debug, Clone)]
 enum DataSource {
+    #[allow(dead_code)] // until `AppUrl::with_websocket` is public.
     WebSocket(String, u16),
 }
 
@@ -74,6 +75,7 @@ impl AppUrl {
     }
 
     /// Sets a websocket data source.
+    #[cfg(feature = "live_visualization")]
     pub(crate) fn with_websocket(mut self, host: impl Display, port: u16) -> Self {
         self.data_source = Some(DataSource::WebSocket(host.to_string(), port));
         self

--- a/rust/foxglove/src/app_url.rs
+++ b/rust/foxglove/src/app_url.rs
@@ -74,7 +74,7 @@ impl AppUrl {
     }
 
     /// Sets a websocket data source.
-    pub fn with_websocket(mut self, host: impl Display, port: u16) -> Self {
+    pub(crate) fn with_websocket(mut self, host: impl Display, port: u16) -> Self {
         self.data_source = Some(DataSource::WebSocket(host.to_string(), port));
         self
     }

--- a/rust/foxglove/src/app_url.rs
+++ b/rust/foxglove/src/app_url.rs
@@ -1,0 +1,114 @@
+//! App URL builder
+
+use std::borrow::Cow;
+use std::fmt::Display;
+
+static BASE_URL: &str = "https://app.foxglove.dev";
+
+#[derive(Debug, Clone)]
+enum DataSource {
+    WebSocket(String, u16),
+}
+
+/// Foxglove app URL.
+#[must_use]
+#[derive(Debug, Default, Clone)]
+pub struct AppUrl {
+    data_source: Option<DataSource>,
+    layout_id: Option<String>,
+    open_in_desktop: bool,
+}
+
+impl Display for AppUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(BASE_URL)?;
+        for (ii, (k, v)) in self.query_params().into_iter().enumerate() {
+            let sep = if ii == 0 { '?' } else { '&' };
+            let venc = urlencoding::encode(&v);
+            write!(f, "{sep}{k}={venc}")?;
+        }
+        Ok(())
+    }
+}
+
+impl AppUrl {
+    /// Creates a new app URL.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a vector of URL query parameters.
+    ///
+    /// The parameter values are not URL-encoded.
+    fn query_params(&self) -> Vec<(&str, Cow<str>)> {
+        let mut params = vec![];
+        if let Some(ds) = &self.data_source {
+            match ds {
+                DataSource::WebSocket(host, port) => params.extend([
+                    ("ds", "foxglove-websocket".into()),
+                    ("ds.url", format!("ws://{host}:{port}").into()),
+                ]),
+            }
+        }
+        if let Some(layout_id) = &self.layout_id {
+            params.push(("layoutId", layout_id.into()));
+        }
+        if self.open_in_desktop {
+            params.push(("openIn", "desktop".into()));
+        }
+        params
+    }
+
+    /// Sets the layout ID.
+    ///
+    /// If no layout ID is specified, the app will use the most recently-used layout.
+    pub fn with_layout_id(mut self, layout_id: impl Into<String>) -> Self {
+        self.layout_id = Some(layout_id.into());
+        self
+    }
+
+    /// Constructs a desktop URL, rather than a web URL.
+    pub fn with_open_in_desktop(mut self) -> Self {
+        self.open_in_desktop = true;
+        self
+    }
+
+    /// Sets a websocket data source.
+    pub fn with_websocket(mut self, host: impl Display, port: u16) -> Self {
+        self.data_source = Some(DataSource::WebSocket(host.to_string(), port));
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_url() {
+        assert_eq!(AppUrl::new().to_string(), BASE_URL);
+        assert_eq!(
+            AppUrl::new().with_layout_id("lay_123").to_string(),
+            format!("{BASE_URL}?layoutId=lay_123")
+        );
+        assert_eq!(
+            AppUrl::new().with_open_in_desktop().to_string(),
+            format!("{BASE_URL}?openIn=desktop")
+        );
+        assert_eq!(
+            AppUrl::new().with_websocket("1.2.3.4", 1234).to_string(),
+            format!("{BASE_URL}?ds=foxglove-websocket&ds.url=ws%3A%2F%2F1.2.3.4%3A1234")
+        );
+        assert_eq!(
+            AppUrl::new()
+                .with_layout_id("lay_123")
+                .with_open_in_desktop()
+                .with_websocket("my.robot.dev", 9999)
+                .to_string(),
+            format!(
+                "{BASE_URL}?ds=foxglove-websocket&ds.url=ws%3A%2F%2Fmy.robot.dev%3A9999\
+                &layoutId=lay_123&openIn=desktop"
+            )
+        );
+    }
+}

--- a/rust/foxglove/src/app_url.rs
+++ b/rust/foxglove/src/app_url.rs
@@ -75,7 +75,7 @@ impl AppUrl {
     }
 
     /// Sets a websocket data source.
-    #[cfg(feature = "live_visualization")]
+    #[cfg(feature = "live_visualization")] // until public
     pub(crate) fn with_websocket(mut self, host: impl Display, port: u16) -> Self {
         self.data_source = Some(DataSource::WebSocket(host.to_string(), port));
         self
@@ -97,6 +97,11 @@ mod tests {
             AppUrl::new().with_open_in_desktop().to_string(),
             format!("{BASE_URL}?openIn=desktop")
         );
+    }
+
+    #[test]
+    #[cfg(feature = "live_visualization")] // until `AppUrl::with_websocket` is public
+    fn test_app_url_webscoket() {
         assert_eq!(
             AppUrl::new().with_websocket("1.2.3.4", 1234).to_string(),
             format!("{BASE_URL}?ds=foxglove-websocket&ds.url=ws%3A%2F%2F1.2.3.4%3A1234")

--- a/rust/foxglove/src/app_url.rs
+++ b/rust/foxglove/src/app_url.rs
@@ -9,7 +9,22 @@ enum DataSource {
     WebSocket(String),
 }
 
-/// Foxglove app URL.
+/// A foxglove app URL.
+///
+/// This struct implements [`Display`] by formatting the URL, so you can use it directly in format
+/// strings, or use `.to_string()` to convert it to a string.
+///
+/// # Example
+///
+/// ```
+/// use foxglove::AppUrl;
+///
+/// let url = AppUrl::new()
+///     .with_layout_id("lay_1234")
+///     .with_websocket("ws://localhost:8765");
+/// println!("Click here: {url}");
+/// assert_eq!(format!("{url}"), url.to_string());
+/// ```
 #[must_use]
 #[derive(Debug, Default, Clone)]
 pub struct AppUrl {

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -291,6 +291,7 @@
 
 use thiserror::Error;
 
+mod app_url;
 mod channel;
 mod channel_builder;
 mod context;
@@ -317,6 +318,7 @@ mod testutil;
 mod throttler;
 mod time;
 
+pub use app_url::AppUrl;
 // Re-export bytes crate for convenience when implementing the `Encode` trait
 pub use bytes;
 pub use channel::{Channel, ChannelId, LazyChannel, LazyRawChannel, RawChannel};

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -244,7 +244,7 @@ impl WebSocketServerHandle {
 
     /// Returns an app URL to open the websocket as a data source.
     pub fn app_url(&self) -> AppUrl {
-        AppUrl::new().with_websocket(self.1.ip(), self.1.port())
+        AppUrl::new().with_websocket(format!("ws://{}:{}", self.1.ip(), self.1.port()))
     }
 
     /// Advertises support for the provided services.

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{Debug, Display};
 use std::future::Future;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::websocket::service::Service;
@@ -9,7 +10,7 @@ use crate::websocket::{
     create_server, AssetHandler, AsyncAssetHandlerFn, BlockingAssetHandlerFn, Capability, Client,
     ConnectionGraph, Parameter, Server, ServerOptions, ShutdownHandle, Status,
 };
-use crate::{get_runtime_handle, Context, FoxgloveError};
+use crate::{get_runtime_handle, AppUrl, Context, FoxgloveError};
 
 /// A WebSocket server for live visualization in Foxglove.
 ///
@@ -197,8 +198,8 @@ impl WebSocketServer {
     /// can safely drop the handle, and the server will run forever.
     pub async fn start(self) -> Result<WebSocketServerHandle, FoxgloveError> {
         let server = create_server(&self.context, self.options);
-        server.start(&self.host, self.port).await?;
-        Ok(WebSocketServerHandle(server))
+        let addr = server.start(&self.host, self.port).await?;
+        Ok(WebSocketServerHandle(server, addr))
     }
 
     /// Starts the websocket server.
@@ -227,7 +228,7 @@ impl WebSocketServer {
 /// A handle to the websocket server.
 ///
 /// This handle can safely be dropped and the server will run forever.
-pub struct WebSocketServerHandle(Arc<Server>);
+pub struct WebSocketServerHandle(Arc<Server>, SocketAddr);
 
 impl Debug for WebSocketServerHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -238,7 +239,12 @@ impl Debug for WebSocketServerHandle {
 impl WebSocketServerHandle {
     /// Returns the local port that the server is listening on.
     pub fn port(&self) -> u16 {
-        self.0.port()
+        self.1.port()
+    }
+
+    /// Returns an app URL to open the websocket as a data source.
+    pub fn app_url(&self) -> AppUrl {
+        AppUrl::new().with_websocket(self.1.ip(), self.1.port())
     }
 
     /// Advertises support for the provided services.


### PR DESCRIPTION
### Changelog
- rust, python: Add websocket server method to get app URL

### Docs
None

### Description
This change adds a method to the websocket server handle to return an app URL that you can use to open the websocket as a data source, with an optional layout.