### PR TITLE
remote_access: Accept client channels without schema data

### DIFF
--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -962,12 +962,19 @@ impl RemoteAccessSession {
         for ch in msg.channels {
             let channel_id = ChannelId::new(ch.id.into());
 
-            // Decode the schema, tolerating absent schemas.
+            // Decode the schema, tolerating absent schemas. Even when binary schema
+            // data is missing, preserve the schema_name so downstream consumers (e.g.
+            // the ROS bridge) can identify the message type.
             let schema = match ch.decode_schema() {
                 Ok(data) => Some(Schema {
                     name: ch.schema_name.to_string(),
                     encoding: ch.schema_encoding.as_deref().unwrap_or("").to_string(),
                     data: data.into(),
+                }),
+                Err(DecodeError::MissingSchema) if !ch.schema_name.is_empty() => Some(Schema {
+                    name: ch.schema_name.to_string(),
+                    encoding: ch.schema_encoding.as_deref().unwrap_or("").to_string(),
+                    data: Vec::new().into(),
                 }),
                 Err(DecodeError::MissingSchema) => None,
                 Err(e) => {

--- a/rust/remote_access_tests/src/mock_listener.rs
+++ b/rust/remote_access_tests/src/mock_listener.rs
@@ -53,10 +53,7 @@ impl MockListener {
 
 impl Listener for MockListener {
     fn on_client_advertise(&self, client: &Client, channel: &ChannelDescriptor) {
-        let schema_name = channel
-            .schema()
-            .map(|s| s.name.clone())
-            .unwrap_or_default();
+        let schema_name = channel.schema().map(|s| s.name.clone()).unwrap_or_default();
         self.advertised.lock().unwrap().push((
             client.participant_id().to_string(),
             channel.topic().to_string(),

--- a/rust/remote_access_tests/src/mock_listener.rs
+++ b/rust/remote_access_tests/src/mock_listener.rs
@@ -8,11 +8,11 @@ use foxglove::remote_access::{Client, Listener};
 /// `on_message_data`, `on_subscribe`, `on_unsubscribe`, `on_connection_graph_subscribe`,
 /// and `on_connection_graph_unsubscribe` callbacks.
 ///
-/// Advertise/unadvertise entries are stored as `(participant_id, topic)`.
+/// Advertise/unadvertise entries are stored as `(participant_id, topic, schema_name)`.
 /// Message data entries are stored as `(client_id, topic, payload)`.
 #[derive(Default)]
 pub struct MockListener {
-    pub advertised: Mutex<Vec<(String, String)>>,
+    pub advertised: Mutex<Vec<(String, String, String)>>,
     pub unadvertised: Mutex<Vec<(String, String)>>,
     pub message_data: Mutex<Vec<(String, String, Vec<u8>)>>,
     pub subscribed: Mutex<Vec<(String, String)>>,
@@ -22,7 +22,7 @@ pub struct MockListener {
 }
 
 impl MockListener {
-    pub fn advertised(&self) -> Vec<(String, String)> {
+    pub fn advertised(&self) -> Vec<(String, String, String)> {
         self.advertised.lock().unwrap().clone()
     }
 
@@ -53,9 +53,14 @@ impl MockListener {
 
 impl Listener for MockListener {
     fn on_client_advertise(&self, client: &Client, channel: &ChannelDescriptor) {
+        let schema_name = channel
+            .schema()
+            .map(|s| s.name.clone())
+            .unwrap_or_default();
         self.advertised.lock().unwrap().push((
             client.participant_id().to_string(),
             channel.topic().to_string(),
+            schema_name,
         ));
     }
 

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -28,6 +28,7 @@ pub struct ClientChannelDesc {
     pub id: u32,
     pub topic: String,
     pub encoding: String,
+    pub schema_name: String,
 }
 use foxglove::protocol::v2::server::ServerMessage;
 use foxglove::remote_access::service::Service;
@@ -436,7 +437,7 @@ impl ViewerConnection {
             id: c.id,
             topic: c.topic.as_str().into(),
             encoding: c.encoding.as_str().into(),
-            schema_name: "".into(),
+            schema_name: c.schema_name.as_str().into(),
             schema_encoding: None,
             schema: None,
         }));

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -932,6 +932,7 @@ async fn livekit_client_advertise_fires_listener_callback() -> Result<()> {
             id: 1,
             topic: "/cmd".to_string(),
             encoding: "json".to_string(),
+            schema_name: String::new(),
         }])
         .await?;
 
@@ -951,6 +952,58 @@ async fn livekit_client_advertise_fires_listener_callback() -> Result<()> {
     info!(
         "on_client_advertise callback validated: {:?}",
         advertised[0]
+    );
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
+/// Test that a client Advertise with a schema_name but no binary schema data still
+/// preserves the schema_name on the ChannelDescriptor delivered to the listener.
+/// This is the typical case for teleop panels (e.g. publishing to /cmd_vel).
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_client_advertise_preserves_schema_name_without_schema_data() -> Result<()> {
+    use std::sync::Arc;
+    let ctx = foxglove::Context::new();
+    let listener = Arc::new(MockListener::default());
+
+    let gw = TestGateway::start_with_options(
+        &ctx,
+        TestGatewayOptions {
+            listener: Some(listener.clone()),
+            capabilities: vec![foxglove::remote_access::Capability::ClientPublish],
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+    let _server_info = viewer.frame_reader.next_server_message().await?;
+
+    // Advertise a channel with schema_name but no schema data — this is what the
+    // Foxglove teleop panel sends for /cmd_vel.
+    viewer
+        .send_client_advertise(&[ClientChannelDesc {
+            id: 1,
+            topic: "/cmd_vel".to_string(),
+            encoding: "json".to_string(),
+            schema_name: "geometry_msgs/msg/Twist".to_string(),
+        }])
+        .await?;
+
+    poll_until(|| listener.advertised().len() == 1).await;
+
+    let advertised = listener.advertised();
+    assert_eq!(advertised.len(), 1);
+    assert_eq!(advertised[0].0, "viewer-1");
+    assert_eq!(advertised[0].1, "/cmd_vel");
+    assert_eq!(
+        advertised[0].2, "geometry_msgs/msg/Twist",
+        "schema_name should be preserved even without binary schema data"
     );
 
     viewer.close().await?;
@@ -987,6 +1040,7 @@ async fn livekit_client_unadvertise_fires_listener_callback() -> Result<()> {
             id: 42,
             topic: "/joy".to_string(),
             encoding: "json".to_string(),
+            schema_name: String::new(),
         }])
         .await?;
     poll_until(|| listener.advertised().len() == 1).await;
@@ -1040,11 +1094,13 @@ async fn livekit_client_disconnect_fires_unadvertise_for_advertised_channels() -
                 id: 1,
                 topic: "/cmd_vel".to_string(),
                 encoding: "json".to_string(),
+                schema_name: String::new(),
             },
             ClientChannelDesc {
                 id: 2,
                 topic: "/joy".to_string(),
                 encoding: "json".to_string(),
+                schema_name: String::new(),
             },
         ])
         .await?;
@@ -1312,6 +1368,7 @@ async fn livekit_client_message_data_fires_listener_callback() -> Result<()> {
             id: 1,
             topic: "/cmd".to_string(),
             encoding: "json".to_string(),
+            schema_name: String::new(),
         }])
         .await?;
     poll_until(|| listener.advertised().len() == 1).await;
@@ -1368,6 +1425,7 @@ async fn livekit_client_message_data_before_advertise_is_delivered() -> Result<(
             id: 1,
             topic: "/cmd".to_string(),
             encoding: "json".to_string(),
+            schema_name: String::new(),
         }])
         .await?;
 
@@ -1467,6 +1525,7 @@ async fn livekit_client_message_advertise_without_capability_sends_error() -> Re
             id: 1,
             topic: "/cmd".to_string(),
             encoding: "json".to_string(),
+            schema_name: String::new(),
         }])
         .await?;
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
We need to accept client-advertised channels that use well-known (e.g.
ROS) schemas without schema data. Websocket already does this.