### PR TITLE
cpp_data_loader.yml: define SDK_VERSION in step

### DIFF
--- a/.github/workflows/cpp_data_loader.yml
+++ b/.github/workflows/cpp_data_loader.yml
@@ -19,8 +19,6 @@ jobs:
   build:
     name: Build C++ Foxglove Data Loader SDK
     runs-on: ubuntu-latest
-    env:
-      SDK_VERSION: ${{inputs.sdk_version || github.sha}}
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -33,11 +31,15 @@ jobs:
           tar xf wasi-sdk-25.0-x86_64-linux.tar.gz
           rm wasi-sdk-25.0-x86_64-linux.tar.gz
           echo WASI_SDK=$(pwd)/wasi-sdk-25.0-x86_64-linux >> $GITHUB_ENV
-      - name: Build the examples
+      - name: Build the example
         working-directory: cpp/foxglove_data_loader
-        run: make package
-      - name: build archive
+        env:
+          SDK_VERSION: ${{inputs.sdk_version || github.sha}}
+        run: make example
+      - name: Build the package
         working-directory: cpp/foxglove_data_loader
+        env:
+          SDK_VERSION: ${{inputs.sdk_version || github.sha}}
         run: make package
       - name: Upload static & shared library to artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Changelog
None
### Docs

None
### Description

The draft release process is broken right now, because job inputs aren't available in the `env` block of a job, apparently.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

