### PR TITLE
c++: Add channel.close() method

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -1957,6 +1957,15 @@ foxglove_error foxglove_raw_channel_create(struct foxglove_string topic,
                                            const struct foxglove_channel **channel);
 
 /**
+ * Close a channel.
+ *
+ * # Safety
+ * `channel` must be a valid pointer to a `foxglove_channel` created via `foxglove_channel_create`.
+ * If channel is null, this does nothing.
+ */
+void foxglove_channel_close(const struct foxglove_channel *channel);
+
+/**
  * Free a channel created via `foxglove_channel_create`.
  *
  * # Safety

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -1959,6 +1959,13 @@ foxglove_error foxglove_raw_channel_create(struct foxglove_string topic,
 /**
  * Close a channel.
  *
+ * You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+ * dynamically, such as the WebSocketServer.
+ *
+ * Attempts to log on a closed channel will elicit a throttled warning message.
+ *
+ * Note this *does not* free the channel.
+ *
  * # Safety
  * `channel` must be a valid pointer to a `foxglove_channel` created via `foxglove_channel_create`.
  * If channel is null, this does nothing.

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -1014,6 +1014,19 @@ pub(crate) unsafe fn do_foxglove_channel_create<T: foxglove::Encode>(
     Ok(Arc::into_raw(builder.build::<T>().into_inner()) as *const FoxgloveChannel)
 }
 
+/// Close a channel.
+///
+/// # Safety
+/// `channel` must be a valid pointer to a `foxglove_channel` created via `foxglove_channel_create`.
+/// If channel is null, this does nothing.
+#[unsafe(no_mangle)]
+pub extern "C" fn foxglove_channel_close(channel: Option<&FoxgloveChannel>) {
+    let Some(channel) = channel else {
+        return;
+    };
+    channel.0.close();
+}
+
 /// Free a channel created via `foxglove_channel_create`.
 ///
 /// # Safety

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -1016,6 +1016,13 @@ pub(crate) unsafe fn do_foxglove_channel_create<T: foxglove::Encode>(
 
 /// Close a channel.
 ///
+/// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+/// dynamically, such as the WebSocketServer.
+///
+/// Attempts to log on a closed channel will elicit a throttled warning message.
+///
+/// Note this *does not* free the channel.
+///
 /// # Safety
 /// `channel` must be a valid pointer to a `foxglove_channel` created via `foxglove_channel_create`.
 /// If channel is null, this does nothing.

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -66,6 +66,14 @@ public:
     const std::byte* data, size_t data_len, std::optional<uint64_t> log_time = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -33,6 +33,10 @@ FoxgloveResult<RawChannel> RawChannel::create(
 RawChannel::RawChannel(const foxglove_channel* channel)
     : impl_(channel) {}
 
+void RawChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t RawChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
 }

--- a/cpp/foxglove/tests/test_channel.cpp
+++ b/cpp/foxglove/tests/test_channel.cpp
@@ -66,6 +66,25 @@ TEST_CASE("channel.has_sinks()") {
   REQUIRE(channel2.value().has_sinks());
 }
 
+TEST_CASE("channel.close() disconnects sinks") {
+  FileCleanup cleanup("test.mcap");
+
+  auto context = foxglove::Context::create();
+
+  foxglove::McapWriterOptions mcap_options = {};
+  mcap_options.context = context;
+  mcap_options.path = "test.mcap";
+  auto writer = foxglove::McapWriter::create(mcap_options);
+  REQUIRE(writer.has_value());
+
+  auto channel = foxglove::RawChannel::create("test", "json", std::nullopt, context);
+  REQUIRE(channel.has_value());
+  REQUIRE(channel.value().has_sinks());
+
+  channel.value().close();
+  REQUIRE(!channel.value().has_sinks());
+}
+
 TEST_CASE("channel.schema()") {
   foxglove::Schema mock_schema;
   mock_schema.encoding = "jsonschema";

--- a/cpp/foxglove/tests/test_channel.cpp
+++ b/cpp/foxglove/tests/test_channel.cpp
@@ -67,13 +67,14 @@ TEST_CASE("channel.has_sinks()") {
 }
 
 TEST_CASE("channel.close() disconnects sinks") {
-  FileCleanup cleanup("test.mcap");
+  auto fname = "test-channel-close-disconnects-sinks.mcap";
+  FileCleanup cleanup(fname);
 
   auto context = foxglove::Context::create();
 
   foxglove::McapWriterOptions mcap_options = {};
   mcap_options.context = context;
-  mcap_options.path = "test.mcap";
+  mcap_options.path = fname;
   auto writer = foxglove::McapWriter::create(mcap_options);
   REQUIRE(writer.has_value());
 


### PR DESCRIPTION
### Changelog
c++: Add channel.close() method

### Description

This adds a close() method to channels in C++.

This is based on #472 because the test makes use of a getter from there.