### PR TITLE
Map re-center 0,0 heuristic

### DIFF
--- a/python/foxglove-sdk/python/foxglove/layouts/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/layouts/__init__.py
@@ -2973,6 +2973,16 @@ class MapConfig(_BaseModel):
     Additional layers displayed on top of the base map layer
     """
 
+    center_latitude: float | None = None
+    """
+    Latitude of the map center in degrees. When set, the map will use this as its center position instead of inferring the center from data.
+    """
+
+    center_longitude: float | None = None
+    """
+    Longitude of the map center in degrees. When set, the map will use this as its center position instead of inferring the center from data.
+    """
+
     def _to_dict(self) -> dict[str, Any]:
         return {
             "customTileUrl": self.custom_tile_url,
@@ -2985,6 +2995,8 @@ class MapConfig(_BaseModel):
             "maxNativeZoom": self.max_native_zoom,
             "topicConfig": self.topic_config,
             "layers": self.layers,
+            "centerLatitude": self.center_latitude,
+            "centerLongitude": self.center_longitude,
         }
 
 


### PR DESCRIPTION
### Changelog

Added `center_latitude` and `center_longitude` fields to `MapConfig` to allow explicit map centering.

### Docs

Updated `MapConfig` schema documentation to include `center_latitude` and `center_longitude` fields.

### Description

The Map panel currently employs a heuristic that treats GPS coordinates at (0,0) (often referred to as "Null Island") as uninitialized data, preventing the map from re-centering to this location. This behavior is problematic for users who legitimately have data near the (0,0) coordinate.

This PR addresses the underlying schema limitation by adding `center_latitude` and `center_longitude` fields to the `MapConfig` layout schema within the `foxglove-sdk`. These new fields enable explicit control over the map's initial center position. When these fields are set, the map will use the provided coordinates as its center, eliminating the need for the problematic 0,0 heuristic in the Map panel's rendering logic. This change provides the necessary API for the Foxglove app to implement the desired behavior.

This change is a schema update in the SDK. Manual testing will be performed in the Foxglove app once the corresponding UI changes are implemented there.

Fixes: [ERT-1471](https://linear.app/foxglove/issue/ERT-1471)

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f4e23778-3517-470b-a5fc-5c1d96cbd4ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4e23778-3517-470b-a5fc-5c1d96cbd4ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

