### PR TITLE
Fix clippy error for implicit string clone

### DIFF
--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -409,7 +409,7 @@ impl Server {
         let mut old_names = vec![];
         for (name, entry) in subs.iter_mut() {
             if entry.remove(&client_id) && entry.is_empty() {
-                old_names.push(name.to_string());
+                old_names.push(name.clone());
             }
         }
         for name in &old_names {


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Looks like this is breaking in CI due to a toolchain upgrade, flagged by @jtbandes. Quick fix to resolve the clippy error.
