### PR TITLE
Make sink_id internal

### DIFF
--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -65,12 +65,23 @@ public:
   /// @param data The message data.
   /// @param data_len The length of the message data, in bytes.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  /// @param sink_id The sink ID associated with the message. Can be used to target logging messages
-  /// to a specific client or mcap file. If omitted, the message is logged to all sinks.
   FoxgloveError log(
+    const std::byte* data, size_t data_len, std::optional<uint64_t> log_time = std::nullopt
+  ) noexcept;
+
+  /// @cond foxglove_internal
+  /// @param data The message data.
+  /// @param data_len The length of the message data, in bytes.
+  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The sink ID associated with the message. Can be used to target logging messages
+  /// to a specific client or mcap file. If omitted, the message is logged to all sinks. Note that
+  /// providing a sink_id is not yet part of the public API. To partition logs among specific sinks,
+  /// set up different `Context`s.
+  FoxgloveError log_(
     const std::byte* data, size_t data_len, std::optional<uint64_t> log_time = std::nullopt,
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
+  /// @endcond
 
   /// @brief Close the channel.
   ///

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -42,8 +42,7 @@ struct ClientChannel {
 struct ClientMetadata {
   /// @brief The ID of the client.
   uint32_t id;
-  /// @brief The sink ID associated with the client. Can be used to
-  /// target logging messages to a specific client.
+  /// @brief The sink ID associated with the client.
   std::optional<uint64_t> sink_id;
 };
 

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -104,6 +104,12 @@ std::optional<std::map<std::string, std::string>> RawChannel::metadata() const n
 }
 
 FoxgloveError RawChannel::log(
+  const std::byte* data, size_t data_len, std::optional<uint64_t> log_time
+) noexcept {
+  return log_(data, data_len, log_time, std::nullopt);
+}
+
+FoxgloveError RawChannel::log_(
   const std::byte* data, size_t data_len, std::optional<uint64_t> log_time,
   std::optional<uint64_t> sink_id
 ) noexcept {

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -109,6 +109,7 @@ FoxgloveError RawChannel::log(
   return log_(data, data_len, log_time, std::nullopt);
 }
 
+/// @cond foxglove_internal
 FoxgloveError RawChannel::log_(
   const std::byte* data, size_t data_len, std::optional<uint64_t> log_time,
   std::optional<uint64_t> sink_id
@@ -122,5 +123,6 @@ FoxgloveError RawChannel::log_(
   );
   return FoxgloveError(error);
 }
+/// @endcond
 
 }  // namespace foxglove

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -133,6 +133,7 @@ impl<T: Encode> Channel<T> {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
+    #[doc(hidden)]
     pub fn log_to_sink(&self, msg: &T, sink_id: Option<SinkId>) {
         self.log_with_meta_to_sink(msg, PartialMetadata::default(), sink_id);
     }
@@ -152,6 +153,7 @@ impl<T: Encode> Channel<T> {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
+    #[doc(hidden)]
     pub fn log_with_meta_to_sink(
         &self,
         msg: &T,

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -168,6 +168,7 @@ impl RawChannel {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
+    #[doc(hidden)]
     pub fn log_to_sink(&self, msg: &[u8], sink_id: Option<SinkId>) {
         self.log_with_meta_to_sink(msg, PartialMetadata::default(), sink_id);
     }
@@ -187,6 +188,7 @@ impl RawChannel {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
+    #[doc(hidden)]
     pub fn log_with_meta_to_sink(
         &self,
         msg: &[u8],


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This makes the sink-specific logging from #515 'internal': C++ now uses an undocumented `log_` function, and rust methods are undocumented. We'll revert the changes here once we've implemented the same functionality for Python and typed channels, and are ready to release the feature.