### PR TITLE
Re-generate LocationFixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS builder
+FROM rust:1.89-bookworm AS builder
 
 ARG MSRV_RUST_VERSION=1.83.0
 
@@ -13,14 +13,14 @@ RUN bash nodesource_setup.sh
 
 RUN apt-get update \
     && apt-get install -y \
-        clang-19 \
-        clang-format-19 \
-        clang-tidy-19 \
-        cmake \
-        doxygen \
-        nodejs \
-        protobuf-compiler \
-        python3.13-dev \
+        clang-19=1:19.1.4-1~deb12u1 \
+        clang-format-19=1:19.1.4-1~deb12u1 \
+        clang-tidy-19=1:19.1.4-1~deb12u1 \
+        cmake=3.25.1-1 \
+        doxygen=1.9.4-4 \
+        nodejs=23.11.1-1nodesource1 \
+        protobuf-compiler=3.21.12-3 \
+        python3.11-dev=3.11.2-6+deb12u6 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ RUN bash nodesource_setup.sh
 
 RUN apt-get update \
     && apt-get install -y \
-        clang-19=1:19.1.4-1~deb12u1 \
-        clang-format-19=1:19.1.4-1~deb12u1 \
-        clang-tidy-19=1:19.1.4-1~deb12u1 \
-        cmake=3.25.1-1 \
-        doxygen=1.9.4-4 \
-        nodejs=23.11.1-1nodesource1 \
-        protobuf-compiler=3.21.12-3 \
-        python3.11-dev=3.11.2-6+deb12u6 \
+        clang-19 \
+        clang-format-19 \
+        clang-tidy-19 \
+        cmake \
+        doxygen \
+        nodejs \
+        protobuf-compiler \
+        python3.13-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable yarn

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2694,7 +2694,8 @@ foxglove_error foxglove_channel_create_location_fixes(struct foxglove_string top
  */
 foxglove_error foxglove_channel_log_location_fixes(const struct foxglove_channel *channel,
                                                    const struct foxglove_location_fixes *msg,
-                                                   const uint64_t *log_time);
+                                                   const uint64_t *log_time,
+                                                   FoxgloveSinkId sink_id);
 
 /**
  * Create a new typed channel, and return an owned raw channel pointer to it.

--- a/c/src/generated_types.rs
+++ b/c/src/generated_types.rs
@@ -2032,6 +2032,7 @@ pub extern "C" fn foxglove_channel_log_location_fixes(
     channel: Option<&FoxgloveChannel>,
     msg: Option<&LocationFixes>,
     log_time: Option<&u64>,
+    sink_id: FoxgloveSinkId,
 ) -> FoxgloveError {
     let mut arena = pin!(Arena::new());
     let arena_pin = arena.as_mut();
@@ -2039,7 +2040,7 @@ pub extern "C" fn foxglove_channel_log_location_fixes(
     match unsafe { LocationFixes::borrow_option_to_native(msg, arena_pin) } {
         Ok(msg) => {
             // Safety: this casts channel back to a typed channel for type of msg, it must have been created for this type.
-            log_msg_to_channel(channel, &*msg, log_time)
+            log_msg_to_channel(channel, &*msg, log_time, sink_id)
         }
         Err(e) => {
             tracing::error!("LocationFixes: {}", e);

--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -1930,8 +1930,10 @@ public:
   ///
   /// @param msg The LocationFixes message to log.
   /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
-    const LocationFixes& msg, std::optional<uint64_t> log_time = std::nullopt
+    const LocationFixes& msg, std::optional<uint64_t> log_time = std::nullopt,
+    std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
   /// @brief Uniquely identifies a channel in the context of this program.

--- a/cpp/foxglove/src/schemas.cpp
+++ b/cpp/foxglove/src/schemas.cpp
@@ -553,14 +553,14 @@ FoxgloveResult<LocationFixesChannel> LocationFixesChannel::create(
 }
 
 FoxgloveError LocationFixesChannel::log(
-  const LocationFixes& msg, std::optional<uint64_t> log_time
+  const LocationFixes& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id
 ) noexcept {
   Arena arena;
   foxglove_location_fixes c_msg;
   locationFixesToC(c_msg, msg, arena);
-  return FoxgloveError(
-    foxglove_channel_log_location_fixes(impl_.get(), &c_msg, log_time ? &*log_time : nullptr)
-  );
+  return FoxgloveError(foxglove_channel_log_location_fixes(
+    impl_.get(), &c_msg, log_time ? &*log_time : nullptr, sink_id ? *sink_id : 0
+  ));
 }
 
 uint64_t LocationFixesChannel::id() const noexcept {

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/channels.pyi
@@ -1247,6 +1247,7 @@ class LocationFixesChannel:
         message: "LocationFixes",
         *,
         log_time: int | None = None,
+        sink_id: int | None = None,
     ) -> None:
         """Log a Foxglove LocationFixes message on the channel."""
         ...

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -2101,10 +2101,13 @@ impl LocationFixesChannel {
     /// :param log_time: The log time is the time, as nanoseconds from the unix epoch, that the
     ///     message was recorded. Usually this is the time log() is called. If omitted, the
     ///     current time is used.
-    #[pyo3(signature = (msg, *, log_time=None))]
-    fn log(&self, msg: &schemas::LocationFixes, log_time: Option<u64>) {
+    /// :param sink_id: The ID of the sink to log to. If omitted, the message is logged to all sinks.
+    #[pyo3(signature = (msg, *, log_time=None, sink_id=None))]
+    fn log(&self, msg: &schemas::LocationFixes, log_time: Option<u64>, sink_id: Option<u64>) {
         let metadata = PartialMetadata { log_time };
-        self.0.log_with_meta(&msg.0, metadata);
+        let sink_id = sink_id.and_then(NonZero::new).map(SinkId::new);
+
+        self.0.log_with_meta_to_sink(&msg.0, metadata, sink_id);
     }
 
     fn __repr__(&self) -> String {


### PR DESCRIPTION
### Changelog
None

### Description

This re-runs `generate` to update schemas. I hadn't merged latest main into #556 before merging, and it missed a recent addition to the channel interface from v0.11.