### PR TITLE
Update .gitattributes to ignore codegen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 schemas/** linguist-generated
+typescript/schemas/src/types/* linguist-generated
+c/src/generated_types.rs linguist-generated
+cpp/foxglove/include/foxglove/schemas.hpp linguist-generated
+rust/foxglove/src/schemas/foxglove.rs linguist-generated
+python/foxglove-sdk/src/generated/* linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
-schemas/** linguist-generated
-typescript/schemas/src/types/* linguist-generated
 c/src/generated_types.rs linguist-generated
 cpp/foxglove/include/foxglove/schemas.hpp linguist-generated
-rust/foxglove/src/schemas/foxglove.rs linguist-generated
 python/foxglove-sdk/src/generated/* linguist-generated
+rust/foxglove/src/schemas/foxglove.rs linguist-generated
+schemas/** linguist-generated
+typescript/schemas/src/types/* linguist-generated


### PR DESCRIPTION
This marks additional generated code to be hidden by default in PR diff display. See [docs](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github).