### PR TITLE
docs: Update SDK docs for derive(Encode) to clarify intended use

### DIFF
--- a/rust/foxglove/src/encode.rs
+++ b/rust/foxglove/src/encode.rs
@@ -10,10 +10,25 @@ mod schemars;
 /// Implementing this trait for your type `T` enables the use of [`Channel<T>`][crate::Channel],
 /// which offers a type-checked `log` method.
 ///
+/// # Deriving `Encode`
+///
 /// This trait may be derived for structs and unit-only enums by enabling the `derive` feature and
-/// using the `#[derive(Encode)]` attribute. Today, this will serialize messages using [protobuf].
-/// This means there are some limitations on the data that you can encode. Notably, enum variants
-/// should have a field with a 0-value, which indicates the default variant.
+/// using the `#[derive(Encode)]` attribute.
+///
+/// The derive macro is a **convenience** for getting data into Foxglove with minimal friction. It
+/// automatically generates a schema and serialization code based on your type's fields. The
+/// underlying serialization format is an implementation detail and may change across SDK versions.
+///
+/// This means the derived schema is **not suitable for schema evolution**. Reordering fields,
+/// adding fields in the middle, or removing fields will silently change the tag assignments and
+/// break compatibility with previously recorded data. There are no compile-time or runtime
+/// warnings when this happens.
+///
+/// If you need backwards-compatible schema evolution or want your data to be portable and
+/// durable across software versions, you should maintain an explicit schema using an established
+/// IDL like [protobuf]. You can then implement `Encode` manually for your generated types. See
+/// the [SDK documentation](https://docs.foxglove.dev/docs/sdk/logging-messages#logging-with-protobuf-schemas)
+/// for an example.
 ///
 /// [protobuf]: https://protobuf.dev/
 pub trait Encode {

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -137,8 +137,8 @@
 //! You can also define your own custom data types by implementing the [`Encode`] trait.
 //!
 //! The easiest way to do this is to enable the `derive` feature and derive the [`Encode`] trait,
-//! which will generate a schema and allow you to log your struct to a channel. This currently uses
-//! protobuf encoding.
+//! which will generate a schema and allow you to log your struct to a channel. The underlying
+//! serialization format is an implementation detail and may change across SDK versions.
 //!
 //! ```no_run
 //! # #[cfg(feature = "derive")]
@@ -156,6 +156,14 @@
 //! });
 //! # }
 //! ```
+//!
+//! **Note:** The `Encode` derive macro is a convenience for getting data into Foxglove with
+//! minimal friction. The generated schema is not designed for evolution — reordering, inserting,
+//! or removing fields will silently break compatibility with previously recorded data. If you need
+//! backwards-compatible schema evolution, maintain an explicit `.proto` file and implement
+//! [`Encode`] manually for your generated types. See
+//! [logging with protobuf schemas](https://docs.foxglove.dev/docs/sdk/logging-messages#logging-with-protobuf-schemas)
+//! for an example.
 //!
 //! If you'd like to use JSON encoding for integration with particular tooling, you can enable the
 //! `schemars` feature, which will provide a blanket [`Encode`] implementation for types that

--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -99,6 +99,17 @@ fn is_array_of_array(ty: &Type) -> bool {
 }
 
 /// Derive macro for enums and structs allowing them to be logged to a Foxglove channel.
+///
+/// This is a convenience for getting data into Foxglove with minimal friction. It generates a
+/// schema and serialization code automatically based on your type's fields. The underlying
+/// serialization format is an implementation detail and may change across SDK versions.
+///
+/// **Important:** The derived schema is not designed for schema evolution. Reordering, inserting,
+/// or removing fields will silently break compatibility with previously recorded data.
+///
+/// If you need backwards-compatible schemas, maintain an explicit `.proto` file and use a library
+/// like [prost](https://docs.rs/prost) to generate your types. You can then implement
+/// `Encode` manually for those types.
 #[proc_macro_derive(Encode)]
 pub fn derive_loggable(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
### Changelog
None

### Docs
https://github.com/foxglove/app/pull/12554

### Description
This change updates the documentation for the `Encode` derive macro, to clarify how it is intended to be used. In particular, we call out the fact that does not guarantee a backwards-compatible serialization format, and suggests the use of protobuf for users that care about such things.