### PR TITLE
Flesh out data loader docs, make backfill optional

### DIFF
--- a/rust/foxglove_data_loader/src/lib.rs
+++ b/rust/foxglove_data_loader/src/lib.rs
@@ -588,19 +588,28 @@ pub trait DataLoader: 'static + Sized {
     /// schemas for the `Initialization` result.
     fn initialize(&mut self) -> Result<Initialization, Self::Error>;
 
-    /// Create a MessageIterator for this DataLoader.
+    /// Create a [`MessageIterator`] for this DataLoader for the requested channels and time range.
     fn create_iter(
         &mut self,
         args: loader::MessageIteratorArgs,
     ) -> Result<Self::MessageIterator, Self::Error>;
 
-    /// Backfill results starting from `args.time` for `args.channels`. The backfill results are the
-    /// first message looking backwards in time so that panels won't be empty before playback
-    /// begins.
+    /// Return the most recent message for each of the requested channels at a particular point in
+    /// time.
+    ///
+    /// Backfill is the first message looking backwards in time from a particular point in time for
+    /// a channel. These messages are used when beginning playback from a certain time so that
+    /// Foxglove panels are not empty as playback begins.
+    ///
+    /// This trait has a default implementation that returns no backfill messages. Implement this
+    /// method with backfill logic specific to your data loader to give users the best experience
+    /// when seeking a recording.
     fn get_backfill(
         &mut self,
-        args: loader::BackfillArgs,
-    ) -> Result<Vec<loader::Message>, Self::Error>;
+        _args: loader::BackfillArgs,
+    ) -> Result<Vec<loader::Message>, Self::Error> {
+        Ok(Vec::new())
+    }
 }
 
 /// Implement MessageIterator for your loader iterator.

--- a/rust/foxglove_data_loader/wit/loader.wit
+++ b/rust/foxglove_data_loader/wit/loader.wit
@@ -16,7 +16,6 @@ interface reader {
         // The host implementation will write up to `len` bytes into the address starting at `ptr`. The caller must ensure that this memory region is valid.
         read: func(ptr: u32, len: u32) -> u64;
         // Get the total size of the file backed by the reader
->>>>>>> a6f0351 (Flesh out data loader docs, make backfill optional)
         size: func() -> u64;
     }
 

--- a/rust/foxglove_data_loader/wit/loader.wit
+++ b/rust/foxglove_data_loader/wit/loader.wit
@@ -8,14 +8,21 @@ interface console {
 
 interface reader {
     resource reader {
+        // Seek to a certain position in the reader
         seek: func(pos: u64) -> u64;
+        // Get the current position of the reader
         position: func() -> u64;
         // Read data into a slice at the provided pointer with the provided length.
         // The host implementation will write up to `len` bytes into the address starting at `ptr`. The caller must ensure that this memory region is valid.
         read: func(ptr: u32, len: u32) -> u64;
+        // Get the total size of the file backed by the reader
+>>>>>>> a6f0351 (Flesh out data loader docs, make backfill optional)
         size: func() -> u64;
     }
 
+    // Open a reader for a particular path.
+    //
+    // This path must be one of the paths passed to the data loader constructor.
     open: func(path: string) -> reader;
 }
 
@@ -23,7 +30,9 @@ interface time {
     type time-nanos = u64;
 
     record time-range {
+        // The start time of the range in nanoseconds
         start-time: time-nanos,
+        // The end time of the range in nanoseconds
         end-time: time-nanos,
     }
 }
@@ -57,14 +66,25 @@ interface loader {
         problems: list<problem>,
     }
 
+    // Arguments to the get_backfill method.
+    //
+    // It contains the time that should be backfilled and the list of requested channels.
     record backfill-args {
         time: time-nanos,
         channels: list<channel-id>,
     }
 
+    // Arguments to the create_iter method.
     record message-iterator-args {
+        // The start time in nanoseconds to begin returning messages from.
+        //
+        // If the start time is not supplied return messages from the beginning of the file.
         start-time: option<time-nanos>,
+        // The end time in nanoseconds to return messages until.
+        //
+        // If the end time is not supplied return messages until the end of the file.
         end-time: option<time-nanos>,
+        // The list of channels to return messages from.
         channels: list<channel-id>,
     }
 
@@ -93,6 +113,7 @@ interface loader {
     }
 
     record message {
+        // The ID of the channel on which this message was recorded.
         channel-id: channel-id,
         // The timestamp in nanoseconds at which the message was recorded.
         log-time: time-nanos,
@@ -102,7 +123,9 @@ interface loader {
         data: list<u8>,
     }
 
+    // Arguments passed to the data loader constructor.
     record data-loader-args {
+        // A list of paths to files available for the data loader to open.
         paths: list<string>,
     }
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

Fleshes out some of the comments on the structs in the WIT that make it to the user but didn't have comments.

Also changes backfill to have an empty default implementation and more comments.
Backfill isn't a strict requirement but does make playback better, so I think having it as an advanced opt-in concept is better.

These docs will be published to docs.rs once the crate is released after #559. So I'll try and get the updates to land before then.
