### PR TITLE
Add Agent sink behind agent feature flag

### DIFF
--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 default = ["derive", "live_visualization", "lz4", "zstd"]
 chrono = ["dep:chrono"]
 derive = ["dep:foxglove_derive"]
+agent = ["live_visualization"]
 live_visualization = [
   "dep:base64",
   "dep:flume",

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -347,6 +347,8 @@ pub use schema::Schema;
 pub use sink::{Sink, SinkId};
 pub(crate) use time::nanoseconds_since_epoch;
 
+#[cfg(feature = "agent")]
+mod agent;
 #[cfg(feature = "live_visualization")]
 mod runtime;
 #[cfg(feature = "live_visualization")]
@@ -355,6 +357,8 @@ pub mod websocket;
 mod websocket_client;
 #[cfg(feature = "live_visualization")]
 mod websocket_server;
+#[cfg(feature = "agent")]
+pub use agent::Agent;
 #[cfg(feature = "live_visualization")]
 pub(crate) use runtime::get_runtime_handle;
 #[cfg(feature = "live_visualization")]

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -60,6 +60,14 @@ impl WebSocketServer {
         Self::default()
     }
 
+    /// Creates a new websocket server with the given options.
+    pub(crate) fn with_options(options: ServerOptions) -> Self {
+        Self {
+            options,
+            ..Self::default()
+        }
+    }
+
     /// Set the websocket server name to advertise to clients.
     ///
     /// By default, the server is not given a name.


### PR DESCRIPTION
### Changelog

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Add Agent sink for remote visualization through Foxglove Agent running on the same host (not yet released).

This adds a non-default feature agent, and behind that an Agent sink. Currently this starts the WebSocketServer, but the implementation will change in the future.

I'd like some feedback about the methods I included on the builder. I think they all make sense going forward, but I'd like a second opinion on that. For now I didn't expose anything other than stop() on the handle.

Things like services and asset handlers might be supported in the future? At any rate they're not supported now, so I left them out.