### PR TITLE
Skip version bump on data loader

### DIFF
--- a/scripts/bumpSdkVersion.ts
+++ b/scripts/bumpSdkVersion.ts
@@ -26,7 +26,8 @@ async function main() {
   // Find all Cargo.toml files in the workspace
   const workspaceRoot = path.resolve(__dirname, "..");
   const cargoFiles = await glob("**/Cargo.toml", {
-    ignore: ["**/target/**", "**/node_modules/**", "cpp/build/**"],
+    // FG-12276: foxglove_data_loader depends on foxglove, but is not yet published
+    ignore: ["**/target/**", "**/node_modules/**", "cpp/build/**", "rust/foxglove_data_loader/**"],
     cwd: workspaceRoot,
     absolute: true,
   });


### PR DESCRIPTION
### Changelog
None

### Description

One more change to unblock SDK publishing: this skips the version bump on foxglove_data_loader, which is not yet published. FG-12276 will properly set that crate up for publishing.