### PR TITLE
Re-introduce sink_id

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2301,7 +2301,8 @@ foxglove_error foxglove_channel_create_arrow_primitive(struct foxglove_string to
  */
 foxglove_error foxglove_channel_log_arrow_primitive(const struct foxglove_channel *channel,
                                                     const struct foxglove_arrow_primitive *msg,
-                                                    const uint64_t *log_time);
+                                                    const uint64_t *log_time,
+                                                    FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2321,7 +2322,8 @@ foxglove_error foxglove_channel_create_camera_calibration(struct foxglove_string
  */
 foxglove_error foxglove_channel_log_camera_calibration(const struct foxglove_channel *channel,
                                                        const struct foxglove_camera_calibration *msg,
-                                                       const uint64_t *log_time);
+                                                       const uint64_t *log_time,
+                                                       FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2341,7 +2343,8 @@ foxglove_error foxglove_channel_create_circle_annotation(struct foxglove_string 
  */
 foxglove_error foxglove_channel_log_circle_annotation(const struct foxglove_channel *channel,
                                                       const struct foxglove_circle_annotation *msg,
-                                                      const uint64_t *log_time);
+                                                      const uint64_t *log_time,
+                                                      FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2361,7 +2364,8 @@ foxglove_error foxglove_channel_create_color(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_color(const struct foxglove_channel *channel,
                                           const struct foxglove_color *msg,
-                                          const uint64_t *log_time);
+                                          const uint64_t *log_time,
+                                          FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2381,7 +2385,8 @@ foxglove_error foxglove_channel_create_compressed_image(struct foxglove_string t
  */
 foxglove_error foxglove_channel_log_compressed_image(const struct foxglove_channel *channel,
                                                      const struct foxglove_compressed_image *msg,
-                                                     const uint64_t *log_time);
+                                                     const uint64_t *log_time,
+                                                     FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2401,7 +2406,8 @@ foxglove_error foxglove_channel_create_compressed_video(struct foxglove_string t
  */
 foxglove_error foxglove_channel_log_compressed_video(const struct foxglove_channel *channel,
                                                      const struct foxglove_compressed_video *msg,
-                                                     const uint64_t *log_time);
+                                                     const uint64_t *log_time,
+                                                     FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2421,7 +2427,8 @@ foxglove_error foxglove_channel_create_cylinder_primitive(struct foxglove_string
  */
 foxglove_error foxglove_channel_log_cylinder_primitive(const struct foxglove_channel *channel,
                                                        const struct foxglove_cylinder_primitive *msg,
-                                                       const uint64_t *log_time);
+                                                       const uint64_t *log_time,
+                                                       FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2441,7 +2448,8 @@ foxglove_error foxglove_channel_create_cube_primitive(struct foxglove_string top
  */
 foxglove_error foxglove_channel_log_cube_primitive(const struct foxglove_channel *channel,
                                                    const struct foxglove_cube_primitive *msg,
-                                                   const uint64_t *log_time);
+                                                   const uint64_t *log_time,
+                                                   FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2461,7 +2469,8 @@ foxglove_error foxglove_channel_create_frame_transform(struct foxglove_string to
  */
 foxglove_error foxglove_channel_log_frame_transform(const struct foxglove_channel *channel,
                                                     const struct foxglove_frame_transform *msg,
-                                                    const uint64_t *log_time);
+                                                    const uint64_t *log_time,
+                                                    FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2481,7 +2490,8 @@ foxglove_error foxglove_channel_create_frame_transforms(struct foxglove_string t
  */
 foxglove_error foxglove_channel_log_frame_transforms(const struct foxglove_channel *channel,
                                                      const struct foxglove_frame_transforms *msg,
-                                                     const uint64_t *log_time);
+                                                     const uint64_t *log_time,
+                                                     FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2501,7 +2511,8 @@ foxglove_error foxglove_channel_create_geo_json(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_geo_json(const struct foxglove_channel *channel,
                                              const struct foxglove_geo_json *msg,
-                                             const uint64_t *log_time);
+                                             const uint64_t *log_time,
+                                             FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2521,7 +2532,8 @@ foxglove_error foxglove_channel_create_grid(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_grid(const struct foxglove_channel *channel,
                                          const struct foxglove_grid *msg,
-                                         const uint64_t *log_time);
+                                         const uint64_t *log_time,
+                                         FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2541,7 +2553,8 @@ foxglove_error foxglove_channel_create_voxel_grid(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_voxel_grid(const struct foxglove_channel *channel,
                                                const struct foxglove_voxel_grid *msg,
-                                               const uint64_t *log_time);
+                                               const uint64_t *log_time,
+                                               FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2561,7 +2574,8 @@ foxglove_error foxglove_channel_create_image_annotations(struct foxglove_string 
  */
 foxglove_error foxglove_channel_log_image_annotations(const struct foxglove_channel *channel,
                                                       const struct foxglove_image_annotations *msg,
-                                                      const uint64_t *log_time);
+                                                      const uint64_t *log_time,
+                                                      FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2581,7 +2595,8 @@ foxglove_error foxglove_channel_create_key_value_pair(struct foxglove_string top
  */
 foxglove_error foxglove_channel_log_key_value_pair(const struct foxglove_channel *channel,
                                                    const struct foxglove_key_value_pair *msg,
-                                                   const uint64_t *log_time);
+                                                   const uint64_t *log_time,
+                                                   FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2601,7 +2616,8 @@ foxglove_error foxglove_channel_create_laser_scan(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_laser_scan(const struct foxglove_channel *channel,
                                                const struct foxglove_laser_scan *msg,
-                                               const uint64_t *log_time);
+                                               const uint64_t *log_time,
+                                               FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2621,7 +2637,8 @@ foxglove_error foxglove_channel_create_line_primitive(struct foxglove_string top
  */
 foxglove_error foxglove_channel_log_line_primitive(const struct foxglove_channel *channel,
                                                    const struct foxglove_line_primitive *msg,
-                                                   const uint64_t *log_time);
+                                                   const uint64_t *log_time,
+                                                   FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2641,7 +2658,8 @@ foxglove_error foxglove_channel_create_location_fix(struct foxglove_string topic
  */
 foxglove_error foxglove_channel_log_location_fix(const struct foxglove_channel *channel,
                                                  const struct foxglove_location_fix *msg,
-                                                 const uint64_t *log_time);
+                                                 const uint64_t *log_time,
+                                                 FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2661,7 +2679,8 @@ foxglove_error foxglove_channel_create_log(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_log(const struct foxglove_channel *channel,
                                         const struct foxglove_log *msg,
-                                        const uint64_t *log_time);
+                                        const uint64_t *log_time,
+                                        FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2681,7 +2700,8 @@ foxglove_error foxglove_channel_create_scene_entity_deletion(struct foxglove_str
  */
 foxglove_error foxglove_channel_log_scene_entity_deletion(const struct foxglove_channel *channel,
                                                           const struct foxglove_scene_entity_deletion *msg,
-                                                          const uint64_t *log_time);
+                                                          const uint64_t *log_time,
+                                                          FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2701,7 +2721,8 @@ foxglove_error foxglove_channel_create_scene_entity(struct foxglove_string topic
  */
 foxglove_error foxglove_channel_log_scene_entity(const struct foxglove_channel *channel,
                                                  const struct foxglove_scene_entity *msg,
-                                                 const uint64_t *log_time);
+                                                 const uint64_t *log_time,
+                                                 FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2721,7 +2742,8 @@ foxglove_error foxglove_channel_create_scene_update(struct foxglove_string topic
  */
 foxglove_error foxglove_channel_log_scene_update(const struct foxglove_channel *channel,
                                                  const struct foxglove_scene_update *msg,
-                                                 const uint64_t *log_time);
+                                                 const uint64_t *log_time,
+                                                 FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2741,7 +2763,8 @@ foxglove_error foxglove_channel_create_model_primitive(struct foxglove_string to
  */
 foxglove_error foxglove_channel_log_model_primitive(const struct foxglove_channel *channel,
                                                     const struct foxglove_model_primitive *msg,
-                                                    const uint64_t *log_time);
+                                                    const uint64_t *log_time,
+                                                    FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2761,7 +2784,8 @@ foxglove_error foxglove_channel_create_packed_element_field(struct foxglove_stri
  */
 foxglove_error foxglove_channel_log_packed_element_field(const struct foxglove_channel *channel,
                                                          const struct foxglove_packed_element_field *msg,
-                                                         const uint64_t *log_time);
+                                                         const uint64_t *log_time,
+                                                         FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2781,7 +2805,8 @@ foxglove_error foxglove_channel_create_point2(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_point2(const struct foxglove_channel *channel,
                                            const struct foxglove_point2 *msg,
-                                           const uint64_t *log_time);
+                                           const uint64_t *log_time,
+                                           FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2801,7 +2826,8 @@ foxglove_error foxglove_channel_create_point3(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_point3(const struct foxglove_channel *channel,
                                            const struct foxglove_point3 *msg,
-                                           const uint64_t *log_time);
+                                           const uint64_t *log_time,
+                                           FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2821,7 +2847,8 @@ foxglove_error foxglove_channel_create_point_cloud(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_point_cloud(const struct foxglove_channel *channel,
                                                 const struct foxglove_point_cloud *msg,
-                                                const uint64_t *log_time);
+                                                const uint64_t *log_time,
+                                                FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2841,7 +2868,8 @@ foxglove_error foxglove_channel_create_points_annotation(struct foxglove_string 
  */
 foxglove_error foxglove_channel_log_points_annotation(const struct foxglove_channel *channel,
                                                       const struct foxglove_points_annotation *msg,
-                                                      const uint64_t *log_time);
+                                                      const uint64_t *log_time,
+                                                      FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2861,7 +2889,8 @@ foxglove_error foxglove_channel_create_pose(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_pose(const struct foxglove_channel *channel,
                                          const struct foxglove_pose *msg,
-                                         const uint64_t *log_time);
+                                         const uint64_t *log_time,
+                                         FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2881,7 +2910,8 @@ foxglove_error foxglove_channel_create_pose_in_frame(struct foxglove_string topi
  */
 foxglove_error foxglove_channel_log_pose_in_frame(const struct foxglove_channel *channel,
                                                   const struct foxglove_pose_in_frame *msg,
-                                                  const uint64_t *log_time);
+                                                  const uint64_t *log_time,
+                                                  FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2901,7 +2931,8 @@ foxglove_error foxglove_channel_create_poses_in_frame(struct foxglove_string top
  */
 foxglove_error foxglove_channel_log_poses_in_frame(const struct foxglove_channel *channel,
                                                    const struct foxglove_poses_in_frame *msg,
-                                                   const uint64_t *log_time);
+                                                   const uint64_t *log_time,
+                                                   FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2921,7 +2952,8 @@ foxglove_error foxglove_channel_create_quaternion(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_quaternion(const struct foxglove_channel *channel,
                                                const struct foxglove_quaternion *msg,
-                                               const uint64_t *log_time);
+                                               const uint64_t *log_time,
+                                               FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2941,7 +2973,8 @@ foxglove_error foxglove_channel_create_raw_audio(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_raw_audio(const struct foxglove_channel *channel,
                                               const struct foxglove_raw_audio *msg,
-                                              const uint64_t *log_time);
+                                              const uint64_t *log_time,
+                                              FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2961,7 +2994,8 @@ foxglove_error foxglove_channel_create_raw_image(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_raw_image(const struct foxglove_channel *channel,
                                               const struct foxglove_raw_image *msg,
-                                              const uint64_t *log_time);
+                                              const uint64_t *log_time,
+                                              FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -2981,7 +3015,8 @@ foxglove_error foxglove_channel_create_sphere_primitive(struct foxglove_string t
  */
 foxglove_error foxglove_channel_log_sphere_primitive(const struct foxglove_channel *channel,
                                                      const struct foxglove_sphere_primitive *msg,
-                                                     const uint64_t *log_time);
+                                                     const uint64_t *log_time,
+                                                     FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -3001,7 +3036,8 @@ foxglove_error foxglove_channel_create_text_annotation(struct foxglove_string to
  */
 foxglove_error foxglove_channel_log_text_annotation(const struct foxglove_channel *channel,
                                                     const struct foxglove_text_annotation *msg,
-                                                    const uint64_t *log_time);
+                                                    const uint64_t *log_time,
+                                                    FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -3021,7 +3057,8 @@ foxglove_error foxglove_channel_create_text_primitive(struct foxglove_string top
  */
 foxglove_error foxglove_channel_log_text_primitive(const struct foxglove_channel *channel,
                                                    const struct foxglove_text_primitive *msg,
-                                                   const uint64_t *log_time);
+                                                   const uint64_t *log_time,
+                                                   FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -3041,7 +3078,8 @@ foxglove_error foxglove_channel_create_triangle_list_primitive(struct foxglove_s
  */
 foxglove_error foxglove_channel_log_triangle_list_primitive(const struct foxglove_channel *channel,
                                                             const struct foxglove_triangle_list_primitive *msg,
-                                                            const uint64_t *log_time);
+                                                            const uint64_t *log_time,
+                                                            FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -3061,7 +3099,8 @@ foxglove_error foxglove_channel_create_vector2(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_vector2(const struct foxglove_channel *channel,
                                             const struct foxglove_vector2 *msg,
-                                            const uint64_t *log_time);
+                                            const uint64_t *log_time,
+                                            FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.
@@ -3081,7 +3120,8 @@ foxglove_error foxglove_channel_create_vector3(struct foxglove_string topic,
  */
 foxglove_error foxglove_channel_log_vector3(const struct foxglove_channel *channel,
                                             const struct foxglove_vector3 *msg,
-                                            const uint64_t *log_time);
+                                            const uint64_t *log_time,
+                                            FoxgloveSinkId sink_id);
 
 /**
  * Create a new connection graph.

--- a/c/src/generated_types.rs
+++ b/c/src/generated_types.rs
@@ -8,7 +8,7 @@ use crate::arena::{Arena, BorrowToNative};
 use crate::util::{bytes_from_raw, string_from_raw, vec_from_raw};
 use crate::{
     do_foxglove_channel_create, log_msg_to_channel, result_to_c, FoxgloveChannel, FoxgloveContext,
-    FoxgloveDuration, FoxgloveError, FoxgloveString, FoxgloveTimestamp,
+    FoxgloveDuration, FoxgloveError, FoxgloveSinkId, FoxgloveString, FoxgloveTimestamp,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -155,6 +155,7 @@ pub extern "C" fn foxglove_channel_log_arrow_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&ArrowPrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -162,7 +163,7 @@ pub extern "C" fn foxglove_channel_log_arrow_primitive(
     match unsafe { ArrowPrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("ArrowPrimitive: {}", e);
@@ -317,6 +318,7 @@ pub extern "C" fn foxglove_channel_log_camera_calibration(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&CameraCalibration>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -324,7 +326,7 @@ pub extern "C" fn foxglove_channel_log_camera_calibration(
     match unsafe { CameraCalibration::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("CameraCalibration: {}", e);
@@ -425,6 +427,7 @@ pub extern "C" fn foxglove_channel_log_circle_annotation(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&CircleAnnotation>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -432,7 +435,7 @@ pub extern "C" fn foxglove_channel_log_circle_annotation(
     match unsafe { CircleAnnotation::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("CircleAnnotation: {}", e);
@@ -504,6 +507,7 @@ pub extern "C" fn foxglove_channel_log_color(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Color>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -511,7 +515,7 @@ pub extern "C" fn foxglove_channel_log_color(
     match unsafe { Color::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Color: {}", e);
@@ -602,6 +606,7 @@ pub extern "C" fn foxglove_channel_log_compressed_image(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&CompressedImage>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -609,7 +614,7 @@ pub extern "C" fn foxglove_channel_log_compressed_image(
     match unsafe { CompressedImage::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("CompressedImage: {}", e);
@@ -726,6 +731,7 @@ pub extern "C" fn foxglove_channel_log_compressed_video(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&CompressedVideo>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -733,7 +739,7 @@ pub extern "C" fn foxglove_channel_log_compressed_video(
     match unsafe { CompressedVideo::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("CompressedVideo: {}", e);
@@ -829,6 +835,7 @@ pub extern "C" fn foxglove_channel_log_cylinder_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&CylinderPrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -836,7 +843,7 @@ pub extern "C" fn foxglove_channel_log_cylinder_primitive(
     match unsafe { CylinderPrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("CylinderPrimitive: {}", e);
@@ -924,6 +931,7 @@ pub extern "C" fn foxglove_channel_log_cube_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&CubePrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -931,7 +939,7 @@ pub extern "C" fn foxglove_channel_log_cube_primitive(
     match unsafe { CubePrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("CubePrimitive: {}", e);
@@ -1035,6 +1043,7 @@ pub extern "C" fn foxglove_channel_log_frame_transform(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&FrameTransform>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1042,7 +1051,7 @@ pub extern "C" fn foxglove_channel_log_frame_transform(
     match unsafe { FrameTransform::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("FrameTransform: {}", e);
@@ -1106,6 +1115,7 @@ pub extern "C" fn foxglove_channel_log_frame_transforms(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&FrameTransforms>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1113,7 +1123,7 @@ pub extern "C" fn foxglove_channel_log_frame_transforms(
     match unsafe { FrameTransforms::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("FrameTransforms: {}", e);
@@ -1181,6 +1191,7 @@ pub extern "C" fn foxglove_channel_log_geo_json(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&GeoJson>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1188,7 +1199,7 @@ pub extern "C" fn foxglove_channel_log_geo_json(
     match unsafe { GeoJson::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("GeoJson: {}", e);
@@ -1306,6 +1317,7 @@ pub extern "C" fn foxglove_channel_log_grid(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Grid>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1313,7 +1325,7 @@ pub extern "C" fn foxglove_channel_log_grid(
     match unsafe { Grid::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Grid: {}", e);
@@ -1440,6 +1452,7 @@ pub extern "C" fn foxglove_channel_log_voxel_grid(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&VoxelGrid>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1447,7 +1460,7 @@ pub extern "C" fn foxglove_channel_log_voxel_grid(
     match unsafe { VoxelGrid::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("VoxelGrid: {}", e);
@@ -1523,6 +1536,7 @@ pub extern "C" fn foxglove_channel_log_image_annotations(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&ImageAnnotations>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1530,7 +1544,7 @@ pub extern "C" fn foxglove_channel_log_image_annotations(
     match unsafe { ImageAnnotations::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("ImageAnnotations: {}", e);
@@ -1599,6 +1613,7 @@ pub extern "C" fn foxglove_channel_log_key_value_pair(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&KeyValuePair>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1606,7 +1621,7 @@ pub extern "C" fn foxglove_channel_log_key_value_pair(
     match unsafe { KeyValuePair::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("KeyValuePair: {}", e);
@@ -1710,6 +1725,7 @@ pub extern "C" fn foxglove_channel_log_laser_scan(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&LaserScan>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1717,7 +1733,7 @@ pub extern "C" fn foxglove_channel_log_laser_scan(
     match unsafe { LaserScan::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("LaserScan: {}", e);
@@ -1828,6 +1844,7 @@ pub extern "C" fn foxglove_channel_log_line_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&LinePrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1835,7 +1852,7 @@ pub extern "C" fn foxglove_channel_log_line_primitive(
     match unsafe { LinePrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("LinePrimitive: {}", e);
@@ -1933,6 +1950,7 @@ pub extern "C" fn foxglove_channel_log_location_fix(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&LocationFix>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -1940,7 +1958,7 @@ pub extern "C" fn foxglove_channel_log_location_fix(
     match unsafe { LocationFix::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("LocationFix: {}", e);
@@ -2032,6 +2050,7 @@ pub extern "C" fn foxglove_channel_log_log(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Log>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2039,7 +2058,7 @@ pub extern "C" fn foxglove_channel_log_log(
     match unsafe { Log::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Log: {}", e);
@@ -2111,6 +2130,7 @@ pub extern "C" fn foxglove_channel_log_scene_entity_deletion(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&SceneEntityDeletion>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2118,7 +2138,7 @@ pub extern "C" fn foxglove_channel_log_scene_entity_deletion(
     match unsafe { SceneEntityDeletion::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("SceneEntityDeletion: {}", e);
@@ -2258,6 +2278,7 @@ pub extern "C" fn foxglove_channel_log_scene_entity(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&SceneEntity>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2265,7 +2286,7 @@ pub extern "C" fn foxglove_channel_log_scene_entity(
     match unsafe { SceneEntity::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("SceneEntity: {}", e);
@@ -2335,6 +2356,7 @@ pub extern "C" fn foxglove_channel_log_scene_update(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&SceneUpdate>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2342,7 +2364,7 @@ pub extern "C" fn foxglove_channel_log_scene_update(
     match unsafe { SceneUpdate::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("SceneUpdate: {}", e);
@@ -2455,6 +2477,7 @@ pub extern "C" fn foxglove_channel_log_model_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&ModelPrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2462,7 +2485,7 @@ pub extern "C" fn foxglove_channel_log_model_primitive(
     match unsafe { ModelPrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("ModelPrimitive: {}", e);
@@ -2534,6 +2557,7 @@ pub extern "C" fn foxglove_channel_log_packed_element_field(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&PackedElementField>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2541,7 +2565,7 @@ pub extern "C" fn foxglove_channel_log_packed_element_field(
     match unsafe { PackedElementField::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("PackedElementField: {}", e);
@@ -2605,6 +2629,7 @@ pub extern "C" fn foxglove_channel_log_point2(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Point2>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2612,7 +2637,7 @@ pub extern "C" fn foxglove_channel_log_point2(
     match unsafe { Point2::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Point2: {}", e);
@@ -2680,6 +2705,7 @@ pub extern "C" fn foxglove_channel_log_point3(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Point3>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2687,7 +2713,7 @@ pub extern "C" fn foxglove_channel_log_point3(
     match unsafe { Point3::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Point3: {}", e);
@@ -2785,6 +2811,7 @@ pub extern "C" fn foxglove_channel_log_point_cloud(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&PointCloud>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2792,7 +2819,7 @@ pub extern "C" fn foxglove_channel_log_point_cloud(
     match unsafe { PointCloud::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("PointCloud: {}", e);
@@ -2899,6 +2926,7 @@ pub extern "C" fn foxglove_channel_log_points_annotation(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&PointsAnnotation>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2906,7 +2934,7 @@ pub extern "C" fn foxglove_channel_log_points_annotation(
     match unsafe { PointsAnnotation::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("PointsAnnotation: {}", e);
@@ -2983,6 +3011,7 @@ pub extern "C" fn foxglove_channel_log_pose(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Pose>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2990,7 +3019,7 @@ pub extern "C" fn foxglove_channel_log_pose(
     match unsafe { Pose::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Pose: {}", e);
@@ -3073,6 +3102,7 @@ pub extern "C" fn foxglove_channel_log_pose_in_frame(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&PoseInFrame>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3080,7 +3110,7 @@ pub extern "C" fn foxglove_channel_log_pose_in_frame(
     match unsafe { PoseInFrame::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("PoseInFrame: {}", e);
@@ -3159,6 +3189,7 @@ pub extern "C" fn foxglove_channel_log_poses_in_frame(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&PosesInFrame>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3166,7 +3197,7 @@ pub extern "C" fn foxglove_channel_log_poses_in_frame(
     match unsafe { PosesInFrame::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("PosesInFrame: {}", e);
@@ -3239,6 +3270,7 @@ pub extern "C" fn foxglove_channel_log_quaternion(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Quaternion>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3246,7 +3278,7 @@ pub extern "C" fn foxglove_channel_log_quaternion(
     match unsafe { Quaternion::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Quaternion: {}", e);
@@ -3331,6 +3363,7 @@ pub extern "C" fn foxglove_channel_log_raw_audio(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&RawAudio>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3338,7 +3371,7 @@ pub extern "C" fn foxglove_channel_log_raw_audio(
     match unsafe { RawAudio::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("RawAudio: {}", e);
@@ -3491,6 +3524,7 @@ pub extern "C" fn foxglove_channel_log_raw_image(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&RawImage>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3498,7 +3532,7 @@ pub extern "C" fn foxglove_channel_log_raw_image(
     match unsafe { RawImage::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("RawImage: {}", e);
@@ -3586,6 +3620,7 @@ pub extern "C" fn foxglove_channel_log_sphere_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&SpherePrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3593,7 +3628,7 @@ pub extern "C" fn foxglove_channel_log_sphere_primitive(
     match unsafe { SpherePrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("SpherePrimitive: {}", e);
@@ -3696,6 +3731,7 @@ pub extern "C" fn foxglove_channel_log_text_annotation(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&TextAnnotation>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3703,7 +3739,7 @@ pub extern "C" fn foxglove_channel_log_text_annotation(
     match unsafe { TextAnnotation::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("TextAnnotation: {}", e);
@@ -3799,6 +3835,7 @@ pub extern "C" fn foxglove_channel_log_text_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&TextPrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3806,7 +3843,7 @@ pub extern "C" fn foxglove_channel_log_text_primitive(
     match unsafe { TextPrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("TextPrimitive: {}", e);
@@ -3908,6 +3945,7 @@ pub extern "C" fn foxglove_channel_log_triangle_list_primitive(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&TriangleListPrimitive>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3915,7 +3953,7 @@ pub extern "C" fn foxglove_channel_log_triangle_list_primitive(
     match unsafe { TriangleListPrimitive::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("TriangleListPrimitive: {}", e);
@@ -3979,6 +4017,7 @@ pub extern "C" fn foxglove_channel_log_vector2(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Vector2>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -3986,7 +4025,7 @@ pub extern "C" fn foxglove_channel_log_vector2(
     match unsafe { Vector2::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Vector2: {}", e);
@@ -4054,6 +4093,7 @@ pub extern "C" fn foxglove_channel_log_vector3(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&Vector3>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -4061,7 +4101,7 @@ pub extern "C" fn foxglove_channel_log_vector3(
     match unsafe { Vector3::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("Vector3: {}", e);

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -1694,6 +1694,7 @@ pub(crate) fn log_msg_to_channel<T: foxglove::Encode>(
     channel: Option<&FoxgloveChannel>,
     msg: &T,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let Some(channel) = channel else {
         tracing::error!("log called with null channel");
@@ -1705,11 +1706,15 @@ pub(crate) fn log_msg_to_channel<T: foxglove::Encode>(
         // We can safely create a Channel from any Arc<RawChannel>
         foxglove::Channel::<T>::from_raw_channel(channel_arc)
     });
-    channel.log_with_meta(
+
+    let sink_id = std::num::NonZeroU64::new(sink_id).map(foxglove::SinkId::new);
+
+    channel.log_with_meta_to_sink(
         msg,
         foxglove::PartialMetadata {
             log_time: log_time.copied(),
         },
+        sink_id,
     );
     FoxgloveError::Ok
 }

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -65,23 +65,14 @@ public:
   /// @param data The message data.
   /// @param data_len The length of the message data, in bytes.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(
-    const std::byte* data, size_t data_len, std::optional<uint64_t> log_time = std::nullopt
-  ) noexcept;
-
-  /// @cond foxglove_internal
-  /// @param data The message data.
-  /// @param data_len The length of the message data, in bytes.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
   /// @param sink_id The sink ID associated with the message. Can be used to target logging messages
   /// to a specific client or mcap file. If omitted, the message is logged to all sinks. Note that
   /// providing a sink_id is not yet part of the public API. To partition logs among specific sinks,
   /// set up different `Context`s.
-  FoxgloveError log_(
+  FoxgloveError log(
     const std::byte* data, size_t data_len, std::optional<uint64_t> log_time = std::nullopt,
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
-  /// @endcond
 
   /// @brief Close the channel.
   ///

--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -1075,8 +1075,10 @@ public:
   ///
   /// @param msg The ArrowPrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const ArrowPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const ArrowPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1120,8 +1122,10 @@ public:
   ///
   /// @param msg The CameraCalibration message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const CameraCalibration& msg, std::optional<uint64_t> log_time = std::nullopt
+    const CameraCalibration& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1165,8 +1169,10 @@ public:
   ///
   /// @param msg The CircleAnnotation message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const CircleAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt
+    const CircleAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1210,7 +1216,11 @@ public:
   ///
   /// @param msg The Color message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Color& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Color& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -1253,8 +1263,10 @@ public:
   ///
   /// @param msg The CompressedImage message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const CompressedImage& msg, std::optional<uint64_t> log_time = std::nullopt
+    const CompressedImage& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1298,8 +1310,10 @@ public:
   ///
   /// @param msg The CompressedVideo message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const CompressedVideo& msg, std::optional<uint64_t> log_time = std::nullopt
+    const CompressedVideo& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1343,8 +1357,10 @@ public:
   ///
   /// @param msg The CylinderPrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const CylinderPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const CylinderPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1388,8 +1404,10 @@ public:
   ///
   /// @param msg The CubePrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const CubePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const CubePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1433,8 +1451,10 @@ public:
   ///
   /// @param msg The FrameTransform message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const FrameTransform& msg, std::optional<uint64_t> log_time = std::nullopt
+    const FrameTransform& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1478,8 +1498,10 @@ public:
   ///
   /// @param msg The FrameTransforms message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const FrameTransforms& msg, std::optional<uint64_t> log_time = std::nullopt
+    const FrameTransforms& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1523,7 +1545,11 @@ public:
   ///
   /// @param msg The GeoJSON message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const GeoJSON& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const GeoJSON& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -1566,7 +1592,11 @@ public:
   ///
   /// @param msg The Grid message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Grid& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Grid& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -1609,7 +1639,11 @@ public:
   ///
   /// @param msg The VoxelGrid message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const VoxelGrid& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const VoxelGrid& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -1652,8 +1686,10 @@ public:
   ///
   /// @param msg The ImageAnnotations message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const ImageAnnotations& msg, std::optional<uint64_t> log_time = std::nullopt
+    const ImageAnnotations& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1697,8 +1733,10 @@ public:
   ///
   /// @param msg The KeyValuePair message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const KeyValuePair& msg, std::optional<uint64_t> log_time = std::nullopt
+    const KeyValuePair& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1742,7 +1780,11 @@ public:
   ///
   /// @param msg The LaserScan message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const LaserScan& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const LaserScan& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -1785,8 +1827,10 @@ public:
   ///
   /// @param msg The LinePrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const LinePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const LinePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1830,8 +1874,10 @@ public:
   ///
   /// @param msg The LocationFix message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const LocationFix& msg, std::optional<uint64_t> log_time = std::nullopt
+    const LocationFix& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1875,7 +1921,11 @@ public:
   ///
   /// @param msg The Log message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Log& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Log& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -1918,8 +1968,10 @@ public:
   ///
   /// @param msg The SceneEntityDeletion message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const SceneEntityDeletion& msg, std::optional<uint64_t> log_time = std::nullopt
+    const SceneEntityDeletion& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -1963,8 +2015,10 @@ public:
   ///
   /// @param msg The SceneEntity message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const SceneEntity& msg, std::optional<uint64_t> log_time = std::nullopt
+    const SceneEntity& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2008,8 +2062,10 @@ public:
   ///
   /// @param msg The SceneUpdate message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const SceneUpdate& msg, std::optional<uint64_t> log_time = std::nullopt
+    const SceneUpdate& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2053,8 +2109,10 @@ public:
   ///
   /// @param msg The ModelPrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const ModelPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const ModelPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2098,8 +2156,10 @@ public:
   ///
   /// @param msg The PackedElementField message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const PackedElementField& msg, std::optional<uint64_t> log_time = std::nullopt
+    const PackedElementField& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2143,7 +2203,11 @@ public:
   ///
   /// @param msg The Point2 message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Point2& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Point2& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -2186,7 +2250,11 @@ public:
   ///
   /// @param msg The Point3 message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Point3& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Point3& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -2229,8 +2297,10 @@ public:
   ///
   /// @param msg The PointCloud message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const PointCloud& msg, std::optional<uint64_t> log_time = std::nullopt
+    const PointCloud& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2274,8 +2344,10 @@ public:
   ///
   /// @param msg The PointsAnnotation message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const PointsAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt
+    const PointsAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2319,7 +2391,11 @@ public:
   ///
   /// @param msg The Pose message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Pose& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Pose& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -2362,8 +2438,10 @@ public:
   ///
   /// @param msg The PoseInFrame message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const PoseInFrame& msg, std::optional<uint64_t> log_time = std::nullopt
+    const PoseInFrame& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2407,8 +2485,10 @@ public:
   ///
   /// @param msg The PosesInFrame message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const PosesInFrame& msg, std::optional<uint64_t> log_time = std::nullopt
+    const PosesInFrame& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2452,8 +2532,10 @@ public:
   ///
   /// @param msg The Quaternion message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const Quaternion& msg, std::optional<uint64_t> log_time = std::nullopt
+    const Quaternion& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2497,7 +2579,11 @@ public:
   ///
   /// @param msg The RawAudio message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const RawAudio& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const RawAudio& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -2540,7 +2626,11 @@ public:
   ///
   /// @param msg The RawImage message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const RawImage& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const RawImage& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -2583,8 +2673,10 @@ public:
   ///
   /// @param msg The SpherePrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const SpherePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const SpherePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2628,8 +2720,10 @@ public:
   ///
   /// @param msg The TextAnnotation message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const TextAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt
+    const TextAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2673,8 +2767,10 @@ public:
   ///
   /// @param msg The TextPrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const TextPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const TextPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2718,8 +2814,10 @@ public:
   ///
   /// @param msg The TriangleListPrimitive message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const TriangleListPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt
+    const TriangleListPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
@@ -2764,7 +2862,11 @@ public:
   ///
   /// @param msg The Vector2 message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Vector2& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Vector2& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
@@ -2807,7 +2909,11 @@ public:
   ///
   /// @param msg The Vector3 message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
-  FoxgloveError log(const Vector3& msg, std::optional<uint64_t> log_time = std::nullopt) noexcept;
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
+  FoxgloveError log(
+    const Vector3& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
+  ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.
   ///

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -104,13 +104,6 @@ std::optional<std::map<std::string, std::string>> RawChannel::metadata() const n
 }
 
 FoxgloveError RawChannel::log(
-  const std::byte* data, size_t data_len, std::optional<uint64_t> log_time
-) noexcept {
-  return log_(data, data_len, log_time, std::nullopt);
-}
-
-/// @cond foxglove_internal
-FoxgloveError RawChannel::log_(
   const std::byte* data, size_t data_len, std::optional<uint64_t> log_time,
   std::optional<uint64_t> sink_id
 ) noexcept {
@@ -123,6 +116,4 @@ FoxgloveError RawChannel::log_(
   );
   return FoxgloveError(error);
 }
-/// @endcond
-
 }  // namespace foxglove

--- a/cpp/foxglove/src/schemas.cpp
+++ b/cpp/foxglove/src/schemas.cpp
@@ -1158,14 +1158,14 @@ FoxgloveResult<VoxelGridChannel> VoxelGridChannel::create(
 }
 
 FoxgloveError VoxelGridChannel::log(
-  const VoxelGrid& msg, std::optional<uint64_t> log_time
+  const VoxelGrid& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_voxel_grid c_msg;
   voxelGridToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_voxel_grid(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_voxel_grid(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t VoxelGridChannel::id() const noexcept {

--- a/cpp/foxglove/src/schemas.cpp
+++ b/cpp/foxglove/src/schemas.cpp
@@ -80,14 +80,14 @@ FoxgloveResult<ArrowPrimitiveChannel> ArrowPrimitiveChannel::create(
 }
 
 FoxgloveError ArrowPrimitiveChannel::log(
-  const ArrowPrimitive& msg, std::optional<uint64_t> log_time
+  const ArrowPrimitive& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_arrow_primitive c_msg;
   arrowPrimitiveToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_arrow_primitive(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_arrow_primitive(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t ArrowPrimitiveChannel::id() const noexcept {
@@ -108,14 +108,14 @@ FoxgloveResult<CameraCalibrationChannel> CameraCalibrationChannel::create(
 }
 
 FoxgloveError CameraCalibrationChannel::log(
-  const CameraCalibration& msg, std::optional<uint64_t> log_time
+  const CameraCalibration& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_camera_calibration c_msg;
   cameraCalibrationToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_camera_calibration(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_camera_calibration(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t CameraCalibrationChannel::id() const noexcept {
@@ -136,14 +136,14 @@ FoxgloveResult<CircleAnnotationChannel> CircleAnnotationChannel::create(
 }
 
 FoxgloveError CircleAnnotationChannel::log(
-  const CircleAnnotation& msg, std::optional<uint64_t> log_time
+  const CircleAnnotation& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_circle_annotation c_msg;
   circleAnnotationToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_circle_annotation(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_circle_annotation(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t CircleAnnotationChannel::id() const noexcept {
@@ -162,9 +162,14 @@ FoxgloveResult<ColorChannel> ColorChannel::create(
   return ColorChannel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError ColorChannel::log(const Color& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError ColorChannel::log(
+  const Color& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   return FoxgloveError(foxglove_channel_log_color(
-    impl_.get(), reinterpret_cast<const foxglove_color*>(&msg), log_time ? &*log_time : nullptr
+    impl_.get(),
+    reinterpret_cast<const foxglove_color*>(&msg),
+    log_time ? &*log_time : nullptr,
+    sink_id ? *sink_id : 0
   ));
 }
 
@@ -186,14 +191,14 @@ FoxgloveResult<CompressedImageChannel> CompressedImageChannel::create(
 }
 
 FoxgloveError CompressedImageChannel::log(
-  const CompressedImage& msg, std::optional<uint64_t> log_time
+  const CompressedImage& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_compressed_image c_msg;
   compressedImageToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_compressed_image(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_compressed_image(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t CompressedImageChannel::id() const noexcept {
@@ -214,14 +219,14 @@ FoxgloveResult<CompressedVideoChannel> CompressedVideoChannel::create(
 }
 
 FoxgloveError CompressedVideoChannel::log(
-  const CompressedVideo& msg, std::optional<uint64_t> log_time
+  const CompressedVideo& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_compressed_video c_msg;
   compressedVideoToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_compressed_video(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_compressed_video(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t CompressedVideoChannel::id() const noexcept {
@@ -242,14 +247,14 @@ FoxgloveResult<CubePrimitiveChannel> CubePrimitiveChannel::create(
 }
 
 FoxgloveError CubePrimitiveChannel::log(
-  const CubePrimitive& msg, std::optional<uint64_t> log_time
+  const CubePrimitive& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_cube_primitive c_msg;
   cubePrimitiveToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_cube_primitive(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_cube_primitive(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t CubePrimitiveChannel::id() const noexcept {
@@ -270,14 +275,14 @@ FoxgloveResult<CylinderPrimitiveChannel> CylinderPrimitiveChannel::create(
 }
 
 FoxgloveError CylinderPrimitiveChannel::log(
-  const CylinderPrimitive& msg, std::optional<uint64_t> log_time
+  const CylinderPrimitive& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_cylinder_primitive c_msg;
   cylinderPrimitiveToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_cylinder_primitive(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_cylinder_primitive(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t CylinderPrimitiveChannel::id() const noexcept {
@@ -298,14 +303,14 @@ FoxgloveResult<FrameTransformChannel> FrameTransformChannel::create(
 }
 
 FoxgloveError FrameTransformChannel::log(
-  const FrameTransform& msg, std::optional<uint64_t> log_time
+  const FrameTransform& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_frame_transform c_msg;
   frameTransformToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_frame_transform(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_frame_transform(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t FrameTransformChannel::id() const noexcept {
@@ -326,14 +331,14 @@ FoxgloveResult<FrameTransformsChannel> FrameTransformsChannel::create(
 }
 
 FoxgloveError FrameTransformsChannel::log(
-  const FrameTransforms& msg, std::optional<uint64_t> log_time
+  const FrameTransforms& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_frame_transforms c_msg;
   frameTransformsToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_frame_transforms(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_frame_transforms(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t FrameTransformsChannel::id() const noexcept {
@@ -352,13 +357,15 @@ FoxgloveResult<GeoJSONChannel> GeoJSONChannel::create(
   return GeoJSONChannel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError GeoJSONChannel::log(const GeoJSON& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError GeoJSONChannel::log(
+  const GeoJSON& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   Arena arena;
   foxglove_geo_json c_msg;
   geoJSONToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_geo_json(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_geo_json(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t GeoJSONChannel::id() const noexcept {
@@ -377,13 +384,15 @@ FoxgloveResult<GridChannel> GridChannel::create(
   return GridChannel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError GridChannel::log(const Grid& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError GridChannel::log(
+  const Grid& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   Arena arena;
   foxglove_grid c_msg;
   gridToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_grid(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_grid(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t GridChannel::id() const noexcept {
@@ -404,14 +413,14 @@ FoxgloveResult<ImageAnnotationsChannel> ImageAnnotationsChannel::create(
 }
 
 FoxgloveError ImageAnnotationsChannel::log(
-  const ImageAnnotations& msg, std::optional<uint64_t> log_time
+  const ImageAnnotations& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_image_annotations c_msg;
   imageAnnotationsToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_image_annotations(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_image_annotations(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t ImageAnnotationsChannel::id() const noexcept {
@@ -432,14 +441,14 @@ FoxgloveResult<KeyValuePairChannel> KeyValuePairChannel::create(
 }
 
 FoxgloveError KeyValuePairChannel::log(
-  const KeyValuePair& msg, std::optional<uint64_t> log_time
+  const KeyValuePair& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_key_value_pair c_msg;
   keyValuePairToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_key_value_pair(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_key_value_pair(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t KeyValuePairChannel::id() const noexcept {
@@ -459,14 +468,14 @@ FoxgloveResult<LaserScanChannel> LaserScanChannel::create(
 }
 
 FoxgloveError LaserScanChannel::log(
-  const LaserScan& msg, std::optional<uint64_t> log_time
+  const LaserScan& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_laser_scan c_msg;
   laserScanToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_laser_scan(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_laser_scan(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t LaserScanChannel::id() const noexcept {
@@ -487,14 +496,14 @@ FoxgloveResult<LinePrimitiveChannel> LinePrimitiveChannel::create(
 }
 
 FoxgloveError LinePrimitiveChannel::log(
-  const LinePrimitive& msg, std::optional<uint64_t> log_time
+  const LinePrimitive& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_line_primitive c_msg;
   linePrimitiveToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_line_primitive(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_line_primitive(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t LinePrimitiveChannel::id() const noexcept {
@@ -515,14 +524,14 @@ FoxgloveResult<LocationFixChannel> LocationFixChannel::create(
 }
 
 FoxgloveError LocationFixChannel::log(
-  const LocationFix& msg, std::optional<uint64_t> log_time
+  const LocationFix& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_location_fix c_msg;
   locationFixToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_location_fix(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_location_fix(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t LocationFixChannel::id() const noexcept {
@@ -541,13 +550,15 @@ FoxgloveResult<LogChannel> LogChannel::create(
   return LogChannel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError LogChannel::log(const Log& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError LogChannel::log(
+  const Log& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   Arena arena;
   foxglove_log c_msg;
   logToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_log(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_log(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t LogChannel::id() const noexcept {
@@ -568,14 +579,14 @@ FoxgloveResult<ModelPrimitiveChannel> ModelPrimitiveChannel::create(
 }
 
 FoxgloveError ModelPrimitiveChannel::log(
-  const ModelPrimitive& msg, std::optional<uint64_t> log_time
+  const ModelPrimitive& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_model_primitive c_msg;
   modelPrimitiveToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_model_primitive(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_model_primitive(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t ModelPrimitiveChannel::id() const noexcept {
@@ -596,14 +607,14 @@ FoxgloveResult<PackedElementFieldChannel> PackedElementFieldChannel::create(
 }
 
 FoxgloveError PackedElementFieldChannel::log(
-  const PackedElementField& msg, std::optional<uint64_t> log_time
+  const PackedElementField& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_packed_element_field c_msg;
   packedElementFieldToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_packed_element_field(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_packed_element_field(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t PackedElementFieldChannel::id() const noexcept {
@@ -622,9 +633,14 @@ FoxgloveResult<Point2Channel> Point2Channel::create(
   return Point2Channel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError Point2Channel::log(const Point2& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError Point2Channel::log(
+  const Point2& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   return FoxgloveError(foxglove_channel_log_point2(
-    impl_.get(), reinterpret_cast<const foxglove_point2*>(&msg), log_time ? &*log_time : nullptr
+    impl_.get(),
+    reinterpret_cast<const foxglove_point2*>(&msg),
+    log_time ? &*log_time : nullptr,
+    sink_id ? *sink_id : 0
   ));
 }
 
@@ -644,9 +660,14 @@ FoxgloveResult<Point3Channel> Point3Channel::create(
   return Point3Channel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError Point3Channel::log(const Point3& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError Point3Channel::log(
+  const Point3& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   return FoxgloveError(foxglove_channel_log_point3(
-    impl_.get(), reinterpret_cast<const foxglove_point3*>(&msg), log_time ? &*log_time : nullptr
+    impl_.get(),
+    reinterpret_cast<const foxglove_point3*>(&msg),
+    log_time ? &*log_time : nullptr,
+    sink_id ? *sink_id : 0
   ));
 }
 
@@ -667,14 +688,14 @@ FoxgloveResult<PointCloudChannel> PointCloudChannel::create(
 }
 
 FoxgloveError PointCloudChannel::log(
-  const PointCloud& msg, std::optional<uint64_t> log_time
+  const PointCloud& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_point_cloud c_msg;
   pointCloudToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_point_cloud(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_point_cloud(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t PointCloudChannel::id() const noexcept {
@@ -695,14 +716,14 @@ FoxgloveResult<PointsAnnotationChannel> PointsAnnotationChannel::create(
 }
 
 FoxgloveError PointsAnnotationChannel::log(
-  const PointsAnnotation& msg, std::optional<uint64_t> log_time
+  const PointsAnnotation& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_points_annotation c_msg;
   pointsAnnotationToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_points_annotation(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_points_annotation(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t PointsAnnotationChannel::id() const noexcept {
@@ -721,13 +742,15 @@ FoxgloveResult<PoseChannel> PoseChannel::create(
   return PoseChannel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError PoseChannel::log(const Pose& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError PoseChannel::log(
+  const Pose& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   Arena arena;
   foxglove_pose c_msg;
   poseToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_pose(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_pose(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t PoseChannel::id() const noexcept {
@@ -748,14 +771,14 @@ FoxgloveResult<PoseInFrameChannel> PoseInFrameChannel::create(
 }
 
 FoxgloveError PoseInFrameChannel::log(
-  const PoseInFrame& msg, std::optional<uint64_t> log_time
+  const PoseInFrame& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_pose_in_frame c_msg;
   poseInFrameToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_pose_in_frame(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_pose_in_frame(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t PoseInFrameChannel::id() const noexcept {
@@ -776,14 +799,14 @@ FoxgloveResult<PosesInFrameChannel> PosesInFrameChannel::create(
 }
 
 FoxgloveError PosesInFrameChannel::log(
-  const PosesInFrame& msg, std::optional<uint64_t> log_time
+  const PosesInFrame& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_poses_in_frame c_msg;
   posesInFrameToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_poses_in_frame(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_poses_in_frame(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t PosesInFrameChannel::id() const noexcept {
@@ -803,10 +826,13 @@ FoxgloveResult<QuaternionChannel> QuaternionChannel::create(
 }
 
 FoxgloveError QuaternionChannel::log(
-  const Quaternion& msg, std::optional<uint64_t> log_time
+  const Quaternion& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   return FoxgloveError(foxglove_channel_log_quaternion(
-    impl_.get(), reinterpret_cast<const foxglove_quaternion*>(&msg), log_time ? &*log_time : nullptr
+    impl_.get(),
+    reinterpret_cast<const foxglove_quaternion*>(&msg),
+    log_time ? &*log_time : nullptr,
+    sink_id ? *sink_id : 0
   ));
 }
 
@@ -826,13 +852,15 @@ FoxgloveResult<RawAudioChannel> RawAudioChannel::create(
   return RawAudioChannel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError RawAudioChannel::log(const RawAudio& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError RawAudioChannel::log(
+  const RawAudio& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   Arena arena;
   foxglove_raw_audio c_msg;
   rawAudioToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_raw_audio(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_raw_audio(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t RawAudioChannel::id() const noexcept {
@@ -851,13 +879,15 @@ FoxgloveResult<RawImageChannel> RawImageChannel::create(
   return RawImageChannel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError RawImageChannel::log(const RawImage& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError RawImageChannel::log(
+  const RawImage& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   Arena arena;
   foxglove_raw_image c_msg;
   rawImageToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_raw_image(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_raw_image(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t RawImageChannel::id() const noexcept {
@@ -878,14 +908,14 @@ FoxgloveResult<SceneEntityChannel> SceneEntityChannel::create(
 }
 
 FoxgloveError SceneEntityChannel::log(
-  const SceneEntity& msg, std::optional<uint64_t> log_time
+  const SceneEntity& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_scene_entity c_msg;
   sceneEntityToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_scene_entity(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_scene_entity(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t SceneEntityChannel::id() const noexcept {
@@ -906,14 +936,14 @@ FoxgloveResult<SceneEntityDeletionChannel> SceneEntityDeletionChannel::create(
 }
 
 FoxgloveError SceneEntityDeletionChannel::log(
-  const SceneEntityDeletion& msg, std::optional<uint64_t> log_time
+  const SceneEntityDeletion& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_scene_entity_deletion c_msg;
   sceneEntityDeletionToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_scene_entity_deletion(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_scene_entity_deletion(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t SceneEntityDeletionChannel::id() const noexcept {
@@ -934,14 +964,14 @@ FoxgloveResult<SceneUpdateChannel> SceneUpdateChannel::create(
 }
 
 FoxgloveError SceneUpdateChannel::log(
-  const SceneUpdate& msg, std::optional<uint64_t> log_time
+  const SceneUpdate& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_scene_update c_msg;
   sceneUpdateToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_scene_update(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_scene_update(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t SceneUpdateChannel::id() const noexcept {
@@ -962,14 +992,14 @@ FoxgloveResult<SpherePrimitiveChannel> SpherePrimitiveChannel::create(
 }
 
 FoxgloveError SpherePrimitiveChannel::log(
-  const SpherePrimitive& msg, std::optional<uint64_t> log_time
+  const SpherePrimitive& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_sphere_primitive c_msg;
   spherePrimitiveToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_sphere_primitive(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_sphere_primitive(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t SpherePrimitiveChannel::id() const noexcept {
@@ -990,14 +1020,14 @@ FoxgloveResult<TextAnnotationChannel> TextAnnotationChannel::create(
 }
 
 FoxgloveError TextAnnotationChannel::log(
-  const TextAnnotation& msg, std::optional<uint64_t> log_time
+  const TextAnnotation& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_text_annotation c_msg;
   textAnnotationToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_text_annotation(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_text_annotation(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t TextAnnotationChannel::id() const noexcept {
@@ -1018,14 +1048,14 @@ FoxgloveResult<TextPrimitiveChannel> TextPrimitiveChannel::create(
 }
 
 FoxgloveError TextPrimitiveChannel::log(
-  const TextPrimitive& msg, std::optional<uint64_t> log_time
+  const TextPrimitive& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_text_primitive c_msg;
   textPrimitiveToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_text_primitive(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_text_primitive(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t TextPrimitiveChannel::id() const noexcept {
@@ -1046,13 +1076,14 @@ FoxgloveResult<TriangleListPrimitiveChannel> TriangleListPrimitiveChannel::creat
 }
 
 FoxgloveError TriangleListPrimitiveChannel::log(
-  const TriangleListPrimitive& msg, std::optional<uint64_t> log_time
+  const TriangleListPrimitive& msg, std::optional<uint64_t> log_time,
+  std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_triangle_list_primitive c_msg;
   triangleListPrimitiveToC(c_msg, msg, arena);
   return FoxgloveError(foxglove_channel_log_triangle_list_primitive(
-    impl_.get(), &c_msg, log_time ? &*log_time : nullptr
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
   ));
 }
 
@@ -1072,9 +1103,14 @@ FoxgloveResult<Vector2Channel> Vector2Channel::create(
   return Vector2Channel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError Vector2Channel::log(const Vector2& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError Vector2Channel::log(
+  const Vector2& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   return FoxgloveError(foxglove_channel_log_vector2(
-    impl_.get(), reinterpret_cast<const foxglove_vector2*>(&msg), log_time ? &*log_time : nullptr
+    impl_.get(),
+    reinterpret_cast<const foxglove_vector2*>(&msg),
+    log_time ? &*log_time : nullptr,
+    sink_id ? *sink_id : 0
   ));
 }
 
@@ -1094,9 +1130,14 @@ FoxgloveResult<Vector3Channel> Vector3Channel::create(
   return Vector3Channel(ChannelUniquePtr(channel));
 }
 
-FoxgloveError Vector3Channel::log(const Vector3& msg, std::optional<uint64_t> log_time) noexcept {
+FoxgloveError Vector3Channel::log(
+  const Vector3& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
+) noexcept {
   return FoxgloveError(foxglove_channel_log_vector3(
-    impl_.get(), reinterpret_cast<const foxglove_vector3*>(&msg), log_time ? &*log_time : nullptr
+    impl_.get(),
+    reinterpret_cast<const foxglove_vector3*>(&msg),
+    log_time ? &*log_time : nullptr,
+    sink_id ? *sink_id : 0
   ));
 }
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -59,12 +59,15 @@ class BaseChannel:
         self,
         msg: bytes,
         log_time: Optional[int] = None,
+        sink_id: Optional[int] = None,
     ) -> None:
         """
         Log a message to the channel.
 
         :param msg: The message to log.
         :param log_time: The optional time the message was logged.
+        :param sink_id: The sink ID to log the message to. If not provided, the message will be
+            sent to all sinks.
         """
         ...
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
@@ -2720,6 +2720,7 @@ class VoxelGridChannel:
         message: "VoxelGrid",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove VoxelGrid message on the channel."""
         ...

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
@@ -107,6 +107,7 @@ class ArrowPrimitiveChannel:
         message: "ArrowPrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove ArrowPrimitive message on the channel."""
         ...
@@ -173,6 +174,7 @@ class CameraCalibrationChannel:
         message: "CameraCalibration",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove CameraCalibration message on the channel."""
         ...
@@ -239,6 +241,7 @@ class CircleAnnotationChannel:
         message: "CircleAnnotation",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove CircleAnnotation message on the channel."""
         ...
@@ -305,6 +308,7 @@ class ColorChannel:
         message: "Color",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Color message on the channel."""
         ...
@@ -371,6 +375,7 @@ class CompressedImageChannel:
         message: "CompressedImage",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove CompressedImage message on the channel."""
         ...
@@ -437,6 +442,7 @@ class CompressedVideoChannel:
         message: "CompressedVideo",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove CompressedVideo message on the channel."""
         ...
@@ -503,6 +509,7 @@ class CubePrimitiveChannel:
         message: "CubePrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove CubePrimitive message on the channel."""
         ...
@@ -569,6 +576,7 @@ class CylinderPrimitiveChannel:
         message: "CylinderPrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove CylinderPrimitive message on the channel."""
         ...
@@ -635,6 +643,7 @@ class FrameTransformChannel:
         message: "FrameTransform",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove FrameTransform message on the channel."""
         ...
@@ -701,6 +710,7 @@ class FrameTransformsChannel:
         message: "FrameTransforms",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove FrameTransforms message on the channel."""
         ...
@@ -767,6 +777,7 @@ class GeoJsonChannel:
         message: "GeoJson",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove GeoJson message on the channel."""
         ...
@@ -833,6 +844,7 @@ class GridChannel:
         message: "Grid",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Grid message on the channel."""
         ...
@@ -899,6 +911,7 @@ class ImageAnnotationsChannel:
         message: "ImageAnnotations",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove ImageAnnotations message on the channel."""
         ...
@@ -965,6 +978,7 @@ class KeyValuePairChannel:
         message: "KeyValuePair",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove KeyValuePair message on the channel."""
         ...
@@ -1031,6 +1045,7 @@ class LaserScanChannel:
         message: "LaserScan",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove LaserScan message on the channel."""
         ...
@@ -1097,6 +1112,7 @@ class LinePrimitiveChannel:
         message: "LinePrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove LinePrimitive message on the channel."""
         ...
@@ -1163,6 +1179,7 @@ class LocationFixChannel:
         message: "LocationFix",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove LocationFix message on the channel."""
         ...
@@ -1229,6 +1246,7 @@ class LogChannel:
         message: "Log",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Log message on the channel."""
         ...
@@ -1295,6 +1313,7 @@ class ModelPrimitiveChannel:
         message: "ModelPrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove ModelPrimitive message on the channel."""
         ...
@@ -1361,6 +1380,7 @@ class PackedElementFieldChannel:
         message: "PackedElementField",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove PackedElementField message on the channel."""
         ...
@@ -1427,6 +1447,7 @@ class Point2Channel:
         message: "Point2",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Point2 message on the channel."""
         ...
@@ -1493,6 +1514,7 @@ class Point3Channel:
         message: "Point3",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Point3 message on the channel."""
         ...
@@ -1559,6 +1581,7 @@ class PointCloudChannel:
         message: "PointCloud",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove PointCloud message on the channel."""
         ...
@@ -1625,6 +1648,7 @@ class PointsAnnotationChannel:
         message: "PointsAnnotation",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove PointsAnnotation message on the channel."""
         ...
@@ -1691,6 +1715,7 @@ class PoseChannel:
         message: "Pose",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Pose message on the channel."""
         ...
@@ -1757,6 +1782,7 @@ class PoseInFrameChannel:
         message: "PoseInFrame",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove PoseInFrame message on the channel."""
         ...
@@ -1823,6 +1849,7 @@ class PosesInFrameChannel:
         message: "PosesInFrame",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove PosesInFrame message on the channel."""
         ...
@@ -1889,6 +1916,7 @@ class QuaternionChannel:
         message: "Quaternion",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Quaternion message on the channel."""
         ...
@@ -1955,6 +1983,7 @@ class RawAudioChannel:
         message: "RawAudio",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove RawAudio message on the channel."""
         ...
@@ -2021,6 +2050,7 @@ class RawImageChannel:
         message: "RawImage",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove RawImage message on the channel."""
         ...
@@ -2087,6 +2117,7 @@ class SceneEntityChannel:
         message: "SceneEntity",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove SceneEntity message on the channel."""
         ...
@@ -2153,6 +2184,7 @@ class SceneEntityDeletionChannel:
         message: "SceneEntityDeletion",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove SceneEntityDeletion message on the channel."""
         ...
@@ -2219,6 +2251,7 @@ class SceneUpdateChannel:
         message: "SceneUpdate",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove SceneUpdate message on the channel."""
         ...
@@ -2285,6 +2318,7 @@ class SpherePrimitiveChannel:
         message: "SpherePrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove SpherePrimitive message on the channel."""
         ...
@@ -2351,6 +2385,7 @@ class TextAnnotationChannel:
         message: "TextAnnotation",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove TextAnnotation message on the channel."""
         ...
@@ -2417,6 +2452,7 @@ class TextPrimitiveChannel:
         message: "TextPrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove TextPrimitive message on the channel."""
         ...
@@ -2483,6 +2519,7 @@ class TriangleListPrimitiveChannel:
         message: "TriangleListPrimitive",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove TriangleListPrimitive message on the channel."""
         ...
@@ -2549,6 +2586,7 @@ class Vector2Channel:
         message: "Vector2",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Vector2 message on the channel."""
         ...
@@ -2615,6 +2653,7 @@ class Vector3Channel:
         message: "Vector3",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove Vector3 message on the channel."""
         ...

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -106,6 +106,7 @@ class Channel:
         msg: Union[JsonMessage, list[Any], bytes, str],
         *,
         log_time: Optional[int] = None,
+        sink_id: Optional[int] = None,
     ) -> None:
         """
         Log a message on the channel.
@@ -121,7 +122,7 @@ class Channel:
             msg = msg.encode("utf-8")
 
         if isinstance(msg, bytes):
-            return self.base.log(msg, log_time)
+            return self.base.log(msg, log_time, sink_id)
 
         raise TypeError(f"Unsupported message type: {type(msg)}")
 
@@ -145,6 +146,7 @@ def log(
     message: Union[JsonMessage, list[Any], bytes, str, _schemas.FoxgloveSchema],
     *,
     log_time: Optional[int] = None,
+    sink_id: Optional[int] = None,
 ) -> None:
     """Log a message on a topic.
 
@@ -190,6 +192,7 @@ def log(
     channel.log(
         cast(Any, message),
         log_time=log_time,
+        sink_id=sink_id,
     )
 
 

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -235,3 +235,9 @@ def test_exposes_unique_channel_ids(new_topic: str) -> None:
     assert ch_1.id() > 0
     assert ch_1.id() < ch_2.id()
     assert ch_2.id() < ch_3.id()
+
+
+def test_log_message_to_specific_sink(new_topic: str) -> None:
+    ctx = Context()
+    ch = Channel(new_topic, context=ctx)
+    ch.log("test", sink_id=1)

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -3,10 +3,11 @@
 
 use super::schemas;
 use crate::{PyContext, PySchema};
-use foxglove::{Channel, ChannelBuilder, PartialMetadata};
+use foxglove::{Channel, ChannelBuilder, PartialMetadata, SinkId};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::collections::BTreeMap;
+use std::num::NonZero;
 
 pub fn register_submodule(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
     let module = PyModule::new(parent_module.py(), "channels")?;
@@ -152,10 +153,13 @@ impl ArrowPrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::ArrowPrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::ArrowPrimitive, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -258,10 +262,13 @@ impl CameraCalibrationChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::CameraCalibration, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::CameraCalibration, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -364,10 +371,13 @@ impl CircleAnnotationChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::CircleAnnotation, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::CircleAnnotation, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -470,10 +480,13 @@ impl ColorChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Color, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Color, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -571,10 +584,13 @@ impl CompressedImageChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::CompressedImage, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::CompressedImage, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -677,10 +693,13 @@ impl CompressedVideoChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::CompressedVideo, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::CompressedVideo, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -783,10 +802,13 @@ impl CylinderPrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::CylinderPrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::CylinderPrimitive, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -889,10 +911,13 @@ impl CubePrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::CubePrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::CubePrimitive, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -995,10 +1020,13 @@ impl FrameTransformChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::FrameTransform, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::FrameTransform, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1101,10 +1129,13 @@ impl FrameTransformsChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::FrameTransforms, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::FrameTransforms, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1207,10 +1238,13 @@ impl GeoJsonChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::GeoJson, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::GeoJson, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1308,10 +1342,13 @@ impl GridChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Grid, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Grid, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1409,10 +1446,13 @@ impl VoxelGridChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::VoxelGrid, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::VoxelGrid, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1515,10 +1555,13 @@ impl ImageAnnotationsChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::ImageAnnotations, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::ImageAnnotations, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1621,10 +1664,13 @@ impl KeyValuePairChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::KeyValuePair, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::KeyValuePair, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1727,10 +1773,13 @@ impl LaserScanChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::LaserScan, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::LaserScan, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1833,10 +1882,13 @@ impl LinePrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::LinePrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::LinePrimitive, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -1939,10 +1991,13 @@ impl LocationFixChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::LocationFix, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::LocationFix, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2045,10 +2100,13 @@ impl LogChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Log, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Log, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2146,10 +2204,13 @@ impl SceneEntityDeletionChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::SceneEntityDeletion, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::SceneEntityDeletion, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2252,10 +2313,13 @@ impl SceneEntityChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::SceneEntity, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::SceneEntity, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2358,10 +2422,13 @@ impl SceneUpdateChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::SceneUpdate, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::SceneUpdate, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2464,10 +2531,13 @@ impl ModelPrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::ModelPrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::ModelPrimitive, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2570,10 +2640,13 @@ impl PackedElementFieldChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::PackedElementField, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::PackedElementField, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2676,10 +2749,13 @@ impl Point2Channel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Point2, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Point2, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2777,10 +2853,13 @@ impl Point3Channel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Point3, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Point3, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2878,10 +2957,13 @@ impl PointCloudChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::PointCloud, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::PointCloud, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -2984,10 +3066,13 @@ impl PointsAnnotationChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::PointsAnnotation, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::PointsAnnotation, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3090,10 +3175,13 @@ impl PoseChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Pose, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Pose, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3191,10 +3279,13 @@ impl PoseInFrameChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::PoseInFrame, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::PoseInFrame, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3297,10 +3388,13 @@ impl PosesInFrameChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::PosesInFrame, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::PosesInFrame, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3403,10 +3497,13 @@ impl QuaternionChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Quaternion, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Quaternion, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3509,10 +3606,13 @@ impl RawAudioChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::RawAudio, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::RawAudio, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3615,10 +3715,13 @@ impl RawImageChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::RawImage, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::RawImage, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3721,10 +3824,13 @@ impl SpherePrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::SpherePrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::SpherePrimitive, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3827,10 +3933,13 @@ impl TextAnnotationChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::TextAnnotation, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::TextAnnotation, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -3933,10 +4042,13 @@ impl TextPrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::TextPrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::TextPrimitive, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -4039,10 +4151,18 @@ impl TriangleListPrimitiveChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::TriangleListPrimitive, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(
+        &self,
+        msg: &schemas::TriangleListPrimitive,
+        log_time: Option<u64>,
+        sink_id: Option<u64>,
+    ) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -4145,10 +4265,13 @@ impl Vector2Channel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Vector2, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Vector2, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -4246,10 +4369,13 @@ impl Vector3Channel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::Vector3, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::Vector3, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -10,6 +10,7 @@ use pyo3::types::PyDict;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::BufWriter;
+use std::num::NonZeroU64;
 use std::path::PathBuf;
 use std::sync::Arc;
 use websocket::start_server;
@@ -89,10 +90,11 @@ impl BaseChannel {
         Ok(BaseChannel(channel))
     }
 
-    #[pyo3(signature = (msg, log_time=None))]
-    fn log(&self, msg: &[u8], log_time: Option<u64>) -> PyResult<()> {
+    #[pyo3(signature = (msg, log_time=None, sink_id=None))]
+    fn log(&self, msg: &[u8], log_time: Option<u64>, sink_id: Option<u64>) -> PyResult<()> {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(msg, metadata);
+        let sink_id = sink_id.and_then(NonZeroU64::new).map(foxglove::SinkId::new);
+        self.0.log_with_meta_to_sink(msg, metadata, sink_id);
         Ok(())
     }
 

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -870,8 +870,7 @@ void FoxgloveBridge::rosMessageHandler(ChannelId channelId, SinkId sinkId,
   }
 
   auto& channel = _channels.at(channelId);
-  // TODO: Change to log() when the released SDK is updated to make this a public overload
-  channel.log_(reinterpret_cast<const std::byte*>(rclSerializedMsg.buffer),
+  channel.log(reinterpret_cast<const std::byte*>(rclSerializedMsg.buffer),
                rclSerializedMsg.buffer_length, timestamp, sinkId);
 }
 

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -133,7 +133,6 @@ impl<T: Encode> Channel<T> {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
-    #[doc(hidden)]
     pub fn log_to_sink(&self, msg: &T, sink_id: Option<SinkId>) {
         self.log_with_meta_to_sink(msg, PartialMetadata::default(), sink_id);
     }
@@ -153,7 +152,6 @@ impl<T: Encode> Channel<T> {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
-    #[doc(hidden)]
     pub fn log_with_meta_to_sink(
         &self,
         msg: &T,

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -168,7 +168,6 @@ impl RawChannel {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
-    #[doc(hidden)]
     pub fn log_to_sink(&self, msg: &[u8], sink_id: Option<SinkId>) {
         self.log_with_meta_to_sink(msg, PartialMetadata::default(), sink_id);
     }
@@ -188,7 +187,6 @@ impl RawChannel {
     ///
     /// The buffering behavior depends on the log sink; see [`McapWriter`][crate::McapWriter] and
     /// [`WebSocketServer`][crate::WebSocketServer] for details.
-    #[doc(hidden)]
     pub fn log_with_meta_to_sink(
         &self,
         msg: &[u8],

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -609,11 +609,12 @@ export function generateChannelClasses(messageSchemas: FoxgloveMessageSchema[]):
 
   const imports = [
     `use crate::{PyContext, PySchema};`,
-    `use foxglove::{Channel, ChannelBuilder, PartialMetadata};`,
+    `use foxglove::{Channel, ChannelBuilder, PartialMetadata, SinkId};`,
     `use pyo3::prelude::*;`,
     `use pyo3::types::PyDict;`,
     `use super::schemas;`,
     `use std::collections::BTreeMap;`,
+    `use std::num::NonZero;`,
   ].join("\n");
 
   const channelModuleRegistration = generateChannelModuleRegistration(schemas);
@@ -708,14 +709,18 @@ impl ${channelClass} {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
     fn log(
         &self,
         msg: &schemas::${schemaClass},
         log_time: Option<u64>,
+        sink_id: Option<u64>,
     ) {
         let metadata = PartialMetadata{ log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {
@@ -804,6 +809,7 @@ export function generatePyChannelStub(messageSchemas: FoxgloveMessageSchema[]): 
         `        message: "${schemaClass}",`,
         `        *,`,
         `        log_time: int | None = None,`,
+        `        sink_id: int | None = None,`,
         `    ) -> None:`,
         `        """Log a Foxglove ${schemaClass} message on the channel."""`,
         `        ...`,

--- a/typescript/schemas/src/internal/generateSdkRustCTypes.ts
+++ b/typescript/schemas/src/internal/generateSdkRustCTypes.ts
@@ -230,14 +230,14 @@ impl BorrowToNative for ${name} {
 /// # Safety
 /// The channel must have been created for this type with foxglove_channel_create_${snakeName}.
 #[unsafe(no_mangle)]
-pub extern "C" fn foxglove_channel_log_${snakeName}(channel: Option<&FoxgloveChannel>, msg: Option<&${name}>, log_time: Option<&u64>) -> FoxgloveError {
+pub extern "C" fn foxglove_channel_log_${snakeName}(channel: Option<&FoxgloveChannel>, msg: Option<&${name}>, log_time: Option<&u64>, sink_id: FoxgloveSinkId) -> FoxgloveError {
   let mut arena = pin!(Arena::new());
   let arena_pin = arena.as_mut();
   // Safety: we're borrowing from the msg, but discard the borrowed message before returning
   match unsafe { ${name}::borrow_option_to_native(msg, arena_pin) } {
     Ok(msg) => {
       // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-      log_msg_to_channel(channel, &*msg, log_time)
+      log_msg_to_channel(channel, &*msg, log_time, sink_id)
     },
     Err(e) => {
       tracing::error!("${name}: {}", e);
@@ -253,7 +253,7 @@ pub extern "C" fn foxglove_channel_log_${snakeName}(channel: Option<&FoxgloveCha
     "use std::mem::ManuallyDrop;",
     "use std::pin::{pin, Pin};",
     "",
-    "use crate::{FoxgloveString, FoxgloveError, FoxgloveChannel, FoxgloveContext, FoxgloveTimestamp, FoxgloveDuration, log_msg_to_channel, result_to_c, do_foxglove_channel_create};",
+    "use crate::{FoxgloveString, FoxgloveError, FoxgloveChannel, FoxgloveContext, FoxgloveTimestamp, FoxgloveDuration, log_msg_to_channel, result_to_c, do_foxglove_channel_create, FoxgloveSinkId};",
     "use crate::arena::{Arena, BorrowToNative};",
     "use crate::util::{bytes_from_raw, string_from_raw, vec_from_raw};",
   ];


### PR DESCRIPTION
### Changelog
See #567

### Description

This reverts #578 (sink IDs) and re-generates the schemas to produce VoxelGrid logging functions that support it.