### PR TITLE
c/cpp: Fix schema name for GeoJSON

### DIFF
--- a/c/src/generated_types.rs
+++ b/c/src/generated_types.rs
@@ -1983,7 +1983,7 @@ pub extern "C" fn foxglove_channel_log_geo_json(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn foxglove_geo_json_schema() -> FoxgloveSchema {
     let native = foxglove::schemas::GeoJson::get_schema().expect("GeoJson schema is Some");
-    let name: &'static str = "foxglove.GeoJson";
+    let name: &'static str = "foxglove.GeoJSON";
     let encoding: &'static str = "protobuf";
     assert_eq!(name, &native.name);
     assert_eq!(encoding, &native.encoding);

--- a/typescript/schemas/src/internal/generateSdkRustCTypes.ts
+++ b/typescript/schemas/src/internal/generateSdkRustCTypes.ts
@@ -255,7 +255,7 @@ pub extern "C" fn foxglove_channel_log_${snakeName}(channel: Option<&FoxgloveCha
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn foxglove_${snakeName}_schema() -> FoxgloveSchema {
     let native = foxglove::schemas::${name}::get_schema().expect("${name} schema is Some");
-    let name: &'static str = "foxglove.${name}";
+    let name: &'static str = "foxglove.${schema.name}";
     let encoding: &'static str = "protobuf";
     assert_eq!(name, &native.name);
     assert_eq!(encoding, &native.encoding);


### PR DESCRIPTION
### Changelog
- C/C++: Fixed schema name for GeoJSON messages

### Docs
None

### Description
I noticed that we were using the wrong schema name for GeoJSON messages in C.