### PR TITLE
Change format usage to embed variables to fix clippy lints

### DIFF
--- a/rust/foxglove/src/library_version.rs
+++ b/rust/foxglove/src/library_version.rs
@@ -20,5 +20,5 @@ pub fn set_sdk_language(language: &'static str) {
 pub(crate) fn get_library_version() -> String {
     let language = CELL.get_or_init(|| COMPILED_SDK_LANGUAGE.as_str());
     let version = env!("CARGO_PKG_VERSION");
-    format!("foxglove-sdk-{}/v{}", language, version)
+    format!("foxglove-sdk-{language}/v{version}")
 }

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -282,8 +282,8 @@ impl ConnectedClient {
         let client_channel = {
             let advertised_channels = self.advertised_channels.lock();
             let Some(channel) = advertised_channels.get(&channel_id) else {
-                tracing::error!("Received message for unknown channel: {}", channel_id);
-                self.send_error(format!("Unknown channel ID: {}", channel_id));
+                tracing::error!("Received message for unknown channel: {channel_id}");
+                self.send_error(format!("Unknown channel ID: {channel_id}"));
                 // Do not forward to server listener
                 return;
             };
@@ -312,8 +312,7 @@ impl ConnectedClient {
                     // Remove the channel ID from the list so we don't invoke the on_client_unadvertise callback
                     channel_ids.swap_remove(i);
                     self.send_warning(format!(
-                        "Client is not advertising channel: {}; ignoring unadvertisement",
-                        id
+                        "Client is not advertising channel: {id}; ignoring unadvertisement"
                     ));
                     continue;
                 };

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -236,7 +236,7 @@ impl Server {
             tasks.replace(JoinSet::new());
         }
 
-        let addr = format!("{}:{}", host, port);
+        let addr = format!("{host}:{port}");
         let listener = TcpListener::bind(&addr)
             .await
             .map_err(FoxgloveError::Bind)?;


### PR DESCRIPTION
Fixes some CI build failures due to a new clippy lint. It started failing since rust 1.88 was released.