### PR TITLE
ci: git rid of deprecated macos runner

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -293,10 +293,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
             target: aarch64
+          - runner: macos-15-intel
+            target: x86_64
     steps:
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
### Changelog
None
### Docs
None

### Description
Remove deprecated `macos-13` runner. Replace with `macos-15-intel`.