### PR TITLE
C FFI: Add explicit null check for FoxgloveString

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -40,6 +40,7 @@ jobs:
             cdylib_artifact_name: libfoxglove-aarch64-unknown-linux-gnu.so
             compiler: clang
             cross: true
+            test_debug: false
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             staticlib_name: libfoxglove.a
@@ -48,6 +49,7 @@ jobs:
             cdylib_artifact_name: libfoxglove-x86_64-unknown-linux-gnu.so
             compiler: clang
             cross: false
+            test_debug: true
 
           # Linux (extra build to test GCC support)
           - runner: ubuntu-24.04
@@ -59,6 +61,7 @@ jobs:
             cross: false
             compiler: gcc
             skip_upload: true
+            test_debug: true
 
           # macOS
           - runner: macos-15
@@ -68,6 +71,8 @@ jobs:
             staticlib_artifact_name: libfoxglove-aarch64-apple-darwin.a
             cdylib_artifact_name: libfoxglove-aarch64-apple-darwin.dylib
             cross: false
+            test_debug: true
+
           - runner: macos-15
             target: x86_64-apple-darwin
             staticlib_name: libfoxglove.a
@@ -75,6 +80,7 @@ jobs:
             staticlib_artifact_name: libfoxglove-x86_64-apple-darwin.a
             cdylib_artifact_name: libfoxglove-x86_64-apple-darwin.dylib
             cross: true
+            test_debug: false
 
           # Windows
           - runner: windows-2025
@@ -84,6 +90,7 @@ jobs:
             staticlib_artifact_name: foxglove-x86_64-pc-windows-msvc.lib
             cdylib_artifact_name: foxglove-x86_64-pc-windows-msvc.dll
             cross: false
+            test_debug: false
           - runner: windows-2025
             target: aarch64-pc-windows-msvc
             staticlib_name: foxglove.lib
@@ -91,6 +98,7 @@ jobs:
             staticlib_artifact_name: foxglove-aarch64-pc-windows-msvc.lib
             cdylib_artifact_name: foxglove-aarch64-pc-windows-msvc.dll
             cross: true
+            test_debug: false
 
           # iOS
           - runner: macos-15
@@ -100,6 +108,7 @@ jobs:
             staticlib_artifact_name: libfoxglove-aarch64-apple-ios.a
             cdylib_artifact_name: libfoxglove-aarch64-apple-ios.dylib
             cross: true
+            test_debug: false
           # iOS simulator
           - runner: macos-15
             target: aarch64-apple-ios-sim
@@ -108,6 +117,7 @@ jobs:
             staticlib_artifact_name: libfoxglove-aarch64-apple-ios-sim.a
             cdylib_artifact_name: libfoxglove-aarch64-apple-ios-sim.dylib
             cross: true
+            test_debug: false
           - runner: macos-15
             target: x86_64-apple-ios
             staticlib_name: libfoxglove.a
@@ -115,6 +125,7 @@ jobs:
             staticlib_artifact_name: libfoxglove-x86_64-apple-ios.a
             cdylib_artifact_name: libfoxglove-x86_64-apple-ios.dylib
             cross: true
+            test_debug: false
 
     name: build (${{ matrix.target }}, ${{ matrix.compiler || 'default compiler' }})
     runs-on: ${{ matrix.runner }}
@@ -161,7 +172,7 @@ jobs:
         working-directory: cpp
 
       - name: Build & test (Debug mode)
-        if: ${{ !fromJson(matrix.cross) }}
+        if: ${{ fromJson(matrix.test_debug) }}
         env:
           CMAKE_BUILD_TYPE: Debug
         run: make test

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -160,6 +160,13 @@ jobs:
         run: make test
         working-directory: cpp
 
