### PR TITLE
remove language referring to optional fields

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -1136,11 +1136,11 @@ typedef struct foxglove_line_primitive {
   const struct foxglove_point3 *points;
   size_t points_count;
   /**
-   * Solid color to use for the whole line. One of `color` or `colors` must be provided.
+   * Solid color to use for the whole line. Ignored if `colors` is non-empty.
    */
   const struct foxglove_color *color;
   /**
-   * Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+   * Per-point colors (if non-empty, must have the same length as `points`).
    */
   const struct foxglove_color *colors;
   size_t colors_count;
@@ -1299,11 +1299,11 @@ typedef struct foxglove_triangle_list_primitive {
   const struct foxglove_point3 *points;
   size_t points_count;
   /**
-   * Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+   * Solid color to use for the whole shape. Ignored if `colors` is non-empty.
    */
   const struct foxglove_color *color;
   /**
-   * Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+   * Per-vertex colors (if specified, must have the same length as `points`).
    */
   const struct foxglove_color *colors;
   size_t colors_count;
@@ -1367,7 +1367,7 @@ typedef struct foxglove_model_primitive {
    */
   bool override_color;
   /**
-   * URL pointing to model file. One of `url` or `data` should be provided.
+   * URL pointing to model file. One of `url` or `data` should be non-empty.
    */
   struct foxglove_string url;
   /**
@@ -1375,7 +1375,7 @@ typedef struct foxglove_model_primitive {
    */
   struct foxglove_string media_type;
   /**
-   * Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+   * Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
    */
   const unsigned char *data;
   size_t data_len;

--- a/c/src/generated_types.rs
+++ b/c/src/generated_types.rs
@@ -2976,10 +2976,10 @@ pub struct LinePrimitive {
     pub points: *const Point3,
     pub points_count: usize,
 
-    /// Solid color to use for the whole line. One of `color` or `colors` must be provided.
+    /// Solid color to use for the whole line. Ignored if `colors` is non-empty.
     pub color: *const Color,
 
-    /// Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+    /// Per-point colors (if non-empty, must have the same length as `points`).
     pub colors: *const Color,
     pub colors_count: usize,
 
@@ -4213,13 +4213,13 @@ pub struct ModelPrimitive {
     /// Whether to use the color specified in `color` instead of any materials embedded in the original model.
     pub override_color: bool,
 
-    /// URL pointing to model file. One of `url` or `data` should be provided.
+    /// URL pointing to model file. One of `url` or `data` should be non-empty.
     pub url: FoxgloveString,
 
     /// [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
     pub media_type: FoxgloveString,
 
-    /// Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+    /// Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
     pub data: *const c_uchar,
     pub data_len: usize,
 }
@@ -6819,10 +6819,10 @@ pub struct TriangleListPrimitive {
     pub points: *const Point3,
     pub points_count: usize,
 
-    /// Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+    /// Solid color to use for the whole shape. Ignored if `colors` is non-empty.
     pub color: *const Color,
 
-    /// Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+    /// Per-vertex colors (if specified, must have the same length as `points`).
     pub colors: *const Color,
     pub colors_count: usize,
 

--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -1085,11 +1085,10 @@ struct LinePrimitive {
   /// @brief Points along the line
   std::vector<Point3> points;
 
-  /// @brief Solid color to use for the whole line. One of `color` or `colors` must be provided.
+  /// @brief Solid color to use for the whole line. Ignored if `colors` is non-empty.
   std::optional<Color> color;
 
-  /// @brief Per-point colors (if specified, must have the same length as `points`). One of `color`
-  /// or `colors` must be provided.
+  /// @brief Per-point colors (if non-empty, must have the same length as `points`).
   std::vector<Color> colors;
 
   /// @brief Indices into the `points` and `colors` attribute arrays, which can be used to avoid
@@ -1330,11 +1329,10 @@ struct TriangleListPrimitive {
   /// @brief Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
   std::vector<Point3> points;
 
-  /// @brief Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+  /// @brief Solid color to use for the whole shape. Ignored if `colors` is non-empty.
   std::optional<Color> color;
 
-  /// @brief Per-vertex colors (if specified, must have the same length as `points`). One of `color`
-  /// or `colors` must be provided.
+  /// @brief Per-vertex colors (if specified, must have the same length as `points`).
   std::vector<Color> colors;
 
   /// @brief Indices into the `points` and `colors` attribute arrays, which can be used to avoid
@@ -1420,7 +1418,7 @@ struct ModelPrimitive {
   /// original model.
   bool override_color = false;
 
-  /// @brief URL pointing to model file. One of `url` or `data` should be provided.
+  /// @brief URL pointing to model file. One of `url` or `data` should be non-empty.
   std::string url;
 
   /// @brief [Media
@@ -1429,7 +1427,7 @@ struct ModelPrimitive {
   /// the inferred media type if `url` is provided.
   std::string media_type;
 
-  /// @brief Embedded model. One of `url` or `data` should be provided. If `data` is provided,
+  /// @brief Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty,
   /// `media_type` must be set to indicate the type of the data.
   std::vector<std::byte> data;
 

--- a/python/foxglove-sdk/src/generated/schemas.rs
+++ b/python/foxglove-sdk/src/generated/schemas.rs
@@ -1261,8 +1261,8 @@ impl From<LaserScan> for foxglove::schemas::LaserScan {
 /// :param thickness: Line thickness
 /// :param scale_invariant: Indicates whether `thickness` is a fixed size in screen pixels (true), or specified in world coordinates and scales with distance from the camera (false)
 /// :param points: Points along the line
-/// :param color: Solid color to use for the whole line. One of `color` or `colors` must be provided.
-/// :param colors: Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+/// :param color: Solid color to use for the whole line. Ignored if `colors` is non-empty.
+/// :param colors: Per-point colors (if non-empty, must have the same length as `points`).
 /// :param indices: Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.
 ///     
 ///     If omitted or empty, indexing will not be used. This default behavior is equivalent to specifying [0, 1, ..., N-1] for the indices (where N is the number of `points` provided).
@@ -1811,9 +1811,9 @@ impl From<SceneUpdate> for foxglove::schemas::SceneUpdate {
 /// :param scale: Scale factor to apply to the model along each axis
 /// :param color: Solid color to use for the whole model if `override_color` is true.
 /// :param override_color: Whether to use the color specified in `color` instead of any materials embedded in the original model.
-/// :param url: URL pointing to model file. One of `url` or `data` should be provided.
+/// :param url: URL pointing to model file. One of `url` or `data` should be non-empty.
 /// :param media_type: [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
-/// :param data: Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+/// :param data: Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/model-primitive
 #[pyclass(module = "foxglove.schemas")]
@@ -2829,8 +2829,8 @@ impl From<TextPrimitive> for foxglove::schemas::TextPrimitive {
 ///
 /// :param pose: Origin of triangles relative to reference frame
 /// :param points: Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
-/// :param color: Solid color to use for the whole shape. One of `color` or `colors` must be provided.
-/// :param colors: Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+/// :param color: Solid color to use for the whole shape. Ignored if `colors` is non-empty.
+/// :param colors: Per-vertex colors (if specified, must have the same length as `points`).
 /// :param indices: Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.
 ///     
 ///     If omitted or empty, indexing will not be used. This default behavior is equivalent to specifying [0, 1, ..., N-1] for the indices (where N is the number of `points` provided).

--- a/ros/src/foxglove_msgs/ros1/LinePrimitive.msg
+++ b/ros/src/foxglove_msgs/ros1/LinePrimitive.msg
@@ -27,10 +27,10 @@ bool scale_invariant
 # Points along the line
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole line. One of `color` or `colors` must be provided.
+# Solid color to use for the whole line. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-point colors (if non-empty, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/ros/src/foxglove_msgs/ros1/ModelPrimitive.msg
+++ b/ros/src/foxglove_msgs/ros1/ModelPrimitive.msg
@@ -15,11 +15,11 @@ foxglove_msgs/Color color
 # Whether to use the color specified in `color` instead of any materials embedded in the original model.
 bool override_color
 
-# URL pointing to model file. One of `url` or `data` should be provided.
+# URL pointing to model file. One of `url` or `data` should be non-empty.
 string url
 
 # [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
 string media_type
 
-# Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+# Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
 uint8[] data

--- a/ros/src/foxglove_msgs/ros1/TriangleListPrimitive.msg
+++ b/ros/src/foxglove_msgs/ros1/TriangleListPrimitive.msg
@@ -9,10 +9,10 @@ geometry_msgs/Pose pose
 # Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+# Solid color to use for the whole shape. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-vertex colors (if specified, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/ros/src/foxglove_msgs/ros2/LinePrimitive.msg
+++ b/ros/src/foxglove_msgs/ros2/LinePrimitive.msg
@@ -27,10 +27,10 @@ bool scale_invariant
 # Points along the line
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole line. One of `color` or `colors` must be provided.
+# Solid color to use for the whole line. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-point colors (if non-empty, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/ros/src/foxglove_msgs/ros2/ModelPrimitive.msg
+++ b/ros/src/foxglove_msgs/ros2/ModelPrimitive.msg
@@ -15,11 +15,11 @@ foxglove_msgs/Color color
 # Whether to use the color specified in `color` instead of any materials embedded in the original model.
 bool override_color
 
-# URL pointing to model file. One of `url` or `data` should be provided.
+# URL pointing to model file. One of `url` or `data` should be non-empty.
 string url
 
 # [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
 string media_type
 
-# Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+# Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
 uint8[] data

--- a/ros/src/foxglove_msgs/ros2/TriangleListPrimitive.msg
+++ b/ros/src/foxglove_msgs/ros2/TriangleListPrimitive.msg
@@ -9,10 +9,10 @@ geometry_msgs/Pose pose
 # Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+# Solid color to use for the whole shape. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-vertex colors (if specified, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/rust/foxglove/src/schemas/foxglove.rs
+++ b/rust/foxglove/src/schemas/foxglove.rs
@@ -378,10 +378,10 @@ pub struct LinePrimitive {
     /// Points along the line
     #[prost(message, repeated, tag = "5")]
     pub points: ::prost::alloc::vec::Vec<Point3>,
-    /// Solid color to use for the whole line. One of `color` or `colors` must be provided.
+    /// Solid color to use for the whole line. Ignored if `colors` is non-empty.
     #[prost(message, optional, tag = "6")]
     pub color: ::core::option::Option<Color>,
-    /// Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+    /// Per-point colors (if non-empty, must have the same length as `points`).
     #[prost(message, repeated, tag = "7")]
     pub colors: ::prost::alloc::vec::Vec<Color>,
     /// Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.
@@ -622,13 +622,13 @@ pub struct ModelPrimitive {
     /// Whether to use the color specified in `color` instead of any materials embedded in the original model.
     #[prost(bool, tag = "4")]
     pub override_color: bool,
-    /// URL pointing to model file. One of `url` or `data` should be provided.
+    /// URL pointing to model file. One of `url` or `data` should be non-empty.
     #[prost(string, tag = "5")]
     pub url: ::prost::alloc::string::String,
     /// [Media type](<https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types>) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
     #[prost(string, tag = "6")]
     pub media_type: ::prost::alloc::string::String,
-    /// Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+    /// Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
     #[prost(bytes = "bytes", tag = "7")]
     pub data: ::prost::bytes::Bytes,
 }
@@ -1184,10 +1184,10 @@ pub struct TriangleListPrimitive {
     /// Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
     #[prost(message, repeated, tag = "2")]
     pub points: ::prost::alloc::vec::Vec<Point3>,
-    /// Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+    /// Solid color to use for the whole shape. Ignored if `colors` is non-empty.
     #[prost(message, optional, tag = "3")]
     pub color: ::core::option::Option<Color>,
-    /// Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+    /// Per-vertex colors (if specified, must have the same length as `points`).
     #[prost(message, repeated, tag = "4")]
     pub colors: ::prost::alloc::vec::Vec<Color>,
     /// Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1414,7 +1414,7 @@ Points along the line
 </td>
 <td>
 
-Solid color to use for the whole line. One of `color` or `colors` must be provided.
+Solid color to use for the whole line. Ignored if `colors` is non-empty.
 
 </td>
 </tr>
@@ -1427,7 +1427,7 @@ Solid color to use for the whole line. One of `color` or `colors` must be provid
 </td>
 <td>
 
-Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+Per-point colors (if non-empty, must have the same length as `points`).
 
 </td>
 </tr>
@@ -1750,7 +1750,7 @@ string
 </td>
 <td>
 
-URL pointing to model file. One of `url` or `data` should be provided.
+URL pointing to model file. One of `url` or `data` should be non-empty.
 
 </td>
 </tr>
@@ -1776,7 +1776,7 @@ bytes
 </td>
 <td>
 
-Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
 
 </td>
 </tr>
@@ -3151,7 +3151,7 @@ Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, .
 </td>
 <td>
 
-Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+Solid color to use for the whole shape. Ignored if `colors` is non-empty.
 
 </td>
 </tr>
@@ -3164,7 +3164,7 @@ Solid color to use for the whole shape. One of `color` or `colors` must be provi
 </td>
 <td>
 
-Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+Per-vertex colors (if specified, must have the same length as `points`).
 
 </td>
 </tr>

--- a/schemas/flatbuffer/LinePrimitive.fbs
+++ b/schemas/flatbuffer/LinePrimitive.fbs
@@ -34,10 +34,10 @@ table LinePrimitive {
   /// Points along the line
   points:[foxglove.Point3] (id: 4);
 
-  /// Solid color to use for the whole line. One of `color` or `colors` must be provided.
+  /// Solid color to use for the whole line. Ignored if `colors` is non-empty.
   color:foxglove.Color (id: 5);
 
-  /// Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+  /// Per-point colors (if non-empty, must have the same length as `points`).
   colors:[foxglove.Color] (id: 6);
 
   /// Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/flatbuffer/ModelPrimitive.fbs
+++ b/schemas/flatbuffer/ModelPrimitive.fbs
@@ -20,13 +20,13 @@ table ModelPrimitive {
   /// Whether to use the color specified in `color` instead of any materials embedded in the original model.
   override_color:bool (id: 3);
 
-  /// URL pointing to model file. One of `url` or `data` should be provided.
+  /// URL pointing to model file. One of `url` or `data` should be non-empty.
   url:string (id: 4);
 
   /// [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
   media_type:string (id: 5);
 
-  /// Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+  /// Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
   data:[uint8] (id: 6);
 }
 

--- a/schemas/flatbuffer/TriangleListPrimitive.fbs
+++ b/schemas/flatbuffer/TriangleListPrimitive.fbs
@@ -14,10 +14,10 @@ table TriangleListPrimitive {
   /// Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
   points:[foxglove.Point3] (id: 1);
 
-  /// Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+  /// Solid color to use for the whole shape. Ignored if `colors` is non-empty.
   color:foxglove.Color (id: 2);
 
-  /// Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+  /// Per-vertex colors (if specified, must have the same length as `points`).
   colors:[foxglove.Color] (id: 3);
 
   /// Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/jsonschema/LinePrimitive.json
+++ b/schemas/jsonschema/LinePrimitive.json
@@ -127,7 +127,7 @@
     },
     "color": {
       "title": "foxglove.Color",
-      "description": "Solid color to use for the whole line. One of `color` or `colors` must be provided.",
+      "description": "Solid color to use for the whole line. Ignored if `colors` is non-empty.",
       "type": "object",
       "properties": {
         "r": {
@@ -185,7 +185,7 @@
           "a"
         ]
       },
-      "description": "Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+      "description": "Per-point colors (if non-empty, must have the same length as `points`)."
     },
     "indices": {
       "type": "array",

--- a/schemas/jsonschema/ModelPrimitive.json
+++ b/schemas/jsonschema/ModelPrimitive.json
@@ -127,7 +127,7 @@
     },
     "url": {
       "type": "string",
-      "description": "URL pointing to model file. One of `url` or `data` should be provided."
+      "description": "URL pointing to model file. One of `url` or `data` should be non-empty."
     },
     "media_type": {
       "type": "string",
@@ -136,7 +136,7 @@
     "data": {
       "type": "string",
       "contentEncoding": "base64",
-      "description": "Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data."
+      "description": "Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data."
     }
   },
   "required": [

--- a/schemas/jsonschema/SceneEntity.json
+++ b/schemas/jsonschema/SceneEntity.json
@@ -737,7 +737,7 @@
           },
           "color": {
             "title": "foxglove.Color",
-            "description": "Solid color to use for the whole line. One of `color` or `colors` must be provided.",
+            "description": "Solid color to use for the whole line. Ignored if `colors` is non-empty.",
             "type": "object",
             "properties": {
               "r": {
@@ -795,7 +795,7 @@
                 "a"
               ]
             },
-            "description": "Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+            "description": "Per-point colors (if non-empty, must have the same length as `points`)."
           },
           "indices": {
             "type": "array",
@@ -920,7 +920,7 @@
           },
           "color": {
             "title": "foxglove.Color",
-            "description": "Solid color to use for the whole shape. One of `color` or `colors` must be provided.",
+            "description": "Solid color to use for the whole shape. Ignored if `colors` is non-empty.",
             "type": "object",
             "properties": {
               "r": {
@@ -978,7 +978,7 @@
                 "a"
               ]
             },
-            "description": "Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+            "description": "Per-vertex colors (if specified, must have the same length as `points`)."
           },
           "indices": {
             "type": "array",
@@ -1257,7 +1257,7 @@
           },
           "url": {
             "type": "string",
-            "description": "URL pointing to model file. One of `url` or `data` should be provided."
+            "description": "URL pointing to model file. One of `url` or `data` should be non-empty."
           },
           "media_type": {
             "type": "string",
@@ -1266,7 +1266,7 @@
           "data": {
             "type": "string",
             "contentEncoding": "base64",
-            "description": "Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data."
+            "description": "Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data."
           }
         },
         "required": [

--- a/schemas/jsonschema/SceneUpdate.json
+++ b/schemas/jsonschema/SceneUpdate.json
@@ -796,7 +796,7 @@
                 },
                 "color": {
                   "title": "foxglove.Color",
-                  "description": "Solid color to use for the whole line. One of `color` or `colors` must be provided.",
+                  "description": "Solid color to use for the whole line. Ignored if `colors` is non-empty.",
                   "type": "object",
                   "properties": {
                     "r": {
@@ -854,7 +854,7 @@
                       "a"
                     ]
                   },
-                  "description": "Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+                  "description": "Per-point colors (if non-empty, must have the same length as `points`)."
                 },
                 "indices": {
                   "type": "array",
@@ -979,7 +979,7 @@
                 },
                 "color": {
                   "title": "foxglove.Color",
-                  "description": "Solid color to use for the whole shape. One of `color` or `colors` must be provided.",
+                  "description": "Solid color to use for the whole shape. Ignored if `colors` is non-empty.",
                   "type": "object",
                   "properties": {
                     "r": {
@@ -1037,7 +1037,7 @@
                       "a"
                     ]
                   },
-                  "description": "Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+                  "description": "Per-vertex colors (if specified, must have the same length as `points`)."
                 },
                 "indices": {
                   "type": "array",
@@ -1316,7 +1316,7 @@
                 },
                 "url": {
                   "type": "string",
-                  "description": "URL pointing to model file. One of `url` or `data` should be provided."
+                  "description": "URL pointing to model file. One of `url` or `data` should be non-empty."
                 },
                 "media_type": {
                   "type": "string",
@@ -1325,7 +1325,7 @@
                 "data": {
                   "type": "string",
                   "contentEncoding": "base64",
-                  "description": "Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data."
+                  "description": "Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data."
                 }
               },
               "required": [

--- a/schemas/jsonschema/TriangleListPrimitive.json
+++ b/schemas/jsonschema/TriangleListPrimitive.json
@@ -98,7 +98,7 @@
     },
     "color": {
       "title": "foxglove.Color",
-      "description": "Solid color to use for the whole shape. One of `color` or `colors` must be provided.",
+      "description": "Solid color to use for the whole shape. Ignored if `colors` is non-empty.",
       "type": "object",
       "properties": {
         "r": {
@@ -156,7 +156,7 @@
           "a"
         ]
       },
-      "description": "Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+      "description": "Per-vertex colors (if specified, must have the same length as `points`)."
     },
     "indices": {
       "type": "array",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -2129,7 +2129,7 @@ export const LinePrimitive = {
     },
     "color": {
       "title": "foxglove.Color",
-      "description": "Solid color to use for the whole line. One of `color` or `colors` must be provided.",
+      "description": "Solid color to use for the whole line. Ignored if `colors` is non-empty.",
       "type": "object",
       "properties": {
         "r": {
@@ -2187,7 +2187,7 @@ export const LinePrimitive = {
           "a"
         ]
       },
-      "description": "Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+      "description": "Per-point colors (if non-empty, must have the same length as `points`)."
     },
     "indices": {
       "type": "array",
@@ -3329,7 +3329,7 @@ export const SceneEntity = {
           },
           "color": {
             "title": "foxglove.Color",
-            "description": "Solid color to use for the whole line. One of `color` or `colors` must be provided.",
+            "description": "Solid color to use for the whole line. Ignored if `colors` is non-empty.",
             "type": "object",
             "properties": {
               "r": {
@@ -3387,7 +3387,7 @@ export const SceneEntity = {
                 "a"
               ]
             },
-            "description": "Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+            "description": "Per-point colors (if non-empty, must have the same length as `points`)."
           },
           "indices": {
             "type": "array",
@@ -3512,7 +3512,7 @@ export const SceneEntity = {
           },
           "color": {
             "title": "foxglove.Color",
-            "description": "Solid color to use for the whole shape. One of `color` or `colors` must be provided.",
+            "description": "Solid color to use for the whole shape. Ignored if `colors` is non-empty.",
             "type": "object",
             "properties": {
               "r": {
@@ -3570,7 +3570,7 @@ export const SceneEntity = {
                 "a"
               ]
             },
-            "description": "Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+            "description": "Per-vertex colors (if specified, must have the same length as `points`)."
           },
           "indices": {
             "type": "array",
@@ -3849,7 +3849,7 @@ export const SceneEntity = {
           },
           "url": {
             "type": "string",
-            "description": "URL pointing to model file. One of `url` or `data` should be provided."
+            "description": "URL pointing to model file. One of `url` or `data` should be non-empty."
           },
           "media_type": {
             "type": "string",
@@ -3858,7 +3858,7 @@ export const SceneEntity = {
           "data": {
             "type": "string",
             "contentEncoding": "base64",
-            "description": "Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data."
+            "description": "Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data."
           }
         },
         "required": [
@@ -4690,7 +4690,7 @@ export const SceneUpdate = {
                 },
                 "color": {
                   "title": "foxglove.Color",
-                  "description": "Solid color to use for the whole line. One of `color` or `colors` must be provided.",
+                  "description": "Solid color to use for the whole line. Ignored if `colors` is non-empty.",
                   "type": "object",
                   "properties": {
                     "r": {
@@ -4748,7 +4748,7 @@ export const SceneUpdate = {
                       "a"
                     ]
                   },
-                  "description": "Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+                  "description": "Per-point colors (if non-empty, must have the same length as `points`)."
                 },
                 "indices": {
                   "type": "array",
@@ -4873,7 +4873,7 @@ export const SceneUpdate = {
                 },
                 "color": {
                   "title": "foxglove.Color",
-                  "description": "Solid color to use for the whole shape. One of `color` or `colors` must be provided.",
+                  "description": "Solid color to use for the whole shape. Ignored if `colors` is non-empty.",
                   "type": "object",
                   "properties": {
                     "r": {
@@ -4931,7 +4931,7 @@ export const SceneUpdate = {
                       "a"
                     ]
                   },
-                  "description": "Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+                  "description": "Per-vertex colors (if specified, must have the same length as `points`)."
                 },
                 "indices": {
                   "type": "array",
@@ -5210,7 +5210,7 @@ export const SceneUpdate = {
                 },
                 "url": {
                   "type": "string",
-                  "description": "URL pointing to model file. One of `url` or `data` should be provided."
+                  "description": "URL pointing to model file. One of `url` or `data` should be non-empty."
                 },
                 "media_type": {
                   "type": "string",
@@ -5219,7 +5219,7 @@ export const SceneUpdate = {
                 "data": {
                   "type": "string",
                   "contentEncoding": "base64",
-                  "description": "Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data."
+                  "description": "Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data."
                 }
               },
               "required": [
@@ -5390,7 +5390,7 @@ export const ModelPrimitive = {
     },
     "url": {
       "type": "string",
-      "description": "URL pointing to model file. One of `url` or `data` should be provided."
+      "description": "URL pointing to model file. One of `url` or `data` should be non-empty."
     },
     "media_type": {
       "type": "string",
@@ -5399,7 +5399,7 @@ export const ModelPrimitive = {
     "data": {
       "type": "string",
       "contentEncoding": "base64",
-      "description": "Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data."
+      "description": "Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data."
     }
   },
   "required": [
@@ -6812,7 +6812,7 @@ export const TriangleListPrimitive = {
     },
     "color": {
       "title": "foxglove.Color",
-      "description": "Solid color to use for the whole shape. One of `color` or `colors` must be provided.",
+      "description": "Solid color to use for the whole shape. Ignored if `colors` is non-empty.",
       "type": "object",
       "properties": {
         "r": {
@@ -6870,7 +6870,7 @@ export const TriangleListPrimitive = {
           "a"
         ]
       },
-      "description": "Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided."
+      "description": "Per-vertex colors (if specified, must have the same length as `points`)."
     },
     "indices": {
       "type": "array",

--- a/schemas/omgidl/foxglove/LinePrimitive.idl
+++ b/schemas/omgidl/foxglove/LinePrimitive.idl
@@ -24,10 +24,10 @@ struct LinePrimitive {
   // Points along the line
   sequence<Point3> points;
 
-  // Solid color to use for the whole line. One of `color` or `colors` must be provided.
+  // Solid color to use for the whole line. Ignored if `colors` is non-empty.
   Color color;
 
-  // Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+  // Per-point colors (if non-empty, must have the same length as `points`).
   sequence<Color> colors;
 
   // Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/omgidl/foxglove/ModelPrimitive.idl
+++ b/schemas/omgidl/foxglove/ModelPrimitive.idl
@@ -20,13 +20,13 @@ struct ModelPrimitive {
   // Whether to use the color specified in `color` instead of any materials embedded in the original model.
   boolean override_color;
 
-  // URL pointing to model file. One of `url` or `data` should be provided.
+  // URL pointing to model file. One of `url` or `data` should be non-empty.
   string url;
 
   // [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
   string media_type;
 
-  // Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+  // Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
   sequence<uint8> data;
 };
 

--- a/schemas/omgidl/foxglove/TriangleListPrimitive.idl
+++ b/schemas/omgidl/foxglove/TriangleListPrimitive.idl
@@ -14,10 +14,10 @@ struct TriangleListPrimitive {
   // Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
   sequence<Point3> points;
 
-  // Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+  // Solid color to use for the whole shape. Ignored if `colors` is non-empty.
   Color color;
 
-  // Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+  // Per-vertex colors (if specified, must have the same length as `points`).
   sequence<Color> colors;
 
   // Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/proto/foxglove/LinePrimitive.proto
+++ b/schemas/proto/foxglove/LinePrimitive.proto
@@ -36,10 +36,10 @@ message LinePrimitive {
   // Points along the line
   repeated foxglove.Point3 points = 5;
 
-  // Solid color to use for the whole line. One of `color` or `colors` must be provided.
+  // Solid color to use for the whole line. Ignored if `colors` is non-empty.
   foxglove.Color color = 6;
 
-  // Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+  // Per-point colors (if non-empty, must have the same length as `points`).
   repeated foxglove.Color colors = 7;
 
   // Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/proto/foxglove/ModelPrimitive.proto
+++ b/schemas/proto/foxglove/ModelPrimitive.proto
@@ -22,12 +22,12 @@ message ModelPrimitive {
   // Whether to use the color specified in `color` instead of any materials embedded in the original model.
   bool override_color = 4;
 
-  // URL pointing to model file. One of `url` or `data` should be provided.
+  // URL pointing to model file. One of `url` or `data` should be non-empty.
   string url = 5;
 
   // [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
   string media_type = 6;
 
-  // Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+  // Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
   bytes data = 7;
 }

--- a/schemas/proto/foxglove/TriangleListPrimitive.proto
+++ b/schemas/proto/foxglove/TriangleListPrimitive.proto
@@ -16,10 +16,10 @@ message TriangleListPrimitive {
   // Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
   repeated foxglove.Point3 points = 2;
 
-  // Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+  // Solid color to use for the whole shape. Ignored if `colors` is non-empty.
   foxglove.Color color = 3;
 
-  // Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+  // Per-vertex colors (if specified, must have the same length as `points`).
   repeated foxglove.Color colors = 4;
 
   // Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/ros1/LinePrimitive.msg
+++ b/schemas/ros1/LinePrimitive.msg
@@ -27,10 +27,10 @@ bool scale_invariant
 # Points along the line
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole line. One of `color` or `colors` must be provided.
+# Solid color to use for the whole line. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-point colors (if non-empty, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/ros1/ModelPrimitive.msg
+++ b/schemas/ros1/ModelPrimitive.msg
@@ -15,11 +15,11 @@ foxglove_msgs/Color color
 # Whether to use the color specified in `color` instead of any materials embedded in the original model.
 bool override_color
 
-# URL pointing to model file. One of `url` or `data` should be provided.
+# URL pointing to model file. One of `url` or `data` should be non-empty.
 string url
 
 # [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
 string media_type
 
-# Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+# Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
 uint8[] data

--- a/schemas/ros1/TriangleListPrimitive.msg
+++ b/schemas/ros1/TriangleListPrimitive.msg
@@ -9,10 +9,10 @@ geometry_msgs/Pose pose
 # Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+# Solid color to use for the whole shape. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-vertex colors (if specified, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/ros2/LinePrimitive.msg
+++ b/schemas/ros2/LinePrimitive.msg
@@ -27,10 +27,10 @@ bool scale_invariant
 # Points along the line
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole line. One of `color` or `colors` must be provided.
+# Solid color to use for the whole line. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-point colors (if non-empty, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/schemas/ros2/ModelPrimitive.msg
+++ b/schemas/ros2/ModelPrimitive.msg
@@ -15,11 +15,11 @@ foxglove_msgs/Color color
 # Whether to use the color specified in `color` instead of any materials embedded in the original model.
 bool override_color
 
-# URL pointing to model file. One of `url` or `data` should be provided.
+# URL pointing to model file. One of `url` or `data` should be non-empty.
 string url
 
 # [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided.
 string media_type
 
-# Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.
+# Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
 uint8[] data

--- a/schemas/ros2/TriangleListPrimitive.msg
+++ b/schemas/ros2/TriangleListPrimitive.msg
@@ -9,10 +9,10 @@ geometry_msgs/Pose pose
 # Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...)
 geometry_msgs/Point[] points
 
-# Solid color to use for the whole shape. One of `color` or `colors` must be provided.
+# Solid color to use for the whole shape. Ignored if `colors` is non-empty.
 foxglove_msgs/Color color
 
-# Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.
+# Per-vertex colors (if specified, must have the same length as `points`).
 foxglove_msgs/Color[] colors
 
 # Indices into the `points` and `colors` attribute arrays, which can be used to avoid duplicating attribute data.

--- a/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
+++ b/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
@@ -517,10 +517,10 @@ export type LinePrimitive = {
   /** Points along the line */
   points: Point3[];
 
-  /** Solid color to use for the whole line. One of \`color\` or \`colors\` must be provided. */
+  /** Solid color to use for the whole line. Ignored if \`colors\` is non-empty. */
   color: Color;
 
-  /** Per-point colors (if specified, must have the same length as \`points\`). One of \`color\` or \`colors\` must be provided. */
+  /** Per-point colors (if non-empty, must have the same length as \`points\`). */
   colors: Color[];
 
   /**
@@ -717,13 +717,13 @@ export type ModelPrimitive = {
   /** Whether to use the color specified in \`color\` instead of any materials embedded in the original model. */
   override_color: boolean;
 
-  /** URL pointing to model file. One of \`url\` or \`data\` should be provided. */
+  /** URL pointing to model file. One of \`url\` or \`data\` should be non-empty. */
   url: string;
 
   /** [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. \`model/gltf-binary\`). Required if \`data\` is provided instead of \`url\`. Overrides the inferred media type if \`url\` is provided. */
   media_type: string;
 
-  /** Embedded model. One of \`url\` or \`data\` should be provided. If \`data\` is provided, \`media_type\` must be set to indicate the type of the data. */
+  /** Embedded model. One of \`url\` or \`data\` should be non-empty. If \`data\` is non-empty, \`media_type\` must be set to indicate the type of the data. */
   data: Uint8Array;
 };
 ",
@@ -1101,10 +1101,10 @@ export type TriangleListPrimitive = {
   /** Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...) */
   points: Point3[];
 
-  /** Solid color to use for the whole shape. One of \`color\` or \`colors\` must be provided. */
+  /** Solid color to use for the whole shape. Ignored if \`colors\` is non-empty. */
   color: Color;
 
-  /** Per-vertex colors (if specified, must have the same length as \`points\`). One of \`color\` or \`colors\` must be provided. */
+  /** Per-vertex colors (if specified, must have the same length as \`points\`). */
   colors: Color[];
 
   /**

--- a/typescript/schemas/src/internal/schemas.ts
+++ b/typescript/schemas/src/internal/schemas.ts
@@ -486,15 +486,13 @@ const LinePrimitive: FoxgloveMessageSchema = {
     {
       name: "color",
       type: { type: "nested", schema: Color },
-      description:
-        "Solid color to use for the whole line. One of `color` or `colors` must be provided.",
+      description: "Solid color to use for the whole line. Ignored if `colors` is non-empty.",
     },
     {
       name: "colors",
       type: { type: "nested", schema: Color },
       array: true,
-      description:
-        "Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.",
+      description: "Per-point colors (if non-empty, must have the same length as `points`).",
     },
     {
       name: "indices",
@@ -567,15 +565,13 @@ const TriangleListPrimitive: FoxgloveMessageSchema = {
     {
       name: "color",
       type: { type: "nested", schema: Color },
-      description:
-        "Solid color to use for the whole shape. One of `color` or `colors` must be provided.",
+      description: "Solid color to use for the whole shape. Ignored if `colors` is non-empty.",
     },
     {
       name: "colors",
       type: { type: "nested", schema: Color },
       array: true,
-      description:
-        "Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided.",
+      description: "Per-vertex colors (if specified, must have the same length as `points`).",
     },
     {
       name: "indices",
@@ -617,7 +613,7 @@ const ModelPrimitive: FoxgloveMessageSchema = {
     {
       name: "url",
       type: { type: "primitive", name: "string" },
-      description: "URL pointing to model file. One of `url` or `data` should be provided.",
+      description: "URL pointing to model file. One of `url` or `data` should be non-empty.",
     },
     {
       name: "media_type",
@@ -629,7 +625,7 @@ const ModelPrimitive: FoxgloveMessageSchema = {
       name: "data",
       type: { type: "primitive", name: "bytes" },
       description:
-        "Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data.",
+        "Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.",
     },
   ],
 };

--- a/typescript/schemas/src/types/LinePrimitive.ts
+++ b/typescript/schemas/src/types/LinePrimitive.ts
@@ -23,10 +23,10 @@ export type LinePrimitive = {
   /** Points along the line */
   points: Point3[];
 
-  /** Solid color to use for the whole line. One of `color` or `colors` must be provided. */
+  /** Solid color to use for the whole line. Ignored if `colors` is non-empty. */
   color: Color;
 
-  /** Per-point colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided. */
+  /** Per-point colors (if non-empty, must have the same length as `points`). */
   colors: Color[];
 
   /**

--- a/typescript/schemas/src/types/ModelPrimitive.ts
+++ b/typescript/schemas/src/types/ModelPrimitive.ts
@@ -19,12 +19,12 @@ export type ModelPrimitive = {
   /** Whether to use the color specified in `color` instead of any materials embedded in the original model. */
   override_color: boolean;
 
-  /** URL pointing to model file. One of `url` or `data` should be provided. */
+  /** URL pointing to model file. One of `url` or `data` should be non-empty. */
   url: string;
 
   /** [Media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of embedded model (e.g. `model/gltf-binary`). Required if `data` is provided instead of `url`. Overrides the inferred media type if `url` is provided. */
   media_type: string;
 
-  /** Embedded model. One of `url` or `data` should be provided. If `data` is provided, `media_type` must be set to indicate the type of the data. */
+  /** Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data. */
   data: Uint8Array;
 };

--- a/typescript/schemas/src/types/TriangleListPrimitive.ts
+++ b/typescript/schemas/src/types/TriangleListPrimitive.ts
@@ -13,10 +13,10 @@ export type TriangleListPrimitive = {
   /** Vertices to use for triangles, interpreted as a list of triples (0-1-2, 3-4-5, ...) */
   points: Point3[];
 
-  /** Solid color to use for the whole shape. One of `color` or `colors` must be provided. */
+  /** Solid color to use for the whole shape. Ignored if `colors` is non-empty. */
   color: Color;
 
-  /** Per-vertex colors (if specified, must have the same length as `points`). One of `color` or `colors` must be provided. */
+  /** Per-vertex colors (if specified, must have the same length as `points`). */
   colors: Color[];
 
   /**


### PR DESCRIPTION
### Changelog
None.

### Docs

Is docs

### Description

Foxglove schemas do not have a notion of optional fields, but some docstrings refer to varying behavior based on "provided" values. This PR updates the language to describe behavior of empty vs. non-empty values in these cases. I've checked that the app behaves as described for `LinePrimitive` and `TriangleListPrimtive` colors.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

