### PR TITLE
rust: specify options when creating mcap writer from context

### DIFF
--- a/rust/foxglove/src/context.rs
+++ b/rust/foxglove/src/context.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 use smallvec::SmallVec;
 use tracing::warn;
 
-use crate::{ChannelBuilder, ChannelId, McapWriter, RawChannel, Sink, SinkId};
+use crate::{ChannelBuilder, ChannelId, McapWriteOptions, McapWriter, RawChannel, Sink, SinkId};
 
 mod lazy_context;
 mod subscriptions;
@@ -254,6 +254,12 @@ impl Context {
     /// Returns a builder for an MCAP writer in this context.
     pub fn mcap_writer(self: &Arc<Self>) -> McapWriter {
         McapWriter::new().context(self)
+    }
+
+    /// Returns a builder for an MCAP writer in this context with the provided
+    /// [`McapWriteOptions`].
+    pub fn mcap_writer_with_options(self: &Arc<Self>, options: McapWriteOptions) -> McapWriter {
+        McapWriter::with_options(options).context(self)
     }
 
     /// Returns a builder for a websocket server in this context.


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- rust: add the `Context::mcap_writer_with_options` method

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

This PR adds a method on the `Context` that makes it easier to create an MCAP writer with options (such as seeking disabled). I'm adding this method because the `.context(..)` method is hidden from public docs and it is more ergonomic to create the writer off the context.

Fixes FIRE-223