### PR TITLE
cpp: add has_sinks() and close() to typed channels

### DIFF
--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -1830,10 +1830,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   ArrowPrimitiveChannel(const ArrowPrimitiveChannel& other) noexcept = delete;
   ArrowPrimitiveChannel& operator=(const ArrowPrimitiveChannel& other) noexcept = delete;
@@ -1878,10 +1891,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   CameraCalibrationChannel(const CameraCalibrationChannel& other) noexcept = delete;
   CameraCalibrationChannel& operator=(const CameraCalibrationChannel& other) noexcept = delete;
@@ -1926,10 +1952,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   CircleAnnotationChannel(const CircleAnnotationChannel& other) noexcept = delete;
   CircleAnnotationChannel& operator=(const CircleAnnotationChannel& other) noexcept = delete;
@@ -1974,10 +2013,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   ColorChannel(const ColorChannel& other) noexcept = delete;
   ColorChannel& operator=(const ColorChannel& other) noexcept = delete;
@@ -2022,10 +2074,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   CompressedImageChannel(const CompressedImageChannel& other) noexcept = delete;
   CompressedImageChannel& operator=(const CompressedImageChannel& other) noexcept = delete;
@@ -2070,10 +2135,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   CompressedVideoChannel(const CompressedVideoChannel& other) noexcept = delete;
   CompressedVideoChannel& operator=(const CompressedVideoChannel& other) noexcept = delete;
@@ -2118,10 +2196,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   CylinderPrimitiveChannel(const CylinderPrimitiveChannel& other) noexcept = delete;
   CylinderPrimitiveChannel& operator=(const CylinderPrimitiveChannel& other) noexcept = delete;
@@ -2166,10 +2257,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   CubePrimitiveChannel(const CubePrimitiveChannel& other) noexcept = delete;
   CubePrimitiveChannel& operator=(const CubePrimitiveChannel& other) noexcept = delete;
@@ -2214,10 +2318,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   FrameTransformChannel(const FrameTransformChannel& other) noexcept = delete;
   FrameTransformChannel& operator=(const FrameTransformChannel& other) noexcept = delete;
@@ -2262,10 +2379,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   FrameTransformsChannel(const FrameTransformsChannel& other) noexcept = delete;
   FrameTransformsChannel& operator=(const FrameTransformsChannel& other) noexcept = delete;
@@ -2310,10 +2440,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   GeoJSONChannel(const GeoJSONChannel& other) noexcept = delete;
   GeoJSONChannel& operator=(const GeoJSONChannel& other) noexcept = delete;
@@ -2358,10 +2501,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   GridChannel(const GridChannel& other) noexcept = delete;
   GridChannel& operator=(const GridChannel& other) noexcept = delete;
@@ -2406,10 +2562,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   VoxelGridChannel(const VoxelGridChannel& other) noexcept = delete;
   VoxelGridChannel& operator=(const VoxelGridChannel& other) noexcept = delete;
@@ -2454,10 +2623,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   ImageAnnotationsChannel(const ImageAnnotationsChannel& other) noexcept = delete;
   ImageAnnotationsChannel& operator=(const ImageAnnotationsChannel& other) noexcept = delete;
@@ -2502,10 +2684,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   KeyValuePairChannel(const KeyValuePairChannel& other) noexcept = delete;
   KeyValuePairChannel& operator=(const KeyValuePairChannel& other) noexcept = delete;
@@ -2550,10 +2745,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   LaserScanChannel(const LaserScanChannel& other) noexcept = delete;
   LaserScanChannel& operator=(const LaserScanChannel& other) noexcept = delete;
@@ -2598,10 +2806,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   LinePrimitiveChannel(const LinePrimitiveChannel& other) noexcept = delete;
   LinePrimitiveChannel& operator=(const LinePrimitiveChannel& other) noexcept = delete;
@@ -2646,10 +2867,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   LocationFixChannel(const LocationFixChannel& other) noexcept = delete;
   LocationFixChannel& operator=(const LocationFixChannel& other) noexcept = delete;
