### PR TITLE
Update the workaround to find the service typesupport handle.

### DIFF
--- a/ros/src/foxglove_bridge/include/foxglove_bridge/generic_client.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/generic_client.hpp
@@ -29,6 +29,8 @@ public:
 private:
   RCLCPP_DISABLE_COPY(GenericClient)
 
+  const rosidl_service_type_support_t* getServiceTypeSupportHandle(const std::string & serviceType);
+
   std::map<int64_t, foxglove::ServiceResponder> pending_requests_;
   std::mutex pending_requests_mutex_;
   std::shared_ptr<rcpputils::SharedLibrary> _typeSupportLib;

--- a/ros/src/foxglove_bridge/src/generic_client.cpp
+++ b/ros/src/foxglove_bridge/src/generic_client.cpp
@@ -59,36 +59,57 @@ std::string getTypeIntrospectionSymbolName(const std::string& serviceType) {
          pkgName + "__" + (middleModule.empty() ? "srv" : middleModule) + "__" + typeName;
 }
 
-/**
- * The default symbol names for getting type support handles for services are missing from the
- * rosidl_typesupport_cpp shared libraries, see
- * https://github.com/ros2/rosidl_typesupport/issues/122
- *
- * We can however, as a (hacky) workaround, use other symbols defined in the shared library.
- * With `nm -C -D /opt/ros/humble/lib/libtest_msgs__rosidl_typesupport_cpp.so` we see that there is
- * `rosidl_service_type_support_t const*
- * rosidl_typesupport_cpp::get_service_type_support_handle<test_msgs::srv::BasicTypes>()` which
- * mangled becomes
- * `_ZN22rosidl_typesupport_cpp31get_service_type_support_handleIN9test_msgs3srv10BasicTypesEEEPK29rosidl_service_type_support_tv`
- * This is the same for galactic, humble and rolling (tested with gcc / clang)
- *
- * This function produces the mangled symbol name for a given service type.
- *
- * \param[in] serviceType The service type, e.g. "test_msgs/srv/BasicTypes"
- * \return Symbol name for getting the service type support handle
- */
-std::string getServiceTypeSupportHandleSymbolName(const std::string& serviceType) {
+const rosidl_service_type_support_t* GenericClient::getServiceTypeSupportHandle(const std::string & serviceType)
+{
+#if RCLCPP_VERSION_GTE(25, 0, 0)
+  // Jazzy and newer can use the built-in rclcpp call.
+  return rclcpp::get_service_typesupport_handle(serviceType, TYPESUPPORT_LIB_NAME, *_typeSupportLib);
+#else
+  // Humble needs to do additional work.
   const auto [pkgName, middleModule, typeName] = extract_type_identifier(serviceType);
+
+  // Humble rosidl 3.1.6 is the first version to have the appropriate __get_service_type_support_handle__ methods
+  // available.  However, rosidl does not have a version macro, so we approximate this with rclcpp versions.
+  // https://github.com/ros2/ros2/commit/9f7d334291ff77a07d68d4d8976871b99e03612b is the version where rosidl
+  // was bumped to 3.1.6, and also bumped rclcpp to version 16.0.11.  Thus, anything older than that version
+  // needs to use the old symbol hack.
+#if RCLCPP_VERSION_GTE(16, 0, 11)
+  const auto typesupportSymbolName = std::string(TYPESUPPORT_LIB_NAME) + "__get_service_type_support_handle__" +
+         pkgName + "__" + (middleModule.empty() ? "srv" : middleModule) + "__" + typeName;
+#else
+  /**
+   * The default symbol names for getting type support handles for services are missing from the
+   * rosidl_typesupport_cpp shared libraries, see
+   * https://github.com/ros2/rosidl_typesupport/issues/122
+   *
+   * We can however, as a (hacky) workaround, use other symbols defined in the shared library.
+   * With `nm -C -D /opt/ros/humble/lib/libtest_msgs__rosidl_typesupport_cpp.so` we see that there is
+   * `rosidl_service_type_support_t const*
+   * rosidl_typesupport_cpp::get_service_type_support_handle<test_msgs::srv::BasicTypes>()` which
+   * mangled becomes
+   * `_ZN22rosidl_typesupport_cpp31get_service_type_support_handleIN9test_msgs3srv10BasicTypesEEEPK29rosidl_service_type_support_tv`
+   * This is the same for galactic, humble and rolling (tested with gcc / clang)
+   */
   const auto lengthPrefixedString = [](const std::string& s) {
     return std::to_string(s.size()) + s;
   };
 
-  return "_ZN" + lengthPrefixedString(TYPESUPPORT_LIB_NAME) +
+  const auto typesupportSymbolName = "_ZN" + lengthPrefixedString(TYPESUPPORT_LIB_NAME) +
          lengthPrefixedString("get_service_type_support_handle") + "IN" +
          lengthPrefixedString(pkgName) +
          lengthPrefixedString(middleModule.empty() ? "srv" : middleModule) +
          lengthPrefixedString(typeName) + "EEEPK" +
          lengthPrefixedString("rosidl_service_type_support_t") + "v";
+#endif
+
+  if (!_typeSupportLib->has_symbol(typesupportSymbolName)) {
+    throw std::runtime_error("Failed to find symbol '" + typesupportSymbolName + "' in " +
+                             _typeSupportLib->get_library_path());
+  }
+
+  const rosidl_service_type_support_t* (*get_ts)() = nullptr;
+  return (reinterpret_cast<decltype(get_ts)>(_typeSupportLib->get_symbol(typesupportSymbolName)))();
+#endif
 }
 
 GenericClient::GenericClient(rclcpp::node_interfaces::NodeBaseInterface* nodeBase,
@@ -107,19 +128,12 @@ GenericClient::GenericClient(rclcpp::node_interfaces::NodeBaseInterface* nodeBas
     throw std::runtime_error("Failed to load shared library for service type " + serviceType);
   }
 
-  const auto typesupportSymbolName = getServiceTypeSupportHandleSymbolName(serviceType);
-  if (!_typeSupportLib->has_symbol(typesupportSymbolName)) {
-    throw std::runtime_error("Failed to find symbol '" + typesupportSymbolName + "' in " +
-                             _typeSupportLib->get_library_path());
-  }
-
-  const rosidl_service_type_support_t* (*get_ts)() = nullptr;
-  _serviceTypeSupportHdl =
-    (reinterpret_cast<decltype(get_ts)>(_typeSupportLib->get_symbol(typesupportSymbolName)))();
+  _serviceTypeSupportHdl = getServiceTypeSupportHandle(serviceType);
 
   const auto typeinstrospection_symbol_name = getTypeIntrospectionSymbolName(serviceType);
 
   // This will throw runtime_error if the symbol was not found.
+  const rosidl_service_type_support_t* (*get_ts)() = nullptr;
   _typeIntrospectionHdl = (reinterpret_cast<decltype(get_ts)>(
     _typeIntrospectionLib->get_symbol(typeinstrospection_symbol_name)))();
 


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The GenericClient implementation in foxglove_bridge needs to get a service typesupport handle in order to initialize itself.

In late 2023, the rclcpp::get_service_typesupport_handle() API was added to ROS as a one-call way to get the typesupport handle for services.  That means that all ROS 2 releases since Iron have that API.

Humble does not have that particular API.  However, since late 2024, it does include the underlying rosidl API, so we can call that without resorting to hacks to find the symbol in the library.  In Humble prior to that 2024 release, we need that symbol lookup hack.

That leads to this patch.  If we are on a new enough rclcpp, we use rclcpp::get_service_typesupport_handle().  If we are on a newer version of Humble, we use the underlying rosidl API.  And if we are on an older version of humble, we use the symbol hack.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

All tests succeed (run with `colcon test`) on Kilted, Jazzy, Humble, and older Humble (prior to the symbol being available).