### PR TITLE
C++ data loaders: correct build string

### DIFF
--- a/cpp/foxglove_data_loader/Makefile
+++ b/cpp/foxglove_data_loader/Makefile
@@ -74,4 +74,5 @@ target/data_loader_example.wasm: examples/data_loader.cpp $(packagefiles)
 		-Wall -Werror \
 		-mexec-model=reactor \
 		-fno-exceptions \
-		--target=wasm32-wasi
+		--target=wasm32-wasip1 \
+		--sysroot=$(WASI_SDK)/share/wasi-sysroot


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

None.

### Description

This should help customers get their build step for C++ data loaders right the first time.