@@ -2694,10 +2928,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   LocationFixesChannel(const LocationFixesChannel& other) noexcept = delete;
   LocationFixesChannel& operator=(const LocationFixesChannel& other) noexcept = delete;
@@ -2742,10 +2989,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   LogChannel(const LogChannel& other) noexcept = delete;
   LogChannel& operator=(const LogChannel& other) noexcept = delete;
@@ -2790,10 +3050,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   SceneEntityDeletionChannel(const SceneEntityDeletionChannel& other) noexcept = delete;
   SceneEntityDeletionChannel& operator=(const SceneEntityDeletionChannel& other) noexcept = delete;
@@ -2838,10 +3111,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   SceneEntityChannel(const SceneEntityChannel& other) noexcept = delete;
   SceneEntityChannel& operator=(const SceneEntityChannel& other) noexcept = delete;
@@ -2886,10 +3172,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   SceneUpdateChannel(const SceneUpdateChannel& other) noexcept = delete;
   SceneUpdateChannel& operator=(const SceneUpdateChannel& other) noexcept = delete;
@@ -2934,10 +3233,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   ModelPrimitiveChannel(const ModelPrimitiveChannel& other) noexcept = delete;
   ModelPrimitiveChannel& operator=(const ModelPrimitiveChannel& other) noexcept = delete;
@@ -2982,10 +3294,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   PackedElementFieldChannel(const PackedElementFieldChannel& other) noexcept = delete;
   PackedElementFieldChannel& operator=(const PackedElementFieldChannel& other) noexcept = delete;
@@ -3030,10 +3355,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   Point2Channel(const Point2Channel& other) noexcept = delete;
   Point2Channel& operator=(const Point2Channel& other) noexcept = delete;
@@ -3078,10 +3416,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   Point3Channel(const Point3Channel& other) noexcept = delete;
   Point3Channel& operator=(const Point3Channel& other) noexcept = delete;
@@ -3126,10 +3477,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   PointCloudChannel(const PointCloudChannel& other) noexcept = delete;
   PointCloudChannel& operator=(const PointCloudChannel& other) noexcept = delete;
@@ -3174,10 +3538,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   PointsAnnotationChannel(const PointsAnnotationChannel& other) noexcept = delete;
   PointsAnnotationChannel& operator=(const PointsAnnotationChannel& other) noexcept = delete;
@@ -3222,10 +3599,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   PoseChannel(const PoseChannel& other) noexcept = delete;
   PoseChannel& operator=(const PoseChannel& other) noexcept = delete;
@@ -3270,10 +3660,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   PoseInFrameChannel(const PoseInFrameChannel& other) noexcept = delete;
   PoseInFrameChannel& operator=(const PoseInFrameChannel& other) noexcept = delete;
@@ -3318,10 +3721,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   PosesInFrameChannel(const PosesInFrameChannel& other) noexcept = delete;
   PosesInFrameChannel& operator=(const PosesInFrameChannel& other) noexcept = delete;
@@ -3366,10 +3782,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   QuaternionChannel(const QuaternionChannel& other) noexcept = delete;
   QuaternionChannel& operator=(const QuaternionChannel& other) noexcept = delete;
@@ -3414,10 +3843,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   RawAudioChannel(const RawAudioChannel& other) noexcept = delete;
   RawAudioChannel& operator=(const RawAudioChannel& other) noexcept = delete;
@@ -3462,10 +3904,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   RawImageChannel(const RawImageChannel& other) noexcept = delete;
   RawImageChannel& operator=(const RawImageChannel& other) noexcept = delete;
@@ -3510,10 +3965,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   SpherePrimitiveChannel(const SpherePrimitiveChannel& other) noexcept = delete;
   SpherePrimitiveChannel& operator=(const SpherePrimitiveChannel& other) noexcept = delete;
@@ -3558,10 +4026,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   TextAnnotationChannel(const TextAnnotationChannel& other) noexcept = delete;
   TextAnnotationChannel& operator=(const TextAnnotationChannel& other) noexcept = delete;
