### PR TITLE
Rust: support filtering logging sinks by topic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example_message_filtering"
+version = "0.0.0"
+dependencies = [
+ "ctrlc",
+ "env_logger",
+ "foxglove",
+]
+
+[[package]]
 name = "example_param_server"
 version = "0.0.0"
 dependencies = [

--- a/rust/examples/message-filtering/Cargo.toml
+++ b/rust/examples/message-filtering/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example_message_filtering"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+foxglove = { path = "../../foxglove" }
+ctrlc = "3.4.5"
+env_logger = "0.11.5"

--- a/rust/examples/message-filtering/src/main.rs
+++ b/rust/examples/message-filtering/src/main.rs
@@ -1,0 +1,205 @@
+//! This example demonstrates how to use the Foxglove SDK to filter messages when logging to an MCAP
+//! file and/or a WebSocket server.
+//!
+//! Oftentimes, you may want to split "heavy" topics out into separate MCAP recordings, but still
+//! log everything for live visualization. Splitting on topic in this way can be useful for
+//! selectively retrieving data from bandwidth-constrained environments, such as with the Foxglove
+//! Agent.
+//!
+//! In this example, we log some point cloud data to one MCAP file, and some minimal metadata to
+//! another.
+use foxglove::schemas::{
+    packed_element_field::NumericType, PackedElementField, PointCloud, Pose, Quaternion, Vector3,
+};
+use foxglove::schemas::{FrameTransform, FrameTransforms};
+use foxglove::{Encode, FilterableChannel, LazyChannel, McapWriter, SinkChannelFilter};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+const SMALL_MCAP_FILE: &str = "example-topic-splitting-small.mcap";
+const LARGE_MCAP_FILE: &str = "example-topic-splitting-large.mcap";
+
+#[derive(Encode)]
+struct Message {
+    state: String,
+}
+
+static INFO_CHANNEL: LazyChannel<Message> = LazyChannel::new("/info");
+static POINT_CLOUD_CHANNEL: LazyChannel<PointCloud> = LazyChannel::new("/point_cloud");
+static POINT_CLOUD_TF_CHANNEL: LazyChannel<FrameTransforms> = LazyChannel::new("/point_cloud_tf");
+
+/// A filter which will drop all of our point_cloud messages
+struct SmallTopicFilter;
+impl SinkChannelFilter for SmallTopicFilter {
+    fn should_subscribe(&self, channel: &dyn FilterableChannel) -> bool {
+        !channel.topic().starts_with("/point_cloud")
+    }
+}
+
+/// A filter which keeps _only_ our point_cloud messages
+struct LargeTopicFilter;
+impl SinkChannelFilter for LargeTopicFilter {
+    fn should_subscribe(&self, channel: &dyn FilterableChannel) -> bool {
+        channel.topic().starts_with("/point_cloud")
+    }
+}
+
+/// We'll send all messages to the Foxglove app. We don't need a filter for this, since its the same
+/// as having no filter applied, but this demonstrates how to apply a filter to the WS server.
+struct LiveVizFilter;
+impl SinkChannelFilter for LiveVizFilter {
+    fn should_subscribe(&self, _channel: &dyn FilterableChannel) -> bool {
+        true
+    }
+}
+
+fn main() {
+    let env = env_logger::Env::default().default_filter_or("debug");
+    env_logger::init_from_env(env);
+
+    let done = Arc::new(AtomicBool::default());
+    ctrlc::set_handler({
+        let done = done.clone();
+        move || {
+            done.store(true, Ordering::Relaxed);
+        }
+    })
+    .expect("Failed to set SIGINT handler");
+
+    // We'll log to both an MCAP file, and to a running Foxglove app via a server.
+    let small_mcap = McapWriter::new()
+        .with_channel_filter(Arc::new(SmallTopicFilter))
+        .create_new_buffered_file(SMALL_MCAP_FILE)
+        .expect("Failed to create mcap writer");
+
+    let large_mcap = McapWriter::new()
+        .with_channel_filter(Arc::new(LargeTopicFilter))
+        .create_new_buffered_file(LARGE_MCAP_FILE)
+        .expect("Failed to create mcap writer");
+
+    foxglove::WebSocketServer::new()
+        .channel_filter(Arc::new(LiveVizFilter))
+        .start_blocking()
+        .expect("Server failed to start");
+
+    let start = SystemTime::now();
+    let cloud_tf = FrameTransforms {
+        transforms: vec![FrameTransform {
+            parent_frame_id: "world".to_string(),
+            child_frame_id: "points".to_string(),
+            translation: Some(Vector3 {
+                x: -10.0,
+                y: -10.0,
+                z: 0.0,
+            }),
+            ..Default::default()
+        }],
+    };
+
+    while !done.load(Ordering::Relaxed) {
+        let elapsed = SystemTime::now()
+            .duration_since(start)
+            .expect("Time went backwards");
+
+        let state = get_state(elapsed);
+        INFO_CHANNEL.log(&Message { state });
+
+        let point_cloud = make_point_cloud(elapsed);
+        POINT_CLOUD_CHANNEL.log(&point_cloud);
+        POINT_CLOUD_TF_CHANNEL.log(&cloud_tf);
+
+        std::thread::sleep(Duration::from_millis(33));
+    }
+
+    small_mcap.close().expect("Failed to close mcap");
+    large_mcap.close().expect("Failed to close mcap");
+}
+
+fn get_state(elapsed: Duration) -> String {
+    let t = elapsed.as_secs_f32().cos();
+    if t > 0.0 {
+        "pos".to_string()
+    } else {
+        "neg".to_string()
+    }
+}
+
+/// Generate an example point cloud.
+///
+/// Adapted from <https://foxglove.dev/blog/visualizing-point-clouds-with-custom-colors>
+fn make_point_cloud(elapsed: Duration) -> PointCloud {
+    let t = elapsed.as_secs_f32();
+    let mut points = Vec::new();
+    for x in 0..20 {
+        for y in 0..20 {
+            let x_coord = x as f32 + (t + y as f32 / 5.0).cos();
+            let y_coord = y as f32;
+            let z_coord = 0.0f32;
+
+            let r = (255.0 * (0.5 + 0.5 * x_coord / 20.0)) as u8;
+            let g = (255.0 * y_coord / 20.0) as u8;
+            let b = (255.0 * (0.5 + 0.5 * t.sin())) as u8;
+            let a = (255.0 * (0.5 + 0.5 * ((x_coord / 20.0) * (y_coord / 20.0)))) as u8;
+
+            points.push((x_coord, y_coord, z_coord, r, g, b, a));
+        }
+    }
+
+    // Pack data into bytes
+    let mut buffer = Vec::new();
+    for (x, y, z, r, g, b, a) in points {
+        buffer.extend_from_slice(&x.to_le_bytes());
+        buffer.extend_from_slice(&y.to_le_bytes());
+        buffer.extend_from_slice(&z.to_le_bytes());
+        buffer.push(r);
+        buffer.push(g);
+        buffer.push(b);
+        buffer.push(a);
+    }
+
+    // Create fields defining the data structure
+    let fields = vec![
+        PackedElementField {
+            name: "x".to_string(),
+            offset: 0,
+            r#type: NumericType::Float32.into(),
+        },
+        PackedElementField {
+            name: "y".to_string(),
+            offset: 4,
+            r#type: NumericType::Float32.into(),
+        },
+        PackedElementField {
+            name: "z".to_string(),
+            offset: 8,
+            r#type: NumericType::Float32.into(),
+        },
+        PackedElementField {
+            name: "rgba".to_string(),
+            offset: 12,
+            r#type: NumericType::Uint32.into(),
+        },
+    ];
+
+    PointCloud {
+        timestamp: None,
+        frame_id: "points".to_string(),
+        pose: Some(Pose {
+            position: Some(Vector3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            }),
+            orientation: Some(Quaternion {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+                w: 1.0,
+            }),
+        }),
+        point_stride: 16, // 4 fields * 4 bytes
+        fields,
+        data: buffer.into(),
+    }
+}

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -323,6 +323,7 @@ mod schema;
 pub mod schemas;
 mod schemas_wkt;
 mod sink;
