### PR TITLE
playground: fix body scrolling

### DIFF
--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -26,9 +26,7 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  overflow: hidden;
 }
 
 button {


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Minor CSS fix to avoid the browser allowing "overscroll" when using the scroll wheel inside the embed or on a non-scrollable element.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

https://github.com/user-attachments/assets/96353ece-3786-47aa-a883-81369406803d

</td><td>

it doesn't do that

</td></tr></table>