### PR TITLE
Remove unused variable

### DIFF
--- a/cpp/foxglove/include/foxglove/server/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/server/parameter.hpp
@@ -258,7 +258,6 @@ public:
       return false;
     }
     try {
-      auto value = this->value();
       const auto& arr = this->get<ParameterValueView::Array>();
       return std::all_of(arr.begin(), arr.end(), [](const ParameterValueView& elem) noexcept {
         return elem.is<T>();


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Remove unused variable causing compiler warnings in projects that include the C++ SDK.
Unit testing and testing that the warning is no longer emitted.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

