### PR TITLE
foxglove_bridge: Drop USE_LOCAL_SDK, update includes

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -175,30 +175,15 @@ jobs:
       - if: contains(matrix.target, 'windows')
         uses: ilammy/setup-nasm@v1
 
-      # Build the Rust/C library with cargo directly.
-      - name: Build C library for ${{ matrix.target }}
-        if: "!matrix.remote_access"
+      - name: Build and package C/C++ SDK
         env:
-          FOXGLOVE_SDK_LANGUAGE: c
-        run: cargo build --release
-        working-directory: c
-
-      # For remote access targets, build the staticlib and cdylib separately so
-      # we can enable remote-access only in the cdylib.
-      - name: Build C staticlib for ${{ matrix.target }}
-        if: matrix.remote_access
-        env:
-          FOXGLOVE_SDK_LANGUAGE: c
-        run: cargo rustc --release --lib --crate-type staticlib
-        working-directory: c
-
-      - name: Build C cdylib with remote access for ${{ matrix.target }}
-        if: matrix.remote_access
-        env:
-          FOXGLOVE_SDK_LANGUAGE: c
           RUSTFLAGS: ${{ runner.os == 'Windows' && '-C target-feature=+crt-static' || '' }}
-        run: cargo rustc --release --lib --crate-type cdylib --features remote-access
-        working-directory: c
+        run: >-
+          make -f Container.mk build-cpp-dist
+          CPP_SDK_DIR=artifacts/foxglove
+          FOXGLOVE_REMOTE_ACCESS=${{ matrix.remote_access && 'ON' || 'OFF' }}
+          STATICLIB_NAME=${{ matrix.staticlib_name }}
+          CDYLIB_NAME=${{ matrix.cdylib_name }}
 
       - name: Ensure generated files are up to date
         run: git diff --exit-code
@@ -209,7 +194,7 @@ jobs:
         run: make build
         working-directory: cpp
         env:
-          FOXGLOVE_PREBUILT_LIB_DIR: ${{ github.workspace }}/target/${{ matrix.target }}/release
+          FOXGLOVE_PREBUILT_LIB_DIR: ${{ github.workspace }}/artifacts/foxglove/lib
           FOXGLOVE_REMOTE_ACCESS: ${{ matrix.remote_access && 'ON' || 'OFF' }}
           CMAKE_ARGS: ${{ matrix.cmake_args || '' }}
       - name: Test C++ library
@@ -225,25 +210,6 @@ jobs:
           REMOTE_DATA_LOADER_BACKEND_EXPECTED_STREAMED_SOURCE_COUNT: "1"
           REMOTE_DATA_LOADER_BACKEND_EXPECTED_STATIC_FILE_SOURCE_COUNT: "0"
         run: cargo run -p remote_data_loader_backend_conformance
