### PR TITLE
C++: Move Timestamp and Duration to schemas namespace

### DIFF
--- a/cpp/examples/foxglove-schemas/src/main.cpp
+++ b/cpp/examples/foxglove-schemas/src/main.cpp
@@ -18,7 +18,7 @@ void log_to_channels(int counter) {
   foxglove::schemas::SceneEntity entity;
   entity.frame_id = "box";
   entity.id = "box_1";
-  entity.lifetime = foxglove::Duration{10, 10000000};
+  entity.lifetime = foxglove::schemas::Duration{10, 10000000};
 
   // Create a cube primitive
   foxglove::schemas::CubePrimitive cube;

--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -102,7 +102,7 @@ struct ArrowPrimitive {
 /// @brief Camera calibration parameters
 struct CameraCalibration {
   /// @brief Timestamp of calibration data
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference for the camera. The origin of the frame is the optical center of the
   /// camera. +x points to the right in the image, +y points down, and +z points into the plane of
@@ -201,7 +201,7 @@ struct Point2 {
 /// @brief A circle annotation on a 2D image
 struct CircleAnnotation {
   /// @brief Timestamp of circle
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Center of the circle in 2D image coordinates (pixels).
   /// @brief The coordinate uses the top-left corner of the top-left pixel of the image as the
@@ -224,7 +224,7 @@ struct CircleAnnotation {
 /// @brief A compressed image
 struct CompressedImage {
   /// @brief Timestamp of image
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference for the image. The origin of the frame is the optical center of the
   /// camera. +x points to the right in the image, +y points down, and +z points into the plane of
@@ -243,7 +243,7 @@ struct CompressedImage {
 /// @brief A single frame of a compressed video bitstream
 struct CompressedVideo {
   /// @brief Timestamp of video frame
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference for the video.
   /// @brief
@@ -330,7 +330,7 @@ struct CubePrimitive {
 /// @brief A transform between two reference frames in 3D space
 struct FrameTransform {
   /// @brief Timestamp of transform
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Name of the parent frame
   std::string parent_frame_id;
@@ -402,7 +402,7 @@ struct PackedElementField {
 /// @brief A 2D grid of data
 struct Grid {
   /// @brief Timestamp of grid
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference
   std::string frame_id;
@@ -450,7 +450,7 @@ struct PointsAnnotation {
     LINE_LIST = 4,
   };
   /// @brief Timestamp of annotation
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Type of points annotation to draw
   PointsAnnotationType type;
@@ -477,7 +477,7 @@ struct PointsAnnotation {
 /// @brief A text label on a 2D image
 struct TextAnnotation {
   /// @brief Timestamp of annotation
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Bottom-left origin of the text label in 2D image coordinates (pixels).
   /// @brief The coordinate uses the top-left corner of the top-left pixel of the image as the
@@ -521,7 +521,7 @@ struct KeyValuePair {
 /// @brief A single scan from a planar laser range-finder
 struct LaserScan {
   /// @brief Timestamp of scan
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference
   std::string frame_id;
@@ -613,7 +613,7 @@ struct LocationFix {
     KNOWN = 3,
   };
   /// @brief Timestamp of the message
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame for the sensor. Latitude and longitude readings are at the origin of the frame.
   std::string frame_id;
@@ -654,7 +654,7 @@ struct Log {
     FATAL = 5,
   };
   /// @brief Timestamp of log message
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Log level
   LogLevel level;
@@ -683,7 +683,7 @@ struct SceneEntityDeletion {
   };
   /// @brief Timestamp of the deletion. Only matching entities earlier than this timestamp will be
   /// deleted.
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Type of deletion action to perform
   SceneEntityDeletionType type;
@@ -784,7 +784,7 @@ struct ModelPrimitive {
 /// all share the same frame of reference.
 struct SceneEntity {
   /// @brief Timestamp of the entity
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference
   std::string frame_id;
@@ -796,7 +796,7 @@ struct SceneEntity {
   /// @brief Length of time (relative to `timestamp`) after which the entity should be automatically
   /// removed. Zero value indicates the entity should remain visible until it is replaced or
   /// deleted.
-  std::optional<foxglove::Duration> lifetime;
+  std::optional<Duration> lifetime;
 
   /// @brief Whether the entity should keep its location in the fixed frame (false) or follow the
   /// frame specified in `frame_id` as it moves relative to the fixed frame (true)
@@ -843,7 +843,7 @@ struct SceneUpdate {
 /// information like normals, intensity, etc.
 struct PointCloud {
   /// @brief Timestamp of point cloud
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference
   std::string frame_id;
@@ -866,7 +866,7 @@ struct PointCloud {
 /// @brief A timestamped pose for an object or reference frame in 3D space
 struct PoseInFrame {
   /// @brief Timestamp of pose
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference for pose position and orientation
   std::string frame_id;
@@ -878,7 +878,7 @@ struct PoseInFrame {
 /// @brief An array of timestamped poses for an object or reference frame in 3D space
 struct PosesInFrame {
   /// @brief Timestamp of pose
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference for pose position and orientation
   std::string frame_id;
@@ -890,7 +890,7 @@ struct PosesInFrame {
 /// @brief A single block of an audio bitstream
 struct RawAudio {
   /// @brief Timestamp of the start of the audio block
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Audio data. The samples in the data must be interleaved and little-endian
   std::vector<std::byte> data;
@@ -908,7 +908,7 @@ struct RawAudio {
 /// @brief A raw image
 struct RawImage {
   /// @brief Timestamp of image
-  std::optional<foxglove::Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
 
   /// @brief Frame of reference for the image. The origin of the frame is the optical center of the
   /// camera. +x points to the right in the image, +y points down, and +z points into the plane of

--- a/cpp/foxglove/include/foxglove/time.hpp
+++ b/cpp/foxglove/include/foxglove/time.hpp
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace foxglove {
+namespace foxglove::schemas {
 
 /// @brief A timestamp in seconds and nanoseconds from the unix epoch.
 struct Timestamp {
@@ -20,4 +20,4 @@ struct Duration {
   uint32_t nsec;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove::schemas

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -376,7 +376,7 @@ TEST_CASE("ImageAnnotations channel") {
 
   // Add a circle annotation
   foxglove::schemas::CircleAnnotation circle;
-  circle.timestamp = foxglove::Timestamp{1000000000, 500000000};
+  circle.timestamp = foxglove::schemas::Timestamp{1000000000, 500000000};
   circle.position = foxglove::schemas::Point2{10.0, 20.0};
   circle.diameter = 15.0;
   circle.thickness = 2.0;
@@ -386,7 +386,7 @@ TEST_CASE("ImageAnnotations channel") {
 
   // Add a points annotation
   foxglove::schemas::PointsAnnotation points;
-  points.timestamp = foxglove::Timestamp{1000000000, 500000000};
+  points.timestamp = foxglove::schemas::Timestamp{1000000000, 500000000};
   points.type = foxglove::schemas::PointsAnnotation::PointsAnnotationType::LINE_STRIP;
   points.points.push_back(foxglove::schemas::Point2{5.0, 10.0});
   points.points.push_back(foxglove::schemas::Point2{15.0, 25.0});
@@ -399,7 +399,7 @@ TEST_CASE("ImageAnnotations channel") {
 
   // Add a text annotation
   foxglove::schemas::TextAnnotation text;
-  text.timestamp = foxglove::Timestamp{1000000000, 500000000};
+  text.timestamp = foxglove::schemas::Timestamp{1000000000, 500000000};
   text.position = foxglove::schemas::Point2{50.0, 60.0};
   text.text = "Sample text";
   text.font_size = 14.0;

--- a/typescript/schemas/src/internal/generateSdkCpp.ts
+++ b/typescript/schemas/src/internal/generateSdkCpp.ts
@@ -15,9 +15,9 @@ function primitiveToCpp(type: FoxglovePrimitive) {
     case "float64":
       return "double";
     case "time":
-      return "std::optional<foxglove::Timestamp>";
+      return "std::optional<Timestamp>";
     case "duration":
-      return "std::optional<foxglove::Duration>";
+      return "std::optional<Duration>";
   }
 }
 


### PR DESCRIPTION
### Changelog
C++: (breaking) Move Timestamp and Duration to schemas namespace

### Description

This moves `Timestamp` and `Duration` schemas to the `foxglove::schemas` namespace, for consistency with other definitions. This is a breaking change for anyone referencing one of these schemas in the prior namespace.