### PR TITLE
Remove ws-protocol from public docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - run: cargo +1.83.0 build -p foxglove --verbose
       - run: cargo clippy --no-deps --all-targets --tests -- -D warnings
       - run: cargo +nightly rustdoc -p foxglove --all-features -- -D warnings --cfg docsrs
+      - run: "[ -d ./target/doc/foxglove ] || exit 1"
+      - name: Check for ws-protocol references in public docs
+        run: '! grep -R "foxglove/ws-protocol" ./target/doc/foxglove'
       - run: cargo test --all-features --verbose
         timeout-minutes: 5
       - run: cargo test -p foxglove --no-default-features --verbose

--- a/rust/examples/ws_server_fetch_asset/src/main.rs
+++ b/rust/examples/ws_server_fetch_asset/src/main.rs
@@ -20,7 +20,7 @@ impl AssetHandler for AssetServer {
     fn fetch(&self, uri: String, responder: AssetResponder) {
         match self.assets.get(&uri) {
             // A real implementation might use std::fs::read to read a file into a Vec<u8>
-            // The ws-protocol doesn't currently support streaming for a single asset.
+            // The SDK doesn't currently support streaming for a single asset.
             Some(asset) => responder.respond_ok(asset),
             None => responder.respond_err(format!("Asset {uri} not found")),
         }

--- a/rust/foxglove/src/websocket/fetch_asset.rs
+++ b/rust/foxglove/src/websocket/fetch_asset.rs
@@ -7,7 +7,7 @@ use super::Client;
 
 /// A handler to respond to fetch asset requests.
 ///
-/// See: <https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#fetch-asset>
+/// This can be used to serve assets to the Foxglove app, including URDF files for the 3D panel.
 pub trait AssetHandler: Send + Sync + 'static {
     /// Fetch an asset with the given uri and return it via the responder.
     /// Fetch should not block, it should call `runtime.spawn`

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -134,7 +134,6 @@ pub(crate) struct Server {
     /// Encodings server can accept from clients. Ignored unless the "clientPublish" capability is set.
     supported_encodings: HashSet<String>,
     /// The current connection graph, unused unless the "connectionGraph" capability is set.
-    /// see https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#connection-graph-update
     connection_graph: parking_lot::Mutex<ConnectionGraph>,
     /// Token for cancelling all tasks
     cancellation_token: CancellationToken,

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -285,18 +285,13 @@ impl WebSocketServerHandle {
 
     /// Publishes a status message to all clients.
     ///
-    /// For more information, refer to the [Status][status] message specification.
-    ///
-    /// [status]: https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#status
+    /// This can be used to communicate information, warnings, and errors to the Foxglove app. An
+    /// ID may be included in the status to later remove it by referencing that ID.
     pub fn publish_status(&self, status: Status) {
         self.0.publish_status(status);
     }
 
     /// Removes status messages by id from all clients.
-    ///
-    /// For more information, refer to the [Remove Status][remove-status] message specification.
-    ///
-    /// [remove-status]: https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#remove-status
     pub fn remove_status(&self, status_ids: Vec<String>) {
         self.0.remove_status(status_ids);
     }


### PR DESCRIPTION
### Changelog
None

### Description

This removes mention of "ws-protocol" from public documentation and examples. ws-protocol is an implementation detail, and consumers of the SDK shouldn't have to understand anything about it.

There are still internal Rust modules which link to the spec in many places, which is still useful. (There was one part of the protocol re-used in the public API, `Status`, which I updated.) I also added a CI check to detect if generated docs accidentally re-introduce a link to the protocol spec or source.
