### PR TITLE
C++: improve docs for log timestamps

### DIFF
--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -45,7 +45,8 @@ public:
   ///
   /// @param data The message data.
   /// @param data_len The length of the message data, in bytes.
-  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The sink ID associated with the message. Can be used to target logging messages
   /// to a specific client or mcap file. If omitted, the message is logged to all sinks. Note that
   /// providing a sink_id is not yet part of the public API. To partition logs among specific sinks,

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -45,7 +45,7 @@ public:
   ///
   /// @param data The message data.
   /// @param data_len The length of the message data, in bytes.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the current time is used.
   /// @param sink_id The sink ID associated with the message. Can be used to target logging messages
   /// to a specific client or mcap file. If omitted, the message is logged to all sinks. Note that
   /// providing a sink_id is not yet part of the public API. To partition logs among specific sinks,

--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -1826,7 +1826,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The ArrowPrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const ArrowPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -1873,7 +1874,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The CameraCalibration message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const CameraCalibration& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -1920,7 +1922,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The CircleAnnotation message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const CircleAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -1967,7 +1970,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Color message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Color& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2014,7 +2018,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The CompressedImage message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const CompressedImage& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2061,7 +2066,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The CompressedVideo message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const CompressedVideo& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2108,7 +2114,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The CylinderPrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const CylinderPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2155,7 +2162,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The CubePrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const CubePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2202,7 +2210,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The FrameTransform message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const FrameTransform& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2249,7 +2258,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The FrameTransforms message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const FrameTransforms& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2296,7 +2306,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The GeoJSON message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const GeoJSON& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2343,7 +2354,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Grid message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Grid& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2390,7 +2402,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The VoxelGrid message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const VoxelGrid& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2437,7 +2450,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The ImageAnnotations message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const ImageAnnotations& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2484,7 +2498,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The KeyValuePair message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const KeyValuePair& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2531,7 +2546,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The LaserScan message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const LaserScan& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2578,7 +2594,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The LinePrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const LinePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2625,7 +2642,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The LocationFix message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const LocationFix& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2672,7 +2690,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The LocationFixes message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const LocationFixes& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2719,7 +2738,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Log message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Log& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2766,7 +2786,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The SceneEntityDeletion message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const SceneEntityDeletion& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2813,7 +2834,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The SceneEntity message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const SceneEntity& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2860,7 +2882,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The SceneUpdate message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const SceneUpdate& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2907,7 +2930,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The ModelPrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const ModelPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -2954,7 +2978,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The PackedElementField message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const PackedElementField& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3001,7 +3026,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Point2 message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Point2& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3048,7 +3074,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Point3 message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Point3& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3095,7 +3122,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The PointCloud message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const PointCloud& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3142,7 +3170,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The PointsAnnotation message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const PointsAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3189,7 +3218,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Pose message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Pose& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3236,7 +3266,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The PoseInFrame message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const PoseInFrame& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3283,7 +3314,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The PosesInFrame message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const PosesInFrame& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3330,7 +3362,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Quaternion message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Quaternion& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3377,7 +3410,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The RawAudio message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const RawAudio& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3424,7 +3458,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The RawImage message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const RawImage& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3471,7 +3506,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The SpherePrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const SpherePrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3518,7 +3554,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The TextAnnotation message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const TextAnnotation& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3565,7 +3602,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The TextPrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const TextPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3612,7 +3650,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The TriangleListPrimitive message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const TriangleListPrimitive& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3660,7 +3699,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Vector2 message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Vector2& msg, std::optional<uint64_t> log_time = std::nullopt,
@@ -3707,7 +3747,8 @@ public:
   /// @brief Log a message to the channel.
   ///
   /// @param msg The Vector3 message to log.
-  /// @param log_time The timestamp of the message. If omitted, the current time is used.
+  /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
+  /// current time is used.
   /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
   FoxgloveError log(
     const Vector3& msg, std::optional<uint64_t> log_time = std::nullopt,

--- a/typescript/schemas/src/internal/generateSdkCpp.ts
+++ b/typescript/schemas/src/internal/generateSdkCpp.ts
@@ -208,7 +208,7 @@ export function generateHppSchemas(
         /// @brief Log a message to the channel.
         ///
         /// @param msg The ${schema.name} message to log.
-        /// @param log_time The timestamp of the message. If omitted, the current time is used.
+        /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the current time is used.
         /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
         FoxgloveError log(const ${schema.name}& msg, std::optional<uint64_t> log_time = std::nullopt, std::optional<uint64_t> sink_id = std::nullopt) noexcept;
 


### PR DESCRIPTION
### Changelog
None

### Description

C++ docs: specify that the timestamp in channel.log() is nanos since epoch.