@@ -3606,10 +4087,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   TextPrimitiveChannel(const TextPrimitiveChannel& other) noexcept = delete;
   TextPrimitiveChannel& operator=(const TextPrimitiveChannel& other) noexcept = delete;
@@ -3654,10 +4148,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   TriangleListPrimitiveChannel(const TriangleListPrimitiveChannel& other) noexcept = delete;
   TriangleListPrimitiveChannel& operator=(const TriangleListPrimitiveChannel& other
@@ -3703,10 +4210,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   Vector2Channel(const Vector2Channel& other) noexcept = delete;
   Vector2Channel& operator=(const Vector2Channel& other) noexcept = delete;
@@ -3751,10 +4271,23 @@ public:
     std::optional<uint64_t> sink_id = std::nullopt
   ) noexcept;
 
+  /// @brief Close the channel.
+  ///
+  /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+  /// dynamically, such as the WebSocketServer.
+  ///
+  /// Attempts to log on a closed channel will elicit a throttled warning message.
+  void close() noexcept;
+
   /// @brief Uniquely identifies a channel in the context of this program.
   ///
   /// @return The ID of the channel.
   [[nodiscard]] uint64_t id() const noexcept;
+
+  /// @brief Find out if any sinks have been added to the channel.
+  ///
+  /// @return True if sinks have been added to the channel, false otherwise.
+  [[nodiscard]] bool has_sinks() const noexcept;
 
   Vector3Channel(const Vector3Channel& other) noexcept = delete;
   Vector3Channel& operator=(const Vector3Channel& other) noexcept = delete;

--- a/cpp/foxglove/src/schemas.cpp
+++ b/cpp/foxglove/src/schemas.cpp
@@ -96,8 +96,16 @@ FoxgloveError ArrowPrimitiveChannel::log(
   ));
 }
 
+void ArrowPrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t ArrowPrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool ArrowPrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<CameraCalibrationChannel> CameraCalibrationChannel::create(
@@ -124,8 +132,16 @@ FoxgloveError CameraCalibrationChannel::log(
   ));
 }
 
+void CameraCalibrationChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t CameraCalibrationChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool CameraCalibrationChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<CircleAnnotationChannel> CircleAnnotationChannel::create(
@@ -152,8 +168,16 @@ FoxgloveError CircleAnnotationChannel::log(
   ));
 }
 
+void CircleAnnotationChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t CircleAnnotationChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool CircleAnnotationChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<ColorChannel> ColorChannel::create(
@@ -179,8 +203,16 @@ FoxgloveError ColorChannel::log(
   ));
 }
 
+void ColorChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t ColorChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool ColorChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<CompressedImageChannel> CompressedImageChannel::create(
@@ -207,8 +239,16 @@ FoxgloveError CompressedImageChannel::log(
   ));
 }
 
+void CompressedImageChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t CompressedImageChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool CompressedImageChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<CompressedVideoChannel> CompressedVideoChannel::create(
@@ -235,8 +275,16 @@ FoxgloveError CompressedVideoChannel::log(
   ));
 }
 
+void CompressedVideoChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t CompressedVideoChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool CompressedVideoChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<CubePrimitiveChannel> CubePrimitiveChannel::create(
@@ -263,8 +311,16 @@ FoxgloveError CubePrimitiveChannel::log(
   ));
 }
 
+void CubePrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t CubePrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool CubePrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<CylinderPrimitiveChannel> CylinderPrimitiveChannel::create(
@@ -291,8 +347,16 @@ FoxgloveError CylinderPrimitiveChannel::log(
   ));
 }
 
+void CylinderPrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t CylinderPrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool CylinderPrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<FrameTransformChannel> FrameTransformChannel::create(
@@ -319,8 +383,16 @@ FoxgloveError FrameTransformChannel::log(
   ));
 }
 
+void FrameTransformChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t FrameTransformChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool FrameTransformChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<FrameTransformsChannel> FrameTransformsChannel::create(
@@ -347,8 +419,16 @@ FoxgloveError FrameTransformsChannel::log(
   ));
 }
 
