### PR TITLE
C++: Include missing <vector>

### DIFF
--- a/cpp/foxglove/include/foxglove/server/connection_graph.hpp
+++ b/cpp/foxglove/include/foxglove/server/connection_graph.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 struct foxglove_connection_graph;
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Add missing `#include <vector>` to prevent build failure.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

I am following https://docs.foxglove.dev/docs/sdk/example step by step with foxglove sdk v0.9.0, in Ubuntu 22.04 / Clang 14.0.0, created `CMakeLists.txt` with the given content, set up the `main.cpp` and built with
```bash
$ mkdir build
$ cd build
$ cmake ..
$ cmake --build .
```

The last build command fails with the following error:
```
[  7%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/main.cpp.o
[ 15%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/channel.cpp.o
[ 23%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/context.cpp.o
[ 30%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/error.cpp.o
[ 38%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/foxglove.cpp.o
[ 46%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/mcap.cpp.o
[ 53%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/schemas.cpp.o
[ 61%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/server.cpp.o
[ 69%] Building CXX object CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/server/connection_graph.cpp.o
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:18:32: error: implicit instantiation of undefined template 'std::vector<foxglove_string>'
  std::vector<foxglove_string> ids;
                               ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:19:28: error: implicit instantiation of undefined template 'std::vector<std::string>'
  ids.reserve(publisher_ids.size());
                           ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:20:25: error: implicit instantiation of undefined template 'std::vector<std::string>'
  for (const auto& id : publisher_ids) {
                        ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:32:32: error: implicit instantiation of undefined template 'std::vector<foxglove_string>'
  std::vector<foxglove_string> ids;
                               ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:33:29: error: implicit instantiation of undefined template 'std::vector<std::string>'
  ids.reserve(subscriber_ids.size());
                            ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:34:25: error: implicit instantiation of undefined template 'std::vector<std::string>'
  for (const auto& id : subscriber_ids) {
                        ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:47:32: error: implicit instantiation of undefined template 'std::vector<foxglove_string>'
  std::vector<foxglove_string> ids;
                               ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:48:27: error: implicit instantiation of undefined template 'std::vector<std::string>'
  ids.reserve(provider_ids.size());
                          ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
/home/sohn/workspace/foxglove-sdk-bridge/build/_deps/foxglove-src/src/server/connection_graph.cpp:49:25: error: implicit instantiation of undefined template 'std::vector<std::string>'
  for (const auto& id : provider_ids) {
                        ^
/usr/lib/llvm-14/bin/../include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
9 errors generated.
gmake[2]: *** [CMakeFiles/foxglove-sdk-bridge.dir/build.make:188: CMakeFiles/foxglove-sdk-bridge.dir/_deps/foxglove-src/src/server/connection_graph.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/foxglove-sdk-bridge.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

It turns out `foxglove/server/connection_graph.hpp` is using `std::vector` but `<vector>` is not included by itself or any included headers. I manually added this inclusion in `build/_deps/foxglove-src/include/foxglove/server/connection_graph.hpp` and confirmed that the build succeeds.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->
Build fails with aforementioned errors

</td><td>

<!--after content goes here-->
Build succeeds

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

