### PR TITLE
Do not send deleted/non-existent params to clients

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -499,7 +499,8 @@ typedef struct foxglove_server_callbacks {
    * `foxglove_parameter_array_create`. Ownership of this value is transferred to the callee, who
    * is responsible for freeing it. A NULL return value is treated as an empty array.
    *
-   * All clients subscribed to updates for the returned parameters will be notified.
+   * All clients subscribed to updates for the returned parameters will be notified. Note that if a
+   * returned parameter is unset, it will not be published to clients.
    */
   struct foxglove_parameter_array *(*on_set_parameters)(const void *context,
                                                         uint32_t client_id,

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -374,7 +374,8 @@ pub struct FoxgloveServerCallbacks {
     /// `foxglove_parameter_array_create`. Ownership of this value is transferred to the callee, who
     /// is responsible for freeing it. A NULL return value is treated as an empty array.
     ///
-    /// All clients subscribed to updates for the returned parameters will be notified.
+    /// All clients subscribed to updates for the returned parameters will be notified. Note that if a
+    /// returned parameter is unset, it will not be published to clients.
     pub on_set_parameters: Option<
         unsafe extern "C" fn(
             context: *const c_void,

--- a/cpp/foxglove/tests/test_server.cpp
+++ b/cpp/foxglove/tests/test_server.cpp
@@ -544,7 +544,6 @@ TEST_CASE("Parameter callbacks") {
       "op": "parameterValues",
       "id": "get-request",
       "parameters": [
-        { "name": "foo" },
         { "name": "bar", "value": "BAR" },
         { "name": "baz", "type": "float64", "value": 1.234 }
       ]
@@ -604,7 +603,6 @@ TEST_CASE("Parameter callbacks") {
       "op": "parameterValues",
       "id": "set-request",
       "parameters": [
-        { "name": "zip" },
         { "name": "bar", "type": "float64", "value": 99.99 },
         { "name": "bytes", "type": "byte_array", "value": "c2VjcmV0" }
       ]

--- a/python/foxglove-sdk/python/foxglove/websocket.py
+++ b/python/foxglove-sdk/python/foxglove/websocket.py
@@ -124,7 +124,8 @@ class ServerListener(Protocol):
         """
         Called by the server when a client sets parameters.
         Note that only `parameters` which have changed are included in the callback, but the return
-        value must include all parameters.
+        value must include all parameters. If a parameter that is unset is included in the return
+        value, it will not be published to clients.
 
         Requires :py:data:`Capability.Parameters`.
 

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -518,12 +518,7 @@ impl ConnectedClient {
 
     pub fn update_parameters(&self, parameters: Vec<Parameter>, request_id: Option<String>) {
         // Filter out parameters that are not set
-        let parameters: Vec<_> = parameters
-            .into_iter()
-            .filter(|p| p.value.is_some())
-            .collect();
-
-        let mut msg = ParameterValues::new(parameters);
+        let mut msg = ParameterValues::new(parameters.into_iter().filter(|p| p.value.is_some()));
         if let Some(id) = request_id {
             msg = msg.with_id(id);
         }

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -482,11 +482,7 @@ impl ConnectedClient {
         if let Some(handler) = server.listener() {
             let parameters =
                 handler.on_get_parameters(Client::new(self), param_names, request_id.as_deref());
-            let mut msg = ParameterValues::new(parameters);
-            if let Some(id) = request_id {
-                msg = msg.with_id(id);
-            }
-            self.send_control_msg(&msg);
+            self.update_parameters(parameters, request_id);
         }
     }
 
@@ -504,10 +500,11 @@ impl ConnectedClient {
         let updated_parameters = if let Some(handler) = server.listener() {
             let updated =
                 handler.on_set_parameters(Client::new(self), parameters, request_id.as_deref());
+
             // Send all the updated_parameters back to the client if request_id is provided.
             // This is the behavior of the reference Python server implementation.
-            if let Some(id) = request_id {
-                self.send_control_msg(&ParameterValues::new(updated.clone()).with_id(id));
+            if request_id.is_some() {
+                self.update_parameters(updated.clone(), request_id);
             }
             updated
         } else {
@@ -519,8 +516,19 @@ impl ConnectedClient {
         server.publish_parameter_values(updated_parameters);
     }
 
-    pub fn update_parameters(&self, parameters: Vec<Parameter>) {
-        self.send_control_msg(&ParameterValues::new(parameters));
+    pub fn update_parameters(&self, parameters: Vec<Parameter>, request_id: Option<String>) {
+        // Filter out parameters that are not set
+        let parameters: Vec<_> = parameters
+            .into_iter()
+            .filter(|p| p.value.is_some())
+            .collect();
+
+        let mut msg = ParameterValues::new(parameters);
+        if let Some(id) = request_id {
+            msg = msg.with_id(id);
+        }
+
+        self.send_control_msg(&msg);
     }
 
     fn on_parameters_subscribe(&self, server: Arc<Server>, names: Vec<String>) {

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -438,12 +438,6 @@ impl Server {
             return;
         }
 
-        // Globally filter out parameters that are not set
-        let parameters: Vec<Parameter> = parameters
-            .into_iter()
-            .filter(|p| p.value.is_some())
-            .collect();
-
         let clients = self.clients.get();
         for client in clients.iter() {
             // Filter parameters by subscriptions.
@@ -461,7 +455,7 @@ impl Server {
 
             // Notify client.
             if !filtered.is_empty() {
-                client.update_parameters(filtered);
+                client.update_parameters(filtered, None);
             }
         }
     }

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -438,6 +438,12 @@ impl Server {
             return;
         }
 
+        // Globally filter out parameters that are not set
+        let parameters: Vec<Parameter> = parameters
+            .into_iter()
+            .filter(|p| p.value.is_some())
+            .collect();
+
         let clients = self.clients.get();
         for client in clients.iter() {
             // Filter parameters by subscriptions.

--- a/rust/foxglove/src/websocket/server_listener.rs
+++ b/rust/foxglove/src/websocket/server_listener.rs
@@ -36,6 +36,8 @@ pub trait ServerListener: Send + Sync {
     /// Should return the updated parameters for the passed parameters.
     /// The implementation could return the modified parameters.
     /// All clients subscribed to updates for the _returned_ parameters will be notified.
+    /// If this callback returns parameters that are unset (i.e. have a None value),
+    /// the unset parameters will not be published to clients.
     ///
     /// Note that only `parameters` which have changed are included in the callback, but the return
     /// value must include all parameters.

--- a/rust/foxglove/src/websocket/ws_protocol/parameter.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/parameter.rs
@@ -62,7 +62,8 @@ pub struct Parameter {
     /// The parameter type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<ParameterType>,
-    /// The parameter value.
+    /// The parameter value. If None, the parameter is treated as unset/deleted, and will not
+    /// be published to clients.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<ParameterValue>,
 }


### PR DESCRIPTION
### Changelog
- WebSocket server will no longer send non-existent or deleted parameters in its response body

### Docs
None

### Description
When publishing parameters to clients in response to get_parameter or set_parameter requests, or updates to subscribed parameters, filter out parameters with None values. This brings the SDK implementation in-line with the same observable behavior as [the previous ws-protocol implementation](https://github.com/foxglove/ws-protocol/blob/305d217eec5e38ff8d6b8e8b4f64d9d087193193/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp#L882-L887).

Part of the motivation here is that, according to [the protocol spec](https://github.com/foxglove/ws-protocol/blob/305d217eec5e38ff8d6b8e8b4f64d9d087193193/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp#L882-L887):

>  If the value is not set (undefined), the parameter shall be unset (removed).

I found that, if these values are not filtered out, and the WebSocket server sends them to the Foxglove app, they still show up in the Parameters panel with an empty value column instead of being fully deleted:

<img width="1512" height="434" alt="image" src="https://github.com/user-attachments/assets/a973a218-af32-42b7-bd2f-fd861eaf09a1" />

After this change, the parameter is no longer present in the UI:

<img width="1249" height="499" alt="image" src="https://github.com/user-attachments/assets/55306c20-ac3c-40d0-8527-a90414ab488d" />

----

Today, this issue is unlikely to come up, because the app currently (1) occasionally polls get_parameters to determine which parameters exist and only requests those and (2) doesn't expose UI elements for deleting parameters. To demonstrate this issue, I had to modify the param_server example to manually publish an empty Parameter. But should either of these change, if we published empty parameter values, the frontend would exhibit unexpected behavior unless it was also modified to ignore parameters from the server with no `value` field.

Alternatively, to avoid this issue without this change, users wanting to use the SDK WebSocketServer to provide parameter functionality would need to be careful in their `on_set_parameters` callback to monitor for deleted parameters and filter them out of the vector of parameters their callback returns. I felt that was also non-ideal and moving it into the SDK provides that safety for free.

This PR also does some light refactoring to eliminate duplicate codepaths for publishing parameters to clients. All parameter publication logic now goes through `ConnectedClient::update_parameters()` to centralize any filtering/message modification we may wish to do in the future.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

The SDK server will publish empty parameters in its JSON response

</td><td>

Parameters without value fields are filtered out any time the server publishes them to a client

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

