### PR TITLE
deps: bump node-forge to 1.3.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7747,9 +7747,9 @@ __metadata:
   linkType: hard
 
 "node-forge@npm:^1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
+  version: 1.3.3
+  resolution: "node-forge@npm:1.3.3"
+  checksum: 10c0/9c6f53b0ebb34865872cf62a35b0aef8fb337e2efc766626c2e3a0040f4c02933bf29a62ba999eb44a2aca73bd512c4eda22705a47b94654b9fb8ed53db9a1db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description

Bumps `node-forge` to 1.3.3 to resolve https://github.com/foxglove/foxglove-sdk/security/dependabot/52


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `node-forge` from `1.3.1` to `1.3.3` in `yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b95b2ca68c04aa341b6a1f4d3fa29a7610a320ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->