### PR TITLE
MCAP attachments

### DIFF
--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -342,7 +342,9 @@ pub use context::{Context, LazyContext};
 #[doc(hidden)]
 pub use decode::Decode;
 pub use encode::Encode;
-pub use mcap_writer::{McapCompression, McapWriteOptions, McapWriter, McapWriterHandle};
+pub use mcap_writer::{
+    McapAttachment, McapCompression, McapWriteOptions, McapWriter, McapWriterHandle,
+};
 pub use metadata::{Metadata, PartialMetadata, ToUnixNanos};
 pub use schema::Schema;
 pub use sink::{Sink, SinkId};


### PR DESCRIPTION
### Changelog

Add `McapWriterHandle::attach()` method and `McapAttachment` type to enable writing attachments to MCAP files via the Rust SDK.

### Docs

Is there a docs repo?

### Description

This PR exposes the mcap crate's attachment functionality through the foxglove SDK, allowing users to store arbitrary binary data (configuration files, calibration data, images, etc.) alongside messages in MCAP recordings.

#### Changes
- Added `McapAttachment` type re-export from the mcap crate
- Added `McapSink::attach()` internal implementation
- Added `McapWriterHandle::attach()` public API with documentation and example
- Added comprehensive tests for attachment functionality

#### Usage example
```rust
use std::borrow::Cow;
use foxglove::{McapWriter, McapAttachment};

let mcap = McapWriter::new()
    .create_new_buffered_file("test.mcap")
    .expect("create failed");

mcap.attach(&McapAttachment {
    log_time: 0,
    create_time: 0,
    name: "config.json".to_string(),
    media_type: "application/json".to_string(),
    data: Cow::Borrowed(br#"{"setting": true}"#),
}).expect("attach failed");

mcap.close().expect("close failed");
```

#### Testing
Added unit tests for basic attachment, multiple attachments, and error handling when attaching after close. All 212 tests pass with `--features unstable`. Manual testing works:
```
$ mcap info test.mcap 
library:   foxglove-sdk-rust/v0.0.0                                    
profile:                                                               
messages:  3204                                                        
duration:  1m22.913993797s                                             
start:     2025-12-10T13:34:08.054447689-07:00 (1765398848.054447689)  
end:       2025-12-10T13:35:30.968441486-07:00 (1765398930.968441486)  
compression:
	lz4: [732/732 chunks] [1.36 GiB/968.95 MiB (30.44%)] [11.69 MiB/sec] 
chunks:
	max uncompressed size: 1.91 MiB
	max compressed size: 1.34 MiB
	overlaps: no
channels:
	[redacted]
channels: 5
attachments: 1
metadata: 1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for writing MCAP attachments via `McapWriterHandle::attach` and re-exports `McapAttachment`, with sink implementation and tests.
> 
> - **Public API**
>   - Re-export `McapAttachment` from `mcap` in `rust/foxglove/src/lib.rs` and `rust/foxglove/src/mcap_writer.rs`.
>   - Add `McapWriterHandle::attach(&McapAttachment)` with docs and example.
> - **MCAP Sink**
>   - Implement `McapSink::attach(&mcap::Attachment)` to write attachments.
> - **Tests**
>   - Add unit tests for attachments: basic write, multiple attachments, and error after close in `rust/foxglove/src/mcap_writer/mcap_sink.rs` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2adb09da41a5ef5b4206143fef54661d9474f363. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->