### PR TITLE
Add documentation for uncalibrated camera handling

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -580,6 +580,8 @@ typedef struct foxglove_camera_calibration {
    *     [ 0  0  1]
    * ```
    *
+   * **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
+   *
    */
   double k[9];
   /**

--- a/c/src/generated_types.rs
+++ b/c/src/generated_types.rs
@@ -288,6 +288,8 @@ pub struct CameraCalibration {
     ///     [ 0  0  1]
     /// ```
     ///
+    /// **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
+    ///
     pub k: [f64; 9],
 
     /// Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/cpp/foxglove/include/foxglove/schemas.hpp
+++ b/cpp/foxglove/include/foxglove/schemas.hpp
@@ -238,6 +238,11 @@ struct CameraCalibration {
   /// @brief     [ 0  0  1]
   /// @brief ```
   /// @brief
+  /// @brief **Uncalibrated cameras:** Following ROS conventions for
+  /// [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html),
+  /// Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data
+  /// will be ignored.
+  /// @brief
   std::array<double, 9> k;
 
   /// @brief Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/python/foxglove-sdk/src/generated/schemas.rs
+++ b/python/foxglove-sdk/src/generated/schemas.rs
@@ -171,6 +171,8 @@ impl From<ArrowPrimitive> for foxglove::schemas::ArrowPrimitive {
 ///         K = [ 0 fy cy]
 ///             [ 0  0  1]
 ///     
+///     **Uncalibrated cameras:** Following ROS conventions for `CameraInfo <https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html>`__, Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
+///     
 /// :param R: Rectification matrix (stereo cameras only, 3x3 row-major matrix)
 ///     
 ///     A rotation matrix aligning the camera coordinate system to the ideal stereo image plane so that epipolar lines in both stereo images are parallel.

--- a/ros/src/foxglove_msgs/ros1/CameraCalibration.msg
+++ b/ros/src/foxglove_msgs/ros1/CameraCalibration.msg
@@ -34,6 +34,8 @@ float64[] D
 # K = [ 0 fy cy]
 #     [ 0  0  1]
 # ```
+# 
+# **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
 float64[9] K
 
 # Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/ros/src/foxglove_msgs/ros2/CameraCalibration.msg
+++ b/ros/src/foxglove_msgs/ros2/CameraCalibration.msg
@@ -34,6 +34,8 @@ float64[] d
 # K = [ 0 fy cy]
 #     [ 0  0  1]
 # ```
+# 
+# **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
 float64[9] k
 
 # Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/rust/foxglove/src/schemas/foxglove.rs
+++ b/rust/foxglove/src/schemas/foxglove.rs
@@ -62,6 +62,8 @@ pub struct CameraCalibration {
     ///     [ 0  0  1]
     /// ```
     ///
+    /// **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](<https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html>), Foxglove also treats K\[0\] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
+    ///
     /// length 9
     #[prost(double, repeated, tag = "6")]
     pub k: ::prost::alloc::vec::Vec<f64>,

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -343,6 +343,8 @@ K = [ 0 fy cy]
     [ 0  0  1]
 ```
 
+**Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
+
 
 </td>
 </tr>

--- a/schemas/flatbuffer/CameraCalibration.fbs
+++ b/schemas/flatbuffer/CameraCalibration.fbs
@@ -37,6 +37,8 @@ table CameraCalibration {
   /// K = [ 0 fy cy]
   ///     [ 0  0  1]
   /// ```
+  /// 
+  /// **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
   /// length 9
   k:[double] (id: 6);
 

--- a/schemas/jsonschema/CameraCalibration.json
+++ b/schemas/jsonschema/CameraCalibration.json
@@ -52,7 +52,7 @@
       },
       "minItems": 9,
       "maxItems": 9,
-      "description": "Intrinsic camera matrix (3x3 row-major matrix)\n\nA 3x3 row-major matrix for the raw (distorted) image.\n\nProjects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx, fy) and principal point (cx, cy).\n\n```\n    [fx  0 cx]\nK = [ 0 fy cy]\n    [ 0  0  1]\n```\n"
+      "description": "Intrinsic camera matrix (3x3 row-major matrix)\n\nA 3x3 row-major matrix for the raw (distorted) image.\n\nProjects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx, fy) and principal point (cx, cy).\n\n```\n    [fx  0 cx]\nK = [ 0 fy cy]\n    [ 0  0  1]\n```\n\n**Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.\n"
     },
     "R": {
       "type": "array",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -180,7 +180,7 @@ export const CameraCalibration = {
       },
       "minItems": 9,
       "maxItems": 9,
-      "description": "Intrinsic camera matrix (3x3 row-major matrix)\n\nA 3x3 row-major matrix for the raw (distorted) image.\n\nProjects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx, fy) and principal point (cx, cy).\n\n```\n    [fx  0 cx]\nK = [ 0 fy cy]\n    [ 0  0  1]\n```\n"
+      "description": "Intrinsic camera matrix (3x3 row-major matrix)\n\nA 3x3 row-major matrix for the raw (distorted) image.\n\nProjects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal lengths (fx, fy) and principal point (cx, cy).\n\n```\n    [fx  0 cx]\nK = [ 0 fy cy]\n    [ 0  0  1]\n```\n\n**Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.\n"
     },
     "R": {
       "type": "array",

--- a/schemas/omgidl/foxglove/CameraCalibration.idl
+++ b/schemas/omgidl/foxglove/CameraCalibration.idl
@@ -37,6 +37,8 @@ struct CameraCalibration {
   // K = [ 0 fy cy]
   //     [ 0  0  1]
   // ```
+  // 
+  // **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
   double K[9];
 
   // Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/schemas/proto/foxglove/CameraCalibration.proto
+++ b/schemas/proto/foxglove/CameraCalibration.proto
@@ -39,6 +39,8 @@ message CameraCalibration {
   // K = [ 0 fy cy]
   //     [ 0  0  1]
   // ```
+  // 
+  // **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
   repeated double K = 6; // length 9
 
   // Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/schemas/ros1/CameraCalibration.msg
+++ b/schemas/ros1/CameraCalibration.msg
@@ -34,6 +34,8 @@ float64[] D
 # K = [ 0 fy cy]
 #     [ 0  0  1]
 # ```
+# 
+# **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
 float64[9] K
 
 # Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/schemas/ros2/CameraCalibration.msg
+++ b/schemas/ros2/CameraCalibration.msg
@@ -34,6 +34,8 @@ float64[] d
 # K = [ 0 fy cy]
 #     [ 0  0  1]
 # ```
+# 
+# **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
 float64[9] k
 
 # Rectification matrix (stereo cameras only, 3x3 row-major matrix)

--- a/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
+++ b/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
@@ -70,6 +70,8 @@ export type CameraCalibration = {
    * K = [ 0 fy cy]
    *     [ 0  0  1]
    * \`\`\`
+   * 
+   * **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
    */
   K: [number, number, number, number, number, number, number, number, number];
 

--- a/typescript/schemas/src/internal/schemas.ts
+++ b/typescript/schemas/src/internal/schemas.ts
@@ -821,6 +821,8 @@ Projects 3D points in the camera coordinate frame to 2D pixel coordinates using 
 K = [ 0 fy cy]
     [ 0  0  1]
 \`\`\`
+
+**Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
 `,
     },
     {

--- a/typescript/schemas/src/types/CameraCalibration.ts
+++ b/typescript/schemas/src/types/CameraCalibration.ts
@@ -39,6 +39,8 @@ export type CameraCalibration = {
    * K = [ 0 fy cy]
    *     [ 0  0  1]
    * ```
+   * 
+   * **Uncalibrated cameras:** Following ROS conventions for [CameraInfo](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/CameraInfo.html), Foxglove also treats K[0] == 0.0 as indicating an uncalibrated camera, and calibration data will be ignored.
    */
   K: [number, number, number, number, number, number, number, number, number];
 


### PR DESCRIPTION
### Changelog
- Added documentation for uncalibrated camera handling in `CameraCalibration` schema, following ROS conventions.

### Description

- Added documentation for uncalibrated camera handling in `CameraCalibration` schema. 
Following ROS conventions, K[0] == 0.0 indicates an uncalibrated camera and calibration data will be ignored by Foxglove.

This PR is related to https://github.com/orgs/foxglove/discussions/1210

ERT-1432
