### PR TITLE
Ignore foxglove_bridge in ROS1

### DIFF
--- a/ros/src/foxglove_bridge/CATKIN_IGNORE
+++ b/ros/src/foxglove_bridge/CATKIN_IGNORE
@@ -1,0 +1,1 @@
+The version of foxglove_bridge in this repo does not support ROS 1. If you are a ROS 1 user, you can find the source code for the legacy version of foxglove_bridge in the ROS 1 foxglove_bridge repo at https://github.com/foxglove/ros-foxglove-bridge


### PR DESCRIPTION
### Changelog
Ensure that foxglove_bridge is ignored in ROS1.

### Docs

None

### Description
I'd like to add foxglove_msgs to [ros-o](https://github.com/ros-o/ros-o) via https://github.com/ubi-agni/ros-builder-action/pull/91 but catkin is picking up on the ROS2 only package `foxglove_bridge`.

For testing I'll point the ros-o build at my fork.


