### PR TITLE
Fix template type issue

### DIFF
--- a/cpp/foxglove/include/foxglove/server/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/server/parameter.hpp
@@ -332,7 +332,7 @@ public:
     const auto& dict = value->get<ParameterValueView::Dict>();
     std::map<std::string, T> result;
     for (const auto& [dictKey, dictValue] : dict) {
-      result.emplace(dictKey, dictValue.get<T>());
+      result.emplace(dictKey, dictValue.template get<T>());
     }
     return result;
   }


### PR DESCRIPTION
### Changelog
Fix a compiler error involving template types.

### Docs

None

### Description

When trying to compile on Ubuntu 24.04 I get the following compiler error
```bash
foxglove-sdk/cpp/foxglove/include/foxglove/server/parameter.hpp:335:50: error: expected unqualified-id before ‘.’ token
  335 |       result.emplace(dictKey, dictValue.template .get<T>());
      |                                                  ^
foxglove-sdk/cpp/foxglove/include/foxglove/server/parameter.hpp:335:56: error: expected primary-expression before ‘>’ token
  335 |       result.emplace(dictKey, dictValue.template .get<T>());
      |                                                        ^
foxglove-sdk/cpp/foxglove/include/foxglove/server/parameter.hpp:335:58: error: expected primary-expression before ‘)’ token
  335 |       result.emplace(dictKey, dictValue.template .get<T>());
```

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

