### PR TITLE
Don't unadvertise a channel if an error prevented it from being advertised

### DIFF
--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -710,11 +710,6 @@ impl ConnectedClient {
     /// Unadvertises a channel to the client.
     fn unadvertise_channel(&self, channel_id: ChannelId) {
         if self.channels.write().remove(&channel_id).is_none() {
-            tracing::debug!(
-                "Client {} is not advertising channel: {}",
-                self.addr,
-                channel_id
-            );
             return;
         }
 

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -709,7 +709,14 @@ impl ConnectedClient {
 
     /// Unadvertises a channel to the client.
     fn unadvertise_channel(&self, channel_id: ChannelId) {
-        self.channels.write().remove(&channel_id);
+        if self.channels.write().remove(&channel_id).is_none() {
+            tracing::debug!(
+                "Client {} is not advertising channel: {}",
+                self.addr,
+                channel_id
+            );
+            return;
+        }
 
         let message = Unadvertise::new([channel_id.into()]);
 

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -227,8 +227,17 @@ async fn test_advertise_to_client() {
     let ch = new_channel("/foo", &ctx);
     ch.log(b"foo bar");
 
+    // Create a channel that requires a schema, but doesn't have one. This won't be advertised.
+    let ch2 = ChannelBuilder::new("/bar")
+        .message_encoding("flatbuffer")
+        .context(&ctx)
+        .build_raw()
+        .expect("Failed to create channel");
+    ch2.log(b"{\"a\":1}");
+
     let msg = expect_recv!(client, ServerMessage::Advertise);
-    let adv_ch = msg.channels.first().expect("not empty");
+    assert_eq!(msg.channels.len(), 1);
+    let adv_ch = &msg.channels[0];
     assert_eq!(adv_ch.id, u64::from(ch.id()));
     assert_eq!(adv_ch.topic, ch.topic());
 
@@ -262,6 +271,17 @@ async fn test_advertise_to_client() {
             ch.id(),
         ))
     );
+
+    // Remove the channels
+    ctx.remove_channel(ch.id());
+    ctx.remove_channel(ch2.id());
+
+    // Ensure we get an unadvertise message only for the first channel
+    let msg = expect_recv!(client, ServerMessage::Unadvertise);
+    assert_eq!(msg.channel_ids.len(), 1);
+    assert_eq!(msg.channel_ids[0], u64::from(ch.id()));
+
+    assert!(client.recv().now_or_never().is_none());
 
     let _ = server.stop();
 }


### PR DESCRIPTION
### Changelog

Fixed a bug where a channel that fails to be advertised to a websocket client would still be unadvertised. Now unadvertise is only sent if advertise succeeded for a channel.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

https://linear.app/foxglove/issue/FG-12137/sdk-websocket-server-should-not-unadvertise-channels-that-it-failed-to

I modified one of our tests to identify this issue and fail, then fixed the bug and verified the test passes now.
