### PR TITLE
Disable Claude PR review for fork PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

The PR review workflow (`pr-review.yml`) was failing for external contributors in the `foxglove-sdk` repository. This was due to GitHub Actions being unable to fetch an OIDC token for pull requests originating from external forks when `id-token: write` permissions are required, leading to an `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable` error.

This change modifies the `pr-review.yml` workflow to include a conditional check: `if: github.event.pull_request.head.repo.full_name == github.repository`. This condition ensures that the Claude code review workflow only executes for pull requests that originate from branches within the `foxglove/foxglove-sdk` repository itself, effectively skipping PRs from external forks.

This resolves the OIDC token error for external contributors, allowing their PRs to proceed without workflow failures, while still providing Claude AI reviews for internal PRs as intended.

**Manual Testing:**
- Verify that the `pr-review` workflow runs successfully for PRs opened from branches within the `foxglove/foxglove-sdk` repository.
- Verify that the `pr-review` workflow is skipped for PRs opened from external forks.

Fixes: [FLE-253](https://linear.app/foxglove/issue/FLE-253/pr-review-workflow-fails-for-external-contributors-in-foxglove-sdk)

---
Linear Issue: [FLE-253](https://linear.app/foxglove/issue/FLE-253/pr-review-workflow-fails-for-external-contributors-in-foxglove-sdk)

<p><a href="https://cursor.com/agents/bc-9a414324-9419-4aed-92f1-8b2fb956e8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a414324-9419-4aed-92f1-8b2fb956e8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

