### PR TITLE
Revert "Ignore foxglove_bridge in ROS1 (#703)"

### DIFF
--- a/ros/src/foxglove_bridge/CATKIN_IGNORE
+++ b/ros/src/foxglove_bridge/CATKIN_IGNORE
@@ -1,1 +1,0 @@
-The version of foxglove_bridge in this repo does not support ROS 1. If you are a ROS 1 user, you can find the source code for the legacy version of foxglove_bridge in the ROS 1 foxglove_bridge repo at https://github.com/foxglove/ros-foxglove-bridge


### PR DESCRIPTION
This reverts commit 3a121300c21fef80b593b65b7fdcdbffee52fd10.

### Changelog
None

### Docs
None

### Description
Revert #703, as it was found to cause issues with ROS Index ignoring the `foxglove_bridge` package and likely will prevent blooming the next release. This is because various ROS 2 tools, including rosindex and bloom, [are aware of CATKIN_IGNORE](https://github.com/ros-infrastructure/rosindex/blob/79e54aba8267da21bdb995648366316782e46fb0/_plugins/rosindex_generator.rb#L471) even for ROS 2 distributions.

Fixes #756 
