### PR TITLE
Encode: make dyn compatible

### DIFF
--- a/rust/examples/prost/src/main.rs
+++ b/rust/examples/prost/src/main.rs
@@ -43,8 +43,8 @@ impl foxglove::Encode for fruit::Apple {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl prost::bytes::BufMut) -> Result<(), Self::Error> {
-        Message::encode(self, buf)?;
+    fn encode(&self, mut buf: &mut dyn prost::bytes::BufMut) -> Result<(), Self::Error> {
+        Message::encode(self, &mut buf)?;
         Ok(())
     }
 }

--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -32,7 +32,7 @@ pub trait Encode {
     fn get_message_encoding() -> String;
 
     /// Encodes message data to the provided buffer.
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error>;
+    fn encode(&self, buf: &mut dyn BufMut) -> Result<(), Self::Error>;
 
     /// Optional. Returns an estimated encoded length for the message data.
     ///
@@ -80,7 +80,7 @@ mod test {
             "json".to_string()
         }
 
-        fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error> {
+        fn encode(&self, buf: &mut dyn BufMut) -> Result<(), Self::Error> {
             serde_json::to_writer(buf.writer(), self)
         }
     }

--- a/rust/foxglove/src/encode/schemars.rs
+++ b/rust/foxglove/src/encode/schemars.rs
@@ -33,7 +33,7 @@ impl<T: Serialize + JsonSchema> Encode for T {
         "json".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error> {
+    fn encode(&self, buf: &mut dyn BufMut) -> Result<(), Self::Error> {
         serde_json::to_writer(buf.writer(), self)
     }
 }

--- a/rust/foxglove/src/log_macro.rs
+++ b/rust/foxglove/src/log_macro.rs
@@ -240,7 +240,7 @@ mod tests {
         impl Encode for Foo {
             type Error = FoxgloveError;
 
-            fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error> {
+            fn encode(&self, buf: &mut dyn BufMut) -> Result<(), Self::Error> {
                 buf.put_u32(self.x);
                 Ok(())
             }
@@ -261,7 +261,7 @@ mod tests {
         impl Encode for Bar {
             type Error = FoxgloveError;
 
-            fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error> {
+            fn encode(&self, buf: &mut dyn BufMut) -> Result<(), Self::Error> {
                 buf.put_u32(self.x);
                 Ok(())
             }
@@ -299,7 +299,7 @@ mod tests {
         impl Encode for Foo {
             type Error = FoxgloveError;
 
-            fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error> {
+            fn encode(&self, buf: &mut dyn BufMut) -> Result<(), Self::Error> {
                 buf.put_u32(self.x);
                 Ok(())
             }
@@ -320,7 +320,7 @@ mod tests {
         impl Encode for Bar {
             type Error = FoxgloveError;
 
-            fn encode(&self, buf: &mut impl BufMut) -> Result<(), Self::Error> {
+            fn encode(&self, buf: &mut dyn BufMut) -> Result<(), Self::Error> {
                 buf.put_u32(self.x);
                 Ok(())
             }

--- a/rust/foxglove/src/schemas/impls.rs
+++ b/rust/foxglove/src/schemas/impls.rs
@@ -18,8 +18,8 @@ impl Encode for ArrowPrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -40,8 +40,8 @@ impl Encode for CameraCalibration {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -62,8 +62,8 @@ impl Encode for CircleAnnotation {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -84,8 +84,8 @@ impl Encode for Color {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -106,8 +106,8 @@ impl Encode for CompressedImage {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -128,8 +128,8 @@ impl Encode for CompressedVideo {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -150,8 +150,8 @@ impl Encode for CubePrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -172,8 +172,8 @@ impl Encode for CylinderPrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -194,8 +194,8 @@ impl Encode for FrameTransform {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -216,8 +216,8 @@ impl Encode for FrameTransforms {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -238,8 +238,8 @@ impl Encode for GeoJson {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -260,8 +260,8 @@ impl Encode for Grid {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -282,8 +282,8 @@ impl Encode for ImageAnnotations {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -304,8 +304,8 @@ impl Encode for KeyValuePair {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -326,8 +326,8 @@ impl Encode for LaserScan {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -348,8 +348,8 @@ impl Encode for LinePrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -370,8 +370,8 @@ impl Encode for LocationFix {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -392,8 +392,8 @@ impl Encode for Log {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -414,8 +414,8 @@ impl Encode for ModelPrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -436,8 +436,8 @@ impl Encode for PackedElementField {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -458,8 +458,8 @@ impl Encode for Point2 {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -480,8 +480,8 @@ impl Encode for Point3 {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -502,8 +502,8 @@ impl Encode for PointCloud {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -524,8 +524,8 @@ impl Encode for PointsAnnotation {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -546,8 +546,8 @@ impl Encode for Pose {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -568,8 +568,8 @@ impl Encode for PoseInFrame {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -590,8 +590,8 @@ impl Encode for PosesInFrame {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -612,8 +612,8 @@ impl Encode for Quaternion {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -634,8 +634,8 @@ impl Encode for RawAudio {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -656,8 +656,8 @@ impl Encode for RawImage {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -678,8 +678,8 @@ impl Encode for SceneEntity {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -700,8 +700,8 @@ impl Encode for SceneEntityDeletion {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -722,8 +722,8 @@ impl Encode for SceneUpdate {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -744,8 +744,8 @@ impl Encode for SpherePrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -766,8 +766,8 @@ impl Encode for TextAnnotation {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -788,8 +788,8 @@ impl Encode for TextPrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -810,8 +810,8 @@ impl Encode for TriangleListPrimitive {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -832,8 +832,8 @@ impl Encode for Vector2 {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }
@@ -854,8 +854,8 @@ impl Encode for Vector3 {
         "protobuf".to_string()
     }
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {
+        ::prost::Message::encode(self, &mut buf)
     }
 
     fn encoded_len(&self) -> Option<usize> { Some(::prost::Message::encoded_len(self)) }

--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -186,7 +186,7 @@ fn derive_struct_impl(input: &DeriveInput, data: &DataStruct) -> TokenStream {
         });
 
         field_encoders.push(quote! {
-            ::foxglove::protobuf::ProtobufField::write_tagged(&self.#field_name, #field_number, buf);
+            ::foxglove::protobuf::ProtobufField::write_tagged(&self.#field_name, #field_number, &mut buf);
         });
     }
 
@@ -290,7 +290,7 @@ fn derive_struct_impl(input: &DeriveInput, data: &DataStruct) -> TokenStream {
                 String::from("protobuf")
             }
 
-            fn encode(&self, buf: &mut impl ::foxglove::bytes::BufMut) -> Result<(), Self::Error> {
+            fn encode(&self, mut buf: &mut dyn ::foxglove::bytes::BufMut) -> Result<(), Self::Error> {
                 if self.encoded_len().is_some_and(|len| len > buf.remaining_mut()) {
                     return Err(::foxglove::FoxgloveError::EncodeError(
                         "insufficient buffer".to_string(),

--- a/rust/foxglove_proto_gen/src/lib.rs
+++ b/rust/foxglove_proto_gen/src/lib.rs
@@ -173,8 +173,8 @@ fn generate_impls(out_dir: &Path, fds: &FileDescriptorSet) -> anyhow::Result<()>
         \"protobuf\".to_string()
     }}
 
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), prost::EncodeError> {{
-        ::prost::Message::encode(self, buf)
+    fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), prost::EncodeError> {{
+        ::prost::Message::encode(self, &mut buf)
     }}
 
     fn encoded_len(&self) -> Option<usize> {{ Some(::prost::Message::encoded_len(self)) }}


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Makes `Encode` dyn compatible by taking the encode target as a dynamic reference. This will result in an extra pointer dereference for every encode() call, which may be optimized away by the compiler.

See https://github.com/orgs/foxglove/discussions/1150 
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>
Fixes: 
<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

