### PR TITLE
Update Docker image tagging scheme

### DIFF
--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -3,7 +3,7 @@ name: Publish ROS Bridge Docker image
 on:
   workflow_dispatch: {}
   push:
-    tags: ['sdk/v*']
+    tags: ['ros-v*']
 
 permissions:
   contents: read
@@ -42,10 +42,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Check if this is a release tag (sdk/v*)
-          if [[ "${GITHUB_REF}" == refs/tags/sdk/v* ]]; then
-            # Extract version from release tag (remove sdk/ prefix)
-            VERSION=${GITHUB_REF#refs/tags/sdk/}
+          # Check if this is a release tag (ros-v*)
+          if [[ "${GITHUB_REF}" == refs/tags/ros-v* ]]; then
+            # Extract version from release tag (remove ros- prefix)
+            VERSION=${GITHUB_REF#refs/tags/ros-}
             echo "Using release version: ${VERSION}"
           else
             # Use git SHA for non-release builds

--- a/ros/src/foxglove_bridge/README.md
+++ b/ros/src/foxglove_bridge/README.md
@@ -17,7 +17,9 @@ Live debugging of ROS systems has traditionally relied on running ROS tooling su
 The `foxglove_bridge` uses the **Foxglove SDK** (this repo!), a similar protocol to rosbridge but with the ability to support additional schema formats such as ROS 2 `.msg` and ROS 2 `.idl`, parameters, graph introspection, and non-ROS systems. The bridge is written in C++ and designed for high performance with low overhead to minimize the impact to your robot stack.
 
 ## Install
+
 ### Install using apt
+
 You can install `foxglove_bridge` using `apt` from the official ROS package channels for any currently supported ROS 2 distribution, as well as ROS Rolling.
 
 ```bash
@@ -27,6 +29,7 @@ sudo apt install ros-$ROS_DISTRO-foxglove-bridge
 Note that packages coming from the ROS channels are updated less frequently than this repository. For the latest set of features, consider [building from source](#build-from-source) or [installing using Docker](#install-using-docker).
 
 ### Install using Docker
+
 Docker images are built and published to our public Docker image registry for your convenience.
 
 > [!NOTE]
@@ -39,17 +42,19 @@ docker pull us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge:<t
 ```
 
 where `<tag>` takes the form of:
+
 ```
-ros-<ROS distro>-<foxglove SDK version>
+ros-<ROS distro>-<package version>
 ```
 
-For example, if you wanted to pull an image based on ROS Kilted and Foxglove SDK v0.11.0:
+For example, if you wanted to pull an image based on ROS Kilted and package version v3.2.1:
+
 ```bash
-docker pull us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge:ros-kilted-v0.11.0
+docker pull us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge:ros-kilted-v3.2.1
 ```
-
 
 ### Build from source
+
 #### Getting the sources
 
 Clone this repo from GitHub and `cd` to the local ROS workspace:


### PR DESCRIPTION
### Changelog
- Foxglove Bridge Docker images now conform to the ROS package version scheme

### Docs
Docs updated to reflect new Docker image tagging scheme

### Description
In #662 we updated the version of `foxglove_bridge` to match that of `foxglove_msgs`, and we release it using the `ros-vx.x.x` git tag (previously we had assumed the version of `foxglove_bridge` could be tied to the SDK version + release instead). This updates our Docker image publication and tagging logic to match.

