### PR TITLE
playground: add title and meta tags

### DIFF
--- a/playground/webpack.config.ts
+++ b/playground/webpack.config.ts
@@ -87,9 +87,9 @@ export default (_env: unknown, argv: WebpackArgv): Configuration => {
 <html>
   <head>
     <title>Foxglove SDK Playground</title>
-    <meta name="description" content="Foxglove is a purpose-built platform that empowers robotics teams to visually debug robots, build reliable autonomy, and scale their development."/>
+    <meta name="description" content="Learn to use the Foxglove SDK to visualize data in a playground environment."/>
     <meta property="og:title" content="Foxglove SDK Playground"/>
-    <meta property="og:description" content="Foxglove is a purpose-built platform that empowers robotics teams to visually debug robots, build reliable autonomy, and scale their development."/>
+    <meta property="og:description" content="Learn to use the Foxglove SDK to visualize data in a playground environment."/>
     <meta property="og:type" content="website"/>
   </head>
   <body>


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Improving site metadata for the playground.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add page title and Open Graph/description metadata to the playground HTML template in `playground/webpack.config.ts`.
> 
> - **Playground build**:
>   - Update `playground/webpack.config.ts` `HtmlWebpackPlugin` template to include page title and metadata (description, og:title, og:description, og:type).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e05c2af86e182f5336c2d80f14c70108d657834e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->