### PR TITLE
cpp: Restrict log levels to foxglove crate

### DIFF
--- a/c/src/logging.rs
+++ b/c/src/logging.rs
@@ -40,7 +40,7 @@ pub extern "C" fn foxglove_set_log_level(level: FoxgloveLoggingLevel) {
         };
 
         let env = env_logger::Env::default()
-            .filter_or("FOXGLOVE_LOG_LEVEL", initial_level)
+            .filter_or("FOXGLOVE_LOG_LEVEL", format!("foxglove={initial_level}"))
             .write_style_or("FOXGLOVE_LOG_STYLE", "auto");
 
         env_logger::Builder::from_env(env)


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
When a user sets a debug log level, that should be scoped to the
foxglove crate, not its transitive dependencies. This is especially
important with libwebrtc, which is insanely noisy at the debug level.