### PR TITLE
cpp: Build remote access for 22.04

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -38,10 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             clang-format-19 clang-tidy-19 \
+            gcc g++ libglib2.0-dev libva-dev  \
             libwebsockets-dev nlohmann-json3-dev
           echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
       - run: clang-format --version
@@ -51,19 +53,6 @@ jobs:
       - run: make CLANG_TIDY=true CMAKE_BUILD_TYPE=Debug test
         working-directory: cpp
 
-  lint-ra:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends clang-format-19 clang-tidy-19 \
-            gcc-14 g++-14 libglib2.0-dev libva-dev
-          echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
-      - run: make CLANG_TIDY=true CMAKE_BUILD_TYPE=Debug test-ra
-        working-directory: cpp
-
   build:
     needs: changes
     if: needs.changes.outputs.build == 'true'
@@ -71,60 +60,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux
+          # Linux (clang, remote access disabled)
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            staticlib_name: libfoxglove.a
+            cdylib_name: libfoxglove.so
+            compiler: clang
+            skip_upload: true
+            cross: false
+
+          # Linux (remote access enabled)
           - runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             staticlib_name: libfoxglove.a
             cdylib_name: libfoxglove.so
-            staticlib_artifact_name: libfoxglove-aarch64-unknown-linux-gnu.a
-            cdylib_artifact_name: libfoxglove-aarch64-unknown-linux-gnu.so
-            compiler: clang
             cross: false
+            remote_access: true
           - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             staticlib_name: libfoxglove.a
             cdylib_name: libfoxglove.so
-            staticlib_artifact_name: libfoxglove-x86_64-unknown-linux-gnu.a
-            cdylib_artifact_name: libfoxglove-x86_64-unknown-linux-gnu.so
-            compiler: clang
-            cross: false
-
-          # Linux (remote access, GCC 14 / libstdc++ / glibc >= 2.39)
-          - runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            staticlib_name: libfoxglove.a
-            cdylib_name: libfoxglove.so
-            staticlib_artifact_name: libfoxglove-aarch64-unknown-linux-gnu.a
-            cdylib_artifact_name: libfoxglove-aarch64-unknown-linux-gnu.so
             cross: false
             remote_access: true
-            artifact_suffix: -glibc2.39
-          - runner: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-            staticlib_name: libfoxglove.a
-            cdylib_name: libfoxglove.so
-            staticlib_artifact_name: libfoxglove-x86_64-unknown-linux-gnu.a
-            cdylib_artifact_name: libfoxglove-x86_64-unknown-linux-gnu.so
-            cross: false
-            remote_access: true
-            artifact_suffix: -glibc2.39
 
           # macOS (remote access enabled)
           - runner: macos-15
             target: aarch64-apple-darwin
             staticlib_name: libfoxglove.a
             cdylib_name: libfoxglove.dylib
-            staticlib_artifact_name: libfoxglove-aarch64-apple-darwin.a
-            cdylib_artifact_name: libfoxglove-aarch64-apple-darwin.dylib
             cross: false
             remote_access: true
-
           - runner: macos-15
             target: x86_64-apple-darwin
             staticlib_name: libfoxglove.a
             cdylib_name: libfoxglove.dylib
-            staticlib_artifact_name: libfoxglove-x86_64-apple-darwin.a
-            cdylib_artifact_name: libfoxglove-x86_64-apple-darwin.dylib
             cross: true
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64
             remote_access: true
@@ -134,16 +103,12 @@ jobs:
             target: x86_64-pc-windows-msvc
             staticlib_name: foxglove.lib
             cdylib_name: foxglove.dll
-            staticlib_artifact_name: foxglove-x86_64-pc-windows-msvc.lib
-            cdylib_artifact_name: foxglove-x86_64-pc-windows-msvc.dll
             cross: false
             remote_access: true
           - runner: windows-2025
             target: aarch64-pc-windows-msvc
             staticlib_name: foxglove.lib
             cdylib_name: foxglove.dll
