### PR TITLE
Add TransportKind option to channels and channel builder

### DIFF
--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -15,7 +15,7 @@ mod raw_channel;
 
 pub use channel_descriptor::ChannelDescriptor;
 pub use lazy_channel::{LazyChannel, LazyRawChannel};
-pub use raw_channel::RawChannel;
+pub use raw_channel::{RawChannel, TransportKind};
 
 /// Stack buffer size to use for encoding messages.
 const STACK_BUFFER_SIZE: usize = 256 * 1024;

--- a/rust/foxglove/src/channel_builder.rs
+++ b/rust/foxglove/src/channel_builder.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::{Channel, Context, Encode, FoxgloveError, RawChannel, Schema};
+use crate::{Channel, Context, Encode, FoxgloveError, RawChannel, Schema, TransportKind};
 
 /// A builder for creating a [`Channel`] or [`RawChannel`].
 #[must_use]
@@ -12,6 +12,7 @@ pub struct ChannelBuilder {
     schema: Option<Schema>,
     metadata: BTreeMap<String, String>,
     context: Arc<Context>,
+    transport_kind: TransportKind,
 }
 
 impl ChannelBuilder {
@@ -25,6 +26,7 @@ impl ChannelBuilder {
             schema: None,
             metadata: BTreeMap::new(),
             context: Context::get_default(),
+            transport_kind: TransportKind::Lossy,
         }
     }
 
@@ -65,6 +67,13 @@ impl ChannelBuilder {
         self
     }
 
+    /// Sets the [`TransportKind`](crate::TransportKind) for the channel.
+    /// It controls how data for the channel is sent over the network with applicable sinks.
+    pub fn transport_kind(mut self, transport_kind: TransportKind) -> Self {
+        self.transport_kind = transport_kind;
+        self
+    }
+
     /// Builds a [`RawChannel`].
     ///
     /// Returns [`FoxgloveError::MessageEncodingRequired`] if no message encoding was specified.
@@ -76,6 +85,7 @@ impl ChannelBuilder {
                 .ok_or_else(|| FoxgloveError::MessageEncodingRequired)?,
             self.schema,
             self.metadata,
+            self.transport_kind,
         );
         channel = self.context.add_channel(channel);
         Ok(channel)

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -339,7 +339,9 @@ pub mod stream;
 pub use app_url::AppUrl;
 // Re-export bytes crate for convenience when implementing the `Encode` trait
 pub use bytes;
-pub use channel::{Channel, ChannelDescriptor, ChannelId, LazyChannel, LazyRawChannel, RawChannel};
+pub use channel::{
+    Channel, ChannelDescriptor, ChannelId, LazyChannel, LazyRawChannel, RawChannel, TransportKind,
+};
 pub use channel_builder::ChannelBuilder;
 pub use context::{Context, LazyContext};
 #[doc(hidden)]


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Adds a TransportKind option to channels that lets users decide between lossy and reliable transport on a per-channel basis. The default is Lossy, but will only affect the new CloudSink. This is not a full QoS solution by any means, but meant to allow users to override the Lossy default for channels that are critically important. Most users shouldn't need to touch this.

I've only added Rust support, if we agree with the direction I'll add Python and C++ before marking it ready for review.

