### PR TITLE
fix(docker): upgrade base image to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Local development image. See Makefile for usage.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 WORKDIR /app
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Upgrade the local dev Docker image from Ubuntu 22.04 to 24.04. This bumps the apt `protobuf-compiler` from 3.12.4 to 3.21.12, which natively supports proto3 optional fields — fixing the `make generate` breakage introduced by #1140 (which switched the base image from `rust:latest`/Debian 12 to Ubuntu 22.04).

This is a simpler alternative to #1147 (which downloads protoc 29.6 from GitHub releases). Ubuntu 24.04's protoc 3.21 produces identical descriptor output to CI's protoc 29.x for our schemas, so no `.bin` file changes are needed.

**Note:** There is still version skew between Docker (protoc 3.21) and CI (protoc 29.x via `arduino/setup-protoc`). This hasn't caused issues since the generated output is identical, but aligning them (e.g. pinning CI or using a shared `.protoc-version` file) would be a good follow-up.

Tested locally: `make generate` completes successfully with no dirty files.