### PR TITLE
playground: fully support dark mode

### DIFF
--- a/playground/src/Editor.tsx
+++ b/playground/src/Editor.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from "@mui/material";
 import * as monaco from "monaco-editor";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 
@@ -80,6 +81,11 @@ export const Editor = forwardRef<EditorInterface, EditorProps>(
         editorRef.current = null;
       };
     }, [initialValue, runner]);
+
+    const isDark = useTheme().palette.mode === "dark";
+    useEffect(() => {
+      monaco.editor.setTheme(isDark ? "vs-dark" : "vs");
+    }, [isDark]);
 
     useImperativeHandle(
       ref,

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -46,6 +46,9 @@ const useStyles = tss.create(({ theme }) => ({
   },
   toast: {
     fontSize: theme.typography.body1.fontSize,
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    boxShadow: theme.shadows[4],
   },
   toastMonospace: {
     maxWidth: "none",
@@ -273,7 +276,6 @@ export function Playground(): React.JSX.Element {
         <FoxgloveViewer
           ref={viewerRef}
           style={{ width: "100%", height: "100%", overflow: "hidden" }}
-          colorScheme="light"
           data={dataSource}
           layout={selectedLayout}
         />


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Support dark mode in the editor and toasts. The embed was previously hard-coded to light mode since the rest of the playground didn't support it, so now it follows the system theme.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<img width="1205" height="877" alt="image" src="https://github.com/user-attachments/assets/df0d3b78-f407-4b73-a9ba-45760f75ff40" />


</td><td>

<img width="1205" height="877" alt="image" src="https://github.com/user-attachments/assets/a9a1a79a-3393-4e8e-aeb3-b8c3cb38a5c7" />


</td></tr></table>
