### PR TITLE
Foxglove SDK checkout composite action

### DIFF
--- a/.github/actions/internal-checkout/action.yml
+++ b/.github/actions/internal-checkout/action.yml
@@ -12,4 +12,6 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: ln -s "$GITHUB_ACTION_PATH/../../.." "${{ inputs.path }}"
+      env:
+        TARGET_PATH: ${{ inputs.path }}
+      run: ln -s "$GITHUB_ACTION_PATH/../../.." "$TARGET_PATH"


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

This PR introduces a composite action at `.github/actions/internal-checkout/action.yml` which creates a symlink to a checkout of the SDK repo. This will be used in `data-platform` CI for a smoke test which will be automatically rolled forward by dependabot.

I have tested that this action works by pointing GitHub CI at it in the forthcoming `data-platform` CI PR.