### PR TITLE
notebook: add opaque_layout param

### DIFF
--- a/python/foxglove-sdk/python/foxglove/notebook/foxglove_widget.py
+++ b/python/foxglove-sdk/python/foxglove/notebook/foxglove_widget.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import anywidget
 import traitlets
@@ -23,6 +23,7 @@ class FoxgloveWidget(anywidget.AnyWidget):
     height = traitlets.Int(default_value=500).tag(sync=True)
     src = traitlets.Unicode(default_value=None, allow_none=True).tag(sync=True)
     _layout = traitlets.Unicode(default_value=None, allow_none=True).tag(sync=True)
+    _opaque_layout = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
 
     def __init__(
         self,
@@ -32,6 +33,7 @@ class FoxgloveWidget(anywidget.AnyWidget):
         height: int | None = None,
         src: str | None = None,
         layout: Layout | None = None,
+        opaque_layout: dict[str, Any] | None = None,
     ):
         """
         :param buffer: The NotebookBuffer object that contains the data to display in the widget.
@@ -39,6 +41,9 @@ class FoxgloveWidget(anywidget.AnyWidget):
         :param height: The height of the widget in pixels. Defaults to 500.
         :param src: The source URL of the Foxglove viewer. Defaults to
             "https://embed.foxglove.dev/".
+        :param opaque_layout: The layout data to load. This is an opaque dict object, which should
+          be parsed from a JSON layout file that was exported from the Foxglove app. If not
+          provided, the default layout will be used.
         """
         super().__init__()
         if width is not None:
@@ -50,8 +55,12 @@ class FoxgloveWidget(anywidget.AnyWidget):
         if src is not None:
             self.src = src
 
+        if layout is not None and opaque_layout is not None:
+            raise ValueError("Cannot specify both layout and opaque_layout")
         if layout is not None:
             self._layout = layout.to_json()
+        elif opaque_layout is not None:
+            self._opaque_layout = opaque_layout
 
         # Callback to get the data to display in the widget
         self._buffer = buffer

--- a/python/foxglove-sdk/python/foxglove/notebook/notebook_buffer.py
+++ b/python/foxglove-sdk/python/foxglove/notebook/notebook_buffer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import uuid
 from tempfile import TemporaryDirectory
-from typing import Literal
+from typing import Any, Literal
 
 from mcap.reader import make_reader
 
@@ -43,6 +43,7 @@ class NotebookBuffer:
         height: int | None = None,
         src: str | None = None,
         layout: Layout | None = None,
+        opaque_layout: dict[str, Any] | None = None,
     ) -> FoxgloveWidget:
         """
         Show the Foxglove viewer. Call this method as the last step of a notebook cell
@@ -54,6 +55,7 @@ class NotebookBuffer:
             height=height,
             src=src,
             layout=layout,
+            opaque_layout=opaque_layout,
         )
         return widget
 


### PR DESCRIPTION
### Changelog

`NotebookBuffer.show()` now has an `opaque_layout` parameter for loading a layout from a JSON file exported from the Foxglove app.

### Docs

Updated docstring

### Description

Adds the ability to load a layout from a file like this:
```py
import foxglove
import json

nb_buffer = foxglove.init_notebook_buffer()

with open("file.json") as f:
    layout = json.load(f)

nb_buffer.show(opaque_layout=layout)
```

This previously existed as an undocumented feature but was removed in #814.