### PR TITLE
Dependabot: Ignore minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
 
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
Our cargo packages are used as libraries, which means we are permissive on which versions of dependencies are used. Cargo uses [caret ranges by default](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements).

We therefore get very little value from endless PRs like https://github.com/foxglove/foxglove-sdk/pull/606 which make minor updates to our lockfile. We can manually update the lockfile occasionally without spamming our git history.

Using learnings from https://github.com/foxglove/ros-typescript/pull/83. Dependabot [does not currently support](https://github.com/dependabot/dependabot-core/issues/4009) `versioning-strategy: "increase-if-necessary"` for Cargo so I left that out.