### PR TITLE
ci: Don't do setup-rust-toolchain in python-linux builds

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -110,10 +110,6 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
-      # rustfmt is used on generated rust schemas for the SDK
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"


### PR DESCRIPTION
@eloff and I have both been bit by [inscrutable build failures in CI](https://github.com/foxglove/foxglove-sdk/actions/runs/15645870788/job/44083140389), where the jobs to build python linux wheels fail to find glibc. I'm pretty sure that this is related to a bad caching strategy. I suspect that if we drop the `setup-rust-toolchain` step from the job, it'll prevent this problem from happening in the future.

We don't really benefit from that step anyway. The maturin-action takes care of installing the rust toolchain. The comment about rustfmt is stale; we used to do rust codegen as part of the python build, but that's ancient history.