### PR TITLE
playground: fix directory removal/creation logic

### DIFF
--- a/playground/src/RunnerWorker.ts
+++ b/playground/src/RunnerWorker.ts
@@ -136,7 +136,11 @@ export class RunnerWorker {
     pyodide.runPython(
       `
         import os, pathlib, shutil
-        shutil.rmtree("/home/pyodide/playground", ignore_errors=True)
+        os.chdir("/home/pyodide")
+        try:
+          shutil.rmtree("/home/pyodide/playground")
+        except FileNotFoundError:
+          pass
         pathlib.Path("/home/pyodide/playground").mkdir(parents=True)
         os.chdir("/home/pyodide/playground")
       `,


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

I realized that clicking "Run" multiple times in a row would throw an error, which was for multiple reasons:
- `mkdir` was failing because the directory already existed
- ...which happened because `rmtree` was not working, because of a "Resource busy" error, which I fixed by adding a `chdir` to leave the target directory before removing it.