### PR TITLE
Programmatic layouts announcement

### DIFF
--- a/blog/announcing-programmatic-layouts-in-foxglove.md
+++ b/blog/announcing-programmatic-layouts-in-foxglove.md
@@ -6,7 +6,9 @@
 
 Robotics experiments often involve a wide variety of data -- 3D scenes, camera feeds, sensor plots, state transitions, and more. Foxglove's [layouts](https://docs.foxglove.dev/docs/visualization/layouts) let you arrange panels to visualize all of this data at once, but until now, creating those layouts required manual configuration in the app or loading opaque JSON files exported from a previous session.
 
-Foxglove's new programmatic layout API lets you define layouts entirely in Python. Build layouts that adapt to your data, compose reusable layout fragments, and pass them directly to the embedded Foxglove viewer in your Jupyter notebooks -- all without ever leaving your code.
+Foxglove's new programmatic layout API lets you define layouts entirely in Python. Build layouts that adapt to your data, compose reusable layout fragments, and pass them directly to the embedded Foxglove viewer in your Jupyter notebooks or the [SDK Playground](https://playground.foxglove.dev) -- all without ever leaving your code.
+
+> **Note:** Programmatic layouts currently work with Foxglove's embedded viewer -- that is, the Jupyter notebook integration and the SDK Playground. They are not yet supported for direct use with the standalone Foxglove app or live WebSocket connections. The WebSocket server's `app_url()` method accepts a `layout_id` to reference an existing saved layout, but does not yet accept inline layout definitions. We're actively exploring ways to bring programmatic layouts to more workflows.
 
 ## The problem
 


### PR DESCRIPTION
### Changelog

Announces the new programmatic layouts feature, allowing users to define, compose, and reuse Foxglove layouts entirely from Python code.

### Docs

This PR introduces a new blog post announcing the programmatic layouts feature. Detailed API documentation for programmatic layouts is available in the `foxglove-sdk`.

### Description

This PR adds a blog post announcing the new programmatic layout API in the `foxglove-sdk`. Previously, creating Foxglove layouts for Jupyter notebooks or other programmatic uses was challenging, requiring manual editing or exporting opaque JSON. This made it difficult to create data-dependent layouts, compose layout fragments, or ensure reproducibility.

The new programmatic layout API provides a fully documented layout format and a collection of Python classes to simplify layout creation. This enables users to define layouts programmatically, compose them from reusable components, and create dynamic, data-dependent visualizations directly within their Python code, significantly enhancing the experience for users running experiments in Jupyter notebooks.

This blog post follows the style and format of previous Foxglove announcements and includes progressive code examples to guide users in adopting the new API.

No manual testing is required for this PR as it only adds a new markdown file for a blog post.

Fixes: https://github.com/foxglove/foxglove-sdk/pull/814
Fixes: https://github.com/foxglove/foxglove-sdk/pull/839
Fixes: https://github.com/foxglove/foxglove-sdk/pull/840

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5479c5a3-e948-49d5-8cc7-dc9227dd2002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5479c5a3-e948-49d5-8cc7-dc9227dd2002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

