### PR TITLE
python: Make Context.default() always return the same object

### DIFF
--- a/python/foxglove-sdk/python/foxglove/tests/test_context.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_context.py
@@ -1,0 +1,10 @@
+from foxglove import Context
+
+
+def test_default_context_is_singleton() -> None:
+    assert Context.default() is Context.default()
+
+
+def test_context_is_distinct() -> None:
+    assert Context() is not Context.default()
+    assert Context() is not Context()

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 #[cfg(not(target_family = "wasm"))]
 use websocket::start_server;
 
@@ -156,8 +156,14 @@ impl PyContext {
 
     /// Returns the default context.
     #[staticmethod]
-    fn default() -> Self {
-        Self(foxglove::Context::get_default())
+    fn default(py: Python) -> Py<Self> {
+        static DEFAULT_CONTEXT: OnceLock<Py<PyContext>> = OnceLock::new();
+        DEFAULT_CONTEXT
+            .get_or_init(|| {
+                let inner = foxglove::Context::get_default();
+                Py::new(py, PyContext(inner)).unwrap()
+            })
+            .clone_ref(py)
     }
 
     /// Create a new channel for logging messages on a topic.


### PR DESCRIPTION
### Changelog
- Python: Context.default() always returns the same object.

### Docs
None

### Description
There can be only one highlander.