-
-      - name: Organize artifacts for zip
-        shell: bash
-        run: |
-          mkdir -p artifacts/foxglove/lib
-          mkdir -p artifacts/foxglove/include
-          mkdir -p artifacts/foxglove/src
-
-          lib_dir="target/${{ matrix.target }}/release"
-          cp "$lib_dir/${{ matrix.staticlib_name }}" artifacts/foxglove/lib/
-          cp "$lib_dir/${{ matrix.cdylib_name }}" artifacts/foxglove/lib/
-          # Include the MSVC import library on Windows (needed for link-time binding)
-          if [ -f "$lib_dir/${{ matrix.cdylib_name }}.lib" ]; then
-            cp "$lib_dir/${{ matrix.cdylib_name }}.lib" artifacts/foxglove/lib/
-          fi
-
-          cp -R c/include/foxglove-c artifacts/foxglove/include/
-          cp -R cpp/foxglove/include/foxglove artifacts/foxglove/include/
-          cp -R cpp/foxglove/src/* artifacts/foxglove/src/
 
       - name: Zip libraries for artifact
         if: runner.os != 'Windows'

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -26,7 +26,7 @@ jobs:
               - 'ros/**'
               - '.github/workflows/ros.yml'
 
-  build-cpp-sdk:
+  build-cpp-dist:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     # Pinned to 22.04 so libfoxglove.a is compatible with ROS Humble (glibc 2.35)
@@ -41,40 +41,18 @@ jobs:
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
-      # For remote access targets, build the staticlib and cdylib separately so
-      # we can enable remote-access only in the cdylib.
-      - name: Build C staticlib
-        env:
-          FOXGLOVE_SDK_LANGUAGE: c
-        run: cargo rustc --release --lib --crate-type staticlib
-        working-directory: c
-
-      - name: Build C cdylib with remote access
-        env:
-          FOXGLOVE_SDK_LANGUAGE: c
-        run: cargo rustc --release --lib --crate-type cdylib --features remote-access
-        working-directory: c
-
-      - name: Organize SDK artifact
-        run: |
-          mkdir -p cpp-sdk/foxglove/lib
-          mkdir -p cpp-sdk/foxglove/include
-          mkdir -p cpp-sdk/foxglove/src
-          cp target/release/libfoxglove.a cpp-sdk/foxglove/lib/
-          cp target/release/libfoxglove.so cpp-sdk/foxglove/lib/
-          cp -R c/include/foxglove-c cpp-sdk/foxglove/include/
-          cp -R cpp/foxglove/include/foxglove cpp-sdk/foxglove/include/
-          cp -R cpp/foxglove/src/* cpp-sdk/foxglove/src/
+      - name: Build C++ SDK
+        run: make -f Container.mk build-cpp-dist
 
       - name: Upload SDK artifact
         uses: actions/upload-artifact@v7
         with:
           name: cpp-sdk
-          path: cpp-sdk/foxglove
+          path: cpp/dist
           retention-days: 1
 
   ros:
-    needs: [changes, build-cpp-sdk]
+    needs: [changes, build-cpp-dist]
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -93,7 +71,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: cpp-sdk
-          path: cpp-sdk/foxglove
+          path: cpp/dist
 
       - name: Run make lint
         run: make lint
@@ -102,7 +80,7 @@ jobs:
       - name: Run make docker-build
         run: |
           make \
-            FOXGLOVE_CPP_SDK_DIR=/sdk/cpp-sdk/foxglove \
+            FOXGLOVE_CPP_SDK_DIR=/sdk/cpp/dist \
             ${{ matrix.ros_distribution == 'rolling' && 'EXTRA_DOCKER_ARGS="--build-arg USE_ROS_TESTING=true"' || '' }} \
             docker-build-${{ matrix.ros_distribution }}
         working-directory: ros
@@ -117,7 +95,7 @@ jobs:
   # individual matrix jobs.
   ros-status:
     name: ros-status
-    needs: [changes, build-cpp-sdk, ros]
+    needs: [changes, build-cpp-dist, ros]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/Container.mk
+++ b/Container.mk
@@ -113,3 +113,25 @@ test-cpp:
 .PHONY: test-cpp-sanitize
 test-cpp-sanitize:
 	make -C cpp SANITIZE=address,undefined FOXGLOVE_REMOTE_ACCESS=OFF test
+
+# Build the C/C++ SDK into a directory suitable for use as
+# FETCHCONTENT_SOURCE_DIR_FOXGLOVE_SDK in CMake.
+CPP_SDK_DIR ?= cpp/dist
+FOXGLOVE_REMOTE_ACCESS ?= ON
+STATICLIB_NAME ?= libfoxglove.a
+CDYLIB_NAME ?= libfoxglove.so
+CARGO_LIB_DIR = target/$(if $(CARGO_BUILD_TARGET),$(CARGO_BUILD_TARGET)/)release
+.PHONY: build-cpp-dist
+build-cpp-dist:
+	cd c && FOXGLOVE_SDK_LANGUAGE=c cargo rustc --release --lib --crate-type staticlib
+	cd c && FOXGLOVE_SDK_LANGUAGE=c cargo rustc --release --lib --crate-type cdylib \
+		$(if $(filter ON,$(FOXGLOVE_REMOTE_ACCESS)),--features remote-access)
+	mkdir -p $(CPP_SDK_DIR)/lib $(CPP_SDK_DIR)/include $(CPP_SDK_DIR)/src
+	cp $(CARGO_LIB_DIR)/$(STATICLIB_NAME) $(CPP_SDK_DIR)/lib/
+	cp $(CARGO_LIB_DIR)/$(CDYLIB_NAME) $(CPP_SDK_DIR)/lib/
+	if [ -f "$(CARGO_LIB_DIR)/$(CDYLIB_NAME).lib" ]; then \
+		cp "$(CARGO_LIB_DIR)/$(CDYLIB_NAME).lib" "$(CPP_SDK_DIR)/lib/"; \
+	fi
+	cp -R c/include/foxglove-c $(CPP_SDK_DIR)/include/
+	cp -R cpp/foxglove/include/foxglove $(CPP_SDK_DIR)/include/
+	cp -R cpp/foxglove/src/* $(CPP_SDK_DIR)/src/

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,5 +1,6 @@
 build
 build-*
+dist
 .cache
 foxglove/docs/generated
 *.zip

--- a/ros/Makefile
+++ b/ros/Makefile
@@ -1,5 +1,4 @@
 ROS_DISTRIBUTIONS := humble jazzy kilted rolling
-USE_LOCAL_SDK := OFF
 FOXGLOVE_CPP_SDK_DIR :=
 EXTRA_DOCKER_ARGS :=
 DOCKER_USER_ARGS :=
@@ -35,7 +34,6 @@ deps:
 .PHONY: build
 build:
 	colcon build --cmake-args \
-		-DUSE_LOCAL_SDK=$(USE_LOCAL_SDK) \
 		$(if $(FOXGLOVE_CPP_SDK_DIR),-DFETCHCONTENT_SOURCE_DIR_FOXGLOVE_SDK=$(FOXGLOVE_CPP_SDK_DIR))
 
 .PHONY: test
@@ -55,8 +53,7 @@ docker-build-image-$(1):
 .PHONY: docker-build-$(1)
 docker-build-$(1): docker-build-image-$(1)
 	docker run --rm $(DOCKER_RUN_ARGS) -v $(PWD)/..:/sdk foxglove-sdk-ros-$(1) \
-		make USE_LOCAL_SDK=$(USE_LOCAL_SDK) \
-		$(if $(FOXGLOVE_CPP_SDK_DIR),FOXGLOVE_CPP_SDK_DIR=$(FOXGLOVE_CPP_SDK_DIR)) \
+		make $(if $(FOXGLOVE_CPP_SDK_DIR),FOXGLOVE_CPP_SDK_DIR=$(FOXGLOVE_CPP_SDK_DIR)) \
 		build
 
 .PHONY: docker-test-$(1)

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -53,14 +53,15 @@ if (ENDIAN)
   add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
 endif()
 
+# FLE-419: Update hashes after v0.22.0 is released.
 set(FOXGLOVE_SDK_VERSION "0.22.0")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   set(FOXGLOVE_SDK_PLATFORM "aarch64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "7b1a7911f4cdf491ea6d38486af6f730ab3c90d4e54071a85bb887994424e51b")
+  set(FOXGLOVE_SDK_SHA "INVALID")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(FOXGLOVE_SDK_PLATFORM "x86_64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "f3d2f6a8ba97fedeae13b978f5e8a51dec4803eddfd23b198a292bf9ab6675ff")
+  set(FOXGLOVE_SDK_SHA "INVALID")
 else()
   message(FATAL_ERROR "Unsupported platform/architecture combination: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
 endif()

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -19,8 +19,6 @@ if (POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
 
-option(USE_LOCAL_SDK "Use pre-built Foxglove SDK binaries from local source tree" OFF)
-
 macro(enable_strict_compiler_warnings target)
   if (MSVC)
     target_compile_options(${target} PRIVATE /WX /W4)
@@ -55,49 +53,36 @@ if (ENDIAN)
   add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
 endif()
 
-if (USE_LOCAL_SDK)
-  set(FOXGLOVE_SDK_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
-  add_library(foxglove_cpp_static STATIC IMPORTED)
-  set_target_properties(foxglove_cpp_static PROPERTIES
-    IMPORTED_LOCATION ${FOXGLOVE_SDK_ROOT}/cpp/build/libfoxglove_cpp_static.a
-  )
-  add_library(foxglove_c_static STATIC IMPORTED)
-  set_target_properties(foxglove_c_static PROPERTIES
-    IMPORTED_LOCATION ${FOXGLOVE_SDK_ROOT}/cpp/build/libfoxglove.a
-  )
+set(FOXGLOVE_SDK_VERSION "0.22.0")
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  set(FOXGLOVE_SDK_PLATFORM "aarch64-unknown-linux-gnu")
+  set(FOXGLOVE_SDK_SHA "7b1a7911f4cdf491ea6d38486af6f730ab3c90d4e54071a85bb887994424e51b")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(FOXGLOVE_SDK_PLATFORM "x86_64-unknown-linux-gnu")
+  set(FOXGLOVE_SDK_SHA "f3d2f6a8ba97fedeae13b978f5e8a51dec4803eddfd23b198a292bf9ab6675ff")
 else()
-  message(STATUS "Fetching Foxglove SDK artifacts from GitHub")
-  set(FOXGLOVE_SDK_VERSION "0.19.0")
-
-  if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-    set(FOXGLOVE_SDK_PLATFORM "aarch64-unknown-linux-gnu")
-    set(FOXGLOVE_SDK_SHA "7b1a7911f4cdf491ea6d38486af6f730ab3c90d4e54071a85bb887994424e51b")
-  elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    set(FOXGLOVE_SDK_PLATFORM "x86_64-unknown-linux-gnu")
-    set(FOXGLOVE_SDK_SHA "f3d2f6a8ba97fedeae13b978f5e8a51dec4803eddfd23b198a292bf9ab6675ff")
-  else()
-    message(FATAL_ERROR "Unsupported platform/architecture combination: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
-  endif()
-  set(FOXGLOVE_SDK_URL "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv${FOXGLOVE_SDK_VERSION}/foxglove-v${FOXGLOVE_SDK_VERSION}-cpp-${FOXGLOVE_SDK_PLATFORM}.zip")
-
-  include(FetchContent)
-  FetchContent_Declare(
-    foxglove_sdk
-    URL ${FOXGLOVE_SDK_URL}
-    URL_HASH SHA256=${FOXGLOVE_SDK_SHA}
-  )
-  FetchContent_MakeAvailable(foxglove_sdk)
-  add_library(foxglove_cpp_static STATIC)
-  target_include_directories(foxglove_cpp_static SYSTEM
-    PUBLIC
-      $<BUILD_INTERFACE:${foxglove_sdk_SOURCE_DIR}/include>
-      $<INSTALL_INTERFACE:include>
-  )
-  file(GLOB_RECURSE FOXGLOVE_SDK_SOURCES CONFIGURE_DEPENDS "${foxglove_sdk_SOURCE_DIR}/src/*.cpp")
-  target_sources(foxglove_cpp_static PRIVATE ${FOXGLOVE_SDK_SOURCES})
-  set_target_properties(foxglove_cpp_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
-  target_link_libraries(foxglove_cpp_static PRIVATE ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.a)
+  message(FATAL_ERROR "Unsupported platform/architecture combination: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
 endif()
+set(FOXGLOVE_SDK_URL "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv${FOXGLOVE_SDK_VERSION}/foxglove-v${FOXGLOVE_SDK_VERSION}-cpp-${FOXGLOVE_SDK_PLATFORM}.zip")
+
+include(FetchContent)
+FetchContent_Declare(
+  foxglove_sdk
+  URL ${FOXGLOVE_SDK_URL}
+  URL_HASH SHA256=${FOXGLOVE_SDK_SHA}
+)
+FetchContent_MakeAvailable(foxglove_sdk)
+add_library(foxglove_cpp_static STATIC)
+target_include_directories(foxglove_cpp_static SYSTEM
+  PUBLIC
+    $<BUILD_INTERFACE:${foxglove_sdk_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+file(GLOB_RECURSE FOXGLOVE_SDK_SOURCES CONFIGURE_DEPENDS "${foxglove_sdk_SOURCE_DIR}/src/*.cpp")
+target_sources(foxglove_cpp_static PRIVATE ${FOXGLOVE_SDK_SOURCES})
+set_target_properties(foxglove_cpp_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(foxglove_cpp_static PRIVATE ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.a)
 
 find_program(GIT_SCM git DOC "Git version control")
 if (GIT_SCM)
@@ -137,30 +122,10 @@ add_library(foxglove_bridge_component SHARED
 target_include_directories(foxglove_bridge_component
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../c/include>
     # For generated version.hpp
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-
-# If using the local SDK, include the C++ SDK headers from the local source tree, else
-# include the C++ SDK headers from the installed location
-if (USE_LOCAL_SDK)
-  target_include_directories(foxglove_bridge_component
-    PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../cpp/foxglove/include>
-  )
-else()
-  target_include_directories(foxglove_bridge_component
-    PUBLIC
-      $<BUILD_INTERFACE:${foxglove_sdk_SOURCE_DIR}/include>
-  )
-endif()
-
-if (USE_LOCAL_SDK)
-  # The locally-built C++ SDK needs to be statically linked to the C SDK
-  target_link_libraries(foxglove_bridge_component foxglove_c_static)
-endif()
 
 if (nlohmann_json_FOUND)
   target_link_libraries(foxglove_bridge_component nlohmann_json::nlohmann_json)

--- a/ros/src/foxglove_bridge/include/foxglove_bridge/generic_client.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/generic_client.hpp
@@ -5,7 +5,7 @@
 #include <rclcpp/version.h>
 #include <rcpputils/shared_library.hpp>
 
-#include <foxglove/server/service.hpp>
+#include <foxglove/websocket.hpp>
 
 namespace foxglove_bridge {
 

--- a/ros/src/foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
@@ -10,7 +10,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <foxglove/server/parameter.hpp>
+#include <foxglove/parameter.hpp>
 
 namespace foxglove_bridge {
 

--- a/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -11,9 +11,9 @@
 #include <rosx_introspection/ros_parser.hpp>
 #include <std_msgs/msg/u_int32.hpp>
 
+#include <foxglove/fetch_asset.hpp>
 #include <foxglove/foxglove.hpp>
-#include <foxglove/server.hpp>
-#include <foxglove/server/fetch_asset.hpp>
+#include <foxglove/websocket.hpp>
 #include <foxglove_bridge/generic_client.hpp>
 #include <foxglove_bridge/message_definition_cache.hpp>
 #include <foxglove_bridge/param_utils.hpp>

--- a/ros/src/foxglove_bridge/tests/client/protocol_types.hpp
+++ b/ros/src/foxglove_bridge/tests/client/protocol_types.hpp
@@ -7,7 +7,7 @@
 #include <variant>
 #include <vector>
 
-#include <foxglove/server/parameter.hpp>
+#include <foxglove/parameter.hpp>
 
 namespace foxglove::test {
 


### PR DESCRIPTION
### Changelog
- foxglove_bridge: Update SDK version to 0.22.0

### Docs
None

### Description
This change updates the bridge build to remove the USE_LOCAL_SDK hack,
in favor of providing FETCHCONTENT_SOURCE_DIR_FOXGLOVE_SDK. This makes
our CI builds more closely resemble the builds on the ROS build farm,
and caught the header deprecation that we merged a few days ago.

To ensure consistency with the preparation of the C++ distribution, I've
extracted that logic to a makefile target that runs in CI and can also
be run locally via Container.mk.

Note that change means that the bridge cannot build against older
releases of the SDK, so we're pre-emptively bumping the SDK version,
even though 0.22.0 hasn't been released yet.

Towards: FLE-326