### PR TITLE
Force the ROS dockerfile to always do an apt-get dist-upgrade.

### DIFF
--- a/Dockerfile.ros
+++ b/Dockerfile.ros
@@ -1,7 +1,26 @@
 ARG ROS_DISTRIBUTION=rolling
 FROM ros:$ROS_DISTRIBUTION-ros-base
 
-RUN apt-get update
+# Prevent errors from apt-get.
+# See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The ROS docker images are only updated when the underlying
+# Ubuntu layer changes; this is a limitation of being an
+# "official" docker image.  Additionally, ROS packages do
+# not have minimum dependency requirements.  That is,
+# ROS package "A" may have a dependency on "B", but it cannot
+# easily specify what version of "B" that it needs.
+# However, the latest versions of the ROS packages
+# are always expected to work together.
+#
+# This means that we *always* have to do an
+# "apt-get dist-upgrade" before we install dependencies
+# with "make deps" below (which calls "rosdep install").
+# That ensures that we have the latest versions of the
+# ROS packages in the underlay and for what is installed
+# by rosdep.
+RUN apt-get update && apt-get -y dist-upgrade
 
 # create foxglove user (or use existing user if UID matches)
 ARG USERNAME=foxglove


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The comment in the code explains the situation, but I'll reproduce it here in the commit as well:

The ROS docker images are only updated when the underlying Ubuntu layer changes; this is a limitation of being an "official" docker image.  Additionally, ROS packages do not have minimum dependency requirements.  That is, ROS package "A" may have a dependency on "B", but it cannot easily specify what version of "B" that it needs.
However, the latest versions of the ROS packages are always expected to work together.

This means that we *always* have to do an
"apt-get dist-upgrade" before we install dependencies with "make deps" below (which calls "rosdep install"). That ensures that we have the latest versions of the ROS packages in the underlay and for what is installed by rosdep.

@defunctzombie FYI.  Assuming we agree on this fix, once this is merged we should be able to make "rolling" builds a required dependency again.