### PR TITLE
Package foxglove_bridge in docker image

### DIFF
--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -56,13 +56,10 @@ jobs:
       - name: Compute image tags
         id: compute-tags
         run: |
-          set -euo pipefail
           IMAGE_BASE="${DOCKER_REPO}"
           DISTRO="${{ matrix.ros_distribution }}"
           TAG="${IMAGE_BASE}:ros-${DISTRO}-${IMAGE_VERSION}"
-          printf 'tag<<EOF\n' >> "$GITHUB_OUTPUT"
-          printf '%s\n' "${TAG}" >> "$GITHUB_OUTPUT"
-          printf 'EOF\n' >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -72,6 +69,6 @@ jobs:
           push: true
           build-args: |
             ROS_DISTRIBUTION=${{ matrix.ros_distribution }}
-          tags: ${{ steps.compute-tags.outputs.tags }}
+          tags: ${{ steps.compute-tags.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -3,7 +3,6 @@ name: Publish ROS Bridge Docker image
 on:
   workflow_dispatch: {}
   push:
-    branches: [main]
     tags: ['sdk/v*']
 
 permissions:
@@ -46,11 +45,11 @@ jobs:
           # Check if this is a release tag (sdk/v*)
           if [[ "${GITHUB_REF}" == refs/tags/sdk/v* ]]; then
             # Extract version from release tag (remove sdk/ prefix)
-            VERSION=$(echo "${GITHUB_REF}" | sed 's|refs/tags/sdk/||')
+            VERSION=${GITHUB_REF#refs/tags/sdk/}
             echo "Using release version: ${VERSION}"
           else
             # Use git SHA for non-release builds
-            VERSION=$(echo "${GITHUB_SHA}")
+            VERSION="${GITHUB_SHA}"
             echo "Using SHA version: ${VERSION}"
           fi
 

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Setup qemu
-        uses: docker/setup-qemu-action@v3
-
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
 
@@ -72,8 +69,7 @@ jobs:
         with:
           context: ros/src/foxglove_bridge
           file: ros/src/foxglove_bridge/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          push: true 
+          push: true
           build-args: |
             ROS_DISTRIBUTION=${{ matrix.ros_distribution }}
           tags: ${{ steps.compute-tags.outputs.tag }}

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Setup qemu
+        uses: docker/setup-qemu-action@v3
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
 
@@ -69,7 +72,8 @@ jobs:
         with:
           context: ros/src/foxglove_bridge
           file: ros/src/foxglove_bridge/Dockerfile
-          push: true
+          platforms: linux/amd64, linux/arm64
+          push: true 
           build-args: |
             ROS_DISTRIBUTION=${{ matrix.ros_distribution }}
           tags: ${{ steps.compute-tags.outputs.tag }}

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -59,12 +59,9 @@ jobs:
           set -euo pipefail
           IMAGE_BASE="${DOCKER_REPO}"
           DISTRO="${{ matrix.ros_distribution }}"
-          TAGS=("${IMAGE_BASE}:ros-${DISTRO}-${IMAGE_VERSION}")
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            TAGS+=("${IMAGE_BASE}:ros-${DISTRO}-latest")
-          fi
-          printf 'tags<<EOF\n' >> "$GITHUB_OUTPUT"
-          printf '%s\n' "${TAGS[@]}" >> "$GITHUB_OUTPUT"
+          TAG="${IMAGE_BASE}:ros-${DISTRO}-${IMAGE_VERSION}"
+          printf 'tag<<EOF\n' >> "$GITHUB_OUTPUT"
+          printf '%s\n' "${TAG}" >> "$GITHUB_OUTPUT"
           printf 'EOF\n' >> "$GITHUB_OUTPUT"
 
       - name: Build and push

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -42,8 +42,8 @@ jobs:
 
           # Check if this is a release tag (sdk/v*)
           if [[ "${GITHUB_REF}" == refs/tags/sdk/v* ]]; then
-            # Extract version from release tag (remove sdk/v prefix)
-            VERSION=$(echo "${GITHUB_REF}" | sed 's|refs/tags/sdk/v||')
+            # Extract version from release tag (remove sdk/ prefix)
+            VERSION=$(echo "${GITHUB_REF}" | sed 's|refs/tags/sdk/||')
             echo "Using release version: ${VERSION}"
           else
             # Use git SHA for non-release builds
@@ -69,7 +69,7 @@ jobs:
         with:
           context: ros/src/foxglove_bridge
           file: ros/src/foxglove_bridge/Dockerfile
-          push: false # TODO: enable push
+          push: true
           build-args: |
             ROS_DISTRIBUTION=${{ matrix.ros_distribution }}
           tags: ${{ steps.compute-tags.outputs.tags }}

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -1,0 +1,80 @@
+name: Publish ROS Bridge Docker image
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main, eric/docker-package-bridge]
+    tags: ['sdk/v*']
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-push:
+    name: "publish (${{ matrix.ros_distribution }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distribution: [humble, jazzy, kilted, rolling]
+    env:
+      REGION: us-central1
+      DOCKER_REGISTRY: $REGION-docker.pkg.dev
+      DOCKER_REPO: $DOCKER_REGISTRY/foxglove-images/images/foxglove_bridge
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v3
+      # - name: Auth gcloud
+      #   uses: google-github-actions/auth@v2
+      #   with:
+      #     credentials_json: ${{ secrets.PUBLISHER_KEY }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Compute version for tagging
+        run: |
+          set -euo pipefail
+
+          # Check if this is a release tag (sdk/v*)
+          if [[ "${GITHUB_REF}" == refs/tags/sdk/v* ]]; then
+            # Extract version from release tag (remove sdk/v prefix)
+            VERSION=$(echo "${GITHUB_REF}" | sed 's|refs/tags/sdk/v||')
+            echo "Using release version: ${VERSION}"
+          else
+            # Use git SHA for non-release builds
+            VERSION=$(echo "${GITHUB_SHA}")
+            echo "Using SHA version: ${VERSION}"
+          fi
+
+          echo "IMAGE_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Compute image tags
+        id: compute-tags
+        run: |
+          set -euo pipefail
+          IMAGE_BASE="${DOCKER_REPO}"
+          DISTRO="${{ matrix.ros_distribution }}"
+          TAGS=("${IMAGE_BASE}:ros-${DISTRO}-${IMAGE_VERSION}")
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            TAGS+=("${IMAGE_BASE}:ros-${DISTRO}-latest")
+          fi
+          printf 'tags<<EOF\n' >> "$GITHUB_OUTPUT"
+          printf '%s\n' "${TAGS[@]}" >> "$GITHUB_OUTPUT"
+          printf 'EOF\n' >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ros/src/foxglove_bridge
+          file: ros/src/foxglove_bridge/Dockerfile
+          push: false # TODO: enable push
+          build-args: |
+            ROS_DISTRIBUTION=${{ matrix.ros_distribution }}
+          tags: ${{ steps.compute-tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -27,10 +27,12 @@ jobs:
 
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
-      # - name: Auth gcloud
-      #   uses: google-github-actions/auth@v2
-      #   with:
-      #     credentials_json: ${{ secrets.PUBLISHER_KEY }}
+
+      - name: Auth gcloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.PUBLISHER_KEY }}
+
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
 

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -3,7 +3,7 @@ name: Publish ROS Bridge Docker image
 on:
   workflow_dispatch: {}
   push:
-    branches: [main, eric/docker-package-bridge]
+    branches: [main]
     tags: ['sdk/v*']
 
 permissions:

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Configure gcloud docker
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
       - name: Compute version for tagging
         run: |
           set -euo pipefail

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -19,9 +19,7 @@ jobs:
       matrix:
         ros_distribution: [humble, jazzy, kilted, rolling]
     env:
-      REGION: us-central1
-      DOCKER_REGISTRY: $REGION-docker.pkg.dev
-      DOCKER_REPO: $DOCKER_REGISTRY/foxglove-images/images/foxglove_bridge
+      DOCKER_REPO: us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge
 
     steps:
       - name: Checkout

--- a/ros/src/foxglove_bridge/Dockerfile
+++ b/ros/src/foxglove_bridge/Dockerfile
@@ -1,0 +1,43 @@
+ARG ROS_DISTRIBUTION=rolling
+FROM ros:$ROS_DISTRIBUTION-ros-base
+
+RUN apt-get update
+
+# Create foxglove user
+ARG USERNAME=foxglove
+ARG USER_UID=1005
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME
+
+USER $USERNAME
+
+# rosdep update must run as user
+RUN rosdep update --include-eol-distros
+
+# Set up the workspace
+WORKDIR /ros
+COPY --chown=$USER_UID:$USER_GID . /ros/src/foxglove_bridge
+
+# Install ROS dependencies
+RUN rosdep install -y \
+    --from-paths src \
+    --ignore-src
+
+# Build bridge
+RUN /bin/bash -c '. /opt/ros/$ROS_DISTRO/setup.bash && \
+    colcon build --packages-select foxglove_bridge'
+
+RUN echo '#!/bin/bash\n\
+set -e\n\
+\n\
+source /ros/install/setup.bash\n\
+\n\
+exec ros2 launch foxglove_bridge foxglove_bridge_launch.xml "$@"' > /ros/entrypoint.sh \
+    && chmod +x /ros/entrypoint.sh
+
+
+EXPOSE 8765
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/ros/src/foxglove_bridge/Dockerfile
+++ b/ros/src/foxglove_bridge/Dockerfile
@@ -29,13 +29,15 @@ RUN rosdep install -y \
 RUN /bin/bash -c '. /opt/ros/$ROS_DISTRO/setup.bash && \
     colcon build --packages-select foxglove_bridge'
 
-RUN echo '#!/bin/bash\n\
-set -e\n\
-\n\
-source /ros/install/setup.bash\n\
-\n\
-exec ros2 launch foxglove_bridge foxglove_bridge_launch.xml "$@"' > /ros/entrypoint.sh \
-    && chmod +x /ros/entrypoint.sh
+RUN <<EOF
+# Write out bash script to source ROS setup script and wrap launch file
+echo '#!/bin/bash
+set -e
+source /ros/install/setup.bash
+exec ros2 launch foxglove_bridge foxglove_bridge_launch.xml "$@"' > /ros/entrypoint.sh
+
+chmod +x /ros/entrypoint.sh
+EOF
 
 
 EXPOSE 8765

--- a/ros/src/foxglove_bridge/README.md
+++ b/ros/src/foxglove_bridge/README.md
@@ -36,9 +36,9 @@ where `<tag>` takes the form of:
 ros-<ROS distro>-<foxglove SDK version>
 ```
 
-For example, if you wanted to pull an image based on ROS Kilted and Foxglove SDK v0.11:
+For example, if you wanted to pull an image based on ROS Kilted and Foxglove SDK v0.11.0:
 ```bash
-docker pull us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge:ros-kilted-v0.11
+docker pull us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge:ros-kilted-v0.11.0
 ```
 
 

--- a/ros/src/foxglove_bridge/README.md
+++ b/ros/src/foxglove_bridge/README.md
@@ -19,10 +19,28 @@ Live debugging of ROS systems has traditionally relied on running ROS tooling su
 The `foxglove_bridge` uses the **Foxglove SDK** (this repo!), a similar protocol to rosbridge but with the ability to support additional schema formats such as ROS 2 `.msg` and ROS 2 `.idl`, parameters, graph introspection, and non-ROS systems. The bridge is written in C++ and designed for high performance with low overhead to minimize the impact to your robot stack.
 
 ## Build and install
+### Install using Docker
+Docker images are built and published to our public Docker image registry for your convenience.
 
-Currently, `foxglove_bridge` must be built from source.
+Images can be pulled with
 
-### Getting the sources
+```bash
+docker pull us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge:<tag>
+```
+
+where `<tag>` takes the form of:
+```
+ros-<ROS distro>-<foxglove SDK version>
+```
+
+For example, if you wanted to pull an image based on ROS Kilted and Foxglove SDK v0.11:
+```bash
+docker pull us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge:ros-kilted-v0.11
+```
+
+
+### Build from source
+#### Getting the sources
 
 Clone this repo from GitHub and `cd` to the local ROS workspace:
 
@@ -33,7 +51,7 @@ cd foxglove-sdk/ros
 
 All commands in this README hereafter assume you're in the `/ros` subdirectory relative to the repository's root.
 
-### Build using your ROS environment
+#### Build using your ROS environment
 
 Make sure you have ROS installed and your setup files are sourced. Then build:
 
@@ -41,7 +59,7 @@ Make sure you have ROS installed and your setup files are sourced. Then build:
 make
 ```
 
-### Build using Docker
+#### Build using Docker
 
 You can also build the bridge using a ROS environment within a Docker container:
 

--- a/ros/src/foxglove_bridge/README.md
+++ b/ros/src/foxglove_bridge/README.md
@@ -22,6 +22,9 @@ The `foxglove_bridge` uses the **Foxglove SDK** (this repo!), a similar protocol
 ### Install using Docker
 Docker images are built and published to our public Docker image registry for your convenience.
 
+> [!NOTE]
+> We currently only provide Docker builds targeted to the `linux/amd64` platform.
+
 Images can be pulled with
 
 ```bash

--- a/ros/src/foxglove_bridge/package.xml
+++ b/ros/src/foxglove_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>foxglove_bridge</name>
-    <version>0.9.0</version>
+    <version>0.11.0</version>
     <description>ROS Foxglove Bridge</description>
     <license>MIT</license>
     <url type="website">https://github.com/foxglove/foxglove-sdk</url>


### PR DESCRIPTION
### Changelog
- [Foxglove Bridge] The public beta of Foxglove Bridge is now packaged as a Docker image in our public image registry

### Docs
README.md for bridge updated with image pull instructions

### Description
Create GHA workflow for pushing a Docker image containing the Foxglove Bridge to our public image registry. This is in response to customer feedback that providing these images helps them more easily deploy Foxglove Bridge.

Images are built against all currently supported versions of ROS. The GHA workflow is currently configured to build the bridge:
- On a push to `main`, where the version identifier will be the git SHA of the commit on `main`
- On an SDK release tag (i.e. `sdk/vxxx`), where the version identifier will be the SDK version number

The version number of Foxglove Bridge is incremented to equal that of Foxglove SDK, as per our consensus that the versioning/release cadence of these components should be coupled going forward.

Fixes: FLE-1