### PR TITLE
Add SO-101 Colab embed notebook using JointStates-only animation

### DIFF
--- a/jupyter_notebooks/README.md
+++ b/jupyter_notebooks/README.md
@@ -1,0 +1,14 @@
+# Jupyter notebook examples
+
+This directory contains notebook examples for the Foxglove embed integration.
+
+## SO-101 JointStates Colab embed
+
+- Notebook: `so101_jointstates_colab_embed.ipynb`
+- Layout JSON: `layouts/so101_jointstates_layout.json`
+
+The notebook shows how to:
+
+1. Load the SO-101 URDF in a Foxglove 3D panel.
+2. Publish sinusoidal `foxglove.JointStates` messages on `/joint_states`.
+3. Animate the robot model using **joint-states-only** control mode (no TF publisher).

--- a/jupyter_notebooks/layouts/so101_jointstates_layout.json
+++ b/jupyter_notebooks/layouts/so101_jointstates_layout.json
@@ -1,0 +1,106 @@
+{
+  "configById": {
+    "3D!so101": {
+      "cameraState": {
+        "distance": 1.1,
+        "perspective": true,
+        "phi": 65,
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOffset": [
+          -0.12,
+          0.02,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "thetaOffset": 130,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-none",
+      "followTf": "base_link",
+      "scene": {
+        "syncCamera": false,
+        "transforms": {
+          "editable": true,
+          "showLabel": false,
+          "enablePreloading": true,
+          "visible": false
+        },
+        "enableStats": false,
+        "meshUpAxis": "z_up"
+      },
+      "topics": {},
+      "layers": {
+        "grid": {
+          "visible": true,
+          "frameLocked": true,
+          "label": "Grid",
+          "instanceId": "grid-so101",
+          "layerId": "foxglove.Grid",
+          "size": 10,
+          "divisions": 10,
+          "lineWidth": 1,
+          "color": "#248eff",
+          "position": [
+            0,
+            0,
+            0
+          ],
+          "rotation": [
+            0,
+            0,
+            0
+          ]
+        },
+        "urdf-so101": {
+          "displayMode": "auto",
+          "fallbackColor": "#ffffff",
+          "showAxis": false,
+          "axisScale": 1,
+          "showOutlines": true,
+          "opacity": 1,
+          "visible": true,
+          "frameLocked": true,
+          "instanceId": "urdf-so101",
+          "label": "SO-101 URDF",
+          "layerId": "foxglove.Urdf",
+          "sourceType": "url",
+          "url": "https://raw.githubusercontent.com/TheRobotStudio/SO-ARM100/refs/heads/main/Simulation/SO101/so101_new_calib.urdf",
+          "filePath": "",
+          "parameter": "",
+          "topic": "",
+          "framePrefix": "",
+          "controlMode": "jointStates",
+          "jointStatesTopic": "/joint_states",
+          "order": 2
+        }
+      },
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "imageMode": {}
+    }
+  },
+  "globalVariables": {},
+  "userNodes": {},
+  "playbackConfig": {
+    "speed": 1
+  },
+  "layout": "3D!so101"
+}

--- a/jupyter_notebooks/so101_jointstates_colab_embed.ipynb
+++ b/jupyter_notebooks/so101_jointstates_colab_embed.ipynb
@@ -1,0 +1,239 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# SO-101 in Foxglove Colab Embed (JointStates-only)\n",
+        "\n",
+        "This notebook demonstrates a simple Foxglove integration for the SO-101 robot model using only `foxglove.JointStates` messages.\n",
+        "\n",
+        "What it does:\n",
+        "- Loads the SO-101 URDF into a 3D panel\n",
+        "- Generates sinusoidal joint motion for six joints\n",
+        "- Displays everything in the embedded Foxglove viewer\n",
+        "\n",
+        "No robot hardware and no TF publisher are required for this example."
+      ],
+      "id": "f27dc72e"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1) Install dependencies\n",
+        "\n",
+        "Run this cell in Colab (or any Jupyter environment) to install the notebook integration extras."
+      ],
+      "id": "899729a0"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%pip install -q \"foxglove-sdk[notebook]\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "3bba0da5"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2) Configure the SO-101 URDF layout and motion parameters\n",
+        "\n",
+        "The URDF is loaded directly from the public GitHub URL and configured to use `jointStates` control mode on `/joint_states`."
+      ],
+      "id": "070cf66b"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import json\n",
+        "import math\n",
+        "import time\n",
+        "\n",
+        "import foxglove\n",
+        "import foxglove.layouts as fl\n",
+        "from foxglove.channels import JointStatesChannel\n",
+        "from foxglove.messages import JointState, JointStates, Timestamp\n",
+        "\n",
+        "URDF_URL = \"https://raw.githubusercontent.com/TheRobotStudio/SO-ARM100/refs/heads/main/Simulation/SO101/so101_new_calib.urdf\"\n",
+        "JOINT_STATES_TOPIC = \"/joint_states\"\n",
+        "\n",
+        "# Joint limits from the SO-101 URDF (radians for revolute joints).\n",
+        "JOINT_LIMITS = {\n",
+        "    \"shoulder_pan\": (-1.91986, 1.91986),\n",
+        "    \"shoulder_lift\": (-1.74533, 1.74533),\n",
+        "    \"elbow_flex\": (-1.69, 1.69),\n",
+        "    \"wrist_flex\": (-1.65806, 1.65806),\n",
+        "    \"wrist_roll\": (-2.74385, 2.84121),\n",
+        "    \"gripper\": (-0.174533, 1.74533),\n",
+        "}\n",
+        "\n",
+        "JOINT_PROFILES = {\n",
+        "    \"shoulder_pan\": {\"frequency_hz\": 0.10, \"phase_rad\": 0.0},\n",
+        "    \"shoulder_lift\": {\"frequency_hz\": 0.13, \"phase_rad\": 0.7},\n",
+        "    \"elbow_flex\": {\"frequency_hz\": 0.16, \"phase_rad\": 1.2},\n",
+        "    \"wrist_flex\": {\"frequency_hz\": 0.22, \"phase_rad\": 2.0},\n",
+        "    \"wrist_roll\": {\"frequency_hz\": 0.27, \"phase_rad\": 2.7},\n",
+        "    \"gripper\": {\"frequency_hz\": 0.18, \"phase_rad\": 1.8},\n",
+        "}\n",
+        "\n",
+        "layout = fl.Layout(\n",
+        "    content=fl.ThreeDeePanel(\n",
+        "        title=\"SO-101 JointStates Demo\",\n",
+        "        config=fl.ThreeDeeConfig(\n",
+        "            follow_tf=\"base_link\",\n",
+        "            follow_mode=\"follow-none\",\n",
+        "            layers={\n",
+        "                \"grid\": fl.BaseRendererGridLayerSettings(\n",
+        "                    label=\"Grid\",\n",
+        "                    size=10,\n",
+        "                    divisions=10,\n",
+        "                    line_width=1,\n",
+        "                    color=\"#248eff\",\n",
+        "                    position=(0.0, 0.0, 0.0),\n",
+        "                    rotation=(0.0, 0.0, 0.0),\n",
+        "                    visible=True,\n",
+        "                ),\n",
+        "                \"so101_urdf\": fl.BaseRendererUrdfLayerSettings(\n",
+        "                    label=\"SO-101 URDF\",\n",
+        "                    source_type=\"url\",\n",
+        "                    url=URDF_URL,\n",
+        "                    control_mode=\"jointStates\",\n",
+        "                    joint_states_topic=JOINT_STATES_TOPIC,\n",
+        "                    display_mode=\"auto\",\n",
+        "                    show_outlines=True,\n",
+        "                    visible=True,\n",
+        "                ),\n",
+        "            },\n",
+        "        ),\n",
+        "    )\n",
+        ")\n",
+        "\n",
+        "# Optional helper: exported layout JSON (same config used below).\n",
+        "layout_json = json.loads(layout.to_json())\n",
+        "layout_json"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "0f608142"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3) Generate sinusoidal `JointStates` messages\n",
+        "\n",
+        "The next cell buffers about 12 seconds of synthetic SO-101 joint motion at 30 Hz.\n",
+        "Only `foxglove.JointStates` is published (no `/tf` topic)."
+      ],
+      "id": "d196d2c0"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "RATE_HZ = 30.0\n",
+        "DURATION_SEC = 12.0\n",
+        "\n",
+        "\n",
+        "def _joint_position_and_velocity(name: str, t_sec: float) -> tuple[float, float]:\n",
+        "    lower, upper = JOINT_LIMITS[name]\n",
+        "    profile = JOINT_PROFILES[name]\n",
+        "\n",
+        "    center = 0.5 * (lower + upper)\n",
+        "    amplitude = 0.25 * (upper - lower)\n",
+        "\n",
+        "    omega = 2.0 * math.pi * profile[\"frequency_hz\"]\n",
+        "    phase = profile[\"phase_rad\"]\n",
+        "\n",
+        "    position = center + amplitude * math.sin(omega * t_sec + phase)\n",
+        "    velocity = amplitude * omega * math.cos(omega * t_sec + phase)\n",
+        "    return position, velocity\n",
+        "\n",
+        "\n",
+        "foxglove.set_log_level(\"INFO\")\n",
+        "nb_buffer = foxglove.init_notebook_buffer()\n",
+        "joint_channel = JointStatesChannel(topic=JOINT_STATES_TOPIC)\n",
+        "\n",
+        "start_time = time.time()\n",
+        "num_samples = int(RATE_HZ * DURATION_SEC)\n",
+        "\n",
+        "for sample_idx in range(num_samples):\n",
+        "    t_sec = sample_idx / RATE_HZ\n",
+        "    timestamp = Timestamp.from_epoch_secs(start_time + t_sec)\n",
+        "\n",
+        "    joints = []\n",
+        "    for joint_name in JOINT_LIMITS:\n",
+        "        position, velocity = _joint_position_and_velocity(joint_name, t_sec)\n",
+        "        joints.append(\n",
+        "            JointState(\n",
+        "                name=joint_name,\n",
+        "                position=position,\n",
+        "                velocity=velocity,\n",
+        "            )\n",
+        "        )\n",
+        "\n",
+        "    joint_channel.log(JointStates(timestamp=timestamp, joints=joints))\n",
+        "\n",
+        "print(f\"Buffered {num_samples} JointStates messages on {JOINT_STATES_TOPIC}.\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7c6d7293"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4) Show the embedded Foxglove viewer\n",
+        "\n",
+        "The viewer below should load the SO-101 URDF and animate the arm using the buffered joint states."
+      ],
+      "id": "51029333"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "widget = nb_buffer.show(\n",
+        "    height=640,\n",
+        "    src=\"https://embed.foxglove.dev/\",\n",
+        "    opaque_layout=layout_json,\n",
+        ")\n",
+        "widget"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "cb6dd061"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5) Next steps for users\n",
+        "\n",
+        "- Tune amplitudes/frequencies in `JOINT_PROFILES`.\n",
+        "- Replace synthetic motion with live robot `JointStates` publishing.\n",
+        "- Swap `URDF_URL` to visualize a different robot model."
+      ],
+      "id": "08aecc56"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