+void FrameTransformsChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t FrameTransformsChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool FrameTransformsChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<GeoJSONChannel> GeoJSONChannel::create(
@@ -374,8 +454,16 @@ FoxgloveError GeoJSONChannel::log(
   ));
 }
 
+void GeoJSONChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t GeoJSONChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool GeoJSONChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<GridChannel> GridChannel::create(
@@ -401,8 +489,16 @@ FoxgloveError GridChannel::log(
   ));
 }
 
+void GridChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t GridChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool GridChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<ImageAnnotationsChannel> ImageAnnotationsChannel::create(
@@ -429,8 +525,16 @@ FoxgloveError ImageAnnotationsChannel::log(
   ));
 }
 
+void ImageAnnotationsChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t ImageAnnotationsChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool ImageAnnotationsChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<KeyValuePairChannel> KeyValuePairChannel::create(
@@ -457,8 +561,16 @@ FoxgloveError KeyValuePairChannel::log(
   ));
 }
 
+void KeyValuePairChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t KeyValuePairChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool KeyValuePairChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<LaserScanChannel> LaserScanChannel::create(
@@ -484,8 +596,16 @@ FoxgloveError LaserScanChannel::log(
   ));
 }
 
+void LaserScanChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t LaserScanChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool LaserScanChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<LinePrimitiveChannel> LinePrimitiveChannel::create(
@@ -512,8 +632,16 @@ FoxgloveError LinePrimitiveChannel::log(
   ));
 }
 
+void LinePrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t LinePrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool LinePrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<LocationFixChannel> LocationFixChannel::create(
@@ -540,8 +668,16 @@ FoxgloveError LocationFixChannel::log(
   ));
 }
 
+void LocationFixChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t LocationFixChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool LocationFixChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<LocationFixesChannel> LocationFixesChannel::create(
@@ -568,8 +704,16 @@ FoxgloveError LocationFixesChannel::log(
   ));
 }
 
+void LocationFixesChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t LocationFixesChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool LocationFixesChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<LogChannel> LogChannel::create(
@@ -595,8 +739,16 @@ FoxgloveError LogChannel::log(
   ));
 }
 
+void LogChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t LogChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool LogChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<ModelPrimitiveChannel> ModelPrimitiveChannel::create(
@@ -623,8 +775,16 @@ FoxgloveError ModelPrimitiveChannel::log(
   ));
 }
 
+void ModelPrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t ModelPrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool ModelPrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<PackedElementFieldChannel> PackedElementFieldChannel::create(
@@ -651,8 +811,16 @@ FoxgloveError PackedElementFieldChannel::log(
   ));
 }
 
+void PackedElementFieldChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t PackedElementFieldChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool PackedElementFieldChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<Point2Channel> Point2Channel::create(
@@ -678,8 +846,16 @@ FoxgloveError Point2Channel::log(
   ));
 }
 
+void Point2Channel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t Point2Channel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool Point2Channel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<Point3Channel> Point3Channel::create(
@@ -705,8 +881,16 @@ FoxgloveError Point3Channel::log(
   ));
 }
 
+void Point3Channel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t Point3Channel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool Point3Channel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<PointCloudChannel> PointCloudChannel::create(
@@ -732,8 +916,16 @@ FoxgloveError PointCloudChannel::log(
   ));
 }
 
+void PointCloudChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t PointCloudChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool PointCloudChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<PointsAnnotationChannel> PointsAnnotationChannel::create(
@@ -760,8 +952,16 @@ FoxgloveError PointsAnnotationChannel::log(
   ));
 }
 
+void PointsAnnotationChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t PointsAnnotationChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool PointsAnnotationChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<PoseChannel> PoseChannel::create(
@@ -787,8 +987,16 @@ FoxgloveError PoseChannel::log(
   ));
 }
 
