### PR TITLE
Skip cloudflare deploy step if the PR is from an external fork.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,6 +87,7 @@ jobs:
       - run: yarn build
         working-directory: playground
       - uses: cloudflare/pages-action@v1.5.0
+        if: github.repository == github.event.pull_request.head.repo.full_name # Only run if not a fork
         id: deploy
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

That's because the cloudflare deploy step requires secrets, which are not passed to a job running on a PR from an external fork.  By skipping it, we lose a bit of convenience, but given that the number of PRs from external forks is minimal, this should be OK.

You can see what happens with an external fork by looking at the CI in https://github.com/foxglove/foxglove-sdk/pull/670 (ignore the CI/rust failure, that's a different problem handled by #671).