### PR TITLE
Ensure writer is closed in examples, add a note about that to doc string

### DIFF
--- a/python/foxglove-sdk-examples/quickstart/main.py
+++ b/python/foxglove-sdk-examples/quickstart/main.py
@@ -22,28 +22,28 @@ size_channel = Channel("/size", message_encoding="json")
 
 # We'll log to both an MCAP file, and to a running Foxglove app via a server.
 file_name = "quickstart-python.mcap"
-writer = foxglove.open_mcap(file_name)
-server = foxglove.start_server()
+# Close the mcap writer with close() or the with statement
+with foxglove.open_mcap(file_name):
+    server = foxglove.start_server()
+    while True:
+        size = abs(math.sin(time.time())) + 1
 
-while True:
-    size = abs(math.sin(time.time())) + 1
-
-    # Log messages on both channels until interrupted. By default, each message
-    # is stamped with the current time.
-    size_channel.log({"size": size})
-    scene_channel.log(
-        SceneUpdate(
-            entities=[
-                SceneEntity(
-                    cubes=[
-                        CubePrimitive(
-                            size=Vector3(x=size, y=size, z=size),
-                            color=Color(r=1.0, g=0, b=0, a=1.0),
-                        )
-                    ],
-                ),
-            ]
+        # Log messages on both channels until interrupted. By default, each message
+        # is stamped with the current time.
+        size_channel.log({"size": size})
+        scene_channel.log(
+            SceneUpdate(
+                entities=[
+                    SceneEntity(
+                        cubes=[
+                            CubePrimitive(
+                                size=Vector3(x=size, y=size, z=size),
+                                color=Color(r=1.0, g=0, b=0, a=1.0),
+                            )
+                        ],
+                    ),
+                ]
+            )
         )
-    )
 
-    time.sleep(0.033)
+        time.sleep(0.033)

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -170,6 +170,8 @@ def open_mcap(
 
     If a context is provided, the MCAP file will be associated with that context. Otherwise, the
     global context will be used.
+
+    You must close the writer with close() or the with statement to ensure the file is correctly finished.
     """
     ...
 


### PR DESCRIPTION
### Changelog
None

### Docs

https://github.com/foxglove/docs/pull/1003/files

### Description

If you don't close the mcap writer, it won't finish the mcap file correctly leading to an obscure error “length out of int32 range” when you try to open it. So we add the with statement and a comment to all examples, to make it clearer for the developer how to avoid that.

