### PR TITLE
Update ROS badges for rolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Visit [Foxglove SDK Docs](https://docs.foxglove.dev/sdk) to get started.
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove_msgs)](https://index.ros.org/p/foxglove_msgs#humble)<br/>
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/foxglove_msgs)](https://index.ros.org/p/foxglove_msgs#jazzy)<br/>
 [![ROS Kilted version](https://img.shields.io/ros/v/kilted/foxglove_msgs)](https://index.ros.org/p/foxglove_msgs#kilted)<br/>
-[![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove_msgs)](https://index.ros.org/p/foxglove_msgs#rolling)
+[![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove-sdk)](https://index.ros.org/p/foxglove_msgs#rolling)
 
 </td>
 <td>Foxglove schemas for ROS</td>
@@ -92,7 +92,7 @@ Visit [Foxglove SDK Docs](https://docs.foxglove.dev/sdk) to get started.
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge#humble)<br/>
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge#jazzy)<br/>
 [![ROS Kilted version](https://img.shields.io/ros/v/kilted/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge#kilted)<br/>
-[![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge#rolling)
+[![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove-sdk)](https://index.ros.org/p/foxglove_bridge#rolling)
 
 </td>
 <td>Foxglove ROS bridge</td>


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Alternative to #684 to fix the broken badge. We need to specify the name of the repository, not the package itself. These used to be the same but now the repository is named `foxglove-sdk`.