### PR TITLE
rustdoc: Fix for latest nightly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Remember to publish new versions of all libraries!
 This package generates source and interface files for the Foxglove SDK, and relies on tooling from the Rust and Python ecosystems.
 
 - Rust, installed via [rustup](https://rustup.rs/)
+  - Documentation generation requires a recent `nightly` build
 - [Protobuf compiler](https://grpc.io/docs/protoc-installation/)
 - Python dependencies installed via [Poetry](https://python-poetry.org/)
 

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -300,7 +300,7 @@
 //! [tokio]: https://docs.rs/tokio/latest/tokio/
 
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use thiserror::Error;
 


### PR DESCRIPTION
### Changelog
None

### Description

This renames the `doc_auto_cfg` feature, following https://github.com/rust-lang/rust/pull/138907. We install the latest nightly build in CI for docs generation; developers will need to update to at least 2025-09-28.