### PR TITLE
Fix data loader seek from end

### DIFF
--- a/rust/foxglove_data_loader/src/lib.rs
+++ b/rust/foxglove_data_loader/src/lib.rs
@@ -104,7 +104,7 @@ impl std::io::Seek for reader::Reader {
             }
             std::io::SeekFrom::End(offset) => {
                 let end = reader::Reader::size(self) as i64;
-                reader::Reader::seek(self, (end - offset) as u64);
+                reader::Reader::seek(self, (end + offset) as u64);
             }
             std::io::SeekFrom::Current(offset) => {
                 let pos = reader::Reader::position(self) as i64;


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

The conversion to `SeekFrom::End` was around the wrong way. This came up when trying to build an MCAP loader that seeks from the end of the file to read summary info.
