### PR TITLE
playground: fix condition to allow deploying on main branch

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -102,7 +102,7 @@ jobs:
       - run: yarn install
       - run: yarn build
       - uses: cloudflare/pages-action@v1.5.0
-        if: github.repository == github.event.pull_request.head.repo.full_name # Only run if not a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }} # Only run if not a fork
         id: deploy
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Since https://github.com/foxglove/foxglove-sdk/pull/672, the playground deploy job was always skipped on the main branch because this condition was false (`github.event.pull_request` is not present on a main branch run). This PR inverts the condition using a different boolean signal (`head.repo.fork`) that we already used in the mcap repo.