-            staticlib_artifact_name: foxglove-aarch64-pc-windows-msvc.lib
-            cdylib_artifact_name: foxglove-aarch64-pc-windows-msvc.dll
             cross: true
             cmake_args: -A ARM64 -DFOXGLOVE_SKIP_TEST_DISCOVERY=ON
             remote_access: true
@@ -153,26 +118,20 @@ jobs:
             target: aarch64-apple-ios
             staticlib_name: libfoxglove.a
             cdylib_name: libfoxglove.dylib
-            staticlib_artifact_name: libfoxglove-aarch64-apple-ios.a
-            cdylib_artifact_name: libfoxglove-aarch64-apple-ios.dylib
             cross: true
           # iOS simulator
           - runner: macos-15
             target: aarch64-apple-ios-sim
             staticlib_name: libfoxglove.a
             cdylib_name: libfoxglove.dylib
-            staticlib_artifact_name: libfoxglove-aarch64-apple-ios-sim.a
-            cdylib_artifact_name: libfoxglove-aarch64-apple-ios-sim.dylib
             cross: true
           - runner: macos-15
             target: x86_64-apple-ios
             staticlib_name: libfoxglove.a
             cdylib_name: libfoxglove.dylib
-            staticlib_artifact_name: libfoxglove-x86_64-apple-ios.a
-            cdylib_artifact_name: libfoxglove-x86_64-apple-ios.dylib
             cross: true
 
-    name: build (${{ matrix.target }}${{ matrix.remote_access && ', remote-access' || '' }})
+    name: build (${{ matrix.target }}${{ matrix.remote_access && ', remote-access' || '' }}${{ matrix.compiler == 'clang' && ', clang' || ''}})
     runs-on: ${{ matrix.runner }}
 
     env:
@@ -204,9 +163,9 @@ jobs:
         if: matrix.remote_access && runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-14 g++-14 libglib2.0-dev libva-dev
-          echo "CC=gcc-14" >> $GITHUB_ENV
-          echo "CXX=g++-14" >> $GITHUB_ENV
+          sudo apt-get install -y libglib2.0-dev libva-dev libwebsockets-dev
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
       - name: Use Clang
         if: matrix.compiler == 'clang'
         run: |
@@ -251,20 +210,21 @@ jobs:
       # Build and test C++ using the pre-built Rust libraries.
       - name: Build C++ library
         if: "!contains(matrix.target, 'apple-ios')"
-        run: make ${{ matrix.remote_access && 'build-ra' || 'build' }}
+        run: make build
         working-directory: cpp
         env:
           FOXGLOVE_PREBUILT_LIB_DIR: ${{ github.workspace }}/target/${{ matrix.target }}/release
+          FOXGLOVE_REMOTE_ACCESS: ${{ matrix.remote_access && 'ON' || 'OFF' }}
           CMAKE_ARGS: ${{ matrix.cmake_args || '' }}
       - name: Test C++ library
         if: "!matrix.cross && !contains(matrix.target, 'apple-ios')"
-        run: ctest --test-dir ${{ matrix.remote_access && 'build-ra' || 'build' }} --verbose
+        run: ctest --test-dir build --verbose
         working-directory: cpp
 
       - name: Run remote data loader backend conformance tests
         if: ${{ !matrix.cross }}
         env:
-          REMOTE_DATA_LOADER_BACKEND_CMD: ${{ format('cpp/{0}/{1}', matrix.remote_access && 'build-ra' || 'build', runner.os == 'Windows' && 'RelWithDebInfo/example_remote_data_loader_backend.exe' || 'example_remote_data_loader_backend') }}
+          REMOTE_DATA_LOADER_BACKEND_CMD: ${{ format('cpp/build/{0}', runner.os == 'Windows' && 'RelWithDebInfo/example_remote_data_loader_backend.exe' || 'example_remote_data_loader_backend') }}
           REMOTE_DATA_LOADER_BACKEND_URL: "http://127.0.0.1:8081/v1/manifest?flightId=TEST123&startTime=2024-01-01T00:00:00Z&endTime=2024-01-01T00:00:05Z"
           REMOTE_DATA_LOADER_BACKEND_EXPECTED_STREAMED_SOURCE_COUNT: "1"
           REMOTE_DATA_LOADER_BACKEND_EXPECTED_STATIC_FILE_SOURCE_COUNT: "0"
