### PR TITLE
Update documentation link for Python SDK

### DIFF
--- a/python/foxglove-sdk/README.md
+++ b/python/foxglove-sdk/README.md
@@ -8,7 +8,7 @@ with the Foxglove app.
 
 ## Get Started
 
-See https://foxglove.github.io/foxglove-sdk/python/
+See https://foxglove-sdk-api-docs.pages.dev/python/
 
 ## Requirements
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

The current link to the SDK docs is broken.  I found a `pages.dev` url which _seems_ like it's what I'm looking for.