### PR TITLE
Fixed typo

### DIFF
--- a/ros/src/foxglove_msgs/ros2/Grid.msg
+++ b/ros/src/foxglove_msgs/ros2/Grid.msg
@@ -24,7 +24,7 @@ uint32 row_stride
 # Number of bytes between cells within a row in `data`
 uint32 cell_stride
 
-# Fields in `data`. S`red`, `green`, `blue`, and `alpha` are optional for customizing the grid's color.
+# Fields in `data`. `red`, `green`, `blue`, and `alpha` are optional for customizing the grid's color.
 # To enable RGB color visualization in the [3D panel](https://docs.foxglove.dev/docs/visualization/panels/3d#rgba-separate-fields-color-mode), include **all four** of these fields in your `fields` array:
 # 
 # - `red` - Red channel value


### PR DESCRIPTION
### Changelog
Fixed a typo. 

### Docs

None  
### Description

Fixed a typo.  


<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

