### PR TITLE
Fix UID conflict in Dockerfile.ros

### DIFF
--- a/Dockerfile.ros
+++ b/Dockerfile.ros
@@ -3,14 +3,22 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 
 RUN apt-get update
 
-# create foxglove user
+# create foxglove user (or use existing user if UID matches)
 ARG USERNAME=foxglove
 ARG USER_UID=1005
 ARG USER_GID=$USER_UID
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME
-USER $USERNAME
+RUN <<EOF
+if ! getent passwd $USER_UID >/dev/null 2>&1; then
+    groupadd --gid $USER_GID $USERNAME
+    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME
+else
+    EXISTING_USER=$(getent passwd $USER_UID | cut -d: -f1)
+    echo "User with UID $USER_UID already exists: $EXISTING_USER"
+    echo "$EXISTING_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$EXISTING_USER
+fi
+EOF
+USER $USER_UID
 
 # rosdep update must run as user
 RUN rosdep update --include-eol-distros

--- a/ros/Makefile
+++ b/ros/Makefile
@@ -33,6 +33,7 @@ define generate_ros_targets
 .PHONY: docker-build-image-$(1)
 docker-build-image-$(1):
 	docker build -t foxglove-sdk-ros-$(1) -f ../Dockerfile.ros \
+		--pull \
 		--build-arg ROS_DISTRIBUTION=$(1) \
 		$(DOCKER_USER_ARGS) \
 		$(EXTRA_DOCKER_ARGS) ..


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Fix issue in ROS Docker builds under Linux where the passed USER_UID (typically 1000) conflicts with an existing user in the ROS base image. Previously, this seems to have worked but after re-pulling the base system layers, it seems a user now exists with UID 1000. This adds logic to check if a user with that UID already exists and, if so, to use it.