### PR TITLE
Claude directory gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cargo/
+.claude/
 .catkin_tools
 .DS_Store
 .idea/


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

This PR adds `.claude/` to the `.gitignore` file.

The `.claude/` directory is created by the Claude Code assistant for local development files. Ignoring this directory prevents these local artifacts from being accidentally committed to the repository, keeping the repository clean and focused on source code.

No manual testing beyond verifying `git status` shows no changes for `.claude/` files.

---
<a href="https://cursor.com/background-agent?bcId=bc-18bec389-57d9-46ff-9062-fbfc4fde8c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18bec389-57d9-46ff-9062-fbfc4fde8c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

