### PR TITLE
Suppress deprecation warning for ament_index API

### DIFF
--- a/ros/src/foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros/src/foxglove_bridge/src/message_definition_cache.cpp
@@ -215,7 +215,12 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
   }
 
   // Get the package share directory, or throw a PackageNotFoundError
+  // TODO: FLE-167: Remove warning once ament_index_cpp is updated and synced across all current
+  // ROS2 distributions.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const std::string share_dir = ament_index_cpp::get_package_share_directory(package);
+#pragma GCC diagnostic pop
 
   // Get the rosidl_interfaces index contents for this package
   std::string index_contents;


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Temporarily suppress deprecation warnings for `get_package_share_directory`, which will cause ROS2 buildfarm builds to pass for Foxglove Bridge. These suppressions will be reverted in #803 once ament/ament_index#105 has merged and ROS packages have synced.

Fixes: FLE-165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily mutes deprecation warnings to unblock ROS2 builds.
> 
> - Wraps `ament_index_cpp::get_package_share_directory` call in `message_definition_cache.cpp` with GCC pragmas to ignore `-Wdeprecated-declarations`
> - Adds TODO noting removal after `ament_index_cpp` update (FLE-167)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14325f43be3534d5c2940bc15c91b82baae31c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->