### PR TITLE
Change Python schemas readme to point to Discord instead of Slack

### DIFF
--- a/python/foxglove-schemas-flatbuffer/README.md
+++ b/python/foxglove-schemas-flatbuffer/README.md
@@ -35,4 +35,4 @@ msg_data = builder.Output()
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/python/foxglove-schemas-protobuf/README.md
+++ b/python/foxglove-schemas-protobuf/README.md
@@ -20,4 +20,4 @@ from foxglove_schemas_protobuf.CompressedImage_pb2 import CompressedImage
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.


### PR DESCRIPTION
This PR replaces a link to Slack with Discord links.