### PR TITLE
docs: Omit CloudSink from C++ and python docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,6 @@ jobs:
 
   build-python-docs:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: python/foxglove-sdk
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -40,10 +37,7 @@ jobs:
           node-version: 22
           cache: yarn
       - uses: astral-sh/setup-uv@v7
-      - run: uv sync --all-extras
-      - run: uv pip install --editable '.[notebook]'
-      - name: Sphinx build
-        run: uv run sphinx-build --fail-on-warning ./python/docs ./python/docs/_build
+      - run: make -f Container.mk docs-python
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Container.mk
+++ b/Container.mk
@@ -31,6 +31,17 @@ benchmark-python:
 	uv --directory python/foxglove-sdk pip install --editable '.[notebook]'
 	uv --directory python/foxglove-sdk run pytest --with-benchmarks
 
+.PHONY: docs-python
+docs-python:
+	uv --directory python/foxglove-sdk lock --check
+	uv --directory python/foxglove-sdk sync --all-extras
+	uv --directory python/foxglove-sdk pip install --editable '.[notebook]'
+	uv --directory python/foxglove-sdk run sphinx-build --fail-on-warning ./python/docs ./python/docs/_build
+
+.PHONY: clean-docs-python
+clean-docs-python:
+	rm -rf python/foxglove-sdk/python/docs/_build
+
 .PHONY: lint-rust
 lint-rust:
 	cargo fmt --all --check

--- a/cpp/Doxyfile
+++ b/cpp/Doxyfile
@@ -1066,7 +1066,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */tests/* */expected.hpp
+EXCLUDE_PATTERNS       = */tests/* */expected.hpp */cloud_sink.*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/python/foxglove-sdk/python/docs/api/index.rst
+++ b/python/foxglove-sdk/python/docs/api/index.rst
@@ -12,7 +12,7 @@ foxglove
 
 .. automodule:: foxglove
    :members:
-   :exclude-members: MCAPWriter, init_notebook_buffer
+   :exclude-members: CloudSink, CloudSinkListener, MCAPWriter, init_notebook_buffer, start_cloud_sink
 
 Notebook Integration
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These interfaces aren't intended to be used publicly just yet.

As a bonus, add a makefile target for generating python docs, and use it in CI.