### PR TITLE
ci: Skip running so100-visualization for now

### DIFF
--- a/scripts/runPythonSdkExamples.ts
+++ b/scripts/runPythonSdkExamples.ts
@@ -23,6 +23,10 @@ const tempFiles: string[] = [];
 
 async function main(opts: { timeout: string; installSdkFromPath: boolean }) {
   for (const example of await readdir(pyExamplesDir)) {
+    // Skip s100-visualization until we figure out what's causing CI failures.
+    if (example === "so100-visualization") {
+      continue;
+    }
     console.debug(`Install & run example ${example}`);
     await installDependencies(example, { installSdkFromPath: opts.installSdkFromPath });
     await runExample(example, parseInt(opts.timeout));


### PR DESCRIPTION
A temporary measure until we get to the bottom of FG-13057.