### PR TITLE
Foxglove Dockerfile apt upgrade

### DIFF
--- a/ros/src/foxglove_bridge/Dockerfile
+++ b/ros/src/foxglove_bridge/Dockerfile
@@ -1,6 +1,10 @@
 ARG ROS_DISTRIBUTION=rolling
 FROM ros:$ROS_DISTRIBUTION-ros-base
 
+# Prevent errors from apt-get.
+# See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Keep ROS rolling base packages in sync.
 RUN apt-get update && apt-get -y dist-upgrade
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Mirror of the fix in #830 for the Dockerfiles we provide to end users for running Foxglove Bridge within a container. This should fix the Docker build issue seen [in the latest GHA job](https://github.com/foxglove/foxglove-sdk/actions/runs/21270646249/job/61219896602) for building a user-facing Docker image on rolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-83d59f22-c920-4727-980f-0d0be281b22b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83d59f22-c920-4727-980f-0d0be281b22b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

