### PR TITLE
playground: add hover tooltip support

### DIFF
--- a/playground/src/Editor.tsx
+++ b/playground/src/Editor.tsx
@@ -70,6 +70,19 @@ export const Editor = forwardRef<EditorInterface, EditorProps>(
           };
         },
       });
+      const hoverProvider = monaco.languages.registerHoverProvider("python", {
+        async provideHover(model, position, _token, _context) {
+          return (
+            (await runner.current?.getHover(
+              model.getValue(),
+              position.lineNumber,
+              position.column,
+            )) ?? {
+              contents: [],
+            }
+          );
+        },
+      });
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
         latestProps.current.onSave?.();
       });
@@ -77,6 +90,7 @@ export const Editor = forwardRef<EditorInterface, EditorProps>(
       return () => {
         signatureProvider.dispose();
         completionProvider.dispose();
+        hoverProvider.dispose();
         editor.dispose();
         editorRef.current = null;
       };

--- a/playground/src/Runner.ts
+++ b/playground/src/Runner.ts
@@ -48,6 +48,14 @@ export class Runner extends EventEmitter<EventMap> {
     return await this.#remote.getSignatureHelp(code, line, col);
   }
 
+  async getHover(
+    code: string,
+    line: number,
+    col: number,
+  ): Promise<monaco.languages.Hover | undefined> {
+    return await this.#remote.getHover(code, line, col);
+  }
+
   dispose(): void {
     this.#remote[Comlink.releaseProxy]();
     this.#worker.terminate();


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Added support for hover tooltips in the playground code editor.

This is not perfect because the tooltips are interpreted as markdown, which isn't always the right way to interpret docstrings. But it's better than nothing:

<img width="617" height="261" alt="image" src="https://github.com/user-attachments/assets/0c6d21ec-ddf3-487b-a2a1-b89f6ea4d302" />

<img width="682" height="359" alt="image" src="https://github.com/user-attachments/assets/5ca9c8ae-856e-402a-9b69-6cd2a31d494f" />

<img width="479" height="169" alt="image" src="https://github.com/user-attachments/assets/fc4140fb-3ca7-4dec-a541-ae482820415a" />
