### PR TITLE
Introduce explicit integer Parameter type

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -205,6 +205,7 @@ enum foxglove_parameter_value_tag
 #endif // __cplusplus
  {
   FOXGLOVE_PARAMETER_VALUE_TAG_NUMBER,
+  FOXGLOVE_PARAMETER_VALUE_TAG_INTEGER,
   FOXGLOVE_PARAMETER_VALUE_TAG_BOOLEAN,
   FOXGLOVE_PARAMETER_VALUE_TAG_STRING,
   FOXGLOVE_PARAMETER_VALUE_TAG_ARRAY,
@@ -379,6 +380,7 @@ typedef struct foxglove_parameter_value_dict {
  */
 typedef union foxglove_parameter_value_data {
   double number;
+  int64_t integer;
   bool boolean;
   struct foxglove_string string;
   struct foxglove_parameter_value_array array;
@@ -3129,6 +3131,20 @@ foxglove_error foxglove_parameter_create_float64(struct foxglove_parameter **par
                                                  double value);
 
 /**
+ * Creates a new integer parameter.
+ *
+ * The value must be freed with `foxglove_parameter_free`, or by passing it to a consuming
+ * function such as `foxglove_parameter_array_push`.
+ *
+ * # Safety
+ * - `param` must be a valid pointer.
+ * - `name` must be a valid `foxglove_string`. This value is copied by this function.
+ */
+foxglove_error foxglove_parameter_create_integer(struct foxglove_parameter **param,
+                                                 struct foxglove_string name,
+                                                 int64_t value);
+
+/**
  * Creates a new boolean parameter.
  *
  * The value must be freed with `foxglove_parameter_free`, or by passing it to a consuming
@@ -3187,6 +3203,14 @@ foxglove_error foxglove_parameter_create_byte_array(struct foxglove_parameter **
 foxglove_error foxglove_parameter_create_float64_array(struct foxglove_parameter **param,
                                                        struct foxglove_string name,
                                                        const double *values,
+                                                       size_t values_len);
+
+/**
+ * Creates a new parameter which is an array of integer values.
+ */
+foxglove_error foxglove_parameter_create_integer_array(struct foxglove_parameter **param,
+                                                       struct foxglove_string name,
+                                                       const int64_t *values,
                                                        size_t values_len);
 
 /**
@@ -3263,6 +3287,14 @@ void foxglove_parameter_free(struct foxglove_parameter *param);
  * function such as `foxglove_parameter_create`.
  */
 struct foxglove_parameter_value *foxglove_parameter_value_create_number(double number);
+
+/**
+ * Creates a new integer parameter value.
+ *
+ * The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
+ * function such as `foxglove_parameter_create`.
+ */
+struct foxglove_parameter_value *foxglove_parameter_value_create_integer(int64_t integer);
 
 /**
  * Creates a new boolean parameter value.

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -3281,7 +3281,7 @@ struct foxglove_parameter *foxglove_parameter_clone(const struct foxglove_parame
 void foxglove_parameter_free(struct foxglove_parameter *param);
 
 /**
- * Creates a new number parameter value.
+ * Creates a newumber float64 parameter value.
  *
  * The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
  * function such as `foxglove_parameter_create`.
@@ -3289,7 +3289,9 @@ void foxglove_parameter_free(struct foxglove_parameter *param);
 struct foxglove_parameter_value *foxglove_parameter_value_create_float64(double number);
 
 /**
- * Creates a new  or by passing it to a consuming
+ * Creates a new integer parameter value.
+ *
+ * The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
  * function such as `foxglove_parameter_create`.
  */
 struct foxglove_parameter_value *foxglove_parameter_value_create_integer(int64_t integer);

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -204,7 +204,7 @@ enum foxglove_parameter_value_tag
   : uint8_t
 #endif // __cplusplus
  {
-  FOXGLOVE_PARAMETER_VALUE_TAG_NUMBER,
+  FOXGLOVE_PARAMETER_VALUE_TAG_FLOAT64,
   FOXGLOVE_PARAMETER_VALUE_TAG_INTEGER,
   FOXGLOVE_PARAMETER_VALUE_TAG_BOOLEAN,
   FOXGLOVE_PARAMETER_VALUE_TAG_STRING,
@@ -379,7 +379,7 @@ typedef struct foxglove_parameter_value_dict {
  * Storage for `FoxgloveParameterValue`.
  */
 typedef union foxglove_parameter_value_data {
-  double number;
+  double float64;
   int64_t integer;
   bool boolean;
   struct foxglove_string string;
@@ -3286,12 +3286,10 @@ void foxglove_parameter_free(struct foxglove_parameter *param);
  * The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
  * function such as `foxglove_parameter_create`.
  */
-struct foxglove_parameter_value *foxglove_parameter_value_create_number(double number);
+struct foxglove_parameter_value *foxglove_parameter_value_create_float64(double number);
 
 /**
- * Creates a new integer parameter value.
- *
- * The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
+ * Creates a new  or by passing it to a consuming
  * function such as `foxglove_parameter_create`.
  */
 struct foxglove_parameter_value *foxglove_parameter_value_create_integer(int64_t integer);

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -3281,7 +3281,7 @@ struct foxglove_parameter *foxglove_parameter_clone(const struct foxglove_parame
 void foxglove_parameter_free(struct foxglove_parameter *param);
 
 /**
- * Creates a newumber float64 parameter value.
+ * Creates a new float64 parameter value.
  *
  * The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
  * function such as `foxglove_parameter_create`.

--- a/c/src/parameter.rs
+++ b/c/src/parameter.rs
@@ -893,7 +893,7 @@ impl Drop for FoxgloveParameterValue {
     }
 }
 
-/// Creates a newumber float64 parameter value.
+/// Creates a new float64 parameter value.
 ///
 /// The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
 /// function such as `foxglove_parameter_create`.

--- a/c/src/parameter.rs
+++ b/c/src/parameter.rs
@@ -893,7 +893,7 @@ impl Drop for FoxgloveParameterValue {
     }
 }
 
-/// Creates a new number parameter value.
+/// Creates a newumber float64 parameter value.
 ///
 /// The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
 /// function such as `foxglove_parameter_create`.
@@ -904,7 +904,9 @@ pub extern "C" fn foxglove_parameter_value_create_float64(
     FoxgloveParameterValue::float64(number).into_raw()
 }
 
-/// Creates a new  or by passing it to a consuming
+/// Creates a new integer parameter value.
+///
+/// The value must be freed with `foxglove_parameter_value_free`, or by passing it to a consuming
 /// function such as `foxglove_parameter_create`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn foxglove_parameter_value_create_integer(

--- a/c/src/parameter.rs
+++ b/c/src/parameter.rs
@@ -769,6 +769,7 @@ impl From<ParameterValue> for FoxgloveParameterValue {
     fn from(value: ParameterValue) -> Self {
         match value {
             ParameterValue::Number(v) => Self::number(v),
+            ParameterValue::Integer(v) => Self::number(v as f64), // TODO: Add integer type?
             ParameterValue::Bool(v) => Self::boolean(v),
             ParameterValue::String(v) => Self::string(v),
             ParameterValue::Array(v) => Self::array(v.into_iter().collect()),

--- a/c/src/parameter/tests.rs
+++ b/c/src/parameter/tests.rs
@@ -118,11 +118,11 @@ fn make_dict_param() -> *mut FoxgloveParameter {
     let array_ptr = foxglove_parameter_value_array_create(2);
     array_insert!(
         array_ptr,
-        foxglove_parameter_value_create_number(std::f64::consts::E)
+        foxglove_parameter_value_create_float64(std::f64::consts::E)
     );
     array_insert!(
         array_ptr,
-        foxglove_parameter_value_create_number(std::f64::consts::PI)
+        foxglove_parameter_value_create_float64(std::f64::consts::PI)
     );
     dict_insert!(
         inner,
@@ -138,8 +138,8 @@ fn make_dict_param() -> *mut FoxgloveParameter {
     );
     dict_insert!(
         outer,
-        "number",
-        foxglove_parameter_value_create_number(1.23)
+        "float64",
+        foxglove_parameter_value_create_float64(1.23)
     );
     dict_insert!(outer, "nested", foxglove_parameter_value_create_dict(inner));
 
@@ -154,16 +154,16 @@ fn make_dict_native() -> Parameter {
         "outer",
         maplit::btreemap! {
             "bool".into() => ParameterValue::Bool(false),
-            "number".into() => ParameterValue::Number(1.23),
             "nested".into() => ParameterValue::Dict(
                 maplit::btreemap! {
                     "string".into() => ParameterValue::String("xyzzy".into()),
                     "f64[]".into() => ParameterValue::Array(vec![
-                        ParameterValue::Number(std::f64::consts::E),
-                        ParameterValue::Number(std::f64::consts::PI),
+                        ParameterValue::Float64(std::f64::consts::E),
+                        ParameterValue::Float64(std::f64::consts::PI),
                     ]),
                 }
-            )
+            ),
+            "float64".into() => ParameterValue::Float64(1.23),
         },
     )
 }

--- a/cpp/foxglove/include/foxglove/server/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/server/parameter.hpp
@@ -45,7 +45,7 @@ public:
   /// @brief A dictionary of values, mapped by string.
   using Dict = std::map<std::string, ParameterValueView>;
   /// @brief A sum type representing the possible values.
-  using Value = std::variant<double, bool, std::string_view, Array, Dict>;
+  using Value = std::variant<double, bool, int64_t, std::string_view, Array, Dict>;
 
   /// @brief Creates a deep clone of this parameter value.
   [[nodiscard]] class ParameterValue clone() const;
@@ -128,6 +128,8 @@ class ParameterValue final {
 public:
   /// @brief Constructor for a floating point value.
   explicit ParameterValue(double value);
+  /// @brief Constructor for an integer value.
+  explicit ParameterValue(int64_t value);
   /// @brief Constructor for a boolean value.
   explicit ParameterValue(bool value);
   /// @brief Constructor for a string value.
@@ -388,6 +390,9 @@ template<>
 /// @tparam std::vector<double> Checks whether the parameter value is a vector of floating point
 /// values.
 
+/// @fn ParameterView::is<std::vector<int64_t>>()
+/// @tparam std::vector<int64_t> Checks whether the parameter value is a vector of integer values.
+
 /// @cond ignore-template-specializations
 /// @brief Checks whether the parameter value is a std::string_view.
 ///
@@ -420,6 +425,13 @@ template<>
 [[nodiscard]] inline bool ParameterView::is<std::vector<double>>() const noexcept {
   return this->isArray<double>();
 }
+
+/// @brief Checks whether the parameter value is a std::vector<int64_t>.
+template<>
+[[nodiscard]] inline bool ParameterView::is<std::vector<int64_t>>() const noexcept {
+  return this->isArray<int64_t>();
+}
+
 /// @endcond
 
 [[nodiscard]] inline bool ParameterView::isByteArray() const noexcept {
@@ -451,6 +463,17 @@ template<>
   return this->getArray<double>();
 }
 
+/// @brief Extracts the value as an array of integer values.
+///
+/// This method will throw an exception if the value is unset or is not an
+/// array of integer values. You can use
+/// `ParameterView::is<std::vector<int64_t>>()` to check that the type matches
+/// before calling this method.
+template<>
+[[nodiscard]] inline std::vector<int64_t> ParameterView::get() const {
+  return this->getArray<int64_t>();
+}
+
 /// @brief Extracts the value as an array of generic values.
 ///
 /// This method will throw an exception if the value is unset or is not an
@@ -476,6 +499,8 @@ public:
   explicit Parameter(std::string_view name);
   /// @brief Constructor for a floating point parameter.
   explicit Parameter(std::string_view name, double value);
+  /// @brief Constructor for an integer parameter.
+  explicit Parameter(std::string_view name, int64_t value);
   /// @brief Constructor for a boolean parameter.
   explicit Parameter(std::string_view name, bool value);
   /// @brief Constructor for a string parameter.
@@ -490,6 +515,8 @@ public:
       : Parameter(name, reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()) {}
   /// @brief Constructor for an array of floating point values.
   explicit Parameter(std::string_view name, const std::vector<double>& values);
+  /// @brief Constructor for an array of integer values.
+  explicit Parameter(std::string_view name, const std::vector<int64_t>& values);
   /// @brief Constructor for an dictionary parameter.
   explicit Parameter(std::string_view name, std::map<std::string, ParameterValue> values);
   /// @brief Constructor for a parameter from raw parts.

--- a/cpp/foxglove/include/foxglove/server/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/server/parameter.hpp
@@ -27,9 +27,9 @@ enum class ParameterType : uint8_t {
   None,
   /// An array of bytes.
   ByteArray,
-  /// A decimal or integer value that can be represented as a `float64`.
+  /// A floating-point value that can be represented as a `float64`.
   Float64,
-  /// An array of decimal or integer values that can be represented as `float64`s.
+  /// An array of floating-point values that can be represented as `float64`s.
   Float64Array,
 };
 

--- a/cpp/foxglove/src/server/parameter.cpp
+++ b/cpp/foxglove/src/server/parameter.cpp
@@ -306,7 +306,6 @@ Parameter::Parameter(std::string_view name, const std::vector<int64_t>& values)
   impl_.reset(ptr);
 }
 
-
 Parameter::Parameter(std::string_view name, std::map<std::string, ParameterValue> values)
     : Parameter::Parameter(name, ParameterType::None, ParameterValue(std::move(values))) {}
 

--- a/cpp/foxglove/src/server/parameter.cpp
+++ b/cpp/foxglove/src/server/parameter.cpp
@@ -14,8 +14,8 @@ ParameterValueView::Value ParameterValueView::value() const {
   // Accessing union members is safe, because the tag serves as a valid
   // discriminator.
   switch (impl_->tag) {
-    case FOXGLOVE_PARAMETER_VALUE_TAG_NUMBER:
-      return impl_->data.number;  // NOLINT(cppcoreguidelines-pro-type-union-access)
+    case FOXGLOVE_PARAMETER_VALUE_TAG_FLOAT64:
+      return impl_->data.float64;  // NOLINT(cppcoreguidelines-pro-type-union-access)
     case FOXGLOVE_PARAMETER_VALUE_TAG_INTEGER:
       return impl_->data.integer;  // NOLINT(cppcoreguidelines-pro-type-union-access)
     case FOXGLOVE_PARAMETER_VALUE_TAG_BOOLEAN:
@@ -72,7 +72,7 @@ ParameterValue::ParameterValue(foxglove_parameter_value* ptr)
 
 ParameterValue::ParameterValue(double value)
     : impl_(nullptr) {
-  foxglove_parameter_value* ptr = foxglove_parameter_value_create_number(value);
+  foxglove_parameter_value* ptr = foxglove_parameter_value_create_float64(value);
   if (ptr == nullptr) {
     throw std::runtime_error("allocation failed");
   }

--- a/cpp/foxglove/tests/test_parameter.cpp
+++ b/cpp/foxglove/tests/test_parameter.cpp
@@ -234,7 +234,6 @@ TEST_CASE("Parameter construction and access") {
     REQUIRE(generic_array.empty());
   }
 
-
   SECTION("parameter with dict value") {
     std::map<std::string, foxglove::ParameterValue> values;
     values.insert(std::make_pair("key1", foxglove::ParameterValue(1.0)));

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -40,17 +40,17 @@ Used with the parameter service during live visualization. Requires the :py:data
 
    .. py:data:: Float64
 
-      A decimal or integer value that can be represented as a 64-bit floating point number.
+      A floating-point value that can be represented as a 64-bit floating point number.
 
    .. py:data:: Float64Array
 
-      An array of decimal or integer values that can be represented as 64-bit floating point numbers.
+      An array of floating-point values that can be represented as 64-bit floating point numbers.
 
 .. autoclass:: foxglove.websocket.ParameterValue
 
-   .. py:class:: Number(value: float)
+      .. py:class:: Float(value: float)
 
-      A decimal or integer value.
+     A floating-point value.
 
    .. py:class:: Bool(value: bool)
 

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -48,9 +48,13 @@ Used with the parameter service during live visualization. Requires the :py:data
 
 .. autoclass:: foxglove.websocket.ParameterValue
 
-      .. py:class:: Float(value: float)
+   .. py:class:: Float64(value: float)
 
      A floating-point value.
+
+   .. py:class:: Integer(value: int)
+
+      An integer value.
 
    .. py:class:: Bool(value: bool)
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -109,7 +109,7 @@ class Parameter:
     :param name: The parameter name.
     :type name: str
     :param value: Optional value, represented as a native python object, or a ParameterValue.
-    :type value: None|bool|float|str|bytes|list|dict|ParameterValue
+    :type value: None|bool|int|float|str|bytes|list|dict|ParameterValue
     :param type: Optional parameter type. This is automatically derived when passing a native
                  python object as the value.
     :type type: ParameterType|None
@@ -149,6 +149,11 @@ class ParameterValue:
     A parameter value.
     """
 
+    class Integer:
+        """An integer value."""
+
+        def __new__(cls, value: int) -> "ParameterValue.Integer": ...
+
     class Bool:
         """A boolean value."""
 
@@ -184,6 +189,7 @@ class ParameterValue:
         ) -> "ParameterValue.Dict": ...
 
 AnyParameterValue = Union[
+    ParameterValue.Integer,
     ParameterValue.Bool,
     ParameterValue.Number,
     ParameterValue.String,
@@ -194,6 +200,7 @@ AnyParameterValue = Union[
 AnyInnerParameterValue = Union[
     AnyParameterValue,
     bool,
+    int,
     float,
     str,
     List["AnyInnerParameterValue"],

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/websocket.pyi
@@ -139,10 +139,10 @@ class ParameterType(Enum):
     """A byte array."""
 
     Float64 = ...
-    """A decimal or integer value that can be represented as a `float64`."""
+    """A floating-point value that can be represented as a `float64`."""
 
     Float64Array = ...
-    """An array of decimal or integer values that can be represented as `float64`s."""
+    """An array of floating-point values that can be represented as `float64`s."""
 
 class ParameterValue:
     """
@@ -159,10 +159,10 @@ class ParameterValue:
 
         def __new__(cls, value: bool) -> "ParameterValue.Bool": ...
 
-    class Number:
-        """A decimal or integer value."""
+    class Float64:
+        """A floating-point value."""
 
-        def __new__(cls, value: float) -> "ParameterValue.Number": ...
+        def __new__(cls, value: float) -> "ParameterValue.Float64": ...
 
     class String:
         """
@@ -191,7 +191,7 @@ class ParameterValue:
 AnyParameterValue = Union[
     ParameterValue.Integer,
     ParameterValue.Bool,
-    ParameterValue.Number,
+    ParameterValue.Float64,
     ParameterValue.String,
     ParameterValue.Array,
     ParameterValue.Dict,

--- a/python/foxglove-sdk/python/foxglove/tests/test_parameters.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_parameters.py
@@ -26,25 +26,49 @@ def test_float() -> None:
 def test_int() -> None:
     p = Parameter("int", value=1)
     assert p.name == "int"
-    assert p.type == ParameterType.Float64
-    assert p.value == ParameterValue.Number(1)
-    assert type(p.get_value()) is float
+    assert p.type is None
+    assert p.value == ParameterValue.Integer(1)
+    assert type(p.get_value()) is int
     assert p.get_value() == 1
 
 
 def test_float_array() -> None:
-    v: AnyNativeParameterValue = [1, 2, 3]
+    v: AnyNativeParameterValue = [1.0, 2.0, 3.0]
     p = Parameter("float_array", value=v)
     assert p.name == "float_array"
     assert p.type == ParameterType.Float64Array
     assert p.value == ParameterValue.Array(
         [
-            ParameterValue.Number(1),
-            ParameterValue.Number(2),
-            ParameterValue.Number(3),
+            ParameterValue.Number(1.0),
+            ParameterValue.Number(2.0),
+            ParameterValue.Number(3.0),
         ]
     )
     assert p.get_value() == v
+
+
+def test_int_array() -> None:
+    v: AnyNativeParameterValue = [1, 2, 3]
+    p = Parameter("int_array", value=v)
+    assert p.name == "int_array"
+    assert p.type is None
+    assert p.value == ParameterValue.Array(
+        [
+            ParameterValue.Integer(1),
+            ParameterValue.Integer(2),
+            ParameterValue.Integer(3),
+        ]
+    )
+    assert p.get_value() == v
+
+
+def test_parameter_value_integer() -> None:
+    p = Parameter("integer_param", value=ParameterValue.Integer(42))
+    assert p.name == "integer_param"
+    assert p.type is None
+    assert p.value == ParameterValue.Integer(42)
+    assert type(p.get_value()) is int
+    assert p.get_value() == 42
 
 
 def test_heterogeneous_array() -> None:
@@ -55,7 +79,7 @@ def test_heterogeneous_array() -> None:
     assert p.value == ParameterValue.Array(
         [
             ParameterValue.String("a"),
-            ParameterValue.Number(2),
+            ParameterValue.Integer(2),
             ParameterValue.Bool(False),
         ]
     )
@@ -94,15 +118,15 @@ def test_dict() -> None:
     assert p.value == ParameterValue.Dict(
         {
             "a": ParameterValue.Bool(True),
-            "b": ParameterValue.Number(2),
+            "b": ParameterValue.Integer(2),
             "c": ParameterValue.String("C"),
             "d": ParameterValue.Dict(
                 {
                     "inner": ParameterValue.Array(
                         [
-                            ParameterValue.Number(1),
-                            ParameterValue.Number(2),
-                            ParameterValue.Number(3),
+                            ParameterValue.Integer(1),
+                            ParameterValue.Integer(2),
+                            ParameterValue.Integer(3),
                         ]
                     )
                 }

--- a/python/foxglove-sdk/python/foxglove/tests/test_parameters.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_parameters.py
@@ -19,7 +19,7 @@ def test_float() -> None:
     p = Parameter("float", value=1.234)
     assert p.name == "float"
     assert p.type == ParameterType.Float64
-    assert p.value == ParameterValue.Number(1.234)
+    assert p.value == ParameterValue.Float64(1.234)
     assert p.get_value() == 1.234
 
 
@@ -39,9 +39,9 @@ def test_float_array() -> None:
     assert p.type == ParameterType.Float64Array
     assert p.value == ParameterValue.Array(
         [
-            ParameterValue.Number(1.0),
-            ParameterValue.Number(2.0),
-            ParameterValue.Number(3.0),
+            ParameterValue.Float64(1.0),
+            ParameterValue.Float64(2.0),
+            ParameterValue.Float64(3.0),
         ]
     )
     assert p.get_value() == v
@@ -138,14 +138,14 @@ def test_dict() -> None:
 
 def test_explicit() -> None:
     # Derive type from value
-    p = Parameter("float", value=ParameterValue.Number(1))
+    p = Parameter("float", value=ParameterValue.Float64(1))
     assert p.type == ParameterType.Float64
     assert p.get_value() == 1
 
     # Override derived type.
     p = Parameter(
         "bad float array",
-        value=ParameterValue.Number(1),
+        value=ParameterValue.Float64(1),
         type=ParameterType.Float64Array,
     )
     assert p.type == ParameterType.Float64Array
@@ -161,7 +161,7 @@ def test_explicit() -> None:
     assert p.get_value() == "1"
 
     # Override derived type with None.
-    p = Parameter("underspecified float", value=ParameterValue.Number(1), type=None)
+    p = Parameter("underspecified float", value=ParameterValue.Float64(1), type=None)
     assert p.type is None
     assert p.get_value() == 1
 

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -24,7 +24,7 @@ AssetHandler = Callable[[str], Optional[bytes]]
 AnyParameterValue = Union[
     ParameterValue.Integer,
     ParameterValue.Bool,
-    ParameterValue.Number,
+    ParameterValue.Float64,
     ParameterValue.String,
     ParameterValue.Array,
     ParameterValue.Dict,

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -22,6 +22,7 @@ from ._foxglove_py.websocket import (
 ServiceHandler = Callable[["ServiceRequest"], bytes]
 AssetHandler = Callable[[str], Optional[bytes]]
 AnyParameterValue = Union[
+    ParameterValue.Integer,
     ParameterValue.Bool,
     ParameterValue.Number,
     ParameterValue.String,
@@ -31,6 +32,7 @@ AnyParameterValue = Union[
 AnyInnerParameterValue = Union[
     AnyParameterValue,
     bool,
+    int,
     float,
     str,
     List["AnyInnerParameterValue"],

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -1065,7 +1065,7 @@ impl<'py> FromPyObject<'py> for ParameterTypeValueConverter {
         if let Ok(val) = obj.extract::<ParameterValueConverter>() {
             let val = val.0;
             let (typ, val) = match val {
-                // If the value is a number, the type is float64.
+                // If the value is a float, the type is float64.
                 PyParameterValue::Float64(_) => (Some(PyParameterType::Float64), val),
                 // If the value is an array of numbers, then the type is float64 array.
                 PyParameterValue::Array(ref vec)

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -809,9 +809,9 @@ impl PyMessageSchema {
 pub enum PyParameterType {
     /// A byte array.
     ByteArray,
-    /// A decimal or integer value that can be represented as a `float64`.
+    /// A floating-point value that can be represented as a `float64`.
     Float64,
-    /// An array of decimal or integer values that can be represented as `float64`s.
+    /// An array of floating-point values that can be represented as `float64`s.
     Float64Array,
 }
 
@@ -841,8 +841,8 @@ impl From<foxglove::websocket::ParameterType> for PyParameterType {
 pub enum PyParameterValue {
     /// An integer value.
     Integer(i64),
-    /// A decimal or integer value.
-    Number(f64),
+    /// A floating-point value.
+    Float64(f64),
     /// A boolean value.
     Bool(bool),
     /// A string value.
@@ -859,7 +859,7 @@ impl From<PyParameterValue> for foxglove::websocket::ParameterValue {
     fn from(value: PyParameterValue) -> Self {
         match value {
             PyParameterValue::Integer(i) => foxglove::websocket::ParameterValue::Integer(i),
-            PyParameterValue::Number(n) => foxglove::websocket::ParameterValue::Number(n),
+            PyParameterValue::Float64(n) => foxglove::websocket::ParameterValue::Float64(n),
             PyParameterValue::Bool(b) => foxglove::websocket::ParameterValue::Bool(b),
             PyParameterValue::String(s) => foxglove::websocket::ParameterValue::String(s),
             PyParameterValue::Array(py_parameter_values) => {
@@ -878,7 +878,7 @@ impl From<foxglove::websocket::ParameterValue> for PyParameterValue {
     fn from(value: foxglove::websocket::ParameterValue) -> Self {
         match value {
             foxglove::websocket::ParameterValue::Integer(n) => PyParameterValue::Integer(n),
-            foxglove::websocket::ParameterValue::Number(n) => PyParameterValue::Number(n),
+            foxglove::websocket::ParameterValue::Float64(n) => PyParameterValue::Float64(n),
             foxglove::websocket::ParameterValue::Bool(b) => PyParameterValue::Bool(b),
             foxglove::websocket::ParameterValue::String(s) => PyParameterValue::String(s),
             foxglove::websocket::ParameterValue::Array(parameter_values) => {
@@ -985,7 +985,7 @@ impl<'py> IntoPyObject<'py> for ParameterValueConverter {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
             PyParameterValue::Integer(v) => v.into_bound_py_any(py),
-            PyParameterValue::Number(v) => v.into_bound_py_any(py),
+            PyParameterValue::Float64(v) => v.into_bound_py_any(py),
             PyParameterValue::Bool(v) => v.into_bound_py_any(py),
             PyParameterValue::String(v) => v.into_bound_py_any(py),
             PyParameterValue::Array(values) => {
@@ -1012,7 +1012,7 @@ impl<'py> FromPyObject<'py> for ParameterValueConverter {
         } else if let Ok(val) = obj.extract::<i64>() {
             Ok(Self(PyParameterValue::Integer(val)))
         } else if let Ok(val) = obj.extract::<f64>() {
-            Ok(Self(PyParameterValue::Number(val)))
+            Ok(Self(PyParameterValue::Float64(val)))
         } else if let Ok(val) = obj.extract::<String>() {
             Ok(Self(PyParameterValue::String(val)))
         } else if let Ok(list) = obj.downcast::<PyList>() {
@@ -1066,10 +1066,12 @@ impl<'py> FromPyObject<'py> for ParameterTypeValueConverter {
             let val = val.0;
             let (typ, val) = match val {
                 // If the value is a number, the type is float64.
-                PyParameterValue::Number(_) => (Some(PyParameterType::Float64), val),
+                PyParameterValue::Float64(_) => (Some(PyParameterType::Float64), val),
                 // If the value is an array of numbers, then the type is float64 array.
                 PyParameterValue::Array(ref vec)
-                    if vec.iter().all(|v| matches!(v, PyParameterValue::Number(_))) =>
+                    if vec
+                        .iter()
+                        .all(|v| matches!(v, PyParameterValue::Float64(_))) =>
                 {
                     (Some(PyParameterType::Float64Array), val)
                 }

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -839,6 +839,8 @@ impl From<foxglove::websocket::ParameterType> for PyParameterType {
 #[pyclass(name = "ParameterValue", module = "foxglove", eq)]
 #[derive(Clone, PartialEq)]
 pub enum PyParameterValue {
+    /// An integer value.
+    Integer(i64),
     /// A decimal or integer value.
     Number(f64),
     /// A boolean value.
@@ -856,6 +858,7 @@ pub enum PyParameterValue {
 impl From<PyParameterValue> for foxglove::websocket::ParameterValue {
     fn from(value: PyParameterValue) -> Self {
         match value {
+            PyParameterValue::Integer(i) => foxglove::websocket::ParameterValue::Integer(i),
             PyParameterValue::Number(n) => foxglove::websocket::ParameterValue::Number(n),
             PyParameterValue::Bool(b) => foxglove::websocket::ParameterValue::Bool(b),
             PyParameterValue::String(s) => foxglove::websocket::ParameterValue::String(s),
@@ -874,8 +877,8 @@ impl From<PyParameterValue> for foxglove::websocket::ParameterValue {
 impl From<foxglove::websocket::ParameterValue> for PyParameterValue {
     fn from(value: foxglove::websocket::ParameterValue) -> Self {
         match value {
+            foxglove::websocket::ParameterValue::Integer(n) => PyParameterValue::Integer(n),
             foxglove::websocket::ParameterValue::Number(n) => PyParameterValue::Number(n),
-            foxglove::websocket::ParameterValue::Integer(n) => PyParameterValue::Number(n as f64), // TODO: Add integer type?
             foxglove::websocket::ParameterValue::Bool(b) => PyParameterValue::Bool(b),
             foxglove::websocket::ParameterValue::String(s) => PyParameterValue::String(s),
             foxglove::websocket::ParameterValue::Array(parameter_values) => {
@@ -981,6 +984,7 @@ impl<'py> IntoPyObject<'py> for ParameterValueConverter {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
+            PyParameterValue::Integer(v) => v.into_bound_py_any(py),
             PyParameterValue::Number(v) => v.into_bound_py_any(py),
             PyParameterValue::Bool(v) => v.into_bound_py_any(py),
             PyParameterValue::String(v) => v.into_bound_py_any(py),
@@ -1005,6 +1009,8 @@ impl<'py> FromPyObject<'py> for ParameterValueConverter {
             Ok(Self(val))
         } else if let Ok(val) = obj.extract::<bool>() {
             Ok(Self(PyParameterValue::Bool(val)))
+        } else if let Ok(val) = obj.extract::<i64>() {
+            Ok(Self(PyParameterValue::Integer(val)))
         } else if let Ok(val) = obj.extract::<f64>() {
             Ok(Self(PyParameterValue::Number(val)))
         } else if let Ok(val) = obj.extract::<String>() {

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -875,6 +875,7 @@ impl From<foxglove::websocket::ParameterValue> for PyParameterValue {
     fn from(value: foxglove::websocket::ParameterValue) -> Self {
         match value {
             foxglove::websocket::ParameterValue::Number(n) => PyParameterValue::Number(n),
+            foxglove::websocket::ParameterValue::Integer(n) => PyParameterValue::Number(n as f64), // TODO: Add integer type?
             foxglove::websocket::ParameterValue::Bool(b) => PyParameterValue::Bool(b),
             foxglove::websocket::ParameterValue::String(s) => PyParameterValue::String(s),
             foxglove::websocket::ParameterValue::Array(parameter_values) => {

--- a/rust/examples/param_server/src/main.rs
+++ b/rust/examples/param_server/src/main.rs
@@ -147,7 +147,7 @@ async fn update_parameters(server: &WebSocketServerHandle, _listener: Arc<ParamL
         interval.tick().await;
         let parameter = Parameter {
             name: "elapsed".to_string(),
-            value: Some(ParameterValue::Number(start.elapsed().as_secs_f64())),
+            value: Some(ParameterValue::Float64(start.elapsed().as_secs_f64())),
             r#type: Some(ParameterType::Float64),
         };
         server.publish_parameter_values(vec![parameter]);

--- a/rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
@@ -45,6 +45,8 @@ mod tests {
     fn message() -> SetParameters {
         SetParameters::new([
             Parameter::empty("empty"),
+            Parameter::integer("int", 123),
+            Parameter::integer_array("int[]", [123, 456]),
             Parameter::float64("f64", 1.23),
             Parameter::float64_array("f64[]", [1.23, 4.56]),
             Parameter::string("str", "hello"),

--- a/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
+assertion_line: 64
 expression: message()
 ---
 {
@@ -7,6 +8,17 @@ expression: message()
   "parameters": [
     {
       "name": "empty"
+    },
+    {
+      "name": "int",
+      "value": 123
+    },
+    {
+      "name": "int[]",
+      "value": [
+        123,
+        456
+      ]
     },
     {
       "name": "f64",

--- a/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode_with_id.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/client/snapshots/foxglove__websocket__ws_protocol__client__set_parameters__tests__encode_with_id.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/foxglove/src/websocket/ws_protocol/client/set_parameters.rs
+assertion_line: 69
 expression: message_with_id()
 ---
 {
@@ -7,6 +8,17 @@ expression: message_with_id()
   "parameters": [
     {
       "name": "empty"
+    },
+    {
+      "name": "int",
+      "value": 123
+    },
+    {
+      "name": "int[]",
+      "value": [
+        123,
+        456
+      ]
     },
     {
       "name": "f64",

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -23,9 +23,9 @@ pub enum DecodeError {
 pub enum ParameterType {
     /// A byte array, encoded as a base64-encoded string.
     ByteArray,
-    /// A decimal or integer value that can be represented as a `float64`.
+    /// A floating-point value that can be represented as a `float64`.
     Float64,
-    /// An array of decimal or integer values that can be represented as `float64`s.
+    /// An array of floating-point values that can be represented as `float64`s.
     Float64Array,
 }
 
@@ -35,12 +35,9 @@ pub enum ParameterType {
 #[serde(untagged)]
 pub enum ParameterValue {
     /// An integer value.
-    /// NOTE: This needs to be before `Number` to ensure that values without a fractional part
-    /// are preferrentially deserialized as integers, not floats.
     Integer(i64),
-    /// A decimal or integer value.
-    /// TODO: Rename to indicate that this is a float only
-    Number(f64),
+    /// A floating-point value.
+    Float64(f64),
     /// A boolean value.
     Bool(bool),
     /// A string value.
@@ -82,7 +79,7 @@ impl Parameter {
         Self {
             name: name.into(),
             r#type: Some(ParameterType::Float64),
-            value: Some(ParameterValue::Number(value)),
+            value: Some(ParameterValue::Float64(value)),
         }
     }
 
@@ -112,7 +109,7 @@ impl Parameter {
             name: name.into(),
             r#type: Some(ParameterType::Float64Array),
             value: Some(ParameterValue::Array(
-                values.into_iter().map(ParameterValue::Number).collect(),
+                values.into_iter().map(ParameterValue::Float64).collect(),
             )),
         }
     }
@@ -260,12 +257,12 @@ mod tests {
             "outer",
             maplit::btreemap! {
                 "bool".into() => ParameterValue::Bool(false),
-                "number".into() => ParameterValue::Number(1.23),
                 "nested".into() => ParameterValue::Dict(
                     maplit::btreemap! {
-                        "inner".into() => ParameterValue::Number(1.0),
+                        "inner".into() => ParameterValue::Float64(1.0),
                     }
-                )
+                ),
+                "float64".into() => ParameterValue::Float64(1.23),
             }
         ));
     }

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -102,8 +102,7 @@ impl<'de> Deserialize<'de> for Parameter {
                             value = Some(map.next_value()?);
                         }
                         _ => {
-                            // Ignore unknown fields
-                            let _: serde_json::Value = map.next_value()?;
+                            return Err(de::Error::unknown_field(&key, &["name", "type", "value"]));
                         }
                     }
                 }
@@ -176,7 +175,7 @@ fn convert_to_float64_array_value(value: serde_json::Value) -> Result<ParameterV
             Ok(ParameterValue::Array(float_values))
         }
         _ => {
-            // For non-array values marked as float64, raise an error
+            // For non-array values marked as float64_array, raise an error
             Err("Value with type set to float64_array was not an array of numbers".to_string())
         }
     }
@@ -232,10 +231,7 @@ fn convert_value_with_homogenization(value: serde_json::Value) -> Result<Paramet
                             }
                         }
                         _ => {
-                            // Convert non-numeric values normally
-                            let param_val: ParameterValue =
-                                serde_json::from_value(item).map_err(|e| e.to_string())?;
-                            float_values.push(param_val);
+                            unreachable!()
                         }
                     }
                 }

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -34,11 +34,13 @@ pub enum ParameterType {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ParameterValue {
+    /// An integer value.
+    /// NOTE: This needs to be before `Number` to ensure that values without a fractional part
+    /// are preferrentially deserialized as integers, not floats.
+    Integer(i64),
     /// A decimal or integer value.
     /// TODO: Rename to indicate that this is a float only
     Number(f64),
-    /// An integer value.
-    Integer(i64),
     /// A boolean value.
     Bool(bool),
     /// A string value.

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -3,7 +3,10 @@
 use std::collections::BTreeMap;
 
 use base64::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 use serde_with::serde_as;
 
 /// Error encountered while trying to decide a base64-encoded byte array parameter value.
@@ -52,7 +55,7 @@ pub enum ParameterValue {
 }
 
 /// Informs the client about a parameter.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Parameter {
     /// The name of the parameter.
     pub name: String,
@@ -62,6 +65,191 @@ pub struct Parameter {
     /// The parameter value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<ParameterValue>,
+}
+
+impl<'de> Deserialize<'de> for Parameter {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ParameterVisitor;
+
+        impl<'de> Visitor<'de> for ParameterVisitor {
+            type Value = Parameter;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a parameter object")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut name: Option<String> = None;
+                let mut r#type: Option<ParameterType> = None;
+                let mut value: Option<serde_json::Value> = None;
+
+                // First pass: collect all fields as raw values
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "name" => {
+                            name = Some(map.next_value()?);
+                        }
+                        "type" => {
+                            r#type = Some(map.next_value()?);
+                        }
+                        "value" => {
+                            value = Some(map.next_value()?);
+                        }
+                        _ => {
+                            // Ignore unknown fields
+                            let _: serde_json::Value = map.next_value()?;
+                        }
+                    }
+                }
+
+                let name = name.ok_or_else(|| de::Error::missing_field("name"))?;
+
+                // Convert value based on type
+                let parameter_value = match (r#type.as_ref(), value) {
+                    (Some(ParameterType::Float64), Some(val)) => {
+                        Some(convert_to_float64_value(val).map_err(de::Error::custom)?)
+                    }
+                    (Some(ParameterType::Float64Array), Some(val)) => {
+                        Some(convert_to_float64_array_value(val).map_err(de::Error::custom)?)
+                    }
+                    (Some(ParameterType::ByteArray), Some(val)) => {
+                        Some(convert_to_byte_array_value(val).map_err(de::Error::custom)?)
+                    }
+                    (_, Some(val)) => {
+                        Some(convert_value_with_homogenization(val).map_err(de::Error::custom)?)
+                    }
+                    (_, None) => None,
+                };
+
+                Ok(Parameter {
+                    name,
+                    r#type,
+                    value: parameter_value,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(ParameterVisitor)
+    }
+}
+
+fn convert_to_float64_value(value: serde_json::Value) -> Result<ParameterValue, String> {
+    match value {
+        serde_json::Value::Number(n) => {
+            if let Some(f) = n.as_f64() {
+                Ok(ParameterValue::Float64(f))
+            } else {
+                Err("Invalid number for float64".to_string())
+            }
+        }
+        _ => {
+            // For non-numeric values marked as float64, raise an error
+            Err("Non-numeric value had type set to float64".to_string())
+        }
+    }
+}
+
+fn convert_to_float64_array_value(value: serde_json::Value) -> Result<ParameterValue, String> {
+    match value {
+        serde_json::Value::Array(arr) => {
+            let mut float_values = Vec::new();
+            for item in arr {
+                match item {
+                    serde_json::Value::Number(n) => {
+                        if let Some(f) = n.as_f64() {
+                            float_values.push(ParameterValue::Float64(f));
+                        } else {
+                            return Err("Invalid number in float64 array".to_string());
+                        }
+                    }
+                    _ => {
+                        return Err("Non-numeric value in float64 array".to_string());
+                    }
+                }
+            }
+            Ok(ParameterValue::Array(float_values))
+        }
+        _ => {
+            // For non-array values marked as float64, raise an error
+            Err("Value with type set to float64_array was not an array of numbers".to_string())
+        }
+    }
+}
+
+fn convert_to_byte_array_value(value: serde_json::Value) -> Result<ParameterValue, String> {
+    match value {
+        serde_json::Value::String(s) => {
+            // Check if the string is a valid base64 encoding
+            if let Err(e) = BASE64_STANDARD.decode(&s) {
+                return Err(e.to_string());
+            }
+            Ok(ParameterValue::String(s))
+        }
+        _ => {
+            // For non-string values marked as byte_array, raise an error
+            Err("Value with type set to byte_array was not a string".to_string())
+        }
+    }
+}
+
+fn convert_value_with_homogenization(value: serde_json::Value) -> Result<ParameterValue, String> {
+    match value {
+        serde_json::Value::Array(arr) => {
+            // Check if array contains mixed numeric types
+            let mut has_int = false;
+            let mut has_float = false;
+            let mut has_other = false;
+
+            for item in &arr {
+                if item.is_i64() {
+                    has_int = true;
+                } else if item.is_f64() {
+                    has_float = true;
+                } else {
+                    has_other = true;
+                }
+            }
+
+            if (has_float || has_int) && has_other {
+                // If the array contains a mix of numeric and non-numeric-values, return an error
+                Err("Array contains a mix of numeric and non-numeric-values".to_string())
+            } else if has_int && has_float {
+                // Homogenize to float64 array
+                let mut float_values = Vec::new();
+                for item in arr {
+                    match item {
+                        serde_json::Value::Number(n) => {
+                            if let Some(f) = n.as_f64() {
+                                float_values.push(ParameterValue::Float64(f));
+                            } else {
+                                return Err("Invalid number in mixed array".to_string());
+                            }
+                        }
+                        _ => {
+                            // Convert non-numeric values normally
+                            let param_val: ParameterValue =
+                                serde_json::from_value(item).map_err(|e| e.to_string())?;
+                            float_values.push(param_val);
+                        }
+                    }
+                }
+                Ok(ParameterValue::Array(float_values))
+            } else {
+                // Array was already homogeneous, use normal deserialization
+                serde_json::from_value(serde_json::Value::Array(arr)).map_err(|e| e.to_string())
+            }
+        }
+        _ => {
+            // For non-array values, use normal deserialization
+            serde_json::from_value(value).map_err(|e| e.to_string())
+        }
+    }
 }
 
 impl Parameter {
@@ -205,6 +393,211 @@ mod tests {
     #[test]
     fn test_byte_array() {
         insta::assert_json_snapshot!(Parameter::byte_array("byte[]", &[0x10, 0x20, 0x30]));
+    }
+
+    #[test]
+    fn test_deserialize_integer() {
+        let json = r#"{"name": "test", "value": 123}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is an integer
+        assert_matches!(param.value, Some(ParameterValue::Integer(_)));
+        assert_eq!(param.value.unwrap(), ParameterValue::Integer(123));
+        assert_eq!(param.r#type, None);
+    }
+
+    #[test]
+    fn test_deserialize_integer_array() {
+        let json = r#"{"name": "test", "value": [123, 456]}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is an integer array
+        assert_matches!(param.value, Some(ParameterValue::Array(_)));
+        assert_eq!(
+            param.value.unwrap(),
+            ParameterValue::Array(vec![
+                ParameterValue::Integer(123),
+                ParameterValue::Integer(456)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_integer_marked_as_float64() {
+        let json = r#"{"name": "test", "value": 123, "type": "float64"}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is a float64
+        assert_matches!(param.value, Some(ParameterValue::Float64(_)));
+        assert_eq!(param.value.unwrap(), ParameterValue::Float64(123.0));
+        assert_eq!(param.r#type, Some(ParameterType::Float64));
+    }
+
+    #[test]
+    fn test_deserialize_integer_array_marked_as_float64() {
+        let json = r#"{"name": "test", "value": [123, 456], "type": "float64_array"}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is a float64 array
+        assert_matches!(param.value, Some(ParameterValue::Array(_)));
+        assert_eq!(param.r#type, Some(ParameterType::Float64Array));
+        assert_eq!(
+            param.value.unwrap(),
+            ParameterValue::Array(vec![
+                ParameterValue::Float64(123.0),
+                ParameterValue::Float64(456.0),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_float64() {
+        let json = r#"{"name": "test", "value": 1.23}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is a float64
+        assert_matches!(param.value, Some(ParameterValue::Float64(_)));
+        assert_eq!(param.value.unwrap(), ParameterValue::Float64(1.23));
+    }
+
+    #[test]
+    fn test_deserialize_float64_array() {
+        let json = r#"{"name": "test", "value": [1.23, 4.56]}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is a float64 array
+        assert_matches!(param.value, Some(ParameterValue::Array(_)));
+        assert_eq!(
+            param.value.unwrap(),
+            ParameterValue::Array(vec![
+                ParameterValue::Float64(1.23),
+                ParameterValue::Float64(4.56),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_numeric_parameter_with_zero_fractional_part() {
+        let json = r#"{"name": "test", "value": 1.0}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is a float64
+        assert_matches!(param.value, Some(ParameterValue::Float64(_)));
+        assert_eq!(param.value.unwrap(), ParameterValue::Float64(1.0));
+    }
+
+    #[test]
+    fn test_deserialize_numeric_array_with_zero_fractional_part() {
+        let json = r#"{"name": "test", "value": [1.0, 2.0]}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // Check that the value is a float64 array
+        assert_matches!(param.value, Some(ParameterValue::Array(_)));
+        assert_eq!(
+            param.value.unwrap(),
+            ParameterValue::Array(vec![
+                ParameterValue::Float64(1.0),
+                ParameterValue::Float64(2.0)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_numeric_array_with_heterogeneous_elements() {
+        let json = r#"{"name": "test", "value": [1, 2.0]}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        // In the case of mixed types, the value is a float64 array
+        assert_matches!(param.value, Some(ParameterValue::Array(_)));
+        assert_eq!(
+            param.value.unwrap(),
+            ParameterValue::Array(vec![
+                ParameterValue::Float64(1.0),
+                ParameterValue::Float64(2.0)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_boolean() {
+        let json = r#"{"name": "test", "value": true}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        assert_matches!(param.value, Some(ParameterValue::Bool(_)));
+        assert_eq!(param.value.unwrap(), ParameterValue::Bool(true));
+    }
+
+    #[test]
+    fn test_deserialize_boolean_array() {
+        let json = r#"{"name": "test", "value": [true, false]}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        assert_matches!(param.value, Some(ParameterValue::Array(_)));
+        assert_eq!(
+            param.value.unwrap(),
+            ParameterValue::Array(vec![
+                ParameterValue::Bool(true),
+                ParameterValue::Bool(false)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_byte_array() {
+        let json = r#"{"name": "test", "value": "Rm94Z2xvdmUgcnVsZXMh", "type": "byte_array"}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        assert_matches!(param.value, Some(ParameterValue::String(_)));
+        assert_eq!(
+            param.decode_byte_array().unwrap().unwrap(),
+            b"Foxglove rules!".to_vec()
+        );
+    }
+
+    #[test]
+    fn test_deserialize_undefined_parameter() {
+        let json = r#"{"name": "test"}"#;
+        let param = serde_json::from_str::<Parameter>(json).unwrap();
+
+        assert_eq!(param.name, "test");
+        assert_matches!(param.value, None);
+        assert_matches!(param.r#type, None);
+    }
+
+    #[test]
+    fn test_deserialize_array_with_mixed_types() {
+        let json = r#"{"name": "test", "value": [1, 2.0, "three"]}"#;
+        let param_result = serde_json::from_str::<Parameter>(json);
+
+        // Check that an error is returned
+        assert_matches!(param_result, Err(_));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_float64_array() {
+        let json = r#"{"name": "test", "value": [true, false, true], type: "float64_array"}"#;
+        let param_result = serde_json::from_str::<Parameter>(json);
+
+        // Check that an error is returned
+        assert_matches!(param_result, Err(_));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_float64_value() {
+        let json = r#"{"name": "test", "value": "three point one four one five", type: "float64"}"#;
+        let param_result = serde_json::from_str::<Parameter>(json);
+
+        // Check that an error is returned
+        assert_matches!(param_result, Err(_));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_byte_array() {
+        let json = r#"{"name": "test", "value": "!!!!", "type": "byte_array"}"#;
+        let param_result = serde_json::from_str::<Parameter>(json);
+
+        // Check that an error is returned
+        assert_matches!(param_result, Err(_));
     }
 
     #[test]

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -35,7 +35,10 @@ pub enum ParameterType {
 #[serde(untagged)]
 pub enum ParameterValue {
     /// A decimal or integer value.
+    /// TODO: Rename to indicate that this is a float only
     Number(f64),
+    /// An integer value.
+    Integer(i64),
     /// A boolean value.
     Bool(bool),
     /// A string value.
@@ -78,6 +81,26 @@ impl Parameter {
             name: name.into(),
             r#type: Some(ParameterType::Float64),
             value: Some(ParameterValue::Number(value)),
+        }
+    }
+
+    /// Creates a new parameter with an integer value.
+    pub fn integer(name: impl Into<String>, value: i64) -> Self {
+        Self {
+            name: name.into(),
+            r#type: None,
+            value: Some(ParameterValue::Integer(value)),
+        }
+    }
+
+    /// Creates a new parameter with an integer array value.
+    pub fn integer_array(name: impl Into<String>, values: impl IntoIterator<Item = i64>) -> Self {
+        Self {
+            name: name.into(),
+            r#type: None,
+            value: Some(ParameterValue::Array(
+                values.into_iter().map(ParameterValue::Integer).collect(),
+            )),
         }
     }
 
@@ -163,6 +186,16 @@ mod tests {
     #[test]
     fn test_float_array() {
         insta::assert_json_snapshot!(Parameter::float64_array("f64[]", [1.23, 4.56]));
+    }
+
+    #[test]
+    fn test_integer() {
+        insta::assert_json_snapshot!(Parameter::integer("i64", 123));
+    }
+
+    #[test]
+    fn test_integer_array() {
+        insta::assert_json_snapshot!(Parameter::integer_array("i64[]", [123, 456]));
     }
 
     #[test]

--- a/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__dict.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__dict.snap
@@ -1,14 +1,15 @@
 ---
 source: rust/foxglove/src/websocket/ws_protocol/parameter.rs
-expression: "Parameter::dict(\"outer\", maplit::btreemap!\n{\n    \"bool\".into() => ParameterValue::Bool(false), \"number\".into() =>\n    ParameterValue::Number(1.23), \"nested\".into() =>\n    ParameterValue::Dict(maplit::btreemap!\n    { \"inner\".into() => ParameterValue::Number(1.0), })\n})"
+assertion_line: 256
+expression: "Parameter::dict(\"outer\", maplit::btreemap!\n{\n    \"bool\".into() => ParameterValue::Bool(false), \"float64\".into() =>\n    ParameterValue::Float64(1.23), \"nested\".into() =>\n    ParameterValue::Dict(maplit::btreemap!\n    { \"inner\".into() => ParameterValue::Float64(1.0), })\n})"
 ---
 {
   "name": "outer",
   "value": {
     "bool": false,
+    "float64": 1.23,
     "nested": {
       "inner": 1.0
-    },
-    "number": 1.23
+    }
   }
 }

--- a/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__integer.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__integer.snap
@@ -1,0 +1,9 @@
+---
+source: rust/foxglove/src/websocket/ws_protocol/parameter.rs
+assertion_line: 193
+expression: "Parameter::integer(\"i64\", 123)"
+---
+{
+  "name": "i64",
+  "value": 123
+}

--- a/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__integer_array.snap
+++ b/rust/foxglove/src/websocket/ws_protocol/snapshots/foxglove__websocket__ws_protocol__parameter__tests__integer_array.snap
@@ -1,0 +1,12 @@
+---
+source: rust/foxglove/src/websocket/ws_protocol/parameter.rs
+assertion_line: 198
+expression: "Parameter::integer_array(\"i64[]\", [123, 456])"
+---
+{
+  "name": "i64[]",
+  "value": [
+    123,
+    456
+  ]
+}


### PR DESCRIPTION
### Changelog
- Introduce an explicit Integer (64-bit signed integer) type for Parameters.
- Rename the Number parameter type to Float64 to make its semantic clearer
- Update Rust/C/C++/Python bindings to allow constructing Integer and IntegerArray parameters, and to rename Number to Float64 for consistency.

### Docs
Documentation comments updated.

### Description
Previously, the Number parameter type was overloaded to represent both integer and floating-point types (this is because when parameters are sent over the wire as JSON, the distinction is lost). SDK users wanting to construct integer parameters needed to cast them to doubles. When these values were round-tripped through the WebSocketServer interface, a fractional part of `.0` was added, which caused some deserialization libraries to treat them as doubles.

While this can be worked around by SDK users by rolling their own serialization and deserialization overloads to infer when a number should be cast to a native integer type or kept as a double, it's more ergonomic for the SDK to allow for constructing parameter values from native integer types, and to make a best-effort attempt to serialize integer parameters without adding a zero fractional part (ie. `"my_param": 42` over `"my_param": 42.0`).

This PR also includes a custom JSON deserializer to more closely align the behavior of parsing params from the wire into the behavior in the protocol spec (namely, more closely respecting and enforcing checks around the `type` tag).

<table><tr><th>Before</th><th>After</th></tr><tr><td>

Only a Number parameter type exists, which handles both floating point and integer values.

</td><td>

A new Integer parameter type exists for handling explicit integers. Number is deprecated and replaced with Float to be more explicit.

</td></tr></table>

Fixes: FG-12407
