### PR TITLE
rust: Enable rust-2024-compatibility lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,35 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-test = "0.2.5"
 
+[workspace.lints.rust]
+# Group to warn about changes coming in Rust 2024 edition. Having this on will
+# make a future transition smoother. Lowering the priority allows overriding
+# several lints in the group that shouldn't be automatically enabled.
+rust-2024-compatibility = { level = "warn", priority = 0 }
+
+# This lint flags all tail expressions that drop tempraries with a custom Drop
+# implementation. We'll manually review these we upgrade to 2024, but generally
+# don't expect any of our code to depend on drop-ordering in this way.
+#
+# See also: https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html
+tail-expr-drop-order = { level = "allow", priority = 1 }
+
+# This lint is extremely conservative in preserving the if-let scoping from the
+# 2021 edition, which typically isn't necessary. We'll manually review this when
+# we upgrade to 2024, but generally don't expect any of our code to depend on
+# the broader scope of 2021's if-let bindings.
+#
+# See also: https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html
+if-let-rescope = { level = "allow", priority = 1 }
+
+# This lint explicitly preserves the 2021 semantics of the `expr` fragment in
+# macro rules, which would only matter if we had special-case patterns for
+# `const` or `_` expressions. We'll manually review this when we upgrade to
+# 2024.
+#
+# See also: https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html
+edition-2024-expr-fragment-specifier = { level = "allow", priority = 1 }
+
 [workspace.lints.clippy]
 assigning_clones = "warn"
 borrow_as_ptr = "warn"

--- a/rust/foxglove/src/log_macro.rs
+++ b/rust/foxglove/src/log_macro.rs
@@ -13,7 +13,7 @@ impl ChannelPlaceholder {
 
     pub unsafe fn log<T: Encode>(channel_ptr: *mut Self, msg: &T, metadata: PartialMetadata) {
         // Safety: we're restoring the Arc<RawChannel> we leaked into_raw in new()
-        let channel_arc = Arc::from_raw(channel_ptr as *mut RawChannel);
+        let channel_arc = unsafe { Arc::from_raw(channel_ptr as *mut RawChannel) };
         // We can safely create a Channel from any Arc<RawChannel>
         let channel = ManuallyDrop::new(Channel::<T>::from_raw_channel(channel_arc));
         channel.log_with_meta(msg, metadata);


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Enables lint rules to ease migration to the 2024 edition.

This change disables several lints that don't benefit us until we're actually ready to cut over to the 2024 edition, at which point they'll be useful for flagging areas for a one-time manual inspection.

This is the spiritual successor to #248.