@@ -294,7 +254,7 @@ jobs:
         working-directory: artifacts
         run: |
           zip -r \
-            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}${{ matrix.artifact_suffix || '' }}.zip \
+            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip \
             foxglove/
 
       - name: Zip libraries for artifact (Windows)
@@ -302,14 +262,15 @@ jobs:
         working-directory: artifacts
         run: |
           7z a -tzip -sse `
-            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}${{ matrix.artifact_suffix || '' }}.zip `
+            foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip `
             foxglove/
 
       - name: Upload static & shared library to artifacts
+        if: ${{ !(matrix.skip_upload || false) }}
         uses: actions/upload-artifact@v7
         with:
-          name: foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}${{ matrix.artifact_suffix || '' }}.zip
-          path: artifacts/foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}${{ matrix.artifact_suffix || '' }}.zip
+          name: foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip
+          path: artifacts/foxglove-${{inputs.sdk-version || github.sha}}-cpp-${{ matrix.target }}.zip
           if-no-files-found: error
 
   test-asan-ubsan:
@@ -328,9 +289,10 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            libglib2.0-dev libva-dev \
             libwebsockets-dev nlohmann-json3-dev
 
-      - run: make SANITIZE=address,undefined test
+      - run: make SANITIZE=address,undefined FOXGLOVE_REMOTE_ACCESS=OFF test
         working-directory: cpp
 
   # Gate job for branch protection. Always posts a status so that the required
@@ -339,7 +301,7 @@ jobs:
   # individual matrix jobs.
   c-cpp-status:
     name: c-cpp-status
-    needs: [changes, lint, lint-ra, build, test-asan-ubsan]
+    needs: [changes, lint, build, test-asan-ubsan]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -144,7 +144,7 @@ jobs:
           target: ${{ matrix.target }}
           # Set a cache key to distinguish the remote-access-enabled linux
           # builds from the non-remote-access-enabled linux builds.
-          cache-key: ${{ matrix.remote_access && 'ra' || '' }}
+          cache-key: ${{ matrix.remote_access && 'ra-v2' || '' }}
 
       - run: echo "IPHONEOS_DEPLOYMENT_TARGET=13.0.0" >> $GITHUB_ENV
         # Min version needed for libaws_lc_sys

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -177,32 +177,28 @@ jobs:
 
       # Build the Rust/C library with cargo directly.
       - name: Build C library for ${{ matrix.target }}
+        if: "!matrix.remote_access"
         env:
           FOXGLOVE_SDK_LANGUAGE: c
         run: cargo build --release
         working-directory: c
 
-      # We include remote access support on platforms that support it, but only
-      # in the cdylib - we don't want to include it in the staticlib. There's no
-      # way to prevent cargo from building the staticlib again in this step, so
-      # we stash and restore the original staticlib.
-      - name: Save base staticlib before RA rebuild
+      # For remote access targets, build the staticlib and cdylib separately so
+      # we can enable remote-access only in the cdylib.
+      - name: Build C staticlib for ${{ matrix.target }}
         if: matrix.remote_access
-        shell: bash
-        run: cp target/${{ matrix.target }}/release/${{ matrix.staticlib_name }} target/${{ matrix.target }}/release/${{ matrix.staticlib_name }}.base
+        env:
+          FOXGLOVE_SDK_LANGUAGE: c
+        run: cargo rustc --release --lib --crate-type staticlib
+        working-directory: c
 
-      - name: Rebuild C library with remote access for ${{ matrix.target }}
+      - name: Build C cdylib with remote access for ${{ matrix.target }}
         if: matrix.remote_access
         env:
           FOXGLOVE_SDK_LANGUAGE: c
           RUSTFLAGS: ${{ runner.os == 'Windows' && '-C target-feature=+crt-static' || '' }}
-        run: cargo build --release --features remote-access
+        run: cargo rustc --release --lib --crate-type cdylib --features remote-access
         working-directory: c
-
-      - name: Restore base staticlib
-        if: matrix.remote_access
-        shell: bash
-        run: mv target/${{ matrix.target }}/release/${{ matrix.staticlib_name }}.base target/${{ matrix.target }}/release/${{ matrix.staticlib_name }}
 
       - name: Ensure generated files are up to date
         run: git diff --exit-code

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libwebsockets-dev nlohmann-json3-dev
       - name: Build C++ SDK
-        run: make build
+        run: make FOXGLOVE_REMOTE_ACCESS=OFF build
         working-directory: cpp
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7

--- a/Container.mk
+++ b/Container.mk
@@ -112,16 +112,4 @@ test-cpp:
 
 .PHONY: test-cpp-sanitize
 test-cpp-sanitize:
-	make -C cpp SANITIZE=address,undefined test
-
-.PHONY: build-cpp-ra
-build-cpp-ra:
-	make -C cpp build-ra
-
-.PHONY: test-cpp-ra
-test-cpp-ra:
-	make -C cpp test-ra
-
-.PHONY: build-cpp-ra-tidy
-build-cpp-ra-tidy:
-	make -C cpp CLANG_TIDY=true build-ra
+	make -C cpp SANITIZE=address,undefined FOXGLOVE_REMOTE_ACCESS=OFF test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,50 @@
 # Local development image. See Makefile for usage.
-FROM rust:1.89-trixie AS builder
-
-ARG MSRV_RUST_VERSION=1.85.0
+FROM ubuntu:22.04
 
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get install -y \
+        cmake \
+        curl \
+        doxygen \
+        gcc \
+        g++ \
+        git \
+        gnupg \
+        libglib2.0-dev \
+        libva-dev \
+        libwebsockets-dev \
+        lsb-release \
+        protobuf-compiler \
+        python3-dev \
+        software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# clang
+RUN curl https://apt.llvm.org/llvm.sh -fsS -o llvm.sh \
+    && bash llvm.sh 19 \
+    && apt-get install -y clang-tidy-19 clang-format-19 \
+    && rm -rf /var/lib/apt/lists/*
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+
+# rust
+ARG MSRV_RUST_VERSION=1.85.0
+RUN curl https://sh.rustup.rs -fsS | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup toolchain install nightly --component rust-src
 RUN rustup toolchain install ${MSRV_RUST_VERSION}
 RUN rustup component add rustfmt clippy
 
-RUN apt-get update \
-    && apt-get install -y \
-        clang-19 \
-        clang-format-19 \
-        clang-tidy-19 \
-        cmake \
-        doxygen \
-        libva-dev \
-        nodejs \
-        npm \
-        protobuf-compiler \
-        python3-dev \
-    && rm -rf /var/lib/apt/lists/*
-
+# node
+RUN curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh \
+  && bash nodesource_setup.sh \
+  && apt-get update \
+  && apt-get install -y nodejs \
+  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable yarn
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
-ENV PATH=/usr/lib/llvm-19/bin:/root/.local/bin:$PATH \
-    COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-
+# python
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -9,7 +9,7 @@ name = "foxglove"
 crate-type = ["staticlib", "cdylib"]
 
 # The `remote_access` feature gates `mod gateway` in src/lib.rs. It can be enabled via
-# the CMake option FOXGLOVE_BUILD_REMOTE_ACCESS, which passes this feature to corrosion.
+# the CMake option FOXGLOVE_REMOTE_ACCESS, which passes this feature to corrosion.
 [features]
 remote-access = ["foxglove/remote-access"]
 

--- a/c/README.md
+++ b/c/README.md
@@ -4,4 +4,4 @@ This crate implements a simple C interface that wraps the Rust SDK. It can be bu
 
 ## Remote access
 
-Remote access support is gated behind the `remote-access` Cargo feature. When enabled, the gateway-specific FFI code in `c/src/gateway.rs` is compiled into the library. The C++ CMake build enables this via `FOXGLOVE_BUILD_REMOTE_ACCESS=ON`, which produces only a shared library (no static library). The generated header (`foxglove-c.h`) guards the gateway declarations with `#if defined(FOXGLOVE_REMOTE_ACCESS)`.
+Remote access support is gated behind the `remote-access` Cargo feature. When enabled, the gateway-specific FFI code in `c/src/gateway.rs` is compiled into the library. The C++ CMake build enables this via `FOXGLOVE_REMOTE_ACCESS=ON`, which produces only a shared library (no static library). The generated header (`foxglove-c.h`) guards the gateway declarations with `#if defined(FOXGLOVE_REMOTE_ACCESS)`.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 option(USE_PACKAGE_MANAGER_DEPENDENCIES
   "Try to find dependencies provided by the local package manager, and if not found, fall back to building them from source"
   ON)
