### PR TITLE
Build TypeScript schemas package during generate

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -200,6 +200,9 @@ async function main({ clean }: { clean: boolean }) {
     }
   });
 
+  // Build the schemas package for easier documentation previews
+  await exec("yarn", ["workspace", "@foxglove/schemas", "clean-build"], { cwd: repoRoot });
+
   await logProgress("Generating OMG IDL definitions", async () => {
     await fs.mkdir(path.join(outDir, "omgidl", "foxglove"), { recursive: true });
     for (const schema of Object.values(foxgloveMessageSchemas)) {

--- a/typescript/schemas/package.json
+++ b/typescript/schemas/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "build": "cp -R ../../schemas/jsonschema ./src/jsonschema && tsc -b",
     "clean": "git clean -Xdf",
-    "prepack": "yarn clean && yarn build"
+    "clean-build": "yarn clean && yarn build",
+    "prepack": "yarn clean-build"
   },
   "dependencies": {
     "@foxglove/rosmsg-msgs-common": "^3.2.2",


### PR DESCRIPTION
This adds a step to the `generate` task. In addition to generating TS schema source, build the `@foxglove/schemas` package, making the dist directory available for local documentation builds. This adds a second or two to the task on my machine.