### PR TITLE
jest: Ignore cpp/

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,7 @@
 {
   "testMatch": ["<rootDir>/**/*.test.ts"],
   "testPathIgnorePatterns": [
+    "<rootDir>/cpp",
     "<rootDir>/rust",
     "<rootDir>/.cargo",
     "<rootDir>/.uv_cache",


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
I had a local `yarn generate` failure because jest picked up some
typescript under `cpp/build/_deps/mcap-src/...`. This change tells rust
to ignore the cpp directory entirely.