### PR TITLE
ci: Update ros workflow to use remote-access build

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -26,7 +26,7 @@ jobs:
               - 'ros/**'
               - '.github/workflows/ros.yml'
 
-  build-cpp:
+  build-cpp-sdk:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     # Pinned to 22.04 so libfoxglove.a is compatible with ROS Humble (glibc 2.35)
@@ -37,21 +37,44 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libwebsockets-dev nlohmann-json3-dev
-      - name: Build C++ SDK
-        run: make FOXGLOVE_REMOTE_ACCESS=OFF build
-        working-directory: cpp
-      - name: Upload build artifacts
+            libglib2.0-dev libva-dev libwebsockets-dev
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
+
+      # For remote access targets, build the staticlib and cdylib separately so
+      # we can enable remote-access only in the cdylib.
+      - name: Build C staticlib
+        env:
+          FOXGLOVE_SDK_LANGUAGE: c
+        run: cargo rustc --release --lib --crate-type staticlib
+        working-directory: c
+
+      - name: Build C cdylib with remote access
+        env:
+          FOXGLOVE_SDK_LANGUAGE: c
+        run: cargo rustc --release --lib --crate-type cdylib --features remote-access
+        working-directory: c
+
+      - name: Organize SDK artifact
+        run: |
+          mkdir -p cpp-sdk/foxglove/lib
+          mkdir -p cpp-sdk/foxglove/include
+          mkdir -p cpp-sdk/foxglove/src
+          cp target/release/libfoxglove.a cpp-sdk/foxglove/lib/
+          cp target/release/libfoxglove.so cpp-sdk/foxglove/lib/
+          cp -R c/include/foxglove-c cpp-sdk/foxglove/include/
+          cp -R cpp/foxglove/include/foxglove cpp-sdk/foxglove/include/
+          cp -R cpp/foxglove/src/* cpp-sdk/foxglove/src/
+
+      - name: Upload SDK artifact
         uses: actions/upload-artifact@v7
         with:
-          name: cpp-build
-          path: |
-            cpp/build/libfoxglove.a
-            cpp/build/libfoxglove_cpp_static.a
+          name: cpp-sdk
+          path: cpp-sdk/foxglove
           retention-days: 1
 
   ros:
-    needs: [changes, build-cpp]
+    needs: [changes, build-cpp-sdk]
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -66,18 +89,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download C++ SDK build
+      - name: Download C++ SDK artifact
         uses: actions/download-artifact@v8
         with:
-          name: cpp-build
-          path: cpp/build
+          name: cpp-sdk
+          path: cpp-sdk/foxglove
 
       - name: Run make lint
         run: make lint
         working-directory: ros
 
       - name: Run make docker-build
-        run: make USE_LOCAL_SDK=ON ${{ matrix.ros_distribution == 'rolling' && 'EXTRA_DOCKER_ARGS="--build-arg USE_ROS_TESTING=true"' || '' }} docker-build-${{ matrix.ros_distribution }}
+        run: |
+          make \
+            FOXGLOVE_CPP_SDK_DIR=/sdk/cpp-sdk/foxglove \
+            ${{ matrix.ros_distribution == 'rolling' && 'EXTRA_DOCKER_ARGS="--build-arg USE_ROS_TESTING=true"' || '' }} \
+            docker-build-${{ matrix.ros_distribution }}
         working-directory: ros
 
       - name: Run make docker-test
@@ -90,7 +117,7 @@ jobs:
   # individual matrix jobs.
   ros-status:
     name: ros-status
-    needs: [changes, build-cpp, ros]
+    needs: [changes, build-cpp-sdk, ros]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/ros/Makefile
+++ b/ros/Makefile
@@ -1,5 +1,6 @@
 ROS_DISTRIBUTIONS := humble jazzy kilted rolling
 USE_LOCAL_SDK := OFF
+FOXGLOVE_CPP_SDK_DIR :=
 EXTRA_DOCKER_ARGS :=
 DOCKER_USER_ARGS :=
 DOCKER_RUN_ARGS :=
@@ -33,7 +34,9 @@ deps:
 
 .PHONY: build
 build:
-	colcon build --cmake-args -DUSE_LOCAL_SDK=$(USE_LOCAL_SDK)
+	colcon build --cmake-args \
+		-DUSE_LOCAL_SDK=$(USE_LOCAL_SDK) \
+		$(if $(FOXGLOVE_CPP_SDK_DIR),-DFETCHCONTENT_SOURCE_DIR_FOXGLOVE_SDK=$(FOXGLOVE_CPP_SDK_DIR))
 
 .PHONY: test
 test:
@@ -51,7 +54,10 @@ docker-build-image-$(1):
 
 .PHONY: docker-build-$(1)
 docker-build-$(1): docker-build-image-$(1)
-	docker run --rm $(DOCKER_RUN_ARGS) -v $(PWD)/..:/sdk foxglove-sdk-ros-$(1) make USE_LOCAL_SDK=$(USE_LOCAL_SDK) build
+	docker run --rm $(DOCKER_RUN_ARGS) -v $(PWD)/..:/sdk foxglove-sdk-ros-$(1) \
+		make USE_LOCAL_SDK=$(USE_LOCAL_SDK) \
+		$(if $(FOXGLOVE_CPP_SDK_DIR),FOXGLOVE_CPP_SDK_DIR=$(FOXGLOVE_CPP_SDK_DIR)) \
+		build
 
 .PHONY: docker-test-$(1)
 docker-test-$(1):


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
The idea here is to lay the groundwork for building the bridge with
remote access support. Rather than USE_LOCAL_SDK, we introduce
FOXGLOVE_CPP_SDK_DIR, and construct an artifact that matches what
we would typically download from the github releases page.