### PR TITLE
Support referencing an enumeration declared in an external schema

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -159,7 +159,7 @@ async function main({ clean }: { clean: boolean }) {
       );
       await fs.writeFile(
         path.join(outDir, "proto", "foxglove", `${schema.name}.proto`),
-        generateProto(schema, enums),
+        generateProto(schema, enums, foxgloveMessageSchemas),
       );
     }
   });


### PR DESCRIPTION
### Changelog

Support referencing an enumeration declared in an external schema.

### Docs

None

### Description

Whenever I use an enumeration in a schema that is different from the "parentSchemaName" field, the generated .proto file fails compiling.

For example, let's suppose I have changed this code:
```diff
index 8ba41b5..69b9265 100644
--- a/typescript/schemas/src/internal/schemas.ts
+++ b/typescript/schemas/src/internal/schemas.ts
@@ -313,6 +313,11 @@ const ArrowPrimitive: FoxgloveMessageSchema = {
   name: "ArrowPrimitive",
   description: "A primitive representing an arrow",
   fields: [
+    {
+      name: "type",
+      type: { type: "enum", enum: SceneEntityDeletionType },
+      description: "Type of deletion action to perform",
+    },
     {
       name: "pose",
       type: { type: "nested", schema: Pose },
```

If I generate the files with "npm run generate", I have an error:
```diff
...
thread 'main' panicked at rust/foxglove_proto_gen/src/bin.rs:12:65:
Failed to generate protos: Failed to load protos

Caused by:
    protoc failed: foxglove/ArrowPrimitive.proto:13:3: "Type" is not defined.
...
```

Indeed, the generated schemas/proto/foxglove/ArrowPrimitive.proto file contains:
```diff
...
import "foxglove/Color.proto";
import "foxglove/Pose.proto";

package foxglove;

// A primitive representing an arrow
message ArrowPrimitive {
  // Type of deletion action to perform
  Type type = 1;
...
```

With the proposed commit, the "npm run generate" now succeeds with this generated code in schemas/proto/foxglove/ArrowPrimitive.proto:
```diff
...
import "foxglove/Color.proto";
import "foxglove/Pose.proto";
import "foxglove/SceneEntityDeletion.proto";

package foxglove;

// A primitive representing an arrow
message ArrowPrimitive {
  // Type of deletion action to perform
  foxglove.SceneEntityDeletion.Type type = 1;
...
```

