### PR TITLE
Narrow channel ID to 32 bits

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -1900,10 +1900,10 @@ typedef struct foxglove_server_callbacks {
    */
   const void *context;
   void (*on_subscribe)(const void *context,
-                       uint64_t channel_id,
+                       uint32_t channel_id,
                        struct foxglove_client_metadata client);
   void (*on_unsubscribe)(const void *context,
-                         uint64_t channel_id,
+                         uint32_t channel_id,
                          struct foxglove_client_metadata client);
   void (*on_client_advertise)(const void *context,
                               uint32_t client_id,
@@ -4105,7 +4105,7 @@ void foxglove_channel_free(const struct foxglove_channel *channel);
  *
  * If the passed channel is null, an invalid id of 0 is returned.
  */
-uint64_t foxglove_channel_get_id(const struct foxglove_channel *channel);
+uint32_t foxglove_channel_get_id(const struct foxglove_channel *channel);
 #endif
 
 #if !defined(__wasm__)

--- a/c/src/channel.rs
+++ b/c/src/channel.rs
@@ -294,11 +294,11 @@ pub extern "C" fn foxglove_channel_free(channel: Option<&FoxgloveChannel>) {
 ///
 /// If the passed channel is null, an invalid id of 0 is returned.
 #[unsafe(no_mangle)]
-pub extern "C" fn foxglove_channel_get_id(channel: Option<&FoxgloveChannel>) -> u64 {
+pub extern "C" fn foxglove_channel_get_id(channel: Option<&FoxgloveChannel>) -> u32 {
     let Some(channel) = channel else {
         return 0;
     };
-    u64::from(channel.0.id())
+    u32::from(channel.0.id())
 }
 
 /// Get the topic of a channel.

--- a/c/src/server.rs
+++ b/c/src/server.rs
@@ -153,14 +153,14 @@ pub struct FoxgloveServerCallbacks {
     pub on_subscribe: Option<
         unsafe extern "C" fn(
             context: *const c_void,
-            channel_id: u64,
+            channel_id: u32,
             client: FoxgloveClientMetadata,
         ),
     >,
     pub on_unsubscribe: Option<
         unsafe extern "C" fn(
             context: *const c_void,
-            channel_id: u64,
+            channel_id: u32,
             client: FoxgloveClientMetadata,
         ),
     >,

--- a/cpp/foxglove/include/foxglove/server.hpp
+++ b/cpp/foxglove/include/foxglove/server.hpp
@@ -106,12 +106,12 @@ struct WebSocketServerCallbacks {
   ///
   /// Only invoked if the channel is associated with the server and isn't already subscribed to by
   /// the client.
-  std::function<void(uint64_t channel_id, const ClientMetadata& client_metadata)> onSubscribe;
+  std::function<void(uint32_t channel_id, const ClientMetadata& client_metadata)> onSubscribe;
 
   /// @brief Callback invoked when a client unsubscribes from a channel.
   ///
   /// Only invoked for channels that had an active subscription from the client.
-  std::function<void(uint64_t channel_id, const ClientMetadata& client_metadata)> onUnsubscribe;
+  std::function<void(uint32_t channel_id, const ClientMetadata& client_metadata)> onUnsubscribe;
 
   /// @brief Callback invoked when a client advertises a client channel.
   ///

--- a/cpp/foxglove/src/server.cpp
+++ b/cpp/foxglove/src/server.cpp
@@ -31,7 +31,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
     if (callbacks->onSubscribe) {
       c_callbacks.on_subscribe = [](
                                    const void* context,
-                                   uint64_t channel_id,
+                                   uint32_t channel_id,
                                    const foxglove_client_metadata c_client_metadata
                                  ) {
         try {
@@ -49,7 +49,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
     }
     if (callbacks->onUnsubscribe) {
       c_callbacks.on_unsubscribe =
-        [](const void* context, uint64_t channel_id, foxglove_client_metadata c_client_metadata) {
+        [](const void* context, uint32_t channel_id, foxglove_client_metadata c_client_metadata) {
           try {
             ClientMetadata client_metadata{
               c_client_metadata.id,

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -93,7 +93,7 @@ impl ArrowPrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -202,7 +202,7 @@ impl CameraCalibrationChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -311,7 +311,7 @@ impl CircleAnnotationChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -420,7 +420,7 @@ impl ColorChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -524,7 +524,7 @@ impl CompressedImageChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -633,7 +633,7 @@ impl CompressedVideoChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -742,7 +742,7 @@ impl CylinderPrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -851,7 +851,7 @@ impl CubePrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -960,7 +960,7 @@ impl FrameTransformChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1069,7 +1069,7 @@ impl FrameTransformsChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1178,7 +1178,7 @@ impl GeoJsonChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1282,7 +1282,7 @@ impl GridChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1386,7 +1386,7 @@ impl VoxelGridChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1495,7 +1495,7 @@ impl ImageAnnotationsChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1604,7 +1604,7 @@ impl KeyValuePairChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1713,7 +1713,7 @@ impl LaserScanChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1822,7 +1822,7 @@ impl LinePrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -1931,7 +1931,7 @@ impl LocationFixChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2040,7 +2040,7 @@ impl LocationFixesChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2149,7 +2149,7 @@ impl LogChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2253,7 +2253,7 @@ impl SceneEntityDeletionChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2362,7 +2362,7 @@ impl SceneEntityChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2471,7 +2471,7 @@ impl SceneUpdateChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2580,7 +2580,7 @@ impl ModelPrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2689,7 +2689,7 @@ impl PackedElementFieldChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2798,7 +2798,7 @@ impl Point2Channel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -2902,7 +2902,7 @@ impl Point3Channel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3006,7 +3006,7 @@ impl PointCloudChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3115,7 +3115,7 @@ impl PointsAnnotationChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3224,7 +3224,7 @@ impl PoseChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3328,7 +3328,7 @@ impl PoseInFrameChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3437,7 +3437,7 @@ impl PosesInFrameChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3546,7 +3546,7 @@ impl QuaternionChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3655,7 +3655,7 @@ impl RawAudioChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3764,7 +3764,7 @@ impl RawImageChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3873,7 +3873,7 @@ impl SpherePrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -3982,7 +3982,7 @@ impl TextAnnotationChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -4091,7 +4091,7 @@ impl TextPrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -4200,7 +4200,7 @@ impl TriangleListPrimitiveChannel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -4314,7 +4314,7 @@ impl Vector2Channel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 
@@ -4418,7 +4418,7 @@ impl Vector3Channel {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -100,7 +100,7 @@ impl BaseChannel {
         Ok(())
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[pyclass(name = "ChannelView", module = "foxglove")]
 pub struct PyChannelView {
     #[pyo3(get)]
-    id: u64,
+    id: u32,
     #[pyo3(get)]
     topic: Py<PyString>,
 }
@@ -300,7 +300,7 @@ impl PyServerListener {
         &self,
         method_name: &str,
         client: Client,
-        channel_id: u64,
+        channel_id: u32,
         topic: &str,
     ) {
         let client_info = PyClient {

--- a/ros/src/foxglove_bridge/tests/client/protocol_types.hpp
+++ b/ros/src/foxglove_bridge/tests/client/protocol_types.hpp
@@ -12,7 +12,7 @@
 namespace foxglove::test {
 
 // Protocol type aliases
-using ChannelId = uint64_t;
+using ChannelId = uint32_t;
 using SubscriptionId = uint32_t;
 using ClientChannelId = uint32_t;
 using ServiceId = uint32_t;

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
 
@@ -20,30 +20,30 @@ const STACK_BUFFER_SIZE: usize = 256 * 1024;
 
 /// Uniquely identifies a channel in the context of this program.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Deserialize, Serialize)]
-pub struct ChannelId(u64);
+pub struct ChannelId(u32);
 
 impl ChannelId {
     /// Returns a new ChannelId
-    pub fn new(id: u64) -> Self {
+    pub fn new(id: u32) -> Self {
         Self(id)
     }
 
     /// Allocates the next channel ID.
     pub(crate) fn next() -> Self {
-        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        static NEXT_ID: AtomicU32 = AtomicU32::new(1);
         let id = NEXT_ID.fetch_add(1, Relaxed);
         Self(id)
     }
 }
 
-impl From<ChannelId> for u64 {
-    fn from(id: ChannelId) -> u64 {
+impl From<ChannelId> for u32 {
+    fn from(id: ChannelId) -> u32 {
         id.0
     }
 }
 
-impl From<u64> for ChannelId {
-    fn from(value: u64) -> Self {
+impl From<u32> for ChannelId {
+    fn from(value: u32) -> Self {
         ChannelId::new(value)
     }
 }
@@ -229,7 +229,7 @@ mod test {
             .context(&ctx)
             .build_raw()
             .expect("Failed to create channel");
-        assert!(u64::from(channel.id()) > 0);
+        assert!(u32::from(channel.id()) > 0);
         assert_eq!(channel.topic(), topic);
         assert_eq!(channel.message_encoding(), message_encoding);
         assert_eq!(channel.schema(), Some(&schema));

--- a/rust/foxglove/src/channel/raw_channel.rs
+++ b/rust/foxglove/src/channel/raw_channel.rs
@@ -13,6 +13,7 @@ use super::ChannelId;
 use crate::log_sink_set::LogSinkSet;
 use crate::sink::SmallSinkVec;
 use crate::throttler::Throttler;
+use crate::FoxgloveError;
 use crate::{nanoseconds_since_epoch, Context, Metadata, PartialMetadata, Schema, SinkId};
 
 /// Interval for throttled warnings.
@@ -52,9 +53,11 @@ impl RawChannel {
         message_encoding: String,
         schema: Option<Schema>,
         metadata: BTreeMap<String, String>,
-    ) -> Arc<Self> {
-        Arc::new(Self {
-            id: ChannelId::next(),
+    ) -> Result<Arc<Self>, FoxgloveError> {
+        let id = ChannelId::next()?;
+
+        Ok(Arc::new(Self {
+            id,
             context: Arc::downgrade(context),
             topic,
             message_encoding,
@@ -63,7 +66,7 @@ impl RawChannel {
             sinks: LogSinkSet::new(),
             closed: AtomicBool::new(false),
             warn_throttler: Mutex::new(Throttler::new(WARN_THROTTLER_INTERVAL)),
-        })
+        }))
     }
 
     /// Returns the channel ID.

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -76,7 +76,7 @@ impl ChannelBuilder {
                 .ok_or_else(|| FoxgloveError::MessageEncodingRequired)?,
             self.schema,
             self.metadata,
-        );
+        )?;
         channel = self.context.add_channel(channel);
         Ok(channel)
     }

--- a/rust/foxglove/src/context/subscriptions/tests.rs
+++ b/rust/foxglove/src/context/subscriptions/tests.rs
@@ -17,7 +17,7 @@ macro_rules! assert_subscribers_eq {
     };
 }
 
-fn chid(id: u64) -> ChannelId {
+fn chid(id: u32) -> ChannelId {
     ChannelId::new(id)
 }
 

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -427,6 +427,9 @@ pub enum FoxgloveError {
     /// An error related to configuration
     #[error("Configuration error: {0}")]
     ConfigurationError(String),
+    /// An error creating or logging to a Channel
+    #[error("Channel error: {0}")]
+    ChannelError(String),
 }
 
 impl From<convert::RangeError> for FoxgloveError {

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -319,7 +319,7 @@ async fn test_advertise_to_client() {
     let msg = expect_recv!(client, ServerMessage::Advertise);
     assert_eq!(msg.channels.len(), 1);
     let adv_ch = &msg.channels[0];
-    assert_eq!(adv_ch.id, u64::from(ch.id()));
+    assert_eq!(adv_ch.id, u32::from(ch.id()));
     assert_eq!(adv_ch.topic, ch.topic());
 
     ch.log(b"foo bar");
@@ -360,7 +360,7 @@ async fn test_advertise_to_client() {
     // Ensure we get an unadvertise message only for the first channel
     let msg = expect_recv!(client, ServerMessage::Unadvertise);
     assert_eq!(msg.channel_ids.len(), 1);
-    assert_eq!(msg.channel_ids[0], u64::from(ch.id()));
+    assert_eq!(msg.channel_ids[0], u32::from(ch.id()));
 
     assert!(client.recv().now_or_never().is_none());
 
@@ -402,7 +402,7 @@ async fn test_advertise_schemaless_channels() {
 
     let msg = expect_recv!(client, ServerMessage::Advertise);
     let adv_chan = msg.channels.first().expect("not empty");
-    assert_eq!(adv_chan.id, u64::from(json_chan.id()));
+    assert_eq!(adv_chan.id, u32::from(json_chan.id()));
     assert_eq!(adv_chan.topic, json_chan.topic());
 
     // Client receives no advertisements for other schemaless channels (not supported)
@@ -465,7 +465,7 @@ async fn test_log_only_to_subscribers() {
     // Read the channel advertisement from each client for all 3 channels
     let expect_ch_ids: Vec<_> = [&ch1, &ch2, &ch3]
         .iter()
-        .map(|c| u64::from(c.id()))
+        .map(|c| u32::from(c.id()))
         .collect();
     for client in [&mut client1, &mut client2, &mut client3] {
         let msg = expect_recv!(client, ServerMessage::Advertise);

--- a/rust/foxglove/src/websocket/ws_protocol/client/subscribe.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/client/subscribe.rs
@@ -32,12 +32,12 @@ pub struct Subscription {
     /// Subscription ID.
     pub id: u32,
     /// Channel ID.
-    pub channel_id: u64,
+    pub channel_id: u32,
 }
 
 impl Subscription {
     /// Creates a new subscription with the specified channel ID and subscription ID.
-    pub fn new(id: u32, channel_id: u64) -> Self {
+    pub fn new(id: u32, channel_id: u32) -> Self {
         Self { id, channel_id }
     }
 }

--- a/rust/foxglove/src/websocket/ws_protocol/server/advertise.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/server/advertise.rs
@@ -41,7 +41,7 @@ impl JsonMessage for Advertise<'_> {}
 #[serde(rename_all = "camelCase")]
 pub struct Channel<'a> {
     /// Channel ID.
-    pub id: u64,
+    pub id: u32,
     /// Topic name.
     #[serde(borrow)]
     pub topic: Cow<'a, str>,
@@ -66,7 +66,7 @@ impl<'a> Channel<'a> {
     /// Creates a new builder for a channel advertisement.
     #[must_use]
     pub fn builder(
-        id: u64,
+        id: u32,
         topic: impl Into<Cow<'a, str>>,
         encoding: impl Into<Cow<'a, str>>,
     ) -> ChannelBuilder<'a> {
@@ -115,7 +115,7 @@ impl<'a> TryFrom<Channel<'a>> for Schema<'a> {
 
 /// Server channel advertisement builder.
 pub struct ChannelBuilder<'a> {
-    id: u64,
+    id: u32,
     topic: Cow<'a, str>,
     encoding: Cow<'a, str>,
     schema: Option<Schema<'a>>,

--- a/rust/foxglove/src/websocket/ws_protocol/server/unadvertise.rs
+++ b/rust/foxglove/src/websocket/ws_protocol/server/unadvertise.rs
@@ -9,12 +9,12 @@ use crate::websocket::ws_protocol::JsonMessage;
 #[serde(tag = "op", rename = "unadvertise", rename_all = "camelCase")]
 pub struct Unadvertise {
     /// IDs of the channels to unadvertise.
-    pub channel_ids: Vec<u64>,
+    pub channel_ids: Vec<u32>,
 }
 
 impl Unadvertise {
     /// Creates a new unadvertise message with the given channel IDs.
-    pub fn new(channel_ids: impl IntoIterator<Item = u64>) -> Self {
+    pub fn new(channel_ids: impl IntoIterator<Item = u32>) -> Self {
         Self {
             channel_ids: channel_ids.into_iter().collect(),
         }

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -680,7 +680,7 @@ impl ${channelClass} {
     }
 
     /// The unique ID of the channel.
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.0.id().into()
     }
 


### PR DESCRIPTION
### Changelog
- The ID of a `Channel` is now represented as an unsigned 32-bit integer

### Docs
API docs should auto-update. I did a quick skim of docs.foxglove.dev and didn't see anything public-facing directly using channel ID.

### Description
This is in service of deprecating subscription ID and using channel ID as the main subscription identifier in the websocket protocol. Addressing subscribed messages can be accomplished by combining the 32-bit channel ID with the client ID when sending over the wire as a 64-bit integer.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

Channel ID is an unsigned 64-bit integer

</td><td>

Channel ID is an unsigned 32-bit integer

</td></tr></table>

Fixes: FLE-64
