### PR TITLE
Update C++ doc generation for template specialization

### DIFF
--- a/Container.mk
+++ b/Container.mk
@@ -59,8 +59,13 @@ docs-rust:
 clean-cpp:
 	rm -rf cpp/build*
 
+.PHONY: clean-docs-cpp
+clean-docs-cpp:
+	rm -rf cpp/foxglove/docs/generated
+	rm -rf cpp/build/docs
+
 .PHONY: docs-cpp
-docs-cpp:
+docs-cpp: clean-docs-cpp
 	poetry install -C cpp/foxglove/docs
 	make -C cpp docs
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -50,7 +50,7 @@ clean-docs:
 	rm -rf ./foxglove/docs/generated
 	rm -rf $(BUILD_DIR)/docs
 
-$(BUILD_DIR)/docs/html:
+$(BUILD_DIR)/docs/html: clean-docs
 	cmake -B $(BUILD_DIR)
 	cmake --build $(BUILD_DIR) --target doxygen
 	cmake --build $(BUILD_DIR) --target html-docs

--- a/cpp/foxglove/include/foxglove/server/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/server/parameter.hpp
@@ -90,6 +90,21 @@ private:
       : impl_(ptr) {}
 };
 
+// Template specializations for ParameterValueView
+//
+// Documented manually as tparams because specializations are merged:
+// https://github.com/doxygen/doxygen/issues/9468
+
+/// @fn ParameterValueView::is<std::string>()
+/// @tparam std::string Checks whether the parameter value is a string.
+
+/// @fn ParameterValueView::get<ParameterValueView>()
+/// @tparam ParameterValueView Extracts the parameter as itself.
+
+/// @fn ParameterValueView::get<std::string>()
+/// @tparam std::string Extracts the parameter as an owned string.
+
+/// @cond ignore-template-specializations
 /// @brief Checks whether the parameter value is a string.
 template<>
 [[nodiscard]] inline bool ParameterValueView::is<std::string>() const noexcept {
@@ -106,6 +121,7 @@ template<>
   auto sv = this->get<std::string_view>();
   return std::string(sv);
 }
+/// @endcond
 
 /// @brief An owned parameter value.
 class ParameterValue final {
@@ -354,9 +370,25 @@ template<>
   return value.has_value() && value->is<ParameterValueView::Dict>();
 }
 
-/// @cond duplicate-ids-bug
+// Template specializations for ParameterView
+//
+// Documented manually as tparams because specializations are merged:
 // https://github.com/doxygen/doxygen/issues/9468
 
+/// @fn ParameterView::is<std::string_view>()
+/// @tparam std::string_view Checks whether the parameter value is a string.
+
+/// @fn ParameterView::is<std::string>()
+/// @note foobar
+/// @tparam std::string Checks whether the parameter value is a string.
+
+/// @fn ParameterView::is<std::vector<std::byte>>()
+/// @tparam std::vector<std::byte> Checks whether the parameter value is a byte array.
+
+/// @fn ParameterView::is<std::vector<double>>()
+/// @tparam std::vector<double> Checks whether the parameter value is a vector of floating point values.
+
+/// @cond ignore-template-specializations
 /// @brief Checks whether the parameter value is a std::string_view.
 ///
 /// Returns false if the parameter type indicates that it is a byte array.
@@ -388,7 +420,6 @@ template<>
 [[nodiscard]] inline bool ParameterView::is<std::vector<double>>() const noexcept {
   return this->isArray<double>();
 }
-
 /// @endcond
 
 [[nodiscard]] inline bool ParameterView::isByteArray() const noexcept {

--- a/cpp/foxglove/include/foxglove/server/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/server/parameter.hpp
@@ -386,7 +386,8 @@ template<>
 /// @tparam std::vector<std::byte> Checks whether the parameter value is a byte array.
 
 /// @fn ParameterView::is<std::vector<double>>()
-/// @tparam std::vector<double> Checks whether the parameter value is a vector of floating point values.
+/// @tparam std::vector<double> Checks whether the parameter value is a vector of floating point
+/// values.
 
 /// @cond ignore-template-specializations
 /// @brief Checks whether the parameter value is a std::string_view.


### PR DESCRIPTION
This is a PR into the branch for #516, and fixes the doc generation errors there.

We needed to ignore the generation of the `ParameterValueView` specializations in addition to `ParameterView`. The additional `@cond` should solve the bug (see issue noted in comments), and get docs state back to where they were.

I also added some manual documentation of the template parameters, so it's clearer from docs what specializations are available. Given the bug, this is the best way I could find to document them; they're listed as template parameters in addition to `T`, which is a little weird but hopefully less confusing than omitting them.
