### PR TITLE
docs: add a copy button to python code-block in sphinx

### DIFF
--- a/python/foxglove-sdk/pyproject.toml
+++ b/python/foxglove-sdk/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
   "sphinx-toolbox>=4.1.2,<5",
   "types-docutils",
   "mcap>=1.3.0,<2",
+  "sphinx-copybutton>=0.5.2",
 ]
 
 [tool.uv]

--- a/python/foxglove-sdk/python/docs/conf.py
+++ b/python/foxglove-sdk/python/docs/conf.py
@@ -28,6 +28,7 @@ extensions: list[str] = [
     "sphinx_autodoc_typehints",
     "enum_tools.autoenum",
     "sphinx_toolbox.more_autodoc.no_docstring",
+    "sphinx_copybutton",
 ]
 
 nitpicky = True

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -166,18 +166,21 @@ def init_notebook_buffer(context: Context | None = None) -> NotebookBuffer:
         it with ``pip install foxglove-sdk[notebook]``.
 
     Example:
-        >>> import foxglove
-        >>>
-        >>> # Create a basic viewer using the default context
-        >>> nb_buffer = foxglove.init_notebook_buffer()
-        >>>
-        >>> # Or use a specific context
-        >>> nb_buffer = foxglove.init_notebook_buffer(context=my_ctx)
-        >>>
-        >>> # ... log data as usual ...
-        >>>
-        >>> # Display the widget in the notebook
-        >>> nb_buffer.show()
+
+    .. code-block:: python
+
+        import foxglove
+
+        # Create a basic viewer using the default context
+        nb_buffer = foxglove.init_notebook_buffer()
+
+        # Or use a specific context
+        nb_buffer = foxglove.init_notebook_buffer(context=my_ctx)
+
+        # ... log data as usual ...
+
+        # Display the widget in the notebook
+        nb_buffer.show()
     """
     try:
         from .notebook.notebook_buffer import NotebookBuffer

--- a/python/foxglove-sdk/uv.lock
+++ b/python/foxglove-sdk/uv.lock
@@ -395,6 +395,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-copybutton" },
     { name = "sphinx-toolbox" },
     { name = "types-docutils" },
 ]
@@ -420,6 +421,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6" },
     { name = "sphinx", specifier = ">=8.0.0,<8.2.0" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.0,<4" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-toolbox", specifier = ">=4.1.2,<5" },
     { name = "types-docutils" },
 ]
@@ -1200,6 +1202,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/dc/dc46c5c7c566b7ec5e8f860f9c89533bf03c0e6aadc96fb9b337867e4460/sphinx_autodoc_typehints-3.0.1-py3-none-any.whl", hash = "sha256:4b64b676a14b5b79cefb6628a6dc8070e320d4963e8ff640a2f3e9390ae9045a", size = 20245, upload-time = "2025-01-16T18:25:27.394Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Changelog

None

### Docs

Add copy button to Python code-blocks in Sphinx generated docs.

### Description

Add the sphinx-copybutton extension. Update the code snippet so that ">>>" is not copied when the button is clicked.

<table><tr><th>Before</th><th>After</th></tr><tr><td>


https://github.com/user-attachments/assets/958b4a34-8ffd-4474-badb-06d51143e774



</td><td>


https://github.com/user-attachments/assets/6212eced-1a88-43a9-90c7-484f7c59b106



</td></tr></table>

<!-- Link relevant GitHub or Linear issues. Use `Fixes: https://github.com/<orgname>/<reponame>/issues/123` for GitHub issues or `Fixes: [ABC-123](https://linear.app/foxglove/issue/ABC-123)` for Linear issues. Put each issue on a separate line. -->
