### PR TITLE
Update VoxelGrid docs to be more in line with Grid for clarity

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -961,7 +961,7 @@ typedef struct foxglove_voxel_grid {
    */
   struct foxglove_string frame_id;
   /**
-   * Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+   * Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
    */
   const struct foxglove_pose *pose;
   /**

--- a/c/src/generated_types.rs
+++ b/c/src/generated_types.rs
@@ -2294,7 +2294,7 @@ pub struct VoxelGrid {
     /// Frame of reference
     pub frame_id: FoxgloveString,
 
-    /// Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+    /// Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
     pub pose: *const Pose,
 
     /// Number of grid rows

--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -821,8 +821,9 @@ struct VoxelGrid {
   /// @brief Frame of reference
   std::string frame_id;
 
-  /// @brief Origin of grid's corner relative to frame of reference; grid is positioned in the x-y
-  /// plane relative to this origin
+  /// @brief Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is
+  /// defined relative to this corner, so an untransformed grid with an identity orientation has
+  /// this corner at the origin.
   std::optional<Pose> pose;
 
   /// @brief Number of grid rows

--- a/python/foxglove-sdk/src/generated/schemas.rs
+++ b/python/foxglove-sdk/src/generated/schemas.rs
@@ -992,7 +992,7 @@ impl From<Grid> for foxglove::schemas::Grid {
 ///
 /// :param timestamp: Timestamp of grid
 /// :param frame_id: Frame of reference
-/// :param pose: Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+/// :param pose: Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
 /// :param row_count: Number of grid rows
 /// :param column_count: Number of grid columns
 /// :param cell_size: Size of single grid cell along x, y, and z axes, relative to `pose`

--- a/ros/src/foxglove_msgs/ros1/VoxelGrid.msg
+++ b/ros/src/foxglove_msgs/ros1/VoxelGrid.msg
@@ -9,7 +9,7 @@ time timestamp
 # Frame of reference
 string frame_id
 
-# Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+# Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
 geometry_msgs/Pose pose
 
 # Number of grid rows

--- a/ros/src/foxglove_msgs/ros2/VoxelGrid.msg
+++ b/ros/src/foxglove_msgs/ros2/VoxelGrid.msg
@@ -9,7 +9,7 @@ builtin_interfaces/Time timestamp
 # Frame of reference
 string frame_id
 
-# Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+# Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
 geometry_msgs/Pose pose
 
 # Number of grid rows

--- a/rust/foxglove/src/schemas/foxglove.rs
+++ b/rust/foxglove/src/schemas/foxglove.rs
@@ -1269,7 +1269,7 @@ pub struct VoxelGrid {
     /// Frame of reference
     #[prost(string, tag = "2")]
     pub frame_id: ::prost::alloc::string::String,
-    /// Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+    /// Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
     #[prost(message, optional, tag = "3")]
     pub pose: ::core::option::Option<Pose>,
     /// Number of grid rows

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3357,7 +3357,7 @@ Frame of reference
 </td>
 <td>
 
-Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
 
 </td>
 </tr>

--- a/schemas/flatbuffer/VoxelGrid.fbs
+++ b/schemas/flatbuffer/VoxelGrid.fbs
@@ -15,7 +15,7 @@ table VoxelGrid {
   /// Frame of reference
   frame_id:string (id: 1);
 
-  /// Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+  /// Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
   pose:foxglove.Pose (id: 2);
 
   /// Number of grid rows

--- a/schemas/jsonschema/VoxelGrid.json
+++ b/schemas/jsonschema/VoxelGrid.json
@@ -26,7 +26,7 @@
     },
     "pose": {
       "title": "foxglove.Pose",
-      "description": "Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin",
+      "description": "Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.",
       "type": "object",
       "properties": {
         "position": {

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -1208,7 +1208,7 @@ export const VoxelGrid = {
     },
     "pose": {
       "title": "foxglove.Pose",
-      "description": "Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin",
+      "description": "Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.",
       "type": "object",
       "properties": {
         "position": {

--- a/schemas/omgidl/foxglove/VoxelGrid.idl
+++ b/schemas/omgidl/foxglove/VoxelGrid.idl
@@ -15,7 +15,7 @@ struct VoxelGrid {
   // Frame of reference
   string frame_id;
 
-  // Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+  // Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
   Pose pose;
 
   // Number of grid rows

--- a/schemas/proto/foxglove/VoxelGrid.proto
+++ b/schemas/proto/foxglove/VoxelGrid.proto
@@ -17,7 +17,7 @@ message VoxelGrid {
   // Frame of reference
   string frame_id = 2;
 
-  // Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+  // Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
   foxglove.Pose pose = 3;
 
   // Number of grid rows

--- a/schemas/ros1/VoxelGrid.msg
+++ b/schemas/ros1/VoxelGrid.msg
@@ -9,7 +9,7 @@ time timestamp
 # Frame of reference
 string frame_id
 
-# Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+# Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
 geometry_msgs/Pose pose
 
 # Number of grid rows

--- a/schemas/ros2/VoxelGrid.msg
+++ b/schemas/ros2/VoxelGrid.msg
@@ -9,7 +9,7 @@ builtin_interfaces/Time timestamp
 # Frame of reference
 string frame_id
 
-# Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin
+# Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.
 geometry_msgs/Pose pose
 
 # Number of grid rows

--- a/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
+++ b/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
@@ -437,7 +437,7 @@ export type VoxelGrid = {
   /** Frame of reference */
   frame_id: string;
 
-  /** Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin */
+  /** Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin. */
   pose: Pose;
 
   /** Number of grid rows */

--- a/typescript/schemas/src/internal/schemas.ts
+++ b/typescript/schemas/src/internal/schemas.ts
@@ -1247,7 +1247,7 @@ const VoxelGrid: FoxgloveMessageSchema = {
       name: "pose",
       type: { type: "nested", schema: Pose },
       description:
-        "Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin",
+        "Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin.",
     },
     {
       name: "row_count",

--- a/typescript/schemas/src/types/VoxelGrid.ts
+++ b/typescript/schemas/src/types/VoxelGrid.ts
@@ -14,7 +14,7 @@ export type VoxelGrid = {
   /** Frame of reference */
   frame_id: string;
 
-  /** Origin of grid's corner relative to frame of reference; grid is positioned in the x-y plane relative to this origin */
+  /** Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin. */
   pose: Pose;
 
   /** Number of grid rows */


### PR DESCRIPTION
### Changelog
Update VoxelGrid docs

### Docs

https://linear.app/foxglove/issue/ERT-1111/voxelgrid-positionorientation-is-wrong

### Description

Update VoxelGrid docs to be in line with Grid Docs

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<img width="851" height="400" alt="image" src="https://github.com/user-attachments/assets/57106113-0692-48bb-9c1f-239690af1e8f" />

</td><td>

Will read "Origin of the grid’s lower-front-left corner in the reference frame. The grid’s pose is defined relative to this corner, so an untransformed grid with an identity orientation has this corner at the origin."

</td></tr></table>

Fixes: ERT-1111


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies `VoxelGrid.pose` to reference the grid’s lower-front-left corner and pose semantics across all schema/message definitions.
> 
> - **Schemas and message definitions**:
>   - Clarify `VoxelGrid.pose` description to: origin is the grid’s lower-front-left corner; pose defined relative to this corner.
>   - Updated across C (`c/include/foxglove-c/foxglove-c.h`), Rust (`c/src/generated_types.rs`, `rust/foxglove/src/schemas/foxglove.rs`), C++ (`cpp/foxglove/include/foxglove/schemas.hpp`), Python docs (`python/foxglove-sdk/src/generated/schemas.rs`), ROS1/ROS2 msgs (`ros*/VoxelGrid.msg`, `schemas/ros*/VoxelGrid.msg`), Flatbuffers (`schemas/flatbuffer/VoxelGrid.fbs`), JSON Schema (`schemas/jsonschema/*.json`, `schemas/jsonschema/index.ts`), OMG IDL (`schemas/omgidl/foxglove/VoxelGrid.idl`), Protobuf (`schemas/proto/foxglove/VoxelGrid.proto`), and TypeScript types/snapshots (`typescript/schemas/src/**`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bbcabab615bf6547463d55189e74fa2bda1c18e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->