-option(FOXGLOVE_BUILD_REMOTE_ACCESS "Build with remote access gateway support" OFF)
+option(FOXGLOVE_REMOTE_ACCESS "Build with remote access gateway support" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -164,7 +164,7 @@ endif()
 # redundant Rust builds and Windows long-path issues with corrosion's nested build directory.
 if(FOXGLOVE_PREBUILT_LIB_DIR)
   get_filename_component(FOXGLOVE_PREBUILT_LIB_DIR "${FOXGLOVE_PREBUILT_LIB_DIR}" ABSOLUTE)
-  if(NOT FOXGLOVE_BUILD_REMOTE_ACCESS)
+  if(NOT FOXGLOVE_REMOTE_ACCESS)
     add_library(foxglove-static STATIC IMPORTED GLOBAL)
     set_target_properties(foxglove-static PROPERTIES
       IMPORTED_LOCATION "${FOXGLOVE_PREBUILT_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}foxglove${CMAKE_STATIC_LIBRARY_SUFFIX}"
@@ -185,7 +185,7 @@ if(FOXGLOVE_PREBUILT_LIB_DIR)
     endforeach()
   endif()
 else()
-  if(FOXGLOVE_BUILD_REMOTE_ACCESS)
+  if(FOXGLOVE_REMOTE_ACCESS)
     # RA builds only produce the cdylib (shared library). A staticlib is not provided because
     # the LiveKit/WebRTC dependency has strict ABI requirements and would leak internal symbols
     # into the consumer's binary.
@@ -271,7 +271,7 @@ target_include_directories(foxglove_cpp_obj PRIVATE
 target_compile_options(foxglove_cpp_obj PRIVATE ${SANITIZER_COMPILE_OPTIONS} ${STRICT_COMPILE_OPTIONS})
 target_link_options(foxglove_cpp_obj PRIVATE ${SANITIZER_LINK_OPTIONS})
 
-if(NOT FOXGLOVE_BUILD_REMOTE_ACCESS)
+if(NOT FOXGLOVE_REMOTE_ACCESS)
   add_library(foxglove_cpp_static STATIC
     $<TARGET_OBJECTS:foxglove_cpp_obj>
     $<TARGET_OBJECTS:foxglove_generated_obj>
@@ -297,7 +297,7 @@ else()
 endif()
 
 set(_foxglove_cpp_targets foxglove_cpp_shared)
-if(NOT FOXGLOVE_BUILD_REMOTE_ACCESS)
+if(NOT FOXGLOVE_REMOTE_ACCESS)
   list(APPEND _foxglove_cpp_targets foxglove_cpp_static)
 endif()
 foreach(_target ${_foxglove_cpp_targets})
@@ -313,7 +313,7 @@ endforeach()
 
 ### Remote Access (optional)
 
-if(FOXGLOVE_BUILD_REMOTE_ACCESS)
+if(FOXGLOVE_REMOTE_ACCESS)
   add_library(foxglove_ra_cpp_obj OBJECT
     "foxglove/include/foxglove/remote_access.hpp"
     "foxglove/src/remote_access.cpp"
@@ -411,7 +411,7 @@ add_foxglove_example(example_connection_graph SOURCES examples/connection-graph/
 add_foxglove_example(example_auto_serialize SOURCES examples/auto-serialize/src/main.cpp LIBS nlohmann_json::nlohmann_json)
 add_foxglove_example(example_message_filtering SOURCES examples/message-filtering/src/main.cpp)
 
-if(FOXGLOVE_BUILD_REMOTE_ACCESS)
+if(FOXGLOVE_REMOTE_ACCESS)
   add_foxglove_example(example_remote_access SOURCES examples/remote-access/src/main.cpp)
 endif()
 
@@ -441,7 +441,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # Install C++ libraries
-if(FOXGLOVE_BUILD_REMOTE_ACCESS)
+if(FOXGLOVE_REMOTE_ACCESS)
   install(TARGETS foxglove_cpp_shared
     EXPORT foxglove-sdkTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -12,6 +12,7 @@ $(info Using sanitizer: $(SANITIZE))
 endif
 
 CMAKE_BUILD_TYPE?=RelWithDebInfo
+FOXGLOVE_REMOTE_ACCESS?=ON
 
 .PHONY: lint
 lint:
@@ -39,33 +40,10 @@ build:
 		$(if $(CLANG_TIDY),-DCLANG_TIDY=$(CLANG_TIDY)) \
 		$(if $(BUILD_OPENCV_EXAMPLE),-DBUILD_OPENCV_EXAMPLE=$(BUILD_OPENCV_EXAMPLE)) \
 		$(if $(FOXGLOVE_PREBUILT_LIB_DIR),-DFOXGLOVE_PREBUILT_LIB_DIR=$(FOXGLOVE_PREBUILT_LIB_DIR)) \
+		-DFOXGLOVE_REMOTE_ACCESS=$(FOXGLOVE_REMOTE_ACCESS) \
 		$(CMAKE_ARGS) \
 		-B $(BUILD_DIR)
 	cmake --build $(BUILD_DIR) -j 8 --config $(CMAKE_BUILD_TYPE)
-
-RA_BUILD_DIR=$(BUILD_DIR)-ra
-
-.PHONY: build-ra
-build-ra:
-	cmake \
-		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
-		-DCMAKE_EXPORT_COMPILE_COMMANDS=true \
-		-DFOXGLOVE_BUILD_REMOTE_ACCESS=ON \
-		$(if $(SANITIZE),-DSANITIZE=$(SANITIZE) -DRust_TOOLCHAIN=nightly) \
-		$(if $(STRICT),-DSTRICT=$(STRICT)) \
-		$(if $(CLANG_TIDY),-DCLANG_TIDY=$(CLANG_TIDY)) \
-		$(if $(FOXGLOVE_PREBUILT_LIB_DIR),-DFOXGLOVE_PREBUILT_LIB_DIR=$(FOXGLOVE_PREBUILT_LIB_DIR)) \
-		$(CMAKE_ARGS) \
-		-B $(RA_BUILD_DIR)
-	cmake --build $(RA_BUILD_DIR) -j 8 --config $(CMAKE_BUILD_TYPE)
-
-.PHONY: test-ra
-test-ra: build-ra
-	cd $(RA_BUILD_DIR) && ctest --verbose
-
-.PHONY: clean-ra
-clean-ra:
-	rm -rf $(RA_BUILD_DIR)
 
 .PHONY: test
 test: build

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -54,7 +54,7 @@ Run example programs (note that a different `build` directory may be used depend
 
 ## Remote access
 
-Remote access support adds the `RemoteAccessGateway` class for live visualization and teleop via the Foxglove platform. It is built by enabling the `FOXGLOVE_BUILD_REMOTE_ACCESS` CMake option, which adds the gateway code to `foxglove_cpp_shared`. Only the shared library is produced — no static library — because the LiveKit/WebRTC dependency has strict ABI requirements and would leak internal symbols into the consumer's binary.
+Remote access support adds the `RemoteAccessGateway` class for live visualization and teleop via the Foxglove platform. It is built by enabling the `FOXGLOVE_REMOTE_ACCESS` CMake option, which adds the gateway code to `foxglove_cpp_shared`. Only the shared library is produced — no static library — because the LiveKit/WebRTC dependency has strict ABI requirements and would leak internal symbols into the consumer's binary.
 
 ### Supported platforms and ABI requirements
 
@@ -62,8 +62,8 @@ The remote access shared library has strict ABI requirements inherited from the 
 
 | Platform | Compiler | C++ stdlib | CRT | Notes |
 |----------|----------|------------|-----|-------|
-| Linux x86_64 | GCC 14+ | libstdc++ | — | glibc >= 2.39 (Ubuntu 24.04+) |
-| Linux aarch64 | GCC 14+ | libstdc++ | — | glibc >= 2.39 (Ubuntu 24.04+) |
+| Linux x86_64 | GCC | libstdc++ | — | glibc >= 2.35 (Ubuntu 22.04+) |
+| Linux aarch64 | GCC | libstdc++ | — | glibc >= 2.35 (Ubuntu 22.04+) |
 | macOS x86_64 | Clang | libc++ | — | Default Xcode toolchain |
 | macOS aarch64 | Clang | libc++ | — | Default Xcode toolchain |
 | Windows x86_64 | MSVC | MSVC STL | `/MT` (static) | Your project must also use `/MT` |
@@ -74,16 +74,14 @@ The remote access shared library has strict ABI requirements inherited from the 
 ### Building locally
 
 ```
-make build-ra
+make build FOXGLOVE_REMOTE_ACCESS=ON
 ```
-
-This uses a separate build directory (`build-ra/`) from the base SDK build.
 
 ### Consuming the library
 
 Link against `foxglove_cpp_shared` and include the same C and C++ headers as the base SDK. The C++ header `foxglove/remote_access.hpp` provides the `RemoteAccessGateway` class.
 
-The gateway-related C declarations in `foxglove-c/foxglove-c.h` are guarded by `#if defined(FOXGLOVE_REMOTE_ACCESS)`. When using CMake and linking against `foxglove_cpp_shared` built with `FOXGLOVE_BUILD_REMOTE_ACCESS=ON`, this define is propagated automatically. Otherwise, define `FOXGLOVE_REMOTE_ACCESS` before including the header.
+The gateway-related C declarations in `foxglove-c/foxglove-c.h` are guarded by `#if defined(FOXGLOVE_REMOTE_ACCESS)`. When using CMake and linking against `foxglove_cpp_shared` built with `FOXGLOVE_REMOTE_ACCESS=ON`, this define is propagated automatically. Otherwise, define `FOXGLOVE_REMOTE_ACCESS` before including the header.
 
 ## Examples
 

--- a/cpp/cmake/foxglove-sdkConfig.cmake.in
+++ b/cpp/cmake/foxglove-sdkConfig.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 # Whether the SDK was built with remote access gateway support.
-set(FOXGLOVE_SDK_REMOTE_ACCESS @FOXGLOVE_BUILD_REMOTE_ACCESS@)
+set(FOXGLOVE_SDK_REMOTE_ACCESS @FOXGLOVE_REMOTE_ACCESS@)
 
 set(_foxglove_lib_dir "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
It turns out we can build remote access for 22.04, which will be instrumental in enabling humble builds of the foxglove bridge on the ROS build farm.

In a subsequent change, we're gonna move the ros jobs into the c/cpp workflow, so that we can re-use the build artifacts there.