+void PoseChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t PoseChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool PoseChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<PoseInFrameChannel> PoseInFrameChannel::create(
@@ -815,8 +1023,16 @@ FoxgloveError PoseInFrameChannel::log(
   ));
 }
 
+void PoseInFrameChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t PoseInFrameChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool PoseInFrameChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<PosesInFrameChannel> PosesInFrameChannel::create(
@@ -843,8 +1059,16 @@ FoxgloveError PosesInFrameChannel::log(
   ));
 }
 
+void PosesInFrameChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t PosesInFrameChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool PosesInFrameChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<QuaternionChannel> QuaternionChannel::create(
@@ -870,8 +1094,16 @@ FoxgloveError QuaternionChannel::log(
   ));
 }
 
+void QuaternionChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t QuaternionChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool QuaternionChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<RawAudioChannel> RawAudioChannel::create(
@@ -897,8 +1129,16 @@ FoxgloveError RawAudioChannel::log(
   ));
 }
 
+void RawAudioChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t RawAudioChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool RawAudioChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<RawImageChannel> RawImageChannel::create(
@@ -924,8 +1164,16 @@ FoxgloveError RawImageChannel::log(
   ));
 }
 
+void RawImageChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t RawImageChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool RawImageChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<SceneEntityChannel> SceneEntityChannel::create(
@@ -952,8 +1200,16 @@ FoxgloveError SceneEntityChannel::log(
   ));
 }
 
+void SceneEntityChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t SceneEntityChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool SceneEntityChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<SceneEntityDeletionChannel> SceneEntityDeletionChannel::create(
@@ -980,8 +1236,16 @@ FoxgloveError SceneEntityDeletionChannel::log(
   ));
 }
 
+void SceneEntityDeletionChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t SceneEntityDeletionChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool SceneEntityDeletionChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<SceneUpdateChannel> SceneUpdateChannel::create(
@@ -1008,8 +1272,16 @@ FoxgloveError SceneUpdateChannel::log(
   ));
 }
 
+void SceneUpdateChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t SceneUpdateChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool SceneUpdateChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<SpherePrimitiveChannel> SpherePrimitiveChannel::create(
@@ -1036,8 +1308,16 @@ FoxgloveError SpherePrimitiveChannel::log(
   ));
 }
 
+void SpherePrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t SpherePrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool SpherePrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<TextAnnotationChannel> TextAnnotationChannel::create(
@@ -1064,8 +1344,16 @@ FoxgloveError TextAnnotationChannel::log(
   ));
 }
 
+void TextAnnotationChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t TextAnnotationChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool TextAnnotationChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<TextPrimitiveChannel> TextPrimitiveChannel::create(
@@ -1092,8 +1380,16 @@ FoxgloveError TextPrimitiveChannel::log(
   ));
 }
 
+void TextPrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t TextPrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool TextPrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<TriangleListPrimitiveChannel> TriangleListPrimitiveChannel::create(
@@ -1121,8 +1417,16 @@ FoxgloveError TriangleListPrimitiveChannel::log(
   ));
 }
 
+void TriangleListPrimitiveChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t TriangleListPrimitiveChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool TriangleListPrimitiveChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<Vector2Channel> Vector2Channel::create(
@@ -1148,8 +1452,16 @@ FoxgloveError Vector2Channel::log(
   ));
 }
 
+void Vector2Channel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t Vector2Channel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool Vector2Channel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<Vector3Channel> Vector3Channel::create(
@@ -1175,8 +1487,16 @@ FoxgloveError Vector3Channel::log(
   ));
 }
 
+void Vector3Channel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t Vector3Channel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool Vector3Channel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 FoxgloveResult<VoxelGridChannel> VoxelGridChannel::create(
@@ -1202,8 +1522,16 @@ FoxgloveError VoxelGridChannel::log(
   ));
 }
 
+void VoxelGridChannel::close() noexcept {
+  foxglove_channel_close(impl_.get());
+}
+
 uint64_t VoxelGridChannel::id() const noexcept {
   return foxglove_channel_get_id(impl_.get());
+}
+
+bool VoxelGridChannel::has_sinks() const noexcept {
+  return foxglove_channel_has_sinks(impl_.get());
 }
 
 #endif

