### PR TITLE
cpp: Add ChannelDescriptor::id()

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -5168,6 +5168,18 @@ void foxglove_context_free(const struct foxglove_context *context);
 
 #if !defined(__wasm__)
 /**
+ * Get the id of a channel descriptor.
+ *
+ * # Safety
+ * `channel` must be a valid pointer to a `foxglove_channel_descriptor`.
+ *
+ * If the passed channel is null, 0 is returned.
+ */
+uint64_t foxglove_channel_descriptor_get_id(const struct foxglove_channel_descriptor *channel);
+#endif
+
+#if !defined(__wasm__)
+/**
  * Get the topic of a channel descriptor.
  *
  * # Safety

--- a/c/src/channel_descriptor.rs
+++ b/c/src/channel_descriptor.rs
@@ -2,6 +2,22 @@ use crate::{FoxgloveError, FoxgloveKeyValue, FoxgloveSchema, FoxgloveString};
 
 pub struct FoxgloveChannelDescriptor(pub(crate) foxglove::ChannelDescriptor);
 
+/// Get the id of a channel descriptor.
+///
+/// # Safety
+/// `channel` must be a valid pointer to a `foxglove_channel_descriptor`.
+///
+/// If the passed channel is null, 0 is returned.
+#[unsafe(no_mangle)]
+pub extern "C" fn foxglove_channel_descriptor_get_id(
+    channel: Option<&FoxgloveChannelDescriptor>,
+) -> u64 {
+    let Some(channel) = channel else {
+        return 0;
+    };
+    channel.0.id().into()
+}
+
 /// Get the topic of a channel descriptor.
 ///
 /// # Safety

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -28,6 +28,9 @@ public:
   explicit ChannelDescriptor(const foxglove_channel_descriptor* channel_descriptor);
   /// @endcond
 
+  /// @brief Get the id of the channel descriptor.
+  [[nodiscard]] uint64_t id() const noexcept;
+
   /// @brief Get the topic of the channel descriptor.
   [[nodiscard]] std::string_view topic() const noexcept;
 

--- a/cpp/foxglove/src/channel.cpp
+++ b/cpp/foxglove/src/channel.cpp
@@ -10,6 +10,10 @@ ChannelDescriptor::ChannelDescriptor(const foxglove_channel_descriptor* channel_
     : channel_descriptor_(channel_descriptor) {}
 /// @endcond
 
+uint64_t ChannelDescriptor::id() const noexcept {
+  return foxglove_channel_descriptor_get_id(channel_descriptor_);
+}
+
 std::string_view ChannelDescriptor::topic() const noexcept {
   foxglove_string topic = foxglove_channel_descriptor_get_topic(channel_descriptor_);
   return {topic.data, topic.len};


### PR DESCRIPTION
### Changelog
- cpp: Add ChannelDescriptor::id()

### Docs
None

### Description
We forgot to add an ID accessor method on the ChannelDescriptor when we
plumbed it through the C/C++ bindings.