### PR TITLE
Enable NPM trusted publishing with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,4 +188,4 @@ jobs:
       - run: yarn workspace @foxglove/schemas pack
       - name: Publish @foxglove/schemas to NPM
         if: startsWith(github.ref, 'refs/tags/typescript/schemas/v')
-        run: npx npm@latest publish typescript/schemas/package.tgz --provenance --access public
+        run: npx npm@11.7.0 publish typescript/schemas/package.tgz --provenance --access public

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,5 @@
   // https://github.com/microsoft/vscode-cpptools/issues/722
   "C_Cpp.autoAddFileAssociations": false,
   "C_Cpp.default.cppStandard": "c++17",
-  "rust-analyzer.check.command": "clippy",
-  "cursorpyright.analysis.typeCheckingMode": "strict"
+  "rust-analyzer.check.command": "clippy"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foxglove-sdk",
   "private": true,
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.12.0",
   "workspaces": [
     "typescript/*",
     "playground",


### PR DESCRIPTION
## Summary
Update npm publish workflow to use OIDC trusted publishing with provenance.

## Changes
- Add `id-token: write` and `contents: read` permissions for OIDC authentication
- Update to `npx npm@11.7.0 publish` with `--provenance` flag for supply chain security
- Update actions to v6
- Remove `NODE_AUTH_TOKEN` secret (no longer needed with OIDC)

## Technical Note
This PR uses `npx npm@11.7.0` instead of `yarn npm publish` because Yarn's npm publish command does not support publishing from tarball paths (e.g., `package.tgz`).

## Status
✅ Trusted publishing has been configured on npmjs.com for this package.