### PR TITLE
Fix a warning on newer versions of CMake.

### DIFF
--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -14,6 +14,11 @@ project(foxglove_bridge LANGUAGES CXX VERSION 3.2.3)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 option(USE_LOCAL_SDK "Use pre-built Foxglove SDK binaries from local source tree" OFF)
 
 macro(enable_strict_compiler_warnings target)


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

With CMake >= 3.24, we get a warning while building foxglove_bridge:

CMake Warning (dev) at /usr/share/cmake-3.28/Modules/FetchContent.cmake:1331 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  CMakeLists.txt:79 (FetchContent_Declare)
This warning is for project developers.  Use -Wno-dev to suppress it.

Suppress this warning by doing what the text suggets and set our CMP0135 policy to NEW.