### PR TITLE
Add C++ example showing logging custom generated protobuf

### DIFF
--- a/cpp/examples/custom-protobuf/CMakeLists.txt
+++ b/cpp/examples/custom-protobuf/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.14)
+project(quickstart LANGUAGES CXX)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find Protocol Buffers
+set(Protobuf_DEBUG ON)  # Enable debug output
+set(Protobuf_USE_STATIC_LIBS ON)  # Force static libraries
+set(Protobuf_VERSION 3.21.12)  # Explicitly set version to match system library
+find_package(Protobuf 3.21.12 REQUIRED)
+
+# Print debug information
+message(STATUS "Protobuf_VERSION: ${Protobuf_VERSION}")
+message(STATUS "Protobuf_PROTOC_EXECUTABLE: ${Protobuf_PROTOC_EXECUTABLE}")
+message(STATUS "Protobuf_INCLUDE_DIR: ${Protobuf_INCLUDE_DIR}")
+message(STATUS "Protobuf_LIBRARIES: ${Protobuf_LIBRARIES}")
+
+# Ensure we use the protoc found by FindProtobuf
+set(Protobuf_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE} CACHE FILEPATH "Protobuf compiler" FORCE)
+
+include_directories(${Protobuf_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# Generate Protocol Buffer files
+set(PROTO_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/protos/fruit.proto
+)
+
+# Create a target for the protobuf generation
+add_library(fruit_proto STATIC)
+protobuf_generate(
+    TARGET fruit_proto
+    LANGUAGE cpp
+    PROTOS ${PROTO_FILES}
+    IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/protos
+)
+
+# Add Protocol Buffers include directories to fruit_proto
+target_include_directories(fruit_proto PUBLIC
+    ${Protobuf_INCLUDE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+# Link Protocol Buffers to fruit_proto
+target_link_libraries(fruit_proto PUBLIC ${Protobuf_LIBRARIES})
+
+# Fetch Foxglove SDK
+include(FetchContent)
+FetchContent_Declare(
+    foxglove
+    # See available releases and builds here: https://github.com/foxglove/foxglove-sdk/releases
+    URL https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.9.0/foxglove-v0.9.0-cpp-x86_64-unknown-linux-gnu.zip
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_MakeAvailable(foxglove)
+
+# Add executable
+add_executable(custom_protobuf
+    main.cpp
+)
+
+# Add include directory for Foxglove SDK
+target_include_directories(custom_protobuf PRIVATE
+    ${foxglove_SOURCE_DIR}/include
+    ${foxglove_SOURCE_DIR}/include/foxglove
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${Protobuf_INCLUDE_DIRS}
+    ${Protobuf_INCLUDE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Find all Foxglove SDK source files
+file(GLOB FOXGLOVE_SOURCES CONFIGURE_DEPENDS
+    "${foxglove_SOURCE_DIR}/src/*.cpp"
+    "${foxglove_SOURCE_DIR}/src/server/*.cpp"
+)
+
+# Add Foxglove SDK source files
+target_sources(custom_protobuf PRIVATE ${FOXGLOVE_SOURCES})
+
+# Link against libfoxglove.a, Protocol Buffers, and our generated protobuf library
+target_link_libraries(custom_protobuf PRIVATE
+    ${foxglove_SOURCE_DIR}/lib/libfoxglove.a
+    ${Protobuf_LIBRARIES}
+    fruit_proto
+)

--- a/cpp/examples/custom-protobuf/README.md
+++ b/cpp/examples/custom-protobuf/README.md
@@ -1,0 +1,14 @@
+To run the example:
+
+```
+export CC=clang
+export CXX=clang++
+sudo apt-get install protobuf-compiler
+mkdir build
+cd build
+cmake ..
+make
+./custom_protobuf
+```
+
+And then open example.mcap in the Foxglove app

--- a/cpp/examples/custom-protobuf/main.cpp
+++ b/cpp/examples/custom-protobuf/main.cpp
@@ -1,0 +1,55 @@
+#include <foxglove/channel.hpp>
+#include <foxglove/foxglove.hpp>
+#include <foxglove/mcap.hpp>
+#include <foxglove/schemas.hpp>
+
+#include <google/protobuf/descriptor.pb.h>
+
+#include <string>
+
+#include "protos/fruit.pb.h"
+
+int main(int argc, const char* argv[]) {
+  foxglove::setLogLevel(foxglove::LogLevel::Debug);
+
+  foxglove::McapWriterOptions mcap_options = {};
+  mcap_options.path = "example.mcap";
+  auto writer_result = foxglove::McapWriter::create(mcap_options);
+  if (!writer_result.has_value()) {
+    std::cerr << "Failed to create writer: " << foxglove::strerror(writer_result.error()) << '\n';
+    return 1;
+  }
+  auto writer = std::move(writer_result.value());
+
+  auto descriptor = fruit::Apple::descriptor();
+
+  // Create a schema for the Apple message
+  foxglove::Schema schema;
+  schema.encoding = "protobuf";
+  schema.name = descriptor->full_name();
+
+  // Create a FileDescriptorSet containing our message descriptor
+  google::protobuf::FileDescriptorSet file_descriptor_set;
+  const google::protobuf::FileDescriptor* file_descriptor = descriptor->file();
+  file_descriptor->CopyTo(file_descriptor_set.add_file());
+
+  std::string serialized_descriptor = file_descriptor_set.SerializeAsString();
+  schema.data = reinterpret_cast<const std::byte*>(serialized_descriptor.data());
+  schema.data_len = serialized_descriptor.size();
+
+  auto channel_result = foxglove::RawChannel::create("/apple", "protobuf", std::move(schema));
+  if (!channel_result.has_value()) {
+    std::cerr << "Failed to create channel: " << foxglove::strerror(channel_result.error()) << '\n';
+    return 1;
+  }
+  auto apple_channel = std::move(channel_result.value());
+
+  // Create an Apple message, serialize it, and log it to the channel
+  fruit::Apple apple;
+  apple.set_color("red");
+  apple.set_diameter(10);
+  std::string apple_data = apple.SerializeAsString();
+  apple_channel.log(reinterpret_cast<const std::byte*>(apple_data.data()), apple_data.size());
+
+  return 0;
+}

--- a/cpp/examples/custom-protobuf/protos/fruit.proto
+++ b/cpp/examples/custom-protobuf/protos/fruit.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package fruit;
+
+message Apple {
+    optional string color = 1;
+    optional int32 diameter = 2;
+}


### PR DESCRIPTION
This adds a C++ example using a custom protobuf type generated with google's C++ protobuf library.

It's painful, I think we could improve this story a lot by moving the boilerplate for the schema and channel creation and serialization into the Foxglove SDK.

The CMakeLists.txt needs some cleanup, it's probably not the minimal version.

Maybe it also needs to be dockerized? It's not trivial to get this working on Linux, nevermind another platform.