### PR TITLE
Disable deprecation warning for get_resource()

### DIFF
--- a/ros/src/foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros/src/foxglove_bridge/src/message_definition_cache.cpp
@@ -223,10 +223,15 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
 #pragma GCC diagnostic pop
 
   // Get the rosidl_interfaces index contents for this package
+  // TODO: FLE-167: Remove warning once ament_index_cpp is updated and synced across all current
+  // ROS2 distributions.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   std::string index_contents;
   if (!ament_index_cpp::get_resource("rosidl_interfaces", package, index_contents)) {
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);
   }
+#pragma GCC diagnostic pop
 
   // Find the first line that ends with the filename we're looking for
   const auto lines = split_string(index_contents);


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
See #804 for general description of the issue. Missed another API that was deprecated. This should make the build pass now, verified by enabling the ros2-testing repo in an ubuntu VM and building successfully.

Fixes: FLE-165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Silences deprecated API warnings in `message_definition_cache.cpp` for compatibility across ROS2 distros.
> 
> - Wraps `ament_index_cpp::get_resource("rosidl_interfaces", ...)` with `#pragma GCC diagnostic push/ignored("-Wdeprecated-declarations")` (mirroring existing handling for `get_package_share_directory`)
> - No functional logic changes; build noise reduced
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aba2b6de705b0c23fa9b875c415cfa5e95e8339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->