### PR TITLE
Fix data loader severity enum ordering

### DIFF
--- a/rust/foxglove_data_loader/wit/loader.wit
+++ b/rust/foxglove_data_loader/wit/loader.wit
@@ -35,8 +35,8 @@ interface loader {
 
     enum severity {
         info,
+        warn,
         error,
-        warn
     }
 
     record problem {


### PR DESCRIPTION
### Description

I'm not sure how this got mixed up, but the app expects the order `info, warn, error`. There was likely a commit I forgot to push when the problems change was added.
