### PR TITLE
fix errors on bridge shutdown

### DIFF
--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -760,10 +760,12 @@ void FoxgloveBridge::clientUnadvertise(ClientId clientId, ChannelId clientChanne
 
   _clientAdvertisedTopics.erase(it);
 
+  if (!_shuttingDown && rclcpp::ok()) {
   // Create a timer that immedeately goes out of scope (so it never fires) which will trigger
   // the previously destroyed publisher to be cleaned up. This is a workaround for
   // https://github.com/ros2/rclcpp/issues/2146
-  this->create_wall_timer(1s, []() {});
+    this->create_wall_timer(1s, []() {});
+  }
 }
 
 void FoxgloveBridge::clientMessage(ClientId clientId, ChannelId clientChannelId,

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -761,9 +761,9 @@ void FoxgloveBridge::clientUnadvertise(ClientId clientId, ChannelId clientChanne
   _clientAdvertisedTopics.erase(it);
 
   if (!_shuttingDown && rclcpp::ok()) {
-  // Create a timer that immedeately goes out of scope (so it never fires) which will trigger
-  // the previously destroyed publisher to be cleaned up. This is a workaround for
-  // https://github.com/ros2/rclcpp/issues/2146
+    // Create a timer that immedeately goes out of scope (so it never fires) which will trigger
+    // the previously destroyed publisher to be cleaned up. This is a workaround for
+    // https://github.com/ros2/rclcpp/issues/2146
     this->create_wall_timer(1s, []() {});
   }
 }

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
@@ -26,12 +26,17 @@ int main(int argc, char* argv[]) {
     numThreads = static_cast<size_t>(dummyNode->get_parameter(numThreadsDescription.name).as_int());
   }
 
-  auto executor =
-    rclcpp::executors::MultiThreadedExecutor::make_shared(rclcpp::ExecutorOptions{}, numThreads);
+  {
+    auto executor =
+      rclcpp::executors::MultiThreadedExecutor::make_shared(rclcpp::ExecutorOptions{}, numThreads);
 
-  foxglove_bridge::FoxgloveBridge node;
-  executor->add_node(node.get_node_base_interface());
-  executor->spin();
+    auto node = std::make_shared<foxglove_bridge::FoxgloveBridge>();
+    executor->add_node(node->get_node_base_interface());
+    executor->spin();
+    executor->remove_node(node->get_node_base_interface());
+    // node and executor go out of scope here; node destructor stops the server while ROS is valid
+  }
+
   rclcpp::shutdown();
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
### Changelog
Fix foxglove bridge node occasionally logging errors when shutting down

### Docs
None

### Description
Fixes https://github.com/foxglove/ros-foxglove-bridge/issues/370

When the foxglove bridge node is shutting down, it occasionally logs the following error(s):
```
[WS] Exception caught when closing connection: Couldn't initialize rcl timer handle: the given context is not valid, either rcl_init() was not called or rcl_shutdown() was called., at ./src/rcl/guard_condition.c:67
```

This PR should fix that by omitting to create the time when the node is shutting down. 


