### PR TITLE
update to MCAP v0.23.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ name = "example_channelless"
 version = "0.0.0"
 dependencies = [
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "mcap",
  "schemars 1.0.4",
  "serde",
@@ -537,7 +537,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -550,7 +550,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "schemars 1.0.4",
  "serde",
 ]
@@ -561,7 +561,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "tokio",
  "tokio-util",
 ]
@@ -570,7 +570,7 @@ dependencies = [
 name = "example_prost"
 version = "0.0.0"
 dependencies = [
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "prost",
  "prost-build",
 ]
@@ -581,16 +581,16 @@ version = "0.0.0"
 dependencies = [
  "ctrlc",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
 ]
 
 [[package]]
 name = "example_structured_logging"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "schemars 1.0.4",
  "serde",
  "serde_json",
@@ -602,7 +602,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "quaternion",
  "tokio",
 ]
@@ -614,7 +614,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
 ]
 
 [[package]]
@@ -623,7 +623,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "tokio",
 ]
 
@@ -635,7 +635,7 @@ dependencies = [
  "bytes",
  "clap",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "futures",
  "parking_lot",
  "schemars 1.0.4",
@@ -656,7 +656,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "mcap",
  "tracing",
 ]
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "foxglove"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -733,7 +733,7 @@ dependencies = [
  "chrono",
  "delegate",
  "flume",
- "foxglove_derive 0.12.0",
+ "foxglove_derive 0.12.1",
  "futures-util",
  "insta",
  "maplit",
@@ -760,11 +760,11 @@ dependencies = [
 
 [[package]]
 name = "foxglove-sdk-python"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "bytes",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "log",
  "prost-types",
  "pyo3",
@@ -779,13 +779,13 @@ dependencies = [
 
 [[package]]
 name = "foxglove_c"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "bitflags",
  "cbindgen",
  "env_logger",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "log",
  "maplit",
  "mcap",
@@ -818,10 +818,10 @@ dependencies = [
 
 [[package]]
 name = "foxglove_derive"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
- "foxglove 0.12.0",
+ "foxglove 0.12.1",
  "proc-macro2",
  "prost",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1254,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "mcap"
-version = "0.23.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232d57c96a84a7ef13f6e9035520d911ab1359b107a7266a57149175b9f0034"
+checksum = "900ec4fb152ab00bd02fe030787593dfd661b7711f7917ac732b85c22c773387"
 dependencies = [
  "bimap",
  "binrw",
@@ -1791,7 +1791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ members = [
   "python/foxglove-sdk",
 ]
 
-exclude = [
-  "rust/examples/rgb_camera_visualization"
-]
+exclude = ["rust/examples/rgb_camera_visualization"]
 
 [workspace.package]
 version = "0.12.0"
@@ -24,7 +22,7 @@ license = "MIT"
 [workspace.dependencies]
 bytes = "1.9.0"
 log = "0.4.22"
-mcap = { version = "0.23", default-features = false }
+mcap = { version = "0.23.3", default-features = false }
 prost = "0.13"
 prost-build = "0.13"
 prost-types = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["rust/examples/rgb_camera_visualization"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 rust-version = "1.83.0"
 repository = "https://github.com/foxglove/foxglove-sdk"

--- a/cpp/foxglove/docs/version.py
+++ b/cpp/foxglove/docs/version.py
@@ -1,1 +1,1 @@
-SDK_VERSION = "0.12.0"
+SDK_VERSION = "0.12.1"

--- a/python/foxglove-sdk/python/docs/version.py
+++ b/python/foxglove-sdk/python/docs/version.py
@@ -1,1 +1,1 @@
-SDK_VERSION = "0.12.0"
+SDK_VERSION = "0.12.1"

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -37,7 +37,7 @@ bytes.workspace = true
 chrono = { version = "0.4.39", optional = true }
 delegate = "0.13.2"
 flume = { version = "0.11.1", optional = true }
-foxglove_derive = { version = "0.12.0", path = "../foxglove_derive", optional = true }
+foxglove_derive = { version = "0.12.1", path = "../foxglove_derive", optional = true }
 futures-util = { version = "0.3.31", features = ["sink", "std"], optional = true }
 mcap.workspace = true
 parking_lot = "0.12.4"


### PR DESCRIPTION
### Changelog
- Fixed an error where the McapWriter would cause a panic if the underlying I/O failed.

### Docs

None.
### Description

The previous version of the MCAP writer library would panic if `write()` was called on it after a previous failed write. The updated version of this library returns an error in this case, which the SDK converts to a logged warning.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

Failing underlying storage for the MCAP writer would cause a panic
</td><td>

If the underlying storage fails, the MCAP writer will not write, and a warning will be logged.
</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

