### PR TITLE
Deploy foxglove data loader crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: rust
     timeout-minutes: 10
+    env:
+      github_ref: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
       - id: detect-version
         name: Detect local Cargo version
         run: |
+          set -eu
+
           version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="'foxglove_data_loader'").version')
           echo "version=$version" >> $GITHUB_OUTPUT
+
+          # remove the prefix from the github ref to get the version
+          expected_version="${github_ref#"refs/tags/rust/foxglove_data_loader/v"}"
+
+          if [ "$version" != "$expected_version" ]; then
+            echo "Expected version '$expected_version' but got '$version'"
+            exit 1
+          fi
       - name: Publish foxglove_data_loader
         run: cargo publish --package foxglove_data_loader
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,23 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  release-foxglove-data-loader:
+    if: startsWith(github.ref, 'refs/tags/rust/foxglove_data_loader/v')
+    runs-on: ubuntu-latest
+    needs: rust
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect-version
+        name: Detect local Cargo version
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="'foxglove_data_loader'").version')
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - name: Publish foxglove_data_loader
+        run: cargo publish --package foxglove_data_loader
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   typescript:
     runs-on: ubuntu-latest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "foxglove_data_loader"
-version = "0.10.1"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "foxglove 0.9.0",

--- a/rust/foxglove_data_loader/Cargo.toml
+++ b/rust/foxglove_data_loader/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "foxglove_data_loader"
-publish = false
+version = "0.0.1"
 description = "Generate wasm to use as a Foxglove data loader"
-version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

Adds a workflow to deploy the `foxglove_data_loader` crate. This avoids extensions needing to use a git dependency. I've set the version to `0.0.1` but we could use a `-beta` version instead.

This will be released separately on the `rust/foxglove_data_loader/v..` tag.

Fixes FG-12509.