### PR TITLE
Fixing cpp lint failures on CI

### DIFF
--- a/cpp/examples/quickstart/src/main.cpp
+++ b/cpp/examples/quickstart/src/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, const char* argv[]) {
                  std::chrono::system_clock::now().time_since_epoch()
     )
                  .count();
-    double size = abs(sin(now)) + 1.0;
+    double size = std::abs(std::sin(now)) + 1.0;
     std::string msg = "{\"size\": " + std::to_string(size) + "}";
     size_channel.log(reinterpret_cast<const std::byte*>(msg.data()), msg.size());
 


### PR DESCRIPTION
I'm not sure yet how the failures managed to get merged, but looking into fixing them in this PR

And it doesn't fail on main. So now the question is why is it failing in a rust PR that didn't touch C++?