### PR TITLE
Use dedicated context in foxglove_bridge

### DIFF
--- a/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -104,6 +104,7 @@ private:
   bool _disableLoanMessage = true;
   std::unordered_map<std::string, std::shared_ptr<RosMsgParser::Parser>> _jsonParsers;
   std::atomic<bool> _shuttingDown = false;
+  foxglove::Context _serverContext;
 
   void subscribeConnectionGraph(bool subscribe);
 

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -76,12 +76,15 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   const auto ignoreUnresponsiveParamNodes =
     this->get_parameter(PARAM_IGN_UNRESPONSIVE_PARAM_NODES).as_bool();
 
+  _serverContext = foxglove::Context::create();
+
   foxglove::WebSocketServerOptions sdkServerOptions;
   _capabilities = processCapabilities(capabilities);
   sdkServerOptions.host = address;
   sdkServerOptions.port = port;
   sdkServerOptions.supported_encodings = {"cdr", "json"};
   sdkServerOptions.capabilities = _capabilities;
+  sdkServerOptions.context = _serverContext;
   if (_useSimTime) {
     sdkServerOptions.capabilities =
       sdkServerOptions.capabilities | foxglove::WebSocketServerCapabilities::Time;
@@ -293,7 +296,7 @@ void FoxgloveBridge::updateAdvertisedTopics(
     }
 
     // Create the new SDK channel
-    auto channelResult = foxglove::RawChannel::create(topic, messageEncoding, schema);
+    auto channelResult = foxglove::RawChannel::create(topic, messageEncoding, schema, _serverContext);
     if (!channelResult.has_value()) {
       RCLCPP_ERROR(this->get_logger(), "Failed to create channel for topic \"%s\" (%s)",
                    topic.c_str(), foxglove::strerror(channelResult.error()));


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Bugfix PR to have the FoxgloveBridge's WebSocketServer use its own context instead of the SDK's default context. This resolves issues in benchmark tests when instantiating FoxgloveBridge in a tight loop using the global context, where clients could receive messages enqueued by previous iterations of the benchmark.

Fixes: FG-12700

