### PR TITLE
ci: Build C libs separately for C++ lint

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -50,7 +50,14 @@ jobs:
       - run: clang-tidy --version
       - run: make lint
         working-directory: cpp
-      - run: make CLANG_TIDY=true CMAKE_BUILD_TYPE=Debug test
+      - name: Build C libs
+        run: make -f Container.mk build-cpp-dist
+      - name: Test with clang tidy
+        run: |
+          make test \
+            CLANG_TIDY=true \
+            CMAKE_BUILD_TYPE=Debug \
+            FOXGLOVE_PREBUILT_LIB_DIR=dist/lib
         working-directory: cpp
 
   build:


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Build C libs outside of corrosion, so that we can take advantage of the
setup-rust-toolchain cache, and get some speedups.