Add a new Jupyter/Colab example that embeds Foxglove, loads the SO-101 URDF, and animates joints using only `foxglove.JointStates` messages.

### Docs

- Added `jupyter_notebooks/so101_jointstates_colab_embed.ipynb`
- Added `jupyter_notebooks/layouts/so101_jointstates_layout.json`
- Added `jupyter_notebooks/README.md` with usage guidance

### Description

This updates the notebook embed example to use an SO-101 workflow instead of a generic dataset walkthrough.

The new notebook is intentionally simple and copyable:

- installs `foxglove-sdk[notebook]`
- configures a 3D panel layout with a URDF layer sourced from:
  - `https://raw.githubusercontent.com/TheRobotStudio/SO-ARM100/refs/heads/main/Simulation/SO101/so101_new_calib.urdf`
- sets URDF `controlMode` to `jointStates` and `jointStatesTopic` to `/joint_states`
- publishes a synthetic sinusoidal trajectory for SO-101 joints on `/joint_states`
- renders the result in the embedded Foxglove viewer (`https://embed.foxglove.dev/`)

The example does not depend on robot hardware, camera streams, or TF publishing, making it a straightforward baseline users can extend.

Manual verification TODO for reviewers:

- [ ] Run the notebook in Colab or Jupyter.
- [ ] Execute cells top-to-bottom.
- [ ] Confirm the embedded 3D panel loads the SO-101 URDF.
- [ ] Confirm joints animate from `/joint_states` with no TF publisher in the notebook.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bcb46ed-ff98-4500-be8b-9e500f9f9cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bcb46ed-ff98-4500-be8b-9e500f9f9cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

