### PR TITLE
Pass embeddedViewer param through jupyter notebook.

### DIFF
--- a/python/foxglove-sdk/notebook-frontend/package.json
+++ b/python/foxglove-sdk/notebook-frontend/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@anywidget/types": "0.2.0",
-    "@foxglove/embed": "0.1.8",
+    "@foxglove/embed": "0.2.3",
     "@foxglove/tsconfig": "2.0.0",
     "esbuild": "0.25.11",
     "typescript": "5.9.3"

--- a/python/foxglove-sdk/notebook-frontend/widget.ts
+++ b/python/foxglove-sdk/notebook-frontend/widget.ts
@@ -24,6 +24,7 @@ function render({ model, el }: RenderProps<WidgetModel>): void {
 
   const viewer = new FoxgloveViewer({
     parent,
+    embeddedViewer: "Python",
     src: model.get("src"),
     orgSlug: undefined,
     initialLayoutParams: initialLayoutParams

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,6 +909,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/embed@npm:0.2.3":
+  version: 0.2.3
+  resolution: "@foxglove/embed@npm:0.2.3"
+  dependencies:
+    tslib: "npm:2.8.1"
+  checksum: 10c0/58a5af91ea86ba68039b48d50bede6a753b3bb9e6a071e906602ff9dc647e8550cb46e94dfa503cc6972df9831b0057678eff3be6de8b7f86a64951b8a74eee3
+  languageName: node
+  linkType: hard
+
 "@foxglove/eslint-plugin@npm:2.1.0":
   version: 2.1.0
   resolution: "@foxglove/eslint-plugin@npm:2.1.0"
@@ -944,7 +953,7 @@ __metadata:
   resolution: "@foxglove/notebook-frontend@workspace:python/foxglove-sdk/notebook-frontend"
   dependencies:
     "@anywidget/types": "npm:0.2.0"
-    "@foxglove/embed": "npm:0.1.8"
+    "@foxglove/embed": "npm:0.2.3"
     "@foxglove/tsconfig": "npm:2.0.0"
     esbuild: "npm:0.25.11"
     typescript: "npm:5.9.3"


### PR DESCRIPTION
### Changelog
Pass embeddedViewer param through jupyter notebook.

### Docs
None

### Description
Passes the `embeddedViewer` param through to Foxglove embedded in a Jupyter notebook.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit viewer context in the Jupyter notebook frontend and aligns dependency version.
> 
> - Set `embeddedViewer: "Python"` when instantiating `FoxgloveViewer` in `widget.ts`
> - Upgrade `@foxglove/embed` from `0.1.8` to `0.2.3` in `package.json` and `yarn.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e071a058f728081870c914c183d005b78aea27c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->