### PR TITLE
ci: Use distinct job names for status checks

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -267,10 +267,10 @@ jobs:
 
   # Gate job for branch protection. Always posts a status so that the required
   # check passes even when the other jobs are skipped. Configure your required
-  # status check to reference this job ("C/C++ / status") instead of the
+  # status check to reference this job ("C/C++ / c-cpp-status") instead of the
   # individual matrix jobs.
   c-cpp-status:
-    name: status
+    name: c-cpp-status
     needs: [changes, lint, build, test-asan-ubsan]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -429,10 +429,10 @@ jobs:
 
   # Gate job for branch protection. Always posts a status so that the required
   # check passes even when the other jobs are skipped. Configure your required
-  # status check to reference this job ("Python / status") instead of the
+  # status check to reference this job ("Python / python-status") instead of the
   # individual matrix jobs.
   python-status:
-    name: status
+    name: python-status
     needs: [changes, lint, lint-and-test-sdk, schemas, sdist, linux, musllinux, windows, macos, playground-wasm, playground, test-sdk-examples]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -59,10 +59,10 @@ jobs:
 
   # Gate job for branch protection. Always posts a status so that the required
   # check passes even when the ros matrix is skipped. Configure your required
-  # status check to reference this job ("ROS / status") instead of the
+  # status check to reference this job ("ROS / ros-status") instead of the
   # individual matrix jobs.
   ros-status:
-    name: status
+    name: ros-status
     needs: [changes, ros]
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Apparently github status checks only match against job name, not workflow name. So in order to ensure that a PR is blocked until all three expected checks are published, we need them to have distinct names.