### PR TITLE
ci: Fix draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   c-cpp:
     uses: ./.github/workflows/c_cpp.yml
+    permissions:
+      pull-requests: read
     with:
       sdk-version: ${{ github.event.inputs.version }}
   cpp-data-loader:


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
The recent changes to the C/C++ workflow require new permissions for
reading pull requests. The draft-release workflow needs to grant these
permissions (even though it never runs on pull-request triggers).