### PR TITLE
rust: Remove dangling "unstable" feature gate

### DIFF
--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -7,7 +7,6 @@ use rcgen::{CertificateParams, Issuer, KeyPair};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-#[cfg(feature = "unstable")]
 use std::sync::Mutex;
 use std::time::Duration;
 use tokio_tungstenite::tungstenite::{self, http::HeaderValue, Message};


### PR DESCRIPTION
Remove a dangling `#[cfg(feature="unstable")]` and make `cargo test` work again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always import `std::sync::Mutex` in `rust/foxglove/src/websocket/tests.rs` by removing the dangling `#[cfg(feature = "unstable")]` gate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4e9ab6e0bec43c93e13552ed3f5c26324fb29f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->