### PR TITLE
Update Foxglove Bridge documentation to remove pre-release copy

### DIFF
--- a/ros/src/foxglove_bridge/README.md
+++ b/ros/src/foxglove_bridge/README.md
@@ -1,10 +1,5 @@
 # foxglove_bridge
 
-> [!IMPORTANT]
-> This upcoming version of `foxglove_bridge` is built using the Foxglove SDK and is in **public beta**. There may be some remaining bugs or unexpected behavior. We encourage users to take it for a spin and submit feedback and bug reports.
->
-> Older versions of `foxglove_bridge`, including those targeting ROS 1, still are available from the [foxglove/ros-foxglove-bridge](https://github.com/foxglove/ros-foxglove-bridge) repository or via the ROS package index for your ROS distro.
-
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#humble)
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#jazzy)
 [![ROS Kilted version](https://img.shields.io/ros/v/kilted/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#kilted)
@@ -12,13 +7,25 @@
 
 High performance ROS 2 WebSocket bridge using the Foxglove SDK, written in C++.
 
+> [!NOTE]
+> The version of `foxglove_bridge` in this repo does not support ROS 1. If you are a ROS 1 user, you can find the source code for the legacy version of `foxglove_bridge` in the [ROS 1 foxglove_bridge repo](https://github.com/foxglove/ros-foxglove-bridge).
+
 ## Motivation
 
 Live debugging of ROS systems has traditionally relied on running ROS tooling such as rviz. This requires either a GUI and connected peripherals on the robot, or replicating the same ROS environment on a network-connected development machine including the same version of ROS, all custom message definitions, etc. To overcome this limitation and allow remote debugging from web tooling or non-ROS systems, rosbridge was developed. However, rosbridge suffers from performance problems with high frequency topics and/or large messages, and the protocol does not support full visibility into ROS systems such as interacting with parameters or seeing the full graph of publishers and subscribers.
 
 The `foxglove_bridge` uses the **Foxglove SDK** (this repo!), a similar protocol to rosbridge but with the ability to support additional schema formats such as ROS 2 `.msg` and ROS 2 `.idl`, parameters, graph introspection, and non-ROS systems. The bridge is written in C++ and designed for high performance with low overhead to minimize the impact to your robot stack.
 
-## Build and install
+## Install
+### Install using apt
+You can install `foxglove_bridge` using `apt` from the official ROS package channels for any currently supported ROS 2 distribution, as well as ROS Rolling.
+
+```bash
+sudo apt install ros-$ROS_DISTRO-foxglove-bridge
+```
+
+Note that packages coming from the ROS channels are updated less frequently than this repository. For the latest set of features, consider [building from source](#build-from-source) or [installing using Docker](#install-using-docker).
+
 ### Install using Docker
 Docker images are built and published to our public Docker image registry for your convenience.
 


### PR DESCRIPTION
### Changelog
None

### Docs
This PR _is_ docs

### Description
Update documentation to remove the banner marking it as a public beta, and provide installation instructions using apt. Also added in a banner for ROS 1 users.

Note that if folks follow the instructions today, they'll pull the old bridge (pre v3.2.x) until each respective ROS distro does its package sync. But the command line will be the same, so I figured there's no harm updating it now.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
Fixes: FG-12734

