### PR TITLE
python: Add missing stub for Timestamp.now()

### DIFF
--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/schemas_wkt.pyi
@@ -75,3 +75,12 @@ class Timestamp:
         :param dt: Datetime
         """
         ...
+
+    @staticmethod
+    def now() -> "Timestamp":
+        """
+        Creates a :py:class:`Timestamp` from the current system time.
+
+        Raises `OverflowError` if the timestamp cannot be represented.
+        """
+        ...


### PR DESCRIPTION
### Changelog
Fix: python: Add missing stub for Timestamp.now()

### Docs
None

### Description

We have a Timestamp.now() implementation, but were missing the stub interface.