### PR TITLE
Add unreliable metadata option when creating channels via the channel builder

### DIFF
--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -59,6 +59,14 @@ impl ChannelBuilder {
         self
     }
 
+    /// Prefer using a unreliable/lossy transport when a sink supports it.
+    /// This enables sending log messages over UDP or similar for sinks that support it.
+    /// It may also effect which messages are dropped when the [`crate::WebSocketServer`] queue fills.
+    /// Has no effect for MCAP sinks.
+    pub fn unreliable(self) -> Self {
+        self.add_metadata("foxglove_unreliable", "1")
+    }
+
     /// Sets the context for this channel.
     pub fn context(mut self, ctx: &Arc<Context>) -> Self {
         self.context = ctx.clone();


### PR DESCRIPTION
### Changelog

Add unreliable channels, a hint to sinks that log messages can be sent over unreliable transports or dropped under pressure.

### Docs

None

### Description

This add an unreliable option to ChannelBuilder, and tags channels with metadata "foxglove_reliable": "1", as well as marks them internally in the SDK with an unreliable boolean. This can be used by sinks or downstream consumers to handle the messages differently (e.g. send them over UDP). Update send_lossy to drop new unreliable when the queue is full instead of the oldest message in the queue.

Ideally we would drop older unreliable messages instead, but this is not possible with flume, we would need our own queue or to fork it and modify it.