### PR TITLE
Add a simple prost example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example_prost"
+version = "0.0.0"
+dependencies = [
+ "foxglove",
+ "prost",
+ "prost-build",
+]
+
+[[package]]
 name = "example_quickstart"
 version = "0.0.0"
 dependencies = [

--- a/rust/examples/prost/.gitignore
+++ b/rust/examples/prost/.gitignore
@@ -1,0 +1,1 @@
+generated/

--- a/rust/examples/prost/Cargo.toml
+++ b/rust/examples/prost/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 workspace = true
 
 [dependencies]
-foxglove = { path = "../../foxglove", features = [] }
+foxglove = { path = "../../foxglove", default-features = false }
 prost = "0.13.5"
 
 [build-dependencies]

--- a/rust/examples/prost/Cargo.toml
+++ b/rust/examples/prost/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example_prost"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+foxglove = { path = "../../foxglove", features = [] }
+prost = "0.13.5"
+
+[build-dependencies]
+prost-build = "0.13.5"

--- a/rust/examples/prost/build.rs
+++ b/rust/examples/prost/build.rs
@@ -1,0 +1,10 @@
+use std::io::Result;
+fn main() -> Result<()> {
+    // Generate the file descriptor set in addition to the Rust source
+    prost_build::Config::new()
+        .out_dir("generated")
+        .file_descriptor_set_path("generated/apple.fdset")
+        .compile_protos(&["src/apple.proto"], &["src/"])?;
+
+    Ok(())
+}

--- a/rust/examples/prost/src/apple.proto
+++ b/rust/examples/prost/src/apple.proto
@@ -1,0 +1,6 @@
+package fruit;
+
+message Apple {
+    optional string color = 1;
+    optional int32 diameter = 2;
+}

--- a/rust/examples/prost/src/main.rs
+++ b/rust/examples/prost/src/main.rs
@@ -1,4 +1,4 @@
-use foxglove::{Channel, ChannelBuilder, McapWriter, Schema};
+use foxglove::{ChannelBuilder, McapWriter, Schema};
 use prost::Message;
 
 pub mod fruit {
@@ -44,7 +44,7 @@ impl foxglove::Encode for fruit::Apple {
     }
 
     fn encode(&self, buf: &mut impl prost::bytes::BufMut) -> Result<(), Self::Error> {
-        prost::Message::encode(self, buf)?;
+        Message::encode(self, buf)?;
         Ok(())
     }
 }

--- a/rust/examples/prost/src/main.rs
+++ b/rust/examples/prost/src/main.rs
@@ -1,0 +1,39 @@
+use foxglove::{ChannelBuilder, McapWriter, Schema};
+use prost::Message;
+
+pub mod fruit {
+    include!("../generated/fruit.rs");
+}
+
+const APPLE_SCHEMA: &[u8] = include_bytes!("../generated/apple.fdset");
+
+/// This example shows how to log custom protobuf messages to an MCAP file, using the
+/// [prost](https://docs.rs/prost) crate.
+///
+/// To run this example, in addition to the `prost` and `prost-build` crates, you must install a
+/// [protobuf compiler](https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation).
+fn main() {
+    let writer = McapWriter::new()
+        .create_new_buffered_file("fruit.mcap")
+        .expect("failed to create writer");
+
+    // Set up a channel for our protobuf messages
+    let schema = Schema::new("apple", "protobuf", APPLE_SCHEMA);
+    let channel = ChannelBuilder::new("/fruit")
+        .message_encoding("protobuf")
+        .schema(schema)
+        .build_raw()
+        .expect("failed to build channel");
+
+    // Create and log a protobuf message
+    let msg = fruit::Apple {
+        color: Some("red".to_string()),
+        diameter: Some(10),
+    };
+    let mut buf = vec![];
+    msg.encode(&mut buf).expect("failed to encode");
+
+    channel.log(&buf);
+
+    writer.close().expect("failed to close writer");
+}

--- a/rust/examples/prost/src/main.rs
+++ b/rust/examples/prost/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         .expect("failed to create writer");
 
     // Set up a channel for our protobuf messages
-    let schema = Schema::new("apple", "protobuf", APPLE_SCHEMA);
+    let schema = Schema::new("fruit.Apple", "protobuf", APPLE_SCHEMA);
     let channel = ChannelBuilder::new("/fruit")
         .message_encoding("protobuf")
         .schema(schema)


### PR DESCRIPTION
This example ties together the basic concepts documented by the prost-build, prost, and foxglove crates. It's less flexible than #481, but is a quicker way to get started with custom serialization and protobuf. I think both examples are useful.