### PR TITLE
playground: adjust height of toolbar to match app bar

### DIFF
--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -22,7 +22,9 @@ const useStyles = tss.create(({ theme }) => ({
   topBar: {
     flex: "0 0 auto",
     display: "flex",
-    padding: "8px 8px 8px 16px",
+    // Match the height of the app bar in the Foxglove app
+    height: "44px",
+    padding: "0 8px 0 16px",
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description

Update the toolbar height to match the embed app bar height. Creates a visually consistent bar across the top between the two halves.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->
<img width="2440" height="292" alt="Screenshot 2025-11-03 at 10 53 40 AM" src="https://github.com/user-attachments/assets/2ab0ed9f-c3a4-4ead-8a8e-0f227c4db791" />


</td><td>

<!--after content goes here-->
<img width="2658" height="200" alt="Screenshot 2025-11-03 at 10 57 42 AM" src="https://github.com/user-attachments/assets/4fd99d54-948d-407d-93e8-bd4f6ec6e7f0" />


</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

