### PR TITLE
C++ fix assertion crash copying zero-length vectors via the arena

### DIFF
--- a/cpp/foxglove/include/foxglove/arena.hpp
+++ b/cpp/foxglove/include/foxglove/arena.hpp
@@ -29,7 +29,8 @@ public:
   /// @param src The source vector containing elements to map
   /// @param map_fn Function taking (T& dest, const S& src) to map elements.
   /// T must be a POD type, without a custom constructor or destructor.
-  /// @return Pointer to the beginning of the allocated array of src.size() T elements
+  /// @return Pointer to the beginning of the allocated array of src.size() T elements, or null if
+  /// elements is 0.
   /// @throws std::bad_alloc if the arena doesn't have enough space
   template<
     typename T, typename S, typename Fn,

--- a/cpp/foxglove/include/foxglove/arena.hpp
+++ b/cpp/foxglove/include/foxglove/arena.hpp
@@ -36,7 +36,7 @@ public:
     typename = std::enable_if_t<std::is_pod_v<T> && std::is_invocable_v<Fn, T&, const S&, Arena&>>>
   T* map(const std::vector<S>& src, Fn&& map_fn) {
     const size_t elements = src.size();
-    T* result = alloc<T>(elements);
+    T* result = (elements > 0) ? alloc<T>(elements) : nullptr;
     T* current = result;
 
     // Convert the elements from S to T, placing them in the result array

--- a/cpp/foxglove/include/foxglove/mcap.hpp
+++ b/cpp/foxglove/include/foxglove/mcap.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
+#include <foxglove/context.hpp>
+#include <foxglove/error.hpp>
+
 #include <memory>
 #include <optional>
 #include <string>
 
 enum foxglove_error : uint8_t;
-enum class FoxgloveError : uint8_t;
 struct foxglove_mcap_writer;
-struct foxglove_context;
 
 /// The foxglove namespace.
 namespace foxglove {


### PR DESCRIPTION
### Changelog

Fix assertion failure in C++ when serializing empty vectors

### Description

arena.hpp:73: T *foxglove::Arena::alloc(size_t) [T = foxglove_scene_entity_deletion]: Assertion `elements > 0' failed.

The problem was that arena alloc expects a non-zero allocation, but arena map was calling it without checking the number of elements for 0 first. This checks and returns a nullptr for empty arrays. This means they're passed to C as a nullptr with length 0, which fits with how we represent empty arrays and strings.

While I was at it, I noticed that forward declaring context and errors in mcap.hpp meant that you had to include both of those headers whenever you import mcap.hpp, I changed this to match how we did channel.hpp and server.hpp, which makes it a little more friendly to use.

