### PR TITLE
Python: expose Context.default in types & docs

### DIFF
--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -115,6 +115,13 @@ class Context:
         """
         ...
 
+    @staticmethod
+    def default() -> "Context":
+        """
+        Returns the default context.
+        """
+        ...
+
 def start_server(
     *,
     name: str | None = None,

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -154,6 +154,7 @@ impl PyContext {
         Self(foxglove::Context::new())
     }
 
+    /// Returns the default context.
     #[staticmethod]
     fn default() -> Self {
         Self(foxglove::Context::get_default())


### PR DESCRIPTION
### Changelog
Python: expose Context.default in types & docs

### Docs
None

### Description

This exposes the `Context.default()` method in Python; a user may want to reference it explicitly.