### PR TITLE
playground: update layout

### DIFF
--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -407,12 +407,12 @@ const DEFAULT_LAYOUT_DATA = {
   layout: {
     first: "3D!1ehnpb2",
     second: {
-      direction: "column",
+      direction: "row",
       second: "Plot!30ea437",
       first: "RawMessages!2zn7j4u",
-      splitPercentage: 67.0375521557719,
+      splitPercentage: 33,
     },
-    direction: "row",
+    direction: "column",
     splitPercentage: 60.57971014492753,
   },
 };


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Update the default layout to move raw message panel and plot below the 3d panel. I think it looks nicer to have the 3d panel have more space.

---
Side note: it was annoying to make this change because I had to manually change `force: true` in the code to actually have the layout override the local storage variant. Took me a moment to realize that.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->
<img width="3248" height="2112" alt="Screenshot 2025-11-05 at 9 03 55 PM" src="https://github.com/user-attachments/assets/a2ac6688-7ce2-41a0-892e-fd8e433cf90e" />


</td><td>

<!--after content goes here-->
<img width="3248" height="2112" alt="Screenshot 2025-11-05 at 9 03 45 PM" src="https://github.com/user-attachments/assets/ff3b82f5-9e8f-4636-a6d9-c6f7abfe23d2" />


</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