+mod sink_channel_filter;
 
 #[cfg(test)]
 mod tests;
@@ -342,6 +343,7 @@ pub use mcap_writer::{McapCompression, McapWriteOptions, McapWriter, McapWriterH
 pub use metadata::{Metadata, PartialMetadata, ToUnixNanos};
 pub use schema::Schema;
 pub use sink::{Sink, SinkId};
+pub use sink_channel_filter::{FilterableChannel, SinkChannelFilter};
 pub(crate) use time::nanoseconds_since_epoch;
 
 #[cfg(feature = "live_visualization")]

--- a/rust/foxglove/src/mcap_writer/mcap_sink.rs
+++ b/rust/foxglove/src/mcap_writer/mcap_sink.rs
@@ -1,5 +1,5 @@
 //! [`Sink`] implementation for an MCAP writer.
-use crate::{ChannelId, FoxgloveError, Metadata, RawChannel, Sink, SinkId};
+use crate::{ChannelId, FoxgloveError, Metadata, RawChannel, Sink, SinkChannelFilter, SinkId};
 use mcap::WriteOptions;
 use parking_lot::Mutex;
 use std::collections::hash_map::Entry;
@@ -13,20 +13,26 @@ type McapChannelId = u16;
 struct WriterState<W: Write + Seek> {
     writer: mcap::Writer<W>,
     // ChannelId -> mcap file channel id.
+    //
+    // If the value is `None`, then we do not log to this channel; for example, if the channel is
+    // filtered out by the `SinkChannelFilter`.
+    //
     // Note that the underlying writer may re-use channel_ids based on the metadata of the channel,
     // so multiple `ChannelIds` may map to the same `McapChannelId`.
-    channel_map: HashMap<ChannelId, McapChannelId>,
+    channel_map: HashMap<ChannelId, Option<McapChannelId>>,
     // Current message sequence number for each channel.
     // Indexed by `McapChannelId` to ensure increasing sequence within each MCAP channel.
     channel_sequence: HashMap<McapChannelId, u32>,
+    channel_filter: Option<Arc<dyn SinkChannelFilter>>,
 }
 
 impl<W: Write + Seek> WriterState<W> {
-    fn new(writer: mcap::Writer<W>) -> Self {
+    fn new(writer: mcap::Writer<W>, channel_filter: Option<Arc<dyn SinkChannelFilter>>) -> Self {
         Self {
             writer,
             channel_map: HashMap::new(),
             channel_sequence: HashMap::new(),
+            channel_filter,
         }
     }
 
@@ -48,6 +54,13 @@ impl<W: Write + Seek> WriterState<W> {
         let mcap_channel_id = match self.channel_map.entry(channel_id) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
+                if let Some(filter) = self.channel_filter.as_ref() {
+                    if !filter.should_subscribe(channel) {
+                        entry.insert(None);
+                        return Ok(());
+                    }
+                }
+
                 let schema_id = if let Some(schema) = channel.schema() {
                     self.writer
                         .add_schema(&schema.name, &schema.encoding, &schema.data)
@@ -66,9 +79,14 @@ impl<W: Write + Seek> WriterState<W> {
                     )
                     .map_err(FoxgloveError::from)?;
 
-                entry.insert(mcap_channel_id);
-                mcap_channel_id
+                entry.insert(Some(mcap_channel_id));
+                Some(mcap_channel_id)
             }
+        };
+
+        // If there is no mcap_channel_id, then the channel is filtering this topic.
+        let Some(mcap_channel_id) = mcap_channel_id else {
+            return Ok(());
         };
 
         let sequence = self.next_sequence(mcap_channel_id);
@@ -102,11 +120,15 @@ impl<W: Write + Seek> Debug for McapSink<W> {
 
 impl<W: Write + Seek> McapSink<W> {
     /// Creates a new MCAP writer sink.
-    pub fn new(writer: W, options: WriteOptions) -> Result<Arc<McapSink<W>>, FoxgloveError> {
+    pub fn new(
+        writer: W,
+        options: WriteOptions,
+        channel_filter: Option<Arc<dyn SinkChannelFilter>>,
+    ) -> Result<Arc<McapSink<W>>, FoxgloveError> {
         let mcap_writer = options.create(writer).map_err(FoxgloveError::from)?;
         let writer = Arc::new(Self {
             sink_id: SinkId::next(),
-            inner: Mutex::new(Some(WriterState::new(mcap_writer))),
+            inner: Mutex::new(Some(WriterState::new(mcap_writer, channel_filter))),
         });
         Ok(writer)
     }
@@ -144,7 +166,9 @@ impl<W: Write + Seek + Send> Sink for McapSink<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ChannelBuilder, Context, Metadata, Schema};
+    use crate::{
+        testutil::read_summary, ChannelBuilder, Context, FilterableChannel, Metadata, Schema,
+    };
     use mcap::McapError;
     use std::path::Path;
     use tempfile::NamedTempFile;
@@ -188,7 +212,6 @@ mod tests {
         let ch1 = new_test_channel(&ctx, "foo".to_string(), "foo_schema".to_string());
         let ch2 = new_test_channel(&ctx, "bar".to_string(), "bar_schema".to_string());
 
-        // Generate a temporary file path without creating the file
         let temp_file = NamedTempFile::new().expect("create tempfile");
         let temp_path = temp_file.path().to_owned();
 
@@ -200,8 +223,8 @@ mod tests {
         let mut ch2_meta_iter = ch2_meta.iter();
 
         // Log two messages to each channel, interleaved
-        let writer =
-            McapSink::new(&temp_file, WriteOptions::default()).expect("failed to create writer");
+        let writer = McapSink::new(&temp_file, WriteOptions::default(), None)
+            .expect("failed to create writer");
         writer
             .log(&ch1, b"msg1", &ch1_meta[0])
             .expect("failed to log to channel 1");
@@ -269,13 +292,12 @@ mod tests {
         let ch2 = new_test_channel(&ctx, "bar".to_string(), "bar_schema".to_string());
         let ch3 = new_test_channel(&ctx, "bar".to_string(), "bar_schema".to_string());
 
-        // Generate a temporary file path without creating the file
         let temp_file = NamedTempFile::new().expect("failed to create tempfile");
         let temp_path = temp_file.path().to_owned();
 
         let metadata = Metadata::default();
-        let writer =
-            McapSink::new(&temp_file, WriteOptions::default()).expect("failed to create writer");
+        let writer = McapSink::new(&temp_file, WriteOptions::default(), None)
+            .expect("failed to create writer");
 
         writer
             .log(&ch1, b"msg1", &metadata)
@@ -324,5 +346,60 @@ mod tests {
         assert_eq!(messages[2].sequence, 2);
         assert_eq!(messages[4].sequence, 3);
         assert_eq!(messages[5].sequence, 4);
+    }
+
+    #[test]
+    fn test_channel_filter() {
+        // Write messages to two topics, but filter out the first.
+        struct Ch1Filter;
+        impl SinkChannelFilter for Ch1Filter {
+            fn should_subscribe(&self, channel: &dyn FilterableChannel) -> bool {
+                channel.topic() == "/2"
+            }
+        }
+
+        let ctx = Context::new();
+
+        let ch1 = ChannelBuilder::new("/1")
+            .context(&ctx)
+            .message_encoding("json")
+            .build_raw()
+            .unwrap();
+        let ch2 = ChannelBuilder::new("/2")
+            .context(&ctx)
+            .message_encoding("json")
+            .build_raw()
+            .unwrap();
+
+        let temp_file1 = NamedTempFile::new().expect("failed to create tempfile");
+        let temp_path1 = temp_file1.path().to_owned();
+        let writer1 = McapSink::new(
+            &temp_file1,
+            WriteOptions::default(),
+            Some(Arc::new(Ch1Filter)),
+        )
+        .expect("failed to create writer");
+
+        let temp_file2 = NamedTempFile::new().expect("failed to create tempfile");
+        let temp_path2 = temp_file2.path().to_owned();
+        let writer2 = McapSink::new(&temp_file2, WriteOptions::default(), None)
+            .expect("failed to create writer");
+
+        writer1.log(&ch1, b"{}", &Metadata::default()).unwrap();
+        writer2.log(&ch1, b"{}", &Metadata::default()).unwrap();
+        writer1.log(&ch2, b"{}", &Metadata::default()).unwrap();
+        writer2.log(&ch2, b"{}", &Metadata::default()).unwrap();
+
+        writer1.finish().expect("failed to finish recording");
+        writer2.finish().expect("failed to finish recording");
+
+        let summary = read_summary(&temp_path1);
+        assert_eq!(summary.channels.len(), 1);
+        assert_eq!(summary.channels.get(&1).unwrap().topic, "/2");
+        assert_eq!(summary.stats.unwrap().message_count, 1);
+
+        let summary = read_summary(&temp_path2);
+        assert_eq!(summary.channels.len(), 2);
+        assert_eq!(summary.stats.unwrap().message_count, 2);
     }
 }

--- a/rust/foxglove/src/sink_channel_filter.rs
+++ b/rust/foxglove/src/sink_channel_filter.rs
@@ -1,0 +1,36 @@
+use std::collections::BTreeMap;
+
+use crate::{ChannelId, RawChannel};
+
+/// Information about a channel, which is passed to a [`SinkChannelFilter`].
+pub trait FilterableChannel {
+    /// The ID of the channel.
+    fn id(&self) -> ChannelId;
+
+    /// The channel's topic.
+    fn topic(&self) -> &str;
+
+    /// The channel's metadata. Empty if it was not set during construction.
+    fn metadata(&self) -> &BTreeMap<String, String>;
+}
+
+impl FilterableChannel for RawChannel {
+    fn id(&self) -> ChannelId {
+        self.id()
+    }
+    fn topic(&self) -> &str {
+        self.topic()
+    }
+    fn metadata(&self) -> &BTreeMap<String, String> {
+        self.metadata()
+    }
+}
+
+/// A filter for channels that can be used to subscribe to or unsubscribe from channels.
+///
+/// This can be used to omit one or more channels from a sink, but still log all channels to another
+/// sink in the same context.
+pub trait SinkChannelFilter: Sync + Send {
+    /// Returns true if the channel should be subscribed to.
+    fn should_subscribe(&self, channel: &dyn FilterableChannel) -> bool;
+}

--- a/rust/foxglove/src/tests.rs
+++ b/rust/foxglove/src/tests.rs
@@ -2,6 +2,7 @@ use std::{error::Error, fmt::Display};
 #[cfg(feature = "live_visualization")]
 mod logging;
 mod schemas;
+mod sinks;
 
 use crate::FoxgloveError;
 

--- a/rust/foxglove/src/tests/sinks.rs
+++ b/rust/foxglove/src/tests/sinks.rs
@@ -1,0 +1,86 @@
+use std::{io::BufWriter, sync::Arc};
+
+use tempfile::NamedTempFile;
+
+use crate::{
+    schemas::Log,
+    testutil::{assert_eventually, read_summary},
+    websocket::{
+        testutil::{expect_recv, WebSocketClient},
+        ws_protocol::{
+            client::{subscribe::Subscription, Subscribe},
+            server::ServerMessage,
+        },
+    },
+    Channel, ChannelBuilder, Context, FilterableChannel, McapWriter, SinkChannelFilter,
+    WebSocketServer,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sink_channel_filtering_on_mcap_and_ws() {
+    // MCAP only sees topic /1
+    struct McapFilter;
+    impl SinkChannelFilter for McapFilter {
+        fn should_subscribe(&self, channel: &dyn FilterableChannel) -> bool {
+            channel.topic() == "/1"
+        }
+    }
+
+    // WS only sees topic /2
+    struct WebsocketFilter;
+    impl SinkChannelFilter for WebsocketFilter {
+        fn should_subscribe(&self, channel: &dyn FilterableChannel) -> bool {
+            channel.topic() == "/2"
+        }
+    }
+
+    let ctx = Context::new();
+
+    let file = NamedTempFile::new().unwrap();
+    let mcap = McapWriter::new()
+        .context(&ctx)
+        .with_channel_filter(Arc::new(McapFilter))
+        .create(BufWriter::new(file))
+        .unwrap();
+
+    let _ = WebSocketServer::new()
+        .bind("127.0.0.1", 11011)
+        .context(&ctx)
+        .channel_filter(Arc::new(WebsocketFilter))
+        .start()
+        .await
+        .expect("Failed to start server");
+
+    let mut client = WebSocketClient::connect("127.0.0.1:11011").await;
+    expect_recv!(client, ServerMessage::ServerInfo);
+
+    let ch1: Channel<Log> = ChannelBuilder::new("/1").context(&ctx).build();
+    let ch2: Channel<Log> = ChannelBuilder::new("/2").context(&ctx).build();
+
+    expect_recv!(client, ServerMessage::Advertise);
+    let subscription_id = 999;
+    let subscribe_msg = Subscribe::new([Subscription {
+        id: subscription_id,
+        channel_id: ch2.id().into(),
+    }]);
+    client.send(&subscribe_msg).await.expect("Failed to send");
+
+    assert_eventually(|| dbg!(ch2.has_sinks() && ch1.has_sinks())).await;
+
+    ch1.log(&Log::default());
+    ch2.log(&Log::default());
+
+    // WS received a message on /2
+    let msg = expect_recv!(client, ServerMessage::MessageData);
+    assert_eq!(msg.subscription_id, subscription_id);
+
+    // MCAP received a message on /1
+    let writer = mcap.close().expect("Failed to close writer");
+    let file = writer.into_inner().expect("Failed to get tempfile");
+    let summary = read_summary(file.path());
+    assert_eq!(summary.channels.len(), 1);
+    assert_eq!(
+        summary.channels.get(&1).expect("Missing channel 1").topic,
+        "/1"
+    );
+}

--- a/rust/foxglove/src/testutil.rs
+++ b/rust/foxglove/src/testutil.rs
@@ -1,11 +1,13 @@
 //! Test utilities.
 
 mod global_context;
+mod mcap;
 mod sink;
 #[cfg(feature = "live_visualization")]
 mod websocket;
 
 pub use global_context::GlobalContextTest;
+pub(crate) use mcap::read_summary;
 pub use sink::{ErrorSink, MockSink, RecordingSink};
 #[cfg(feature = "live_visualization")]
 pub(crate) use websocket::{assert_eventually, RecordingServerListener};

--- a/rust/foxglove/src/testutil/mcap.rs
+++ b/rust/foxglove/src/testutil/mcap.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+/// Returns the summary section from a finished MCAP file. The summary section must exist.
+pub fn read_summary(mcap: impl AsRef<Path>) -> mcap::Summary {
+    let written = std::fs::read(mcap).expect("failed to read mcap");
+    let summary = mcap::Summary::read(written.as_ref()).expect("failed to read summary");
+    summary.expect("missing summary")
+}

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -13,6 +13,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_util::sync::CancellationToken;
 
 use crate::library_version::get_library_version;
+use crate::sink_channel_filter::SinkChannelFilter;
 use crate::websocket::connected_client::ShutdownReason;
 use crate::{Context, FoxgloveError};
 
@@ -42,6 +43,7 @@ pub(crate) struct ServerOptions {
     pub supported_encodings: Option<HashSet<String>>,
     pub runtime: Option<Handle>,
     pub fetch_asset_handler: Option<Box<dyn AssetHandler>>,
+    pub channel_filter: Option<Arc<dyn SinkChannelFilter>>,
 }
 
 impl std::fmt::Debug for ServerOptions {
@@ -125,6 +127,8 @@ pub(crate) struct Server {
     session_id: parking_lot::RwLock<String>,
     name: String,
     clients: CowVec<Arc<ConnectedClient>>,
+    /// Channel subscription filter
+    channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     /// Callbacks for handling client messages, etc.
     listener: Option<Arc<dyn ServerListener>>,
     /// Capabilities advertised to clients
@@ -183,6 +187,7 @@ impl Server {
                 .message_backlog_size
                 .unwrap_or(DEFAULT_MESSAGE_BACKLOG_SIZE) as u32,
             runtime: opts.runtime.unwrap_or_else(crate::get_runtime_handle),
+            channel_filter: opts.channel_filter.clone(),
             listener: opts.listener,
             session_id: parking_lot::RwLock::new(
                 opts.session_id.unwrap_or_else(Self::generate_session_id),
@@ -532,6 +537,7 @@ impl Server {
             ws_stream,
             addr,
             self.message_backlog_size as usize,
+            self.channel_filter.clone(),
         );
         self.register_client_and_advertise(&client);
         client.run().await;

--- a/rust/foxglove/src/websocket/testutil.rs
+++ b/rust/foxglove/src/websocket/testutil.rs
@@ -11,6 +11,20 @@ use super::handshake::SUBPROTOCOL;
 use super::ws_protocol::server::ServerMessage;
 use super::ws_protocol::ParseError;
 
+// pub mod testutil {
+macro_rules! expect_recv {
+    ($client:expr, $variant:path) => {{
+        let msg = $client.recv().await.expect("Failed to recv");
+        match msg {
+            $variant(m) => m,
+            _ => panic!("Received unexpected message: {msg:?}"),
+        }
+    }};
+}
+
+pub(crate) use expect_recv;
+// }
+
 #[derive(Debug, thiserror::Error)]
 pub enum RecvError {
     #[error("unexpected end of stream")]

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use crate::sink_channel_filter::SinkChannelFilter;
 use crate::websocket::service::Service;
 use crate::websocket::{
     create_server, AssetHandler, AsyncAssetHandlerFn, BlockingAssetHandlerFn, Capability, Client,
@@ -74,6 +75,15 @@ impl WebSocketServer {
     pub fn bind(mut self, host: impl Into<String>, port: u16) -> Self {
         self.host = host.into();
         self.port = port;
+        self
+    }
+
+    /// Sets a channel filter for the server.
+    ///
+    /// The filter is a function that takes a channel and returns a boolean indicating whether the
+    /// channel should be logged.
+    pub fn channel_filter(mut self, filter: Arc<dyn SinkChannelFilter>) -> Self {
+        self.options.channel_filter = Some(filter);
         self
     }
 


### PR DESCRIPTION
### Changelog
Rust: support filtering logging sinks by topic

### Docs
TBD.

### Description

This implements sink filtering, so that a user can (for example) log "heavy" topics to a different MCAP than the rest of their data, but still log all messages to a WS server in the same context. Python and C++ will follow, but released at the same time.

The example and tests (which make up most of the changeset here) illustrate the usage. I started with a version that also allowed you to change filtering on the sink after the fact, but decided to keep it simpler for now.