### PR TITLE
Skip publishing data_loader for now

### DIFF
--- a/rust/foxglove_data_loader/Cargo.toml
+++ b/rust/foxglove_data_loader/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "foxglove_data_loader"
+publish = false
 description = "Generate wasm to use as a Foxglove data loader"
 version.workspace = true
 edition.workspace = true
@@ -14,7 +15,7 @@ anyhow = "1.0.98"
 [dependencies.foxglove]
 version = "0.9.0"
 default-features = false
-features = [ "derive" ]
+features = ["derive"]
 
 [dev-dependencies]
 prost.workspace = true


### PR DESCRIPTION
### Changelog
None

### Description

This turns off publishing for the foxglove_data_loader crate, since we have not yet published it, to unblock the release process for SDK. FG-12276 tracks the setup needed to publish this new crate.