### PR TITLE
Improve "getting started" reference docs

### DIFF
--- a/cpp/foxglove/docs/index.rst
+++ b/cpp/foxglove/docs/index.rst
@@ -18,6 +18,8 @@ compile the SDK source as part of your build process. The SDK assumes C++17 or n
 Download the library, source, and header files for your platform from the
 `SDK release <https://github.com/foxglove/foxglove-sdk/releases?q=sdk&expanded=true>`_ assets.
 
+For a hands-on walk-through using CMake, see https://docs.foxglove.dev/docs/sdk/example?lang=cpp.
+
 Overview
 --------
 
@@ -31,7 +33,7 @@ A "channel" gives a way to log related messages which have the same schema. Each
 instantiated with a unique topic name.
 
 You can log messages with arbitrary schemas and provide your own encoding, by instantiating a
-:class:`foxglove::Channel`.
+:class:`foxglove::RawChannel`.
 
 Thread safety
 -------------
@@ -40,6 +42,57 @@ Sinks, channels, and contexts are thread-safe. Sinks and channels can be created
 and shared or moved between threads. Logging is atomic and thread-safe.
 
 Other types in the SDK are not thread-safe.
+
+Concepts
+--------
+
+Context
+^^^^^^^
+
+A :class:`foxglove::Context` is the binding between channels and sinks. Each channel and sink belongs to
+exactly one context. Sinks receive advertisements about channels on the context, and can optionally
+subscribe to receive logged messages on those channels.
+
+When the context goes out of scope, its corresponding channels and sinks will be disconnected from
+one another, and logging will stop. Attempts to log further messages on the channels will elicit
+throttled warning messages.
+
+Since many applications only need a single context, the SDK provides a static default context for
+convenience.
+
+
+Channels
+^^^^^^^^
+
+A :class:`foxglove::RawChannel` gives a way to log related messages which have the same type, or
+:class:`foxglove::Schema`. Each channel is instantiated with a unique "topic", or name, which is typically
+prefixed by a `/`. If you're familiar with MCAP, it's the same concept as an [MCAP channel](https://mcap.dev/guides/concepts#channel).
+
+A channel is always associated with exactly one :class:`foxglove::Context` throughout its lifecycle. The
+channel remains attached to the context until it is either explicitly closed with
+`close`, or the context is dropped. Attempting to log a message on a closed channel
+will elicit a throttled warning.
+
+Sinks
+^^^^^
+
+A "sink" is a destination for logged messages. If you do not configure a sink, log messages will
+simply be dropped without being recorded. You can configure multiple sinks, and you can create
+or destroy them dynamically at runtime.
+
+A sink is typically associated with exactly one :class:`foxglove::Context` throughout its lifecycle.
+Details about how the sink is registered and unregistered from the context are sink-specific.
+
+To create an MCAP file sink, call :func:`foxglove::McapWriter::create` and keep a reference to the returned handle.
+As long as the handle remains in scope, events will be logged to the MCAP file. When the handle is
+closed or dropped, the sink will be unregistered from the :class:`foxglove::Context`, and the file will be
+finalized and flushed.
+
+To create a live visualization server sink, call :func:`foxglove::WebSocketServer::create`. By default, the server
+listens on ``127.0.0.1:8765``. Each client that connects to the websocket server is its own independent
+sink. The sink is dynamically added to the :class:`foxglove::Context` associated with the server when the client
+connects, and removed from the context when the client disconnects.
+
 
 
 .. toctree::

--- a/python/foxglove-sdk/README.md
+++ b/python/foxglove-sdk/README.md
@@ -1,37 +1,15 @@
 # Foxglove Python SDK
 
+The official [Foxglove](https://docs.foxglove.dev/docs) SDK for Python.
+
+This package provides support for integrating with the Foxglove platform. It can be used to log
+events to local [MCAP](https://mcap.dev/) files or a local visualization server that communicates
+with the Foxglove app.
+
+## Get Started
+
+See https://foxglove.github.io/foxglove-sdk/python/
+
 ## Requirements
 
 - Python 3.9+
-
-### Examples
-
-To get started, install Poetry https://python-poetry.org/docs/#installation, and then the project dependencies. For example:
-
-```sh
-pipx install poetry
-poetry install
-```
-
-Examples are available in [foxglove-sdk-examples](https://github.com/foxglove/foxglove-sdk/tree/main/python/foxglove-sdk-examples).
-
-## Overview
-
-To record messages, you need at least one sink and at least one channel.
-
-A "sink" is a destination for logged messages — either an MCAP file or a live visualization server.
-Use `open_mcap` to register a new MCAP sink. Use `start_server` to create a new live visualization
-server.
-
-A "channel" gives a way to log related messages which have the same schema. Each channel is
-instantiated with a unique topic name.
-
-The SDK provides classes for well-known schemas. These can be used in conjunction with associated
-channel classes for type-safe logging, which ensures at compile time that messages logged to a
-channel all share a common schema. For example, you may create a `SceneUpdateChannel` on which you
-will log `SceneUpdate` messages.
-
-You can also log messages with arbitrary schemas and provide your own encoding, by instantiating a
-`Channel` class.
-
-See the examples for more details.

--- a/python/foxglove-sdk/python/docs/index.rst
+++ b/python/foxglove-sdk/python/docs/index.rst
@@ -13,18 +13,52 @@ This package provides support for integrating with the Foxglove platform. It can
 events to local `MCAP <https://mcap.dev/>`_ files or a local visualization server that communicates
 with the Foxglove app.
 
+Getting started
+---------------
 
-Overview
+Install the ``foxglove-sdk`` package from `PyPI <https://pypi.org/project/foxglove-sdk/>`_.
+
+This will depend on your package manager. Our `examples
+<https://github.com/foxglove/foxglove-sdk/tree/main/python/foxglove-sdk-examples>`_ use `poetry
+<https://python-poetry.org/>`_.
+
+To record messages, you need to initialize either an MCAP file writer or a WebSocket server for
+live visualization.
+
+For a hands-on walk-through, see https://docs.foxglove.dev/docs/sdk/example?lang=python.
+
+Concepts
 --------
 
-To record messages, you need at least one sink and at least one channel.
+Context
+^^^^^^^
 
-A "sink" is a destination for logged messages — either an MCAP file or a live visualization server.
-Use :py:func:`.open_mcap` to register a new MCAP sink. Use
-:py:func:`.start_server` to create a new live visualization server.
+A :py:class:`.Context` is the binding between channels and sinks. Each channel and sink belongs to
+exactly one context. Sinks receive advertisements about channels on the context, and can optionally
+subscribe to receive logged messages on those channels.
 
-A "channel" gives a way to log related messages which have the same schema. Each channel is
-instantiated with a unique topic name.
+When the context goes out of scope, its corresponding channels and sinks will be disconnected from
+one another, and logging will stop. Attempts to log further messages on the channels will elicit
+throttled warning messages.
+
+Since many applications only need a single context, the SDK provides a static default context for
+convenience.
+
+
+Channels
+^^^^^^^^
+
+A :py:class:`.Channel` gives a way to log related messages which have the same type, or
+:py:class:`.Schema`. Each channel is instantiated with a unique "topic", or name, which is typically
+prefixed by a `/`. If you're familiar with MCAP, it's the same concept as an [MCAP channel](https://mcap.dev/guides/concepts#channel).
+
+A channel is always associated with exactly one :py:class:`.Context` throughout its lifecycle. The
+channel remains attached to the context until it is either explicitly closed with
+`Channel.close`, or the context is dropped. Attempting to log a message on a closed channel
+will elicit a throttled warning.
+
+Schemas
+^^^^^^^
 
 The SDK provides classes for well-known schemas. These can be used in conjunction with associated
 channel classes for type-safe logging, which ensures at compile time that messages logged to a
@@ -35,6 +69,26 @@ we plan to address in the future.
 
 You can also log messages with arbitrary schemas and provide your own encoding, by instantiating a
 :py:class:`.Channel` class.
+
+Sinks
+^^^^^
+
+A "sink" is a destination for logged messages. If you do not configure a sink, log messages will
+simply be dropped without being recorded. You can configure multiple sinks, and you can create
+or destroy them dynamically at runtime.
+
+A sink is typically associated with exactly one :py:class:`.Context` throughout its lifecycle.
+Details about how the sink is registered and unregistered from the context are sink-specific.
+
+To create an MCAP file sink, use :py:func:`.open_mcap` and keep a reference to the returned handle.
+As long as the handle remains in scope, events will be logged to the MCAP file. When the handle is
+closed or dropped, the sink will be unregistered from the :py:class:`.Context`, and the file will be
+finalized and flushed.
+
+To create a live visualization server sink, use :py:func:`.start_server`. By default, the server
+listens on ``127.0.0.1:8765``. Each client that connects to the websocket server is its own independent
+sink. The sink is dynamically added to the :py:class:`.Context` associated with the server when the client
+connects, and removed from the context when the client disconnects.
 
 
 .. toctree::

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -17,7 +17,7 @@
 //! ```
 //!
 //! The following sections illustrate how to use the SDK. For a more hands-on walk-through, see
-//! https://docs.foxglove.dev/docs/sdk/example.
+//! <https://docs.foxglove.dev/docs/sdk/example>.
 //!
 //! # Recording messages
 //!

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -9,9 +9,22 @@
 //!
 //! # Getting started
 //!
-//! To record messages, you need at least one sink. In this example, we create an MCAP file sink,
-//! and log a [`Log`](`crate::schemas::Log`) message on a topic called `/log`. We write one log
-//! message and close the file.
+//! The easiest way to get started is to install the `foxglove` crate with default features, which
+//! will allow logging messages to the Foxglove app and to an MCAP file.
+//!
+//! ```bash
+//! cargo add foxglove
+//! ```
+//!
+//! The following sections illustrate how to use the SDK. For a more hands-on walk-through, see
+//! https://docs.foxglove.dev/docs/sdk/example.
+//!
+//! # Recording messages
+//!
+//! To record messages, you need to initialize either an MCAP file writer or a WebSocket server for
+//! live visualization. In this example, we create an MCAP writer, and record a
+//! [`Log`](`crate::schemas::Log`) message on a topic called `/log`. We write one log message and
+//! close the file.
 //!
 //! ```no_run
 //! use foxglove::schemas::Log;


### PR DESCRIPTION
### Changelog
None

### Description

This improves the main reference doc page in all languages, to make it easier to get started with the SDK, and introduce the concepts (from the Rust docs) in Python and C++.