### PR TITLE
Update foxglove_bridge to use new ament_index API

### DIFF
--- a/ros/src/foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros/src/foxglove_bridge/src/message_definition_cache.cpp
@@ -231,6 +231,9 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
 #if AMENT_INDEX_CPP_VERSION_GTE(1, 13, 0)
   ament_index_cpp::PathWithResource path_with_resource =
     ament_index_cpp::get_resource("rosidl_interfaces", package);
+  if (path_with_resource.resourcePath == std::nullopt) {
+    throw DefinitionNotFoundError(definition_identifier.package_resource_name);
+  }
   index_contents = path_with_resource.contents;
 #else
   if (!ament_index_cpp::get_resource("rosidl_interfaces", package, index_contents)) {


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Upstream ROS 2 has changed the ament_index_cpp API in two ways:
* `ament_index_cpp::get_package_share_directory` -> `ament_index_cpp::get_package_share_path`
* `ament_index_cpp::get_resource(type, package, contents)` -> `ament_index_cpp::get_resource(type, package)` (the contents are returned)

Because we want this package to work on older ROS 2 versions, we use conditional compilation on the AMENT_INDEX_CPP version to fix things so it works for all currently supported ROS 2 (Humble, Jazzy, Kilted, and Rolling).

Fixes: FLE-165

