### PR TITLE
Python: add session_id option to start_server

### DIFF
--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -39,6 +39,7 @@ def start_server(
     services: Optional[List[Service]] = None,
     asset_handler: Optional[AssetHandler] = None,
     context: Optional[Context] = None,
+    session_id: Optional[str] = None,
 ) -> WebSocketServer:
     """
     Start a websocket server for live visualization.
@@ -51,9 +52,12 @@ def start_server(
         protocol.
     :param supported_encodings: A list of encodings to advertise to clients.
     :param services: A list of services to advertise to clients.
-    :param asset_handler: A callback function that returns the asset for a given URI, or None if
-        it doesn't exist.
+    :param asset_handler: A callback function that returns the asset for a given URI, or None if it
+        doesn't exist.
     :param context: The context to use for logging. If None, the global context is used.
+    :param session_id: An ID which allows the client to understand if the connection is a
+        re-connection or a new server instance. If None, then an ID is generated based on the
+        current time.
     """
     return _foxglove.start_server(
         name=name,
@@ -65,6 +69,7 @@ def start_server(
         services=services,
         asset_handler=asset_handler,
         context=context,
+        session_id=session_id,
     )
 
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -121,6 +121,7 @@ def start_server(
     services: Optional[List["Service"]] = None,
     asset_handler: Optional["AssetHandler"] = None,
     context: Optional["Context"] = None,
+    session_id: Optional[str] = None,
 ) -> WebSocketServer:
     """
     Start a websocket server for live visualization.

--- a/python/foxglove-sdk/python/foxglove/tests/test_server.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_server.py
@@ -17,7 +17,7 @@ def test_server_interface() -> None:
     """
     Exercise the server interface; will also be checked with mypy.
     """
-    server = start_server(port=0)
+    server = start_server(port=0, session_id="test-session")
     assert isinstance(server.port, int)
     assert server.port != 0
 
@@ -46,7 +46,7 @@ def test_server_interface() -> None:
     server.publish_status("test message", StatusLevel.Info, "some-id")
     server.broadcast_time(time.time_ns())
     server.remove_status(["some-id"])
-    server.clear_session()
+    server.clear_session("new-session")
     server.stop()
 
 

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -366,7 +366,7 @@ impl foxglove::websocket::service::Handler for ServiceHandler {
 /// To connect to this server: open Foxglove, choose "Open a new connection", and select Foxglove
 /// WebSocket. The default connection string matches the defaults used by the SDK.
 #[pyfunction]
-#[pyo3(signature = (*, name = None, host="127.0.0.1", port=8765, capabilities=None, server_listener=None, supported_encodings=None, services=None, asset_handler=None, context=None))]
+#[pyo3(signature = (*, name = None, host="127.0.0.1", port=8765, capabilities=None, server_listener=None, supported_encodings=None, services=None, asset_handler=None, context=None, session_id=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn start_server(
     py: Python<'_>,
@@ -379,12 +379,15 @@ pub fn start_server(
     services: Option<Vec<PyService>>,
     asset_handler: Option<Py<PyAny>>,
     context: Option<PyRef<PyContext>>,
+    session_id: Option<String>,
 ) -> PyResult<PyWebSocketServer> {
-    let session_id = time::SystemTime::now()
-        .duration_since(time::UNIX_EPOCH)
-        .expect("Failed to create session ID; invalid system time")
-        .as_millis()
-        .to_string();
+    let session_id = session_id.unwrap_or_else(|| {
+        time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .expect("Failed to create session ID; invalid system time")
+            .as_millis()
+            .to_string()
+    });
 
     let mut server = WebSocketServer::new()
         .session_id(session_id)

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -15,7 +15,6 @@ use pyo3::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time;
 
 /// Information about a channel.
 #[pyclass(name = "ChannelView", module = "foxglove")]
@@ -381,17 +380,11 @@ pub fn start_server(
     context: Option<PyRef<PyContext>>,
     session_id: Option<String>,
 ) -> PyResult<PyWebSocketServer> {
-    let session_id = session_id.unwrap_or_else(|| {
-        time::SystemTime::now()
-            .duration_since(time::UNIX_EPOCH)
-            .expect("Failed to create session ID; invalid system time")
-            .as_millis()
-            .to_string()
-    });
+    let mut server = WebSocketServer::new().bind(host, port);
 
-    let mut server = WebSocketServer::new()
-        .session_id(session_id)
-        .bind(host, port);
+    if let Some(session_id) = session_id {
+        server = server.session_id(session_id);
+    }
 
     if let Some(py_obj) = server_listener {
         let listener = PyServerListener { listener: py_obj };


### PR DESCRIPTION
### Changelog
Python: add session_id option to start_server

### Description

This adds the session_id option to start_server. Typically, the default will work just fine, but we provide this option for other languages, and clear_session() also optionally accepts an explicit ID.