### PR TITLE
Fix python build issues on windows and with sdk examples

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
-          args: --release --out dist --find-interpreter
+          args: --release --out dist -i python
           sccache: "false"
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           working-directory: python/foxglove-sdk
-          args: --release --out dist -i python
+          args: --release --out dist --interpreter python
           sccache: "false"
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/python/foxglove-sdk-examples/so100-visualization/pyproject.toml
+++ b/python/foxglove-sdk-examples/so100-visualization/pyproject.toml
@@ -9,7 +9,8 @@ python = "^3.10"
 foxglove-sdk = "^0.4.0"
 scipy = "^1.0"
 yourdfpy = "*"
-lerobot = {version = "*", extras = ["feetech"]}
+lerobot = { version = "*", extras = ["feetech"] }
+av = "15.1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -60,6 +60,15 @@ impl WebSocketServer {
         Self::default()
     }
 
+    // JUST FOR TESTING THE BUILD
+    #[allow(unused)]
+    pub(crate) fn with_options(options: ServerOptions) -> Self {
+        Self {
+            options,
+            ..Self::default()
+        }
+    }
+
     /// Set the websocket server name to advertise to clients.
     ///
     /// By default, the server is not given a name.

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -60,15 +60,6 @@ impl WebSocketServer {
         Self::default()
     }
 
-    // JUST FOR TESTING THE BUILD
-    #[allow(unused)]
-    pub(crate) fn with_options(options: ServerOptions) -> Self {
-        Self {
-            options,
-            ..Self::default()
-        }
-    }
-
     /// Set the websocket server name to advertise to clients.
     ///
     /// By default, the server is not given a name.


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Two separate issues fixed:

1) test-sdk-examples tries to install av v16 which doesn't have wheels for all platforms (no Linux x86 or x64!)
2) windows x86 builds try to use 64bit python when they should use the 32bit version