+      - name: Build & test (Debug mode)
+        if: ${{ !fromJson(matrix.cross) }}
+        env:
+          CMAKE_BUILD_TYPE: Debug
+        run: make test
+        working-directory: cpp
+
       - name: Organize artifacts for zip
         shell: bash
         run: |

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -73,13 +73,11 @@ impl FoxgloveString {
     /// The [`data`] field must be valid UTF-8, correctly aligned, and have a length equal to
     /// [`FoxgloveString.len`].
     unsafe fn as_utf8_str(&self) -> Result<&str, std::str::Utf8Error> {
-        std::str::from_utf8(unsafe {
-            if self.data.is_null() {
-                &[]
-            } else {
-                std::slice::from_raw_parts(self.data.cast(), self.len)
-            }
-        })
+        if self.data.is_null() {
+            Ok("")
+        } else {
+            std::str::from_utf8(unsafe { std::slice::from_raw_parts(self.data.cast(), self.len) })
+        }
     }
 
     pub fn as_ptr(&self) -> *const c_char {

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -445,7 +445,11 @@ impl FoxgloveSchema {
         let encoding = unsafe { self.encoding.as_utf8_str() }.map_err(|e| {
             foxglove::FoxgloveError::Utf8Error(format!("schema encoding invalid: {e}"))
         })?;
-        let data = unsafe { std::slice::from_raw_parts(self.data, self.data_len) };
+        let data = if self.data.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(self.data, self.data_len) }
+        };
         Ok(foxglove::Schema::new(name, encoding, data.to_owned()))
     }
 }

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -70,9 +70,16 @@ impl FoxgloveString {
     ///
     /// # Safety
     ///
-    /// The [`data`] field must be valid UTF-8, and have a length equal to [`FoxgloveString.len`].
+    /// The [`data`] field must be valid UTF-8, correctly aligned, and have a length equal to
+    /// [`FoxgloveString.len`].
     unsafe fn as_utf8_str(&self) -> Result<&str, std::str::Utf8Error> {
-        std::str::from_utf8(unsafe { std::slice::from_raw_parts(self.data.cast(), self.len) })
+        std::str::from_utf8(unsafe {
+            if self.data.is_null() {
+                &[]
+            } else {
+                std::slice::from_raw_parts(self.data.cast(), self.len)
+            }
+        })
     }
 
     pub fn as_ptr(&self) -> *const c_char {

--- a/c/src/parameter.rs
+++ b/c/src/parameter.rs
@@ -475,7 +475,11 @@ pub unsafe extern "C" fn foxglove_parameter_create_float64_array(
     values: *const f64,
     values_len: usize,
 ) -> FoxgloveError {
-    let values = unsafe { std::slice::from_raw_parts(values, values_len) };
+    let values = if values.is_null() {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(values, values_len) }
+    };
     let array = values
         .iter()
         .copied()
@@ -493,7 +497,11 @@ pub unsafe extern "C" fn foxglove_parameter_create_integer_array(
     values: *const i64,
     values_len: usize,
 ) -> FoxgloveError {
-    let values = unsafe { std::slice::from_raw_parts(values, values_len) };
+    let values = if values.is_null() {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(values, values_len) }
+    };
     let array = values
         .iter()
         .copied()
@@ -574,7 +582,11 @@ pub unsafe extern "C" fn foxglove_parameter_decode_byte_array(
     if capacity < base64::decoded_len_estimate(encoded.len()) {
         return FoxgloveError::BufferTooShort;
     }
-    let buffer = unsafe { std::slice::from_raw_parts_mut(data, capacity) };
+    let buffer = if data.is_null() {
+        &mut []
+    } else {
+        unsafe { std::slice::from_raw_parts_mut(data, capacity) }
+    };
     match BASE64_STANDARD.decode_slice_unchecked(encoded, buffer) {
         Ok(written) => {
             unsafe { *len = written };

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@
 # the sources under `cpp/foxglove`, link with the C static or shared library, and add both the C/C++
 # includes to include paths.
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 project(foxglove-sdk)
 
 # Enable ccache if available
@@ -16,6 +16,10 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if (MSVC)
+  set(CMAKE_VS_USE_DEBUG_LIBRARIES "$<CONFIG:Debug>")
+endif()
 
 include(CTest)
 include(FetchContent)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@
 # the sources under `cpp/foxglove`, link with the C static or shared library, and add both the C/C++
 # includes to include paths.
 
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.25)
 project(foxglove-sdk)
 
 # Enable ccache if available
@@ -16,10 +16,6 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-
-if (MSVC)
-  set(CMAKE_VS_USE_DEBUG_LIBRARIES "$<CONFIG:Debug>")
-endif()
 
 include(CTest)
 include(FetchContent)

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -11,6 +11,8 @@ BUILD_DIR=build-sanitize-$(subst $(comma),-,$(SANITIZE))
 $(info Using sanitizer: $(SANITIZE))
 endif
 
+CMAKE_BUILD_TYPE?=RelWithDebInfo
+
 .PHONY: lint
 lint:
 	find . -path './build*' -prune -name '*.h' -o -name '*.hpp' -o -name '*.cpp' |\
@@ -30,13 +32,13 @@ clean:
 .PHONY: build
 build:
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=true \
 		$(if $(SANITIZE),-DSANITIZE=$(SANITIZE) -DRust_TOOLCHAIN=nightly) \
 		$(if $(STRICT),-DSTRICT=$(STRICT)) \
 		$(if $(CLANG_TIDY),-DCLANG_TIDY=$(CLANG_TIDY)) \
 		-B $(BUILD_DIR)
-	cmake --build $(BUILD_DIR) -j 8 --config RelWithDebInfo
+	cmake --build $(BUILD_DIR) -j 8 --config $(CMAKE_BUILD_TYPE)
 
 .PHONY: test
 test: build


### PR DESCRIPTION
### Changelog
C++: Fix a precondition assertion from the Rust library which could panic in Debug configurations

### Description

This adds an explicit null check for string data in `as_utf8_str`. Without this, Rust's precondition assertion would panic in Debug targets (`-DCMAKE_BUILD_TYPE=Debug`) as described in #526. See [docs](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#ffi-handling-null-pointers). This also adds similar checks for other public methods using `slice.from_raw_parts`.

This will now also test a Debug build of the C++ SDK in CI.