--- a/cpp/foxglove/tests/test_channel.cpp
+++ b/cpp/foxglove/tests/test_channel.cpp
@@ -1,6 +1,7 @@
 #include <foxglove/channel.hpp>
 #include <foxglove/error.hpp>
 #include <foxglove/mcap.hpp>
+#include <foxglove/schemas.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -78,12 +79,19 @@ TEST_CASE("channel.close() disconnects sinks") {
   auto writer = foxglove::McapWriter::create(mcap_options);
   REQUIRE(writer.has_value());
 
-  auto channel = foxglove::RawChannel::create("test", "json", std::nullopt, context);
-  REQUIRE(channel.has_value());
-  REQUIRE(channel.value().has_sinks());
+  auto raw_channel = foxglove::RawChannel::create("raw_test", "json", std::nullopt, context);
+  REQUIRE(raw_channel.has_value());
+  REQUIRE(raw_channel.value().has_sinks());
 
-  channel.value().close();
-  REQUIRE(!channel.value().has_sinks());
+  raw_channel.value().close();
+  REQUIRE(!raw_channel.value().has_sinks());
+
+  auto typed_channel = foxglove::schemas::LogChannel::create("test", context);
+  REQUIRE(typed_channel.has_value());
+  REQUIRE(typed_channel.value().has_sinks());
+
+  typed_channel.value().close();
+  REQUIRE(!typed_channel.value().has_sinks());
 }
 
 TEST_CASE("channel.schema()") {

--- a/typescript/schemas/src/internal/generateSdkCpp.ts
+++ b/typescript/schemas/src/internal/generateSdkCpp.ts
@@ -212,10 +212,23 @@ export function generateHppSchemas(
         /// @param sink_id The ID of the sink to log to. If omitted, the message is logged to all sinks.
         FoxgloveError log(const ${schema.name}& msg, std::optional<uint64_t> log_time = std::nullopt, std::optional<uint64_t> sink_id = std::nullopt) noexcept;
 
+        /// @brief Close the channel.
+        ///
+        /// You can use this to explicitly unadvertise the channel to sinks that subscribe to channels
+        /// dynamically, such as the WebSocketServer.
+        ///
+        /// Attempts to log on a closed channel will elicit a throttled warning message.
+        void close() noexcept;
+
         /// @brief Uniquely identifies a channel in the context of this program.
         ///
         /// @return The ID of the channel.
         [[nodiscard]] uint64_t id() const noexcept;
+
+        /// @brief Find out if any sinks have been added to the channel.
+        ///
+        /// @return True if sinks have been added to the channel, false otherwise.
+        [[nodiscard]] bool has_sinks() const noexcept;
 
         ${schema.name}Channel(const ${schema.name}Channel& other) noexcept = delete;
         ${schema.name}Channel& operator=(const ${schema.name}Channel& other) noexcept = delete;
@@ -377,9 +390,17 @@ export function generateCppSchemas(schemas: FoxgloveMessageSchema[]): string {
       `FoxgloveError ${schema.name}Channel::log(const ${schema.name}& msg, std::optional<uint64_t> log_time, std::optional<uint64_t> sink_id) noexcept {`,
       ...conversionCode,
       "}\n",
+      `void ${schema.name}Channel::close() noexcept {
+        foxglove_channel_close(impl_.get());
+      }
+      `,
       `uint64_t ${schema.name}Channel::id() const noexcept {`,
       "    return foxglove_channel_get_id(impl_.get());",
       "}\n\n",
+      `bool ${schema.name}Channel::has_sinks() const noexcept {
+        return foxglove_channel_has_sinks(impl_.get());
+      }
+      `,
     ];
   });
 


### PR DESCRIPTION
### Changelog
cpp: added `has_sinks()` and `close()` to schema-specific channels.

### Docs

None

### Description

Adds two methods that were present on RawChannel, but not typed channels.

Resolves #619 
