### PR TITLE
foxglove_bridge: fix message format error when using cache

### DIFF
--- a/ros/src/foxglove_bridge/include/foxglove_bridge/message_definition_cache.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/message_definition_cache.hpp
@@ -79,7 +79,7 @@ private:
 
   std::unordered_map<DefinitionIdentifier, MessageSpec, DefinitionIdentifierHash>
     msg_specs_by_definition_identifier_;
-  std::unordered_map<std::string, std::string> full_text_cache_;
+  std::unordered_map<std::string, std::pair<MessageDefinitionFormat, std::string>> full_text_cache_;
 };
 
 std::set<std::string> parse_dependencies(MessageDefinitionFormat format, const std::string& text,

--- a/ros/src/foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros/src/foxglove_bridge/src/message_definition_cache.cpp
@@ -341,8 +341,8 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
 
 std::pair<MessageDefinitionFormat, const std::string&> MessageDefinitionCache::get_full_text(
   const std::string& root_package_resource_name) {
-  if (full_text_cache_.find(root_package_resource_name) != full_text_cache_.end()) {
-    return {MessageDefinitionFormat::MSG, full_text_cache_[root_package_resource_name]};
+  if (auto it = full_text_cache_.find(root_package_resource_name); it != full_text_cache_.end()) {
+    return it->second;
   }
 
   std::unordered_set<DefinitionIdentifier, DefinitionIdentifierHash> seen_deps;
@@ -376,8 +376,9 @@ std::pair<MessageDefinitionFormat, const std::string&> MessageDefinitionCache::g
     result = delimiter(root_definition_identifier) + append_recursive(root_definition_identifier);
   }
 
-  auto [it, _] = full_text_cache_.emplace(root_package_resource_name, result);
-  return {format, it->second};
+  auto [it, _] =
+    full_text_cache_.emplace(root_package_resource_name, std::make_pair(format, result));
+  return it->second;
 }
 
 }  // namespace foxglove_bridge


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Fix message format error when using cache, foxglove shows "Failed to parse channel schema".

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

foxglove_bridge contains a hard-coded issue when retrieving cached message files, causing IDL files to be correctly recognized only on the first attempt. Subsequent cached requests return an incorrect format.

Here is the first discussions:
https://github.com/orgs/foxglove/discussions/1195

This fix was tested on my computer, both MSG and IDL worked well.
