### PR TITLE
notebook: add border to widget

### DIFF
--- a/python/foxglove-sdk/python/foxglove/notebook/foxglove_widget.py
+++ b/python/foxglove-sdk/python/foxglove/notebook/foxglove_widget.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import anywidget
 import traitlets
+from ipywidgets import Layout as WidgetLayout  # type: ignore
 
 if TYPE_CHECKING:
     from ..layouts import Layout
@@ -45,7 +46,12 @@ class FoxgloveWidget(anywidget.AnyWidget):
           be parsed from a JSON layout file that was exported from the Foxglove app. If not
           provided, the default layout will be used.
         """
-        super().__init__()
+        super().__init__(
+            layout=WidgetLayout(
+                border="var(--jp-border-width, 1px) solid "
+                + "var(--jp-cell-editor-border-color, #d5d5d5)"
+            ),
+        )
         if width is not None:
             self.width = width
         else:


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Add a 1px border to the jupyter widget. This should follow the theme color from the jupyter environment.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<img width="1206" height="775" alt="image" src="https://github.com/user-attachments/assets/55004796-3e6a-40a2-bc3f-2afff9c67bb0" />

</td><td>

<img width="1198" height="771" alt="image" src="https://github.com/user-attachments/assets/f4c4e646-d615-4cb7-9e82-010972d14794" />

</td></tr></table>