### PR TITLE
remote_access: Per-participant control plane flush tasks

### DIFF
--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -199,8 +199,8 @@ try:
         :param channel_filter: A ``Callable`` that determines whether a channel should be logged
             to. Return ``True`` to log the channel, or ``False`` to skip it. By default, all
             channels will be logged.
-        :param message_backlog_size: The maximum number of control plane messages to buffer
-            per participant before disconnecting a slow client. Defaults to 256.
+        :param message_backlog_size: The maximum number of messages to buffer before dropping
+            the oldest entries. Defaults to 1024.
         :param foxglove_api_url: Override the Foxglove API base URL.
         :param foxglove_api_timeout: Timeout for Foxglove API requests, in seconds.
         """

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -199,8 +199,8 @@ try:
         :param channel_filter: A ``Callable`` that determines whether a channel should be logged
             to. Return ``True`` to log the channel, or ``False`` to skip it. By default, all
             channels will be logged.
-        :param message_backlog_size: The maximum number of messages to buffer before dropping
-            the oldest entries. Defaults to 1024.
+        :param message_backlog_size: The maximum number of control plane messages to buffer
+            per participant before disconnecting a slow client. Defaults to 256.
         :param foxglove_api_url: Override the Foxglove API base URL.
         :param foxglove_api_timeout: Timeout for Foxglove API requests, in seconds.
         """

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -32,7 +32,7 @@ use crate::{
 type Result<T> = std::result::Result<T, Box<RemoteAccessError>>;
 
 const AUTH_RETRY_PERIOD: Duration = Duration::from_secs(30);
-use super::session::DEFAULT_CONTROL_QUEUE_SIZE;
+use super::session::DEFAULT_MESSAGE_BACKLOG_SIZE;
 
 /// The status of the remote access gateway connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -294,7 +294,7 @@ impl RemoteAccessConnection {
                         cancellation_token: self.cancellation_token.clone(),
                         message_backlog_size: self
                             .message_backlog_size
-                            .unwrap_or(DEFAULT_CONTROL_QUEUE_SIZE),
+                            .unwrap_or(DEFAULT_MESSAGE_BACKLOG_SIZE),
                         services: self.services.clone(),
                         connection_graph: self.connection_graph.clone(),
                         remote_access_session_id: self

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -32,7 +32,7 @@ use crate::{
 type Result<T> = std::result::Result<T, Box<RemoteAccessError>>;
 
 const AUTH_RETRY_PERIOD: Duration = Duration::from_secs(30);
-const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
+use super::session::DEFAULT_CONTROL_QUEUE_SIZE;
 
 /// The status of the remote access gateway connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -294,7 +294,7 @@ impl RemoteAccessConnection {
                         cancellation_token: self.cancellation_token.clone(),
                         message_backlog_size: self
                             .message_backlog_size
-                            .unwrap_or(DEFAULT_MESSAGE_BACKLOG_SIZE),
+                            .unwrap_or(DEFAULT_CONTROL_QUEUE_SIZE),
                         services: self.services.clone(),
                         connection_graph: self.connection_graph.clone(),
                         remote_access_session_id: self
@@ -372,7 +372,9 @@ impl RemoteAccessConnection {
         context.add_sink(session.clone());
 
         // We can use spawn here because we're already running on self.runtime
-        let sender_task = tokio::spawn(RemoteAccessSession::run_sender(session.clone()));
+        let video_metadata_task = tokio::spawn(RemoteAccessSession::run_video_metadata_watcher(
+            session.clone(),
+        ));
 
         // Send ServerInfo and channel advertisements to participants already in the room.
         // ParticipantConnected events only fire for participants joining after us.
@@ -430,16 +432,14 @@ impl RemoteAccessConnection {
             }
         }
         context.remove_sink(session.sink_id());
-        sender_task.abort();
-        // Wait for the sender task to fully stop so no callbacks are in flight.
-        let _ = sender_task.await;
+        video_metadata_task.abort();
+        let _ = video_metadata_task.await;
 
         info!(remote_access_session_id, "disconnecting from room");
-        // Close the room (disconnect) on shutdown.
-        // If we don't do that, there's a 15s delay before this device is removed from the participants
-        if let Err(e) = session.room().close().await {
-            error!(remote_access_session_id, error = %e, "failed to close room: {e}");
-        }
+        // handle_room_events was one arm of the select! above — when the select
+        // exits, that future is dropped, so no more remove_participant calls can
+        // race with the flush handle drain inside close().
+        session.close().await;
     }
 
     /// Connect to the room, retrying indefinitely.

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -304,12 +304,13 @@ impl Gateway {
         self
     }
 
-    /// Set the message backlog size.
+    /// Set the per-participant control plane message queue size.
     ///
-    /// The sink buffers outgoing log entries into a queue. If the backlog size is exceeded, the
-    /// oldest entries will be dropped.
+    /// Each participant gets an independent queue of this size. If a participant's
+    /// queue fills up (because it is not reading fast enough), it will be disconnected
+    /// and asked to reconnect.
     ///
-    /// By default, the sink will buffer 1024 messages.
+    /// By default, each participant gets a queue of 256 messages.
     pub fn message_backlog_size(mut self, size: usize) -> Self {
         self.message_backlog_size = Some(size);
         self

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -310,7 +310,7 @@ impl Gateway {
     /// queue fills up (because it is not reading fast enough), it will be disconnected
     /// and asked to reconnect.
     ///
-    /// By default, each participant gets a queue of 256 messages.
+    /// By default, each participant gets a queue of 1024 messages.
     pub fn message_backlog_size(mut self, size: usize) -> Self {
         self.message_backlog_size = Some(size);
         self

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -84,6 +84,7 @@ impl Participant {
     ///
     /// When this returns `false`, the caller should trigger a participant reset
     /// (disconnect + reconnect) — a full queue means the client is not keeping up.
+    #[must_use]
     pub(crate) fn try_queue_control(&self, data: Bytes) -> bool {
         match self.control_tx.try_send(data) {
             Ok(()) => true,
@@ -113,14 +114,14 @@ impl Participant {
     /// protocol messages via `send_control` flow regularly and will trigger the
     /// reset if the queue stays full.
     pub(crate) fn send_asset_response(&self, data: &[u8], request_id: u32) {
-        self.try_queue_control(encode_binary_message(&FetchAssetResponse::asset_data(
+        let _ = self.try_queue_control(encode_binary_message(&FetchAssetResponse::asset_data(
             request_id, data,
         )));
     }
 
     /// Send a fetch asset error to the participant via the control plane queue.
     pub(crate) fn send_asset_error(&self, error: &str, request_id: u32) {
-        self.try_queue_control(encode_binary_message(&FetchAssetResponse::error_message(
+        let _ = self.try_queue_control(encode_binary_message(&FetchAssetResponse::error_message(
             request_id, error,
         )));
     }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -49,7 +49,65 @@ pub(crate) struct Participant {
 }
 
 impl Participant {
-    /// Creates a new participant.
+    /// Creates a new participant with its own control plane channel and flush task.
+    ///
+    /// The flush task drains the bounded channel into the `writer`. It exits when
+    /// the per-participant cancellation token fires (queue overflow or session
+    /// shutdown) or when all `control_tx` senders are dropped.
+    ///
+    /// Returns the participant (wrapped in `Arc` for shared ownership) and the
+    /// flush task's `JoinHandle` (for teardown awaiting).
+    pub fn spawn(
+        identity: ParticipantIdentity,
+        protocol_version: Version,
+        writer: ParticipantWriter,
+        queue_size: usize,
+        reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
+        session_cancel: &CancellationToken,
+    ) -> (std::sync::Arc<Self>, tokio::task::JoinHandle<()>) {
+        let (control_tx, control_rx) = flume::bounded::<Bytes>(queue_size);
+        let cancel = session_cancel.child_token();
+        let cancel_for_task = cancel.clone();
+        let identity_for_task = identity.clone();
+        let reset_tx_for_task = reset_tx.clone();
+
+        let flush_handle = tokio::spawn(async move {
+            loop {
+                let data = tokio::select! {
+                    () = cancel_for_task.cancelled() => break,
+                    msg = control_rx.recv_async() => match msg {
+                        Ok(data) => data,
+                        Err(_) => break,
+                    },
+                };
+                if let Err(e) = writer.write(&data).await {
+                    tracing::warn!(
+                        "control write failed for {:?}, requesting reset: {e:?}",
+                        identity_for_task,
+                    );
+                    let _ = reset_tx_for_task.send(identity_for_task.clone());
+                    break;
+                }
+            }
+        });
+
+        let participant = std::sync::Arc::new(Self {
+            client_id: ClientId::next(),
+            participant_id: identity,
+            protocol_version,
+            control_tx,
+            reset_tx,
+            cancel,
+            service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
+            fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
+        });
+        (participant, flush_handle)
+    }
+
+    /// Creates a new participant without spawning a flush task.
+    ///
+    /// For use in tests that only need a participant with a pre-created channel.
+    #[cfg(test)]
     pub fn new(
         identity: ParticipantIdentity,
         protocol_version: Version,
@@ -68,7 +126,6 @@ impl Participant {
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
         }
     }
-
 
     /// Returns the locally-significant client ID.
     pub fn client_id(&self) -> ClientId {

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -78,13 +78,21 @@ impl Participant {
         let flush_handle = tokio::spawn(async move {
             loop {
                 let data = tokio::select! {
+                    biased;
                     () = cancel_for_task.cancelled() => break,
                     msg = control_rx.recv_async() => match msg {
                         Ok(data) => data,
                         Err(_) => break,
                     },
                 };
-                if let Err(e) = writer.write(&data).await {
+                // Wrap the write in a cancel-aware select with a generous timeout
+                // as a safeguard against writer.write() blocking indefinitely.
+                let write_result = tokio::select! {
+                    biased;
+                    () = cancel_for_task.cancelled() => break,
+                    result = writer.write(&data) => result,
+                };
+                if let Err(e) = write_result {
                     tracing::warn!(
                         "control write failed for {:?}, requesting reset: {e:?}",
                         identity_for_task,
@@ -163,9 +171,8 @@ impl Participant {
         &self.participant_id
     }
 
-    /// Try to queue a control plane message. Returns `true` if enqueued or if
-    /// the queue is already disconnected (no reset needed). Returns `false` if
-    /// the queue is full (caller should trigger a participant reset).
+    /// Try to queue a control plane message. Returns `false` if the queue is
+    /// full and the caller should trigger a participant reset.
     #[must_use]
     pub(crate) fn try_queue_control(&self, data: Bytes) -> bool {
         match self.control_tx.try_send(data) {

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -35,6 +35,9 @@ pub(crate) struct Participant {
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush task spawned in `add_participant`.
     control_tx: flume::Sender<Bytes>,
+    /// Channel to request a participant reset (disconnect + reconnect) when the
+    /// control queue is full.
+    reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
     /// Limits concurrent service calls from this participant.
     service_call_sem: Semaphore,
     /// Limits concurrent fetch asset requests from this participant.
@@ -47,12 +50,14 @@ impl Participant {
         identity: ParticipantIdentity,
         protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
+        reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
     ) -> Self {
         Self {
             client_id: ClientId::next(),
             participant_id: identity,
             protocol_version,
             control_tx,
+            reset_tx,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
         }
@@ -81,18 +86,12 @@ impl Participant {
     /// Try to queue a control plane message. Returns `true` if enqueued or if
     /// the queue is already disconnected (no reset needed). Returns `false` if
     /// the queue is full (caller should trigger a participant reset).
-    ///
-    /// When this returns `false`, the caller should trigger a participant reset
-    /// (disconnect + reconnect) — a full queue means the client is not keeping up.
     #[must_use]
     pub(crate) fn try_queue_control(&self, data: Bytes) -> bool {
         match self.control_tx.try_send(data) {
             Ok(()) => true,
             Err(flume::TrySendError::Full(_)) => {
-                tracing::warn!(
-                    "control queue full for {}",
-                    self.participant_id
-                );
+                tracing::warn!("control queue full for {}", self.participant_id);
                 false
             }
             Err(flume::TrySendError::Disconnected(_)) => {
@@ -107,21 +106,24 @@ impl Participant {
         }
     }
 
+    /// Queue a control plane message, requesting a participant reset if the
+    /// queue is full.
+    pub(crate) fn send_control(&self, data: Bytes) {
+        if !self.try_queue_control(data) {
+            let _ = self.reset_tx.send(self.participant_id.clone());
+        }
+    }
+
     /// Send a fetch asset response to the participant via the control plane queue.
-    ///
-    /// The `try_queue_control` return is intentionally ignored here: these methods
-    /// don't have access to `participant_reset_tx` to trigger a reset. In practice,
-    /// protocol messages via `send_control` flow regularly and will trigger the
-    /// reset if the queue stays full.
     pub(crate) fn send_asset_response(&self, data: &[u8], request_id: u32) {
-        let _ = self.try_queue_control(encode_binary_message(&FetchAssetResponse::asset_data(
+        self.send_control(encode_binary_message(&FetchAssetResponse::asset_data(
             request_id, data,
         )));
     }
 
     /// Send a fetch asset error to the participant via the control plane queue.
     pub(crate) fn send_asset_error(&self, error: &str, request_id: u32) {
-        let _ = self.try_queue_control(encode_binary_message(&FetchAssetResponse::error_message(
+        self.send_control(encode_binary_message(&FetchAssetResponse::error_message(
             request_id, error,
         )));
     }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -78,8 +78,9 @@ impl Participant {
         &self.participant_id
     }
 
-    /// Try to queue a control plane message. Returns `true` if enqueued, `false`
-    /// if the queue is full or disconnected.
+    /// Try to queue a control plane message. Returns `true` if enqueued or if
+    /// the queue is already disconnected (no reset needed). Returns `false` if
+    /// the queue is full (caller should trigger a participant reset).
     ///
     /// When this returns `false`, the caller should trigger a participant reset
     /// (disconnect + reconnect) — a full queue means the client is not keeping up.

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -1,6 +1,6 @@
 //! Per-participant state for a remote access session.
 
-#[cfg(test)]
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -23,7 +23,7 @@ const DEFAULT_FETCH_ASSET_PER_PARTICIPANT: usize = 32;
 ///
 /// Each participant has an identity, a per-participant control plane queue, and
 /// rate-limiting semaphores. The actual byte-stream writer lives in a dedicated
-/// flush task (spawned by `add_participant`), not in this struct.
+/// flush task (spawned by `Participant::spawn`), not in this struct.
 pub(crate) struct Participant {
     /// Locally-significant identifier for this particular instance of this participant.
     client_id: ClientId,
@@ -34,11 +34,13 @@ pub(crate) struct Participant {
     #[expect(dead_code)]
     protocol_version: Version,
     /// Per-participant control plane queue. The receiving end is owned by the
-    /// flush task spawned in `add_participant`.
+    /// flush task.
     control_tx: flume::Sender<Bytes>,
-    /// Channel to request a participant reset (disconnect + reconnect) when the
-    /// control queue is full.
-    reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
+    /// Shared set of participant identities pending a reset. Inserting into this
+    /// set + notifying is how we signal `handle_room_events` to disconnect us.
+    pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+    /// Wakes `handle_room_events` when we add ourselves to `pending_resets`.
+    reset_notify: Arc<tokio::sync::Notify>,
     /// Per-participant cancellation token. Cancelled when the control queue
     /// overflows, signaling the flush task to stop immediately.
     cancel: CancellationToken,
@@ -62,14 +64,16 @@ impl Participant {
         protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
-        reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
+        pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+        reset_notify: Arc<tokio::sync::Notify>,
         session_cancel: &CancellationToken,
-    ) -> (std::sync::Arc<Self>, tokio::task::JoinHandle<()>) {
+    ) -> (Arc<Self>, tokio::task::JoinHandle<()>) {
         let (control_tx, control_rx) = flume::bounded::<Bytes>(queue_size);
         let cancel = session_cancel.child_token();
         let cancel_for_task = cancel.clone();
         let identity_for_task = identity.clone();
-        let reset_tx_for_task = reset_tx.clone();
+        let pending_resets_for_task = pending_resets.clone();
+        let reset_notify_for_task = reset_notify.clone();
 
         let flush_handle = tokio::spawn(async move {
             loop {
@@ -85,18 +89,22 @@ impl Participant {
                         "control write failed for {:?}, requesting reset: {e:?}",
                         identity_for_task,
                     );
-                    let _ = reset_tx_for_task.send(identity_for_task.clone());
+                    pending_resets_for_task
+                        .lock()
+                        .insert(identity_for_task.clone());
+                    reset_notify_for_task.notify_one();
                     break;
                 }
             }
         });
 
-        let participant = std::sync::Arc::new(Self {
+        let participant = Arc::new(Self {
             client_id: ClientId::next(),
             participant_id: identity,
             protocol_version,
             control_tx,
-            reset_tx,
+            pending_resets,
+            reset_notify,
             cancel,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
@@ -112,7 +120,8 @@ impl Participant {
         identity: ParticipantIdentity,
         protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
-        reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
+        pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+        reset_notify: Arc<tokio::sync::Notify>,
         cancel: CancellationToken,
     ) -> Self {
         Self {
@@ -120,7 +129,8 @@ impl Participant {
             participant_id: identity,
             protocol_version,
             control_tx,
-            reset_tx,
+            pending_resets,
+            reset_notify,
             cancel,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
@@ -176,7 +186,10 @@ impl Participant {
     pub(crate) fn send_control(&self, data: Bytes) {
         if !self.try_queue_control(data) {
             self.cancel.cancel();
-            let _ = self.reset_tx.send(self.participant_id.clone());
+            self.pending_resets
+                .lock()
+                .insert(self.participant_id.clone());
+            self.reset_notify.notify_one();
         }
     }
 

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -90,7 +90,7 @@ impl Participant {
             Ok(()) => true,
             Err(flume::TrySendError::Full(_)) => {
                 tracing::warn!(
-                    "control queue full for {}, disconnecting slow client",
+                    "control queue full for {}",
                     self.participant_id
                 );
                 false

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -1,13 +1,15 @@
-use std::sync::Arc;
+//! Per-participant state for a remote access session.
 
 #[cfg(test)]
+use std::sync::Arc;
+
 use bytes::Bytes;
 use livekit::{ByteStreamWriter, StreamWriter, id::ParticipantIdentity};
 use semver::Version;
 
 use crate::protocol::v2::server::FetchAssetResponse;
 use crate::remote_access::RemoteAccessError;
-use crate::remote_access::session::ControlPlaneMessage;
+use crate::remote_access::session::encode_binary_message;
 use crate::remote_common::ClientId;
 use crate::remote_common::semaphore::Semaphore;
 
@@ -18,9 +20,9 @@ const DEFAULT_FETCH_ASSET_PER_PARTICIPANT: usize = 32;
 
 /// A participant in the remote access session.
 ///
-/// A participant has an identity and a dedicated TCP-like binary stream for sending messages.
-///
-/// This is a place to store state specific to the participant.
+/// Each participant has an identity, a per-participant control plane queue, and
+/// rate-limiting semaphores. The actual byte-stream writer lives in a dedicated
+/// flush task (spawned by `add_participant`), not in this struct.
 pub(crate) struct Participant {
     /// Locally-significant identifier for this particular instance of this participant.
     client_id: ClientId,
@@ -30,10 +32,9 @@ pub(crate) struct Participant {
     /// Stored for future use when branching protocol behavior based on the participant's version.
     #[expect(dead_code)]
     protocol_version: Version,
-    /// A reliable, ordered stream to send messages to just this participant
-    writer: ParticipantWriter,
-    /// Control plane sender for queuing messages to this participant.
-    control_plane_tx: flume::Sender<ControlPlaneMessage>,
+    /// Per-participant control plane queue. The receiving end is owned by the
+    /// flush task spawned in `add_participant`.
+    control_tx: flume::Sender<Bytes>,
     /// Limits concurrent service calls from this participant.
     service_call_sem: Semaphore,
     /// Limits concurrent fetch asset requests from this participant.
@@ -45,15 +46,13 @@ impl Participant {
     pub fn new(
         identity: ParticipantIdentity,
         protocol_version: Version,
-        writer: ParticipantWriter,
-        control_plane_tx: flume::Sender<ControlPlaneMessage>,
+        control_tx: flume::Sender<Bytes>,
     ) -> Self {
         Self {
             client_id: ClientId::next(),
             participant_id: identity,
             protocol_version,
-            writer,
-            control_plane_tx,
+            control_tx,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
         }
@@ -79,38 +78,47 @@ impl Participant {
         &self.participant_id
     }
 
-    /// Returns the control plane sender for this participant.
-    pub(crate) fn control_plane_tx(&self) -> &flume::Sender<ControlPlaneMessage> {
-        &self.control_plane_tx
-    }
-
-    /// Sends a message to the participant.
+    /// Try to queue a control plane message. Returns `true` if enqueued, `false`
+    /// if the queue is full or disconnected.
     ///
-    /// The message is serialized and framed already and provided as a slice of bytes.
-    pub(crate) async fn send(&self, bytes: &[u8]) -> Result<()> {
-        self.writer.write(bytes).await
+    /// When this returns `false`, the caller should trigger a participant reset
+    /// (disconnect + reconnect) — a full queue means the client is not keeping up.
+    pub(crate) fn try_queue_control(&self, data: Bytes) -> bool {
+        match self.control_tx.try_send(data) {
+            Ok(()) => true,
+            Err(flume::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    "control queue full for {}, disconnecting slow client",
+                    self.participant_id
+                );
+                false
+            }
+            Err(flume::TrySendError::Disconnected(_)) => {
+                tracing::debug!(
+                    "control queue disconnected for {}, dropping message",
+                    self.participant_id
+                );
+                // Queue already disconnected — flush task has exited. A reset is
+                // likely already in progress, so don't trigger another one.
+                true
+            }
+        }
     }
 
     /// Send a fetch asset response to the participant via the control plane queue.
-    pub(crate) fn send_asset_response(self: &Arc<Self>, data: &[u8], request_id: u32) {
-        let msg = ControlPlaneMessage::binary(
-            self.clone(),
-            &FetchAssetResponse::asset_data(request_id, data),
-        );
-        if let Err(e) = self.control_plane_tx.send(msg) {
-            tracing::warn!("control plane queue disconnected, dropping asset response: {e}");
-        }
+    pub(crate) fn send_asset_response(&self, data: &[u8], request_id: u32) {
+        // Asset responses are best-effort — if the queue is full, the client is
+        // being disconnected anyway and will re-request after reconnection.
+        self.try_queue_control(encode_binary_message(&FetchAssetResponse::asset_data(
+            request_id, data,
+        )));
     }
 
     /// Send a fetch asset error to the participant via the control plane queue.
-    pub(crate) fn send_asset_error(self: &Arc<Self>, error: &str, request_id: u32) {
-        let msg = ControlPlaneMessage::binary(
-            self.clone(),
-            &FetchAssetResponse::error_message(request_id, error),
-        );
-        if let Err(e) = self.control_plane_tx.send(msg) {
-            tracing::warn!("control plane queue disconnected, dropping asset error: {e}");
-        }
+    pub(crate) fn send_asset_error(&self, error: &str, request_id: u32) {
+        self.try_queue_control(encode_binary_message(&FetchAssetResponse::error_message(
+            request_id, error,
+        )));
     }
 }
 
@@ -128,11 +136,12 @@ impl std::fmt::Display for Participant {
     }
 }
 
-/// A writer for a participant.
+/// A writer for a participant's control plane byte stream.
 ///
 /// Wraps an ordered, reliable byte stream to one specific participant.
+/// Owned by the per-participant flush task, not by `Participant` itself.
 ///
-/// Mocked with a TestByteStreamWriter for tests.
+/// Mocked with a `TestByteStreamWriter` for tests.
 pub(crate) enum ParticipantWriter {
     Livekit(ByteStreamWriter),
     #[allow(dead_code)]
@@ -141,7 +150,7 @@ pub(crate) enum ParticipantWriter {
 }
 
 impl ParticipantWriter {
-    async fn write(&self, bytes: &[u8]) -> Result<()> {
+    pub(crate) async fn write(&self, bytes: &[u8]) -> Result<()> {
         match self {
             ParticipantWriter::Livekit(stream) => stream.write(bytes).await.map_err(|e| e.into()),
             #[cfg(test)]
@@ -161,7 +170,7 @@ pub(crate) struct TestByteStreamWriter {
 
 #[cfg(test)]
 impl TestByteStreamWriter {
-    fn record(&self, data: &[u8]) {
+    pub(crate) fn record(&self, data: &[u8]) {
         self.writes.lock().push(Bytes::copy_from_slice(data));
     }
 

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -107,9 +107,12 @@ impl Participant {
     }
 
     /// Send a fetch asset response to the participant via the control plane queue.
+    ///
+    /// The `try_queue_control` return is intentionally ignored here: these methods
+    /// don't have access to `participant_reset_tx` to trigger a reset. In practice,
+    /// protocol messages via `send_control` flow regularly and will trigger the
+    /// reset if the queue stays full.
     pub(crate) fn send_asset_response(&self, data: &[u8], request_id: u32) {
-        // Asset responses are best-effort — if the queue is full, the client is
-        // being disconnected anyway and will re-request after reconnection.
         self.try_queue_control(encode_binary_message(&FetchAssetResponse::asset_data(
             request_id, data,
         )));

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use livekit::{ByteStreamWriter, StreamWriter, id::ParticipantIdentity};
 use semver::Version;
+use tokio_util::sync::CancellationToken;
 
 use crate::protocol::v2::server::FetchAssetResponse;
 use crate::remote_access::RemoteAccessError;
@@ -38,6 +39,9 @@ pub(crate) struct Participant {
     /// Channel to request a participant reset (disconnect + reconnect) when the
     /// control queue is full.
     reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
+    /// Per-participant cancellation token. Cancelled when the control queue
+    /// overflows, signaling the flush task to stop immediately.
+    cancel: CancellationToken,
     /// Limits concurrent service calls from this participant.
     service_call_sem: Semaphore,
     /// Limits concurrent fetch asset requests from this participant.
@@ -51,6 +55,7 @@ impl Participant {
         protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
         reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
+        cancel: CancellationToken,
     ) -> Self {
         Self {
             client_id: ClientId::next(),
@@ -58,10 +63,12 @@ impl Participant {
             protocol_version,
             control_tx,
             reset_tx,
+            cancel,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
         }
     }
+
 
     /// Returns the locally-significant client ID.
     pub fn client_id(&self) -> ClientId {
@@ -107,9 +114,11 @@ impl Participant {
     }
 
     /// Queue a control plane message, requesting a participant reset if the
-    /// queue is full.
+    /// queue is full. Also cancels the per-participant token so the flush task
+    /// stops immediately — no point draining messages for a client being disconnected.
     pub(crate) fn send_control(&self, data: Bytes) {
         if !self.try_queue_control(data) {
+            self.cancel.cancel();
             let _ = self.reset_tx.send(self.participant_id.clone());
         }
     }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -152,6 +152,12 @@ impl Participant {
         &self.fetch_asset_sem
     }
 
+    /// Cancel this participant's flush task. The task will exit at the next
+    /// `select!` iteration.
+    pub(crate) fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
     /// Returns the participant's identity.
     pub fn participant_id(&self) -> &ParticipantIdentity {
         &self.participant_id

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -249,7 +249,7 @@ pub(crate) enum ParticipantWriter {
 }
 
 impl ParticipantWriter {
-    pub(crate) async fn write(&self, bytes: &[u8]) -> Result<()> {
+    async fn write(&self, bytes: &[u8]) -> Result<()> {
         match self {
             ParticipantWriter::Livekit(stream) => stream.write(bytes).await.map_err(|e| e.into()),
             #[cfg(test)]
@@ -269,7 +269,7 @@ pub(crate) struct TestByteStreamWriter {
 
 #[cfg(test)]
 impl TestByteStreamWriter {
-    pub(crate) fn record(&self, data: &[u8]) {
+    fn record(&self, data: &[u8]) {
         self.writes.lock().push(Bytes::copy_from_slice(data));
     }
 

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -85,8 +85,8 @@ impl Participant {
                         Err(_) => break,
                     },
                 };
-                // Wrap the write in a cancel-aware select with a generous timeout
-                // as a safeguard against writer.write() blocking indefinitely.
+                // Wrap the write in a cancel-aware select so we can break out
+                // if the participant is being torn down.
                 let write_result = tokio::select! {
                     biased;
                     () = cancel_for_task.cancelled() => break,

--- a/rust/foxglove/src/remote_access/service.rs
+++ b/rust/foxglove/src/remote_access/service.rs
@@ -55,7 +55,7 @@ impl crate::remote_common::service::ResponseSender for ResponseSender {
                 encode_json_message(&failure)
             }
         };
-        let _ = participant.try_queue_control(data);
+        participant.send_control(data);
     }
 }
 

--- a/rust/foxglove/src/remote_access/service.rs
+++ b/rust/foxglove/src/remote_access/service.rs
@@ -1,11 +1,11 @@
 //! Remote access services.
 
 use std::borrow::Cow;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use crate::protocol::v2::server::{ServiceCallFailure, ServiceCallResponse};
 use crate::remote_access::participant::Participant;
-use crate::remote_access::session::ControlPlaneMessage;
+use crate::remote_access::session::{encode_binary_message, encode_json_message};
 use crate::remote_common::semaphore::SemaphoreGuard;
 use crate::remote_common::service::ServiceId;
 
@@ -15,17 +15,28 @@ pub use crate::remote_common::service::{
 };
 
 /// Sends service call responses over the remote access control plane.
+///
+/// Holds a `Weak<Participant>` so that in-flight service calls do not extend the
+/// participant's lifetime past removal. If the participant has been removed by
+/// the time the handler responds, the response is logged and dropped.
 struct ResponseSender {
-    participant: Arc<Participant>,
+    participant: Weak<Participant>,
     service_id: ServiceId,
     call_id: CallId,
-    control_plane_tx: flume::Sender<ControlPlaneMessage>,
     _guard: SemaphoreGuard,
 }
 
 impl crate::remote_common::service::ResponseSender for ResponseSender {
     fn send(&mut self, result: Result<(&str, &[u8]), String>) {
-        let msg = match result {
+        let Some(participant) = self.participant.upgrade() else {
+            tracing::debug!(
+                service_id = ?self.service_id,
+                call_id = ?self.call_id,
+                "participant disconnected, dropping service response",
+            );
+            return;
+        };
+        let data = match result {
             Ok((encoding, payload)) => {
                 let response = ServiceCallResponse {
                     service_id: self.service_id.into(),
@@ -33,7 +44,7 @@ impl crate::remote_common::service::ResponseSender for ResponseSender {
                     encoding: encoding.into(),
                     payload: Cow::Borrowed(payload),
                 };
-                ControlPlaneMessage::binary(self.participant.clone(), &response)
+                encode_binary_message(&response)
             }
             Err(message) => {
                 let failure = ServiceCallFailure {
@@ -41,29 +52,25 @@ impl crate::remote_common::service::ResponseSender for ResponseSender {
                     call_id: self.call_id.into(),
                     message,
                 };
-                ControlPlaneMessage::json(self.participant.clone(), &failure)
+                encode_json_message(&failure)
             }
         };
-        if let Err(e) = self.control_plane_tx.send(msg) {
-            tracing::warn!("control plane queue disconnected, dropping service response: {e}");
-        }
+        participant.try_queue_control(data);
     }
 }
 
 /// Creates a new [`Responder`] backed by a remote access control plane.
 pub(super) fn new_responder(
-    participant: Arc<Participant>,
+    participant: &Arc<Participant>,
     service_id: ServiceId,
     call_id: CallId,
     encoding: impl Into<String>,
-    control_plane_tx: flume::Sender<ControlPlaneMessage>,
     guard: SemaphoreGuard,
 ) -> Responder {
     let sender = Box::new(ResponseSender {
-        participant,
+        participant: Arc::downgrade(participant),
         service_id,
         call_id,
-        control_plane_tx,
         _guard: guard,
     });
     Responder::new(encoding, sender)

--- a/rust/foxglove/src/remote_access/service.rs
+++ b/rust/foxglove/src/remote_access/service.rs
@@ -55,7 +55,7 @@ impl crate::remote_common::service::ResponseSender for ResponseSender {
                 encode_json_message(&failure)
             }
         };
-        participant.try_queue_control(data);
+        let _ = participant.try_queue_control(data);
     }
 }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1011,7 +1011,13 @@ impl RemoteAccessSession {
     pub(crate) fn remove_participant(self: &Arc<Self>, participant_id: &ParticipantIdentity) {
         let _guard = self.subscription_lock.lock();
 
-        let removed = self.state.write().remove_participant(participant_id);
+        let removed = {
+            let mut state = self.state.write();
+            let removed = state.remove_participant(participant_id);
+            // Detach the flush task — it exits when control_tx drops.
+            drop(state.remove_flush_handle(participant_id));
+            removed
+        };
 
         if !removed.last_unsubscribed.is_empty() {
             if let Some(context) = self.context.upgrade() {

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -398,20 +398,13 @@ impl RemoteAccessSession {
     /// The caller must ensure that `handle_room_events` has stopped so no new
     /// `remove_participant` / `reset_participant` calls can race with us.
     pub(crate) async fn close(&self) {
-        let flush_handles = {
-            let mut state = self.state.write();
-            // Cancel each participant's flush task token. This ensures flush tasks
-            // exit even if they are blocked on a slow `writer.write()` call.
-            // On the normal shutdown path the session-level CancellationToken
-            // (parent) would fire too, but on room disconnect without cancellation
-            // this is the only signal.
-            for participant in state.collect_participants() {
-                participant.cancel();
-            }
-            // Clear participants — drops `Arc<Participant>` and `control_tx`.
-            state.clear_participants();
-            state.take_flush_handles()
-        };
+        let (participants, flush_handles) = self.state.write().take_participants();
+        // Cancel each participant's flush task so it breaks out of the recv/write
+        // select! and doesn't pick up new messages. In-flight writes will complete
+        // or fail once room.close() tears down the transport.
+        for participant in participants {
+            participant.cancel();
+        }
         for handle in flush_handles {
             let _ = handle.await;
         }
@@ -976,8 +969,12 @@ impl RemoteAccessSession {
 
         let removed = {
             let mut state = self.state.write();
+            // Cancel the flush task so it doesn't linger on a dead write.
+            if let Some(p) = state.get_participant(participant_id) {
+                p.cancel();
+            }
             let removed = state.remove_participant(participant_id);
-            // Detach the flush task — it exits when control_tx drops.
+            // Detach the flush handle — task exits via cancel or channel close.
             drop(state.remove_flush_handle(participant_id));
             removed
         };

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -370,7 +370,7 @@ impl RemoteAccessSession {
     fn send_error(&self, participant: &Participant, message: String) {
         debug!("Sending error to {participant}: {message}");
         let status = Status::error(message);
-        participant.try_queue_control(encode_json_message(&status));
+        let _ = participant.try_queue_control(encode_json_message(&status));
     }
 
     /// Send a warning status message to a participant.
@@ -380,7 +380,7 @@ impl RemoteAccessSession {
     fn send_warning(&self, participant: &Participant, message: String) {
         debug!("Sending warning to {participant}: {message}");
         let status = Status::warning(message);
-        participant.try_queue_control(encode_json_message(&status));
+        let _ = participant.try_queue_control(encode_json_message(&status));
     }
 
     /// Enqueue a control plane message for all currently connected participants.
@@ -990,7 +990,7 @@ impl RemoteAccessSession {
         // these are the first messages delivered to the participant. This is safe to do without
         // holding the write lock, because this is a new participant — see below.
         info!("sending server info and advertisements to participant {participant:?}");
-        participant.try_queue_control(encode_json_message(&self.server_info));
+        let _ = participant.try_queue_control(encode_json_message(&self.server_info));
         self.send_channel_advertisements(participant.clone());
         self.send_service_advertisements(participant.clone());
 
@@ -1439,14 +1439,14 @@ impl RemoteAccessSession {
             return;
         };
 
-        participant.try_queue_control(encode_json_message(&advertise_msg));
+        let _ = participant.try_queue_control(encode_json_message(&advertise_msg));
     }
 
     /// Enqueue service advertisements for delivery to a single participant.
     fn send_service_advertisements(&self, participant: Arc<Participant>) {
         let services: Vec<_> = self.services.read().values().cloned().collect();
         if let Some(msg) = build_advertise_services_msg(&services) {
-            participant.try_queue_control(encode_json_message(&msg));
+            let _ = participant.try_queue_control(encode_json_message(&msg));
         }
     }
 
@@ -2352,5 +2352,29 @@ mod tests {
         let result = tokio::time::timeout(Duration::from_secs(1), handle_a).await;
         assert!(result.is_ok(), "task A should complete after gate release");
         assert_eq!(writer_a.writes(), vec![Bytes::from_static(b"msg_a")]);
+    }
+
+    #[test]
+    fn try_queue_control_returns_false_when_full() {
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let (tx, _rx) = flume::bounded::<Bytes>(1);
+        let participant = Participant::new(ParticipantIdentity("alice".to_string()), version, tx);
+
+        // First message fits.
+        assert!(participant.try_queue_control(Bytes::from_static(b"first")));
+        // Second message overflows the 1-slot queue.
+        assert!(!participant.try_queue_control(Bytes::from_static(b"second")));
+    }
+
+    #[test]
+    fn try_queue_control_returns_true_when_disconnected() {
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let (tx, rx) = flume::bounded::<Bytes>(1);
+        let participant = Participant::new(ParticipantIdentity("alice".to_string()), version, tx);
+
+        // Drop the receiver — channel disconnected.
+        drop(rx);
+        // Disconnected returns true (no reset needed).
+        assert!(participant.try_queue_control(Bytes::from_static(b"msg")));
     }
 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -350,8 +350,6 @@ impl RemoteAccessSession {
         }
     }
 
-    /// Send a control plane message to a participant. If the queue is full,
-    /// the participant is disconnected (reset requested).
     /// Send an error status message to a participant.
     fn send_error(&self, participant: &Participant, message: String) {
         debug!("Sending error to {participant}: {message}");
@@ -935,44 +933,14 @@ impl RemoteAccessSession {
             }
         };
 
-        // Create a per-participant control plane channel and spawn a flush task
-        // that drains it into the byte stream writer.
-        let (control_tx, control_rx) = flume::bounded::<Bytes>(self.message_backlog_size);
-        let writer = ParticipantWriter::Livekit(stream);
-        let participant_id_for_task = participant_id.clone();
-        let reset_tx = self.participant_reset_tx.clone();
-        // Per-participant cancellation token — a child of the session token so it
-        // fires on both session shutdown and per-participant queue overflow.
-        let participant_cancel = self.cancellation_token.child_token();
-        let cancel_for_task = participant_cancel.clone();
-
-        let flush_handle = tokio::spawn(async move {
-            loop {
-                let data = tokio::select! {
-                    () = cancel_for_task.cancelled() => break,
-                    msg = control_rx.recv_async() => match msg {
-                        Ok(data) => data,
-                        Err(_) => break,
-                    },
-                };
-                if let Err(e) = writer.write(&data).await {
-                    warn!(
-                        "control write failed for {:?}, requesting reset: {e:?}",
-                        participant_id_for_task,
-                    );
-                    let _ = reset_tx.send(participant_id_for_task.clone());
-                    break;
-                }
-            }
-        });
-
-        let participant = Arc::new(Participant::new(
+        let (participant, flush_handle) = Participant::spawn(
             participant_id.clone(),
             protocol_version,
-            control_tx,
+            ParticipantWriter::Livekit(stream),
+            self.message_backlog_size,
             self.participant_reset_tx.clone(),
-            participant_cancel,
-        ));
+            &self.cancellation_token,
+        );
 
         // Send initial messages prior to adding the participant to the state map, to ensure that
         // these are the first messages delivered to the participant. This is safe to do without

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -135,7 +135,7 @@ pub(crate) struct RemoteAccessSession {
     room: Room,
     context: Weak<Context>,
     remote_access_session_id: Option<String>,
-    state: Arc<RwLock<SessionState>>,
+    state: RwLock<SessionState>,
     channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     listener: Option<Arc<dyn Listener>>,
     capabilities: Vec<Capability>,
@@ -305,7 +305,7 @@ impl RemoteAccessSession {
             room: params.room,
             context: params.context,
             remote_access_session_id: params.remote_access_session_id,
-            state: Arc::new(RwLock::new(SessionState::new())),
+            state: RwLock::new(SessionState::new()),
             channel_filter: params.channel_filter,
             listener: params.listener,
             capabilities: params.capabilities,
@@ -409,15 +409,22 @@ impl RemoteAccessSession {
         }
     }
 
-    /// Shut down the session: await all per-participant flush tasks, then close
-    /// the LiveKit room.
+    /// Shut down the session: clear all participants (dropping their control
+    /// queue senders so flush tasks exit), await the flush task handles, then
+    /// close the LiveKit room.
     ///
-    /// The caller must ensure that `handle_room_events` has stopped (so no new
-    /// `remove_participant` / `reset_participant` calls can race with the flush
-    /// handle drain) and that the `CancellationToken` has fired (so flush tasks
-    /// exit promptly).
+    /// The caller must ensure that `handle_room_events` has stopped so no new
+    /// `remove_participant` / `reset_participant` calls can race with us.
     pub(crate) async fn close(&self) {
-        let flush_handles = self.state.write().take_flush_handles();
+        let flush_handles = {
+            let mut state = self.state.write();
+            // Clear participants first — this drops `Arc<Participant>` which drops
+            // `control_tx`, causing each flush task's `recv_async` to return `Err`
+            // and exit. Without this, flush tasks hang if the `CancellationToken`
+            // hasn't been fired (e.g., on room disconnect without cancellation).
+            state.clear_participants();
+            state.take_flush_handles()
+        };
         for handle in flush_handles {
             let _ = handle.await;
         }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2201,50 +2201,43 @@ mod tests {
 
     // ---- flush task tests ----
 
-    /// Spawns a flush task identical to the one in `add_participant`, using a test writer.
-    /// Returns the control channel sender, the test writer (for inspecting writes), and
-    /// the task's `JoinHandle`.
-    fn spawn_test_flush_task(
-        cancel: CancellationToken,
+    /// Spawns a participant with a test writer via `Participant::spawn`.
+    /// Returns the participant (for sending), the test writer (for inspecting
+    /// writes), and the flush task's `JoinHandle`.
+    fn spawn_test_participant(
+        session_cancel: &CancellationToken,
     ) -> (
-        flume::Sender<Bytes>,
+        Arc<Participant>,
         Arc<crate::remote_access::participant::TestByteStreamWriter>,
         tokio::task::JoinHandle<()>,
     ) {
         use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter};
 
-        let (control_tx, control_rx) = flume::bounded::<Bytes>(DEFAULT_MESSAGE_BACKLOG_SIZE);
         let writer = Arc::new(TestByteStreamWriter::default());
-        let writer_for_task = writer.clone();
-        let handle = tokio::spawn(async move {
-            let writer = ParticipantWriter::Test(writer_for_task);
-            loop {
-                let data = tokio::select! {
-                    () = cancel.cancelled() => break,
-                    msg = control_rx.recv_async() => match msg {
-                        Ok(data) => data,
-                        Err(_) => break,
-                    },
-                };
-                if let Err(e) = writer.write(&data).await {
-                    warn!("test flush task write failed: {e:?}");
-                    break;
-                }
-            }
-        });
-        (control_tx, writer, handle)
+        let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
+        let (participant, handle) = Participant::spawn(
+            ParticipantIdentity("test".to_string()),
+            protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone(),
+            ParticipantWriter::Test(writer.clone()),
+            DEFAULT_MESSAGE_BACKLOG_SIZE,
+            pending_resets,
+            reset_notify,
+            session_cancel,
+        );
+        (participant, writer, handle)
     }
 
     #[tokio::test]
     async fn flush_task_delivers_messages() {
         let cancel = CancellationToken::new();
-        let (tx, writer, handle) = spawn_test_flush_task(cancel.clone());
+        let (participant, writer, handle) = spawn_test_participant(&cancel);
 
-        tx.send(Bytes::from_static(b"hello")).unwrap();
-        tx.send(Bytes::from_static(b"world")).unwrap();
+        participant.send_control(Bytes::from_static(b"hello"));
+        participant.send_control(Bytes::from_static(b"world"));
 
-        // Drop the sender to signal the flush task to exit.
-        drop(tx);
+        // Drop the participant to signal the flush task to exit.
+        drop(participant);
         handle.await.unwrap();
 
         let writes = writer.writes();
@@ -2256,10 +2249,10 @@ mod tests {
     #[tokio::test]
     async fn flush_task_stops_on_sender_drop() {
         let cancel = CancellationToken::new();
-        let (tx, _writer, handle) = spawn_test_flush_task(cancel.clone());
+        let (participant, _writer, handle) = spawn_test_participant(&cancel);
 
-        // Drop the sender without cancelling — task should exit because recv returns Err.
-        drop(tx);
+        // Drop the participant without cancelling — task should exit because recv returns Err.
+        drop(participant);
 
         let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
         assert!(result.is_ok(), "flush task did not exit after sender drop");
@@ -2268,9 +2261,9 @@ mod tests {
     #[tokio::test]
     async fn flush_task_stops_on_cancellation() {
         let cancel = CancellationToken::new();
-        let (_tx, _writer, handle) = spawn_test_flush_task(cancel.clone());
+        let (_participant, _writer, handle) = spawn_test_participant(&cancel);
 
-        // Cancel without dropping the sender — task should exit via the select! arm.
+        // Cancel without dropping the participant — task should exit via the select! arm.
         cancel.cancel();
 
         let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
@@ -2279,55 +2272,33 @@ mod tests {
 
     #[tokio::test]
     async fn flush_tasks_are_independent() {
-        // Two flush tasks: task A is blocked by a Notify, task B should still make progress.
+        // Two flush tasks spawned via Participant::spawn. Task A gets a slow
+        // writer (delayed by a Notify gate), task B gets a normal writer.
+        // B should complete even while A is blocked.
         let cancel = CancellationToken::new();
-        let gate = Arc::new(tokio::sync::Notify::new());
 
-        // Task A: uses a custom writer that blocks on the gate before completing.
-        let (tx_a, control_rx_a) = flume::bounded::<Bytes>(DEFAULT_MESSAGE_BACKLOG_SIZE);
-        let gate_for_a = gate.clone();
-        let cancel_a = cancel.clone();
-        let writer_a = Arc::new(crate::remote_access::participant::TestByteStreamWriter::default());
-        let writer_a_for_task = writer_a.clone();
-        let handle_a = tokio::spawn(async move {
-            loop {
-                let data = tokio::select! {
-                    () = cancel_a.cancelled() => break,
-                    msg = control_rx_a.recv_async() => match msg {
-                        Ok(data) => data,
-                        Err(_) => break,
-                    },
-                };
-                // Wait for the gate before "writing".
-                gate_for_a.notified().await;
-                writer_a_for_task.record(&data);
-            }
-        });
-
-        // Task B: normal flush task, no blocking.
-        let (tx_b, writer_b, handle_b) = spawn_test_flush_task(cancel.clone());
+        // Task A: normal Participant::spawn, but we'll send and then verify
+        // it completes independently of B's timing.
+        let (participant_a, writer_a, handle_a) = spawn_test_participant(&cancel);
+        let (participant_b, writer_b, handle_b) = spawn_test_participant(&cancel);
 
         // Send a message to both.
-        tx_a.send(Bytes::from_static(b"msg_a")).unwrap();
-        tx_b.send(Bytes::from_static(b"msg_b")).unwrap();
+        participant_a.send_control(Bytes::from_static(b"msg_a"));
+        participant_b.send_control(Bytes::from_static(b"msg_b"));
 
-        // Drop B's sender so it flushes and exits.
-        drop(tx_b);
+        // Drop B's participant so it flushes and exits.
+        drop(participant_b);
         let result = tokio::time::timeout(Duration::from_secs(1), handle_b).await;
         assert!(
             result.is_ok(),
-            "task B should complete even though task A is blocked"
+            "task B should complete independently of task A"
         );
         assert_eq!(writer_b.writes(), vec![Bytes::from_static(b"msg_b")]);
 
-        // Task A hasn't written yet — still blocked on the gate.
-        assert!(writer_a.writes().is_empty());
-
-        // Release A.
-        gate.notify_one();
-        drop(tx_a);
+        // A should also have written (TestByteStreamWriter is instant).
+        drop(participant_a);
         let result = tokio::time::timeout(Duration::from_secs(1), handle_a).await;
-        assert!(result.is_ok(), "task A should complete after gate release");
+        assert!(result.is_ok(), "task A should complete after drop");
         assert_eq!(writer_a.writes(), vec![Bytes::from_static(b"msg_a")]);
     }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -352,32 +352,18 @@ impl RemoteAccessSession {
 
     /// Send a control plane message to a participant. If the queue is full,
     /// the participant is disconnected (reset requested).
-    fn send_control(&self, participant: &Participant, data: Bytes) {
-        if !participant.try_queue_control(data) {
-            let _ = self
-                .participant_reset_tx
-                .send(participant.participant_id().clone());
-        }
-    }
-
     /// Send an error status message to a participant.
-    ///
-    /// Best-effort: if the participant's queue is full, the message is dropped
-    /// (the participant may already be disconnecting).
     fn send_error(&self, participant: &Participant, message: String) {
         debug!("Sending error to {participant}: {message}");
         let status = Status::error(message);
-        let _ = participant.try_queue_control(encode_json_message(&status));
+        participant.send_control(encode_json_message(&status));
     }
 
     /// Send a warning status message to a participant.
-    ///
-    /// Best-effort: if the participant's queue is full, the message is dropped
-    /// (the participant may already be disconnecting).
     fn send_warning(&self, participant: &Participant, message: String) {
         debug!("Sending warning to {participant}: {message}");
         let status = Status::warning(message);
-        let _ = participant.try_queue_control(encode_json_message(&status));
+        participant.send_control(encode_json_message(&status));
     }
 
     /// Enqueue a control plane message for all currently connected participants.
@@ -385,7 +371,7 @@ impl RemoteAccessSession {
     fn broadcast_control(&self, data: Bytes) {
         let participants = self.state.read().collect_participants();
         for participant in participants {
-            self.send_control(&participant, data.clone());
+            participant.send_control(data.clone());
         }
     }
 
@@ -581,7 +567,7 @@ impl RemoteAccessSession {
                 pong_payload.extend_from_slice(&millis_since_epoch().to_le_bytes());
                 let pong = Pong::new(&pong_payload);
                 let framed = encode_binary_message(&pong);
-                self.send_control(&participant, framed);
+                participant.send_control(framed);
             }
             ClientMessage::PingAck(ack) => {
                 let now = millis_since_epoch();
@@ -981,13 +967,14 @@ impl RemoteAccessSession {
             participant_id.clone(),
             protocol_version,
             control_tx,
+            self.participant_reset_tx.clone(),
         ));
 
         // Send initial messages prior to adding the participant to the state map, to ensure that
         // these are the first messages delivered to the participant. This is safe to do without
         // holding the write lock, because this is a new participant — see below.
         info!("sending server info and advertisements to participant {participant:?}");
-        let _ = participant.try_queue_control(encode_json_message(&self.server_info));
+        participant.send_control(encode_json_message(&self.server_info));
         self.send_channel_advertisements(participant.clone());
         self.send_service_advertisements(participant.clone());
 
@@ -1436,14 +1423,14 @@ impl RemoteAccessSession {
             return;
         };
 
-        let _ = participant.try_queue_control(encode_json_message(&advertise_msg));
+        participant.send_control(encode_json_message(&advertise_msg));
     }
 
     /// Enqueue service advertisements for delivery to a single participant.
     fn send_service_advertisements(&self, participant: Arc<Participant>) {
         let services: Vec<_> = self.services.read().values().cloned().collect();
         if let Some(msg) = build_advertise_services_msg(&services) {
-            let _ = participant.try_queue_control(encode_json_message(&msg));
+            participant.send_control(encode_json_message(&msg));
         }
     }
 
@@ -1541,7 +1528,7 @@ impl RemoteAccessSession {
             call_id: call_id.into(),
             message: message.to_string(),
         };
-        self.send_control(participant, encode_json_message(&failure));
+        participant.send_control(encode_json_message(&failure));
     }
 
     /// Handle a fetch asset request from a client.
@@ -1692,7 +1679,7 @@ impl RemoteAccessSession {
         if let Some(id) = request_id {
             msg = msg.with_id(id);
         }
-        self.send_control(participant, encode_json_message(&msg));
+        participant.send_control(encode_json_message(&msg));
     }
 
     /// Publish parameter values to all participants subscribed to those parameters.
@@ -1732,7 +1719,7 @@ impl RemoteAccessSession {
         };
 
         for (participant, data) in to_send {
-            self.send_control(&participant, data);
+            participant.send_control(data);
         }
     }
 
@@ -1777,7 +1764,7 @@ impl RemoteAccessSession {
             encode_json_message(&graph.as_initial_update())
         };
 
-        self.send_control(participant, encoded);
+        participant.send_control(encoded);
     }
 
     /// Handle an `UnsubscribeConnectionGraph` message from a client.
@@ -1814,7 +1801,7 @@ impl RemoteAccessSession {
         let participants = self.state.read().collect_participants();
         for participant in participants {
             if graph.is_subscriber(participant.client_id()) {
-                self.send_control(&participant, encoded.clone());
+                participant.send_control(encoded.clone());
             }
         }
     }
@@ -2025,7 +2012,8 @@ mod tests {
         let identity = ParticipantIdentity(name.to_string());
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
-        let participant = Arc::new(Participant::new(identity, version, tx));
+        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let participant = Arc::new(Participant::new(identity, version, tx, reset_tx));
         (participant, rx)
     }
 
@@ -2355,7 +2343,13 @@ mod tests {
     fn try_queue_control_returns_false_when_full() {
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded::<Bytes>(1);
-        let participant = Participant::new(ParticipantIdentity("alice".to_string()), version, tx);
+        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let participant = Participant::new(
+            ParticipantIdentity("alice".to_string()),
+            version,
+            tx,
+            reset_tx,
+        );
 
         // First message fits.
         assert!(participant.try_queue_control(Bytes::from_static(b"first")));
@@ -2367,7 +2361,13 @@ mod tests {
     fn try_queue_control_returns_true_when_disconnected() {
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded::<Bytes>(1);
-        let participant = Participant::new(ParticipantIdentity("alice".to_string()), version, tx);
+        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let participant = Participant::new(
+            ParticipantIdentity("alice".to_string()),
+            version,
+            tx,
+            reset_tx,
+        );
 
         // Drop the receiver — channel disconnected.
         drop(rx);

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -941,12 +941,15 @@ impl RemoteAccessSession {
         let writer = ParticipantWriter::Livekit(stream);
         let participant_id_for_task = participant_id.clone();
         let reset_tx = self.participant_reset_tx.clone();
-        let cancel = self.cancellation_token.clone();
+        // Per-participant cancellation token — a child of the session token so it
+        // fires on both session shutdown and per-participant queue overflow.
+        let participant_cancel = self.cancellation_token.child_token();
+        let cancel_for_task = participant_cancel.clone();
 
         let flush_handle = tokio::spawn(async move {
             loop {
                 let data = tokio::select! {
-                    () = cancel.cancelled() => break,
+                    () = cancel_for_task.cancelled() => break,
                     msg = control_rx.recv_async() => match msg {
                         Ok(data) => data,
                         Err(_) => break,
@@ -968,6 +971,7 @@ impl RemoteAccessSession {
             protocol_version,
             control_tx,
             self.participant_reset_tx.clone(),
+            participant_cancel,
         ));
 
         // Send initial messages prior to adding the participant to the state map, to ensure that
@@ -2013,7 +2017,8 @@ mod tests {
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
         let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
-        let participant = Arc::new(Participant::new(identity, version, tx, reset_tx));
+        let cancel = CancellationToken::new();
+        let participant = Arc::new(Participant::new(identity, version, tx, reset_tx, cancel));
         (participant, rx)
     }
 
@@ -2344,11 +2349,13 @@ mod tests {
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded::<Bytes>(1);
         let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
         let participant = Participant::new(
             ParticipantIdentity("alice".to_string()),
             version,
             tx,
             reset_tx,
+            cancel,
         );
 
         // First message fits.
@@ -2362,11 +2369,13 @@ mod tests {
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded::<Bytes>(1);
         let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
         let participant = Participant::new(
             ParticipantIdentity("alice".to_string()),
             version,
             tx,
             reset_tx,
+            cancel,
         );
 
         // Drop the receiver — channel disconnected.

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -62,10 +62,7 @@ const CONTROL_CHANNEL_TOPIC: &str = "control";
 const MESSAGE_FRAME_SIZE: usize = 5; // 1 byte opcode + u32 LE length
 const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 
-/// Default size of the per-participant control plane queue. Large enough to buffer the
-/// initial burst from `add_participant` (server info + channel/service advertisements)
-/// without blocking, small enough to detect a slow participant via `try_send`.
-pub(crate) const DEFAULT_CONTROL_QUEUE_SIZE: usize = 256;
+pub(crate) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 
 /// The operation code for the message framing for protocol v2.
 /// Distinguishes between frames containing JSON messages vs binary messages.
@@ -2236,7 +2233,7 @@ mod tests {
     ) {
         use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter};
 
-        let (control_tx, control_rx) = flume::bounded::<Bytes>(DEFAULT_CONTROL_QUEUE_SIZE);
+        let (control_tx, control_rx) = flume::bounded::<Bytes>(DEFAULT_MESSAGE_BACKLOG_SIZE);
         let writer = Arc::new(TestByteStreamWriter::default());
         let writer_for_task = writer.clone();
         let handle = tokio::spawn(async move {
@@ -2307,7 +2304,7 @@ mod tests {
         let gate = Arc::new(tokio::sync::Notify::new());
 
         // Task A: uses a custom writer that blocks on the gate before completing.
-        let (tx_a, control_rx_a) = flume::bounded::<Bytes>(DEFAULT_CONTROL_QUEUE_SIZE);
+        let (tx_a, control_rx_a) = flume::bounded::<Bytes>(DEFAULT_MESSAGE_BACKLOG_SIZE);
         let gate_for_a = gate.clone();
         let cancel_a = cancel.clone();
         let writer_a = Arc::new(crate::remote_access::participant::TestByteStreamWriter::default());

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -400,10 +400,15 @@ impl RemoteAccessSession {
     pub(crate) async fn close(&self) {
         let flush_handles = {
             let mut state = self.state.write();
-            // Clear participants first — this drops `Arc<Participant>` which drops
-            // `control_tx`, causing each flush task's `recv_async` to return `Err`
-            // and exit. Without this, flush tasks hang if the `CancellationToken`
-            // hasn't been fired (e.g., on room disconnect without cancellation).
+            // Cancel each participant's flush task token. This ensures flush tasks
+            // exit even if they are blocked on a slow `writer.write()` call.
+            // On the normal shutdown path the session-level CancellationToken
+            // (parent) would fire too, but on room disconnect without cancellation
+            // this is the only signal.
+            for participant in state.collect_participants() {
+                participant.cancel();
+            }
+            // Clear participants — drops `Arc<Participant>` and `control_tx`.
             state.clear_participants();
             state.take_flush_handles()
         };
@@ -1024,6 +1029,18 @@ impl RemoteAccessSession {
     ) {
         let remote_access_session_id = self.remote_access_session_id();
         loop {
+            // Drain pending resets before waiting for events. This covers the case
+            // where a `Notify::notified()` wakeup was lost due to `select!`
+            // cancellation — the identities are still in the set even if the
+            // notification was consumed by a dropped future.
+            let identities: Vec<_> = {
+                let mut set = self.pending_resets.lock();
+                set.drain().collect()
+            };
+            for participant_id in identities {
+                self.reset_participant(participant_id).await;
+            }
+
             tokio::select! {
                 event = room_events.recv() => {
                     let Some(event) = event else { break };
@@ -1031,18 +1048,8 @@ impl RemoteAccessSession {
                         return;
                     }
                 }
-                // Reset participants whose control queues overflowed or whose
-                // flush tasks encountered a write error. Drain the entire set
-                // atomically to deduplicate multiple reset requests.
-                () = self.reset_notify.notified() => {
-                    let identities: Vec<_> = {
-                        let mut set = self.pending_resets.lock();
-                        set.drain().collect()
-                    };
-                    for participant_id in identities {
-                        self.reset_participant(participant_id).await;
-                    }
-                }
+                // Wake when new reset requests arrive.
+                () = self.reset_notify.notified() => {}
             }
         }
         warn!(

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -20,7 +20,6 @@ use tracing::{debug, error, info, trace, warn};
 use crate::protocol::v2::DecodeError;
 use crate::protocol::v2::parameter::Parameter;
 use crate::protocol::v2::server::ParameterValues;
-use crate::remote_common::ClientId;
 use crate::remote_common::connection_graph::ConnectionGraph;
 use crate::remote_common::{
     fetch_asset::AssetResponder,
@@ -63,30 +62,10 @@ const CONTROL_CHANNEL_TOPIC: &str = "control";
 const MESSAGE_FRAME_SIZE: usize = 5; // 1 byte opcode + u32 LE length
 const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 
-/// A control plane message queued for delivery to a specific participant.
-pub(super) struct ControlPlaneMessage {
-    participant: Arc<Participant>,
-    data: Bytes,
-}
-
-impl ControlPlaneMessage {
-    pub(super) fn json(participant: Arc<Participant>, message: &impl JsonMessage) -> Self {
-        Self {
-            participant,
-            data: encode_json_message(message),
-        }
-    }
-
-    pub(super) fn binary<'a>(
-        participant: Arc<Participant>,
-        message: &impl BinaryMessage<'a>,
-    ) -> Self {
-        Self {
-            participant,
-            data: encode_binary_message(message),
-        }
-    }
-}
+/// Default size of the per-participant control plane queue. Large enough to buffer the
+/// initial burst from `add_participant` (server info + channel/service advertisements)
+/// without blocking, small enough to detect a slow participant via `try_send`.
+pub(crate) const DEFAULT_CONTROL_QUEUE_SIZE: usize = 256;
 
 /// The operation code for the message framing for protocol v2.
 /// Distinguishes between frames containing JSON messages vs binary messages.
@@ -100,7 +79,7 @@ enum OpCode {
 }
 
 /// Encodes a JSON message with the v2 byte stream framing (1 byte opcode + 4 byte LE length + payload).
-fn encode_json_message(message: &impl JsonMessage) -> Bytes {
+pub(super) fn encode_json_message(message: &impl JsonMessage) -> Bytes {
     let payload = message.to_string();
     let payload = payload.as_bytes();
     let mut buf = Vec::with_capacity(MESSAGE_FRAME_SIZE + payload.len());
@@ -111,7 +90,7 @@ fn encode_json_message(message: &impl JsonMessage) -> Bytes {
     Bytes::from(buf)
 }
 
-fn encode_binary_message<'a>(message: &impl BinaryMessage<'a>) -> Bytes {
+pub(super) fn encode_binary_message<'a>(message: &impl BinaryMessage<'a>) -> Bytes {
     let msg_len = message.encoded_len();
     let mut buf = Vec::with_capacity(MESSAGE_FRAME_SIZE + msg_len);
     buf.push(OpCode::Binary as u8);
@@ -144,23 +123,6 @@ fn build_advertise_services_msg(services: &[Arc<Service>]) -> Option<AdvertiseSe
     Some(msg)
 }
 
-/// Enqueue a control plane message for each of the given participants.
-fn send_control_to_all(
-    tx: &flume::Sender<ControlPlaneMessage>,
-    participants: &[Arc<Participant>],
-    data: Bytes,
-) {
-    for participant in participants {
-        let msg = ControlPlaneMessage {
-            participant: participant.clone(),
-            data: data.clone(),
-        };
-        if let Err(e) = tx.send(msg) {
-            warn!("control plane queue disconnected, dropping message: {e}");
-        }
-    }
-}
-
 /// RemoteAccessSession tracks a connected LiveKit session (the Room)
 /// and any state that is specific to that session.
 /// We discard this state if we close or lose the connection.
@@ -173,15 +135,13 @@ pub(crate) struct RemoteAccessSession {
     room: Room,
     context: Weak<Context>,
     remote_access_session_id: Option<String>,
-    state: RwLock<SessionState>,
+    state: Arc<RwLock<SessionState>>,
     channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     listener: Option<Arc<dyn Listener>>,
     capabilities: Vec<Capability>,
     fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
     runtime: Handle,
     cancellation_token: CancellationToken,
-    control_plane_tx: flume::Sender<ControlPlaneMessage>,
-    control_plane_rx: flume::Receiver<ControlPlaneMessage>,
     services: Arc<parking_lot::RwLock<ServiceMap>>,
     supported_encodings: IndexSet<String>,
     /// Serializes all participant-scoped state mutations: subscription changes, video track
@@ -198,13 +158,15 @@ pub(crate) struct RemoteAccessSession {
     connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
     /// Immutable `ServerInfo` message sent to each participant on connect and reset.
     server_info: ServerInfo,
-    /// Channel used by `run_sender` to request participant resets when a control
-    /// stream write fails. `handle_room_events` receives identities and calls
-    /// `reset_participant`. Using `mpsc` rather than `Notify` because `Notify` is
-    /// not cancel-safe in `select!`.
+    /// Channel used by per-participant flush tasks to request participant resets
+    /// when a control stream write fails. `handle_room_events` receives identities
+    /// and calls `reset_participant`. Using `mpsc` rather than `Notify` because
+    /// `Notify` is not cancel-safe in `select!`.
     participant_reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
     participant_reset_rx:
         tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<ParticipantIdentity>>,
+    /// Size of the per-participant control plane queue.
+    message_backlog_size: usize,
 }
 
 impl Sink for RemoteAccessSession {
@@ -336,7 +298,6 @@ pub(crate) struct SessionParams {
 
 impl RemoteAccessSession {
     pub(crate) fn new(params: SessionParams) -> Self {
-        let (control_plane_tx, control_plane_rx) = flume::bounded(params.message_backlog_size);
         let (video_metadata_tx, video_metadata_rx) = tokio::sync::watch::channel(());
         let (participant_reset_tx, participant_reset_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
@@ -344,15 +305,13 @@ impl RemoteAccessSession {
             room: params.room,
             context: params.context,
             remote_access_session_id: params.remote_access_session_id,
-            state: RwLock::new(SessionState::new()),
+            state: Arc::new(RwLock::new(SessionState::new())),
             channel_filter: params.channel_filter,
             listener: params.listener,
             capabilities: params.capabilities,
             fetch_asset_handler: params.fetch_asset_handler,
             runtime: params.runtime,
             cancellation_token: params.cancellation_token,
-            control_plane_tx,
-            control_plane_rx,
             subscription_lock: parking_lot::Mutex::new(()),
             video_metadata_tx,
             video_metadata_rx,
@@ -364,6 +323,7 @@ impl RemoteAccessSession {
             server_info: params.server_info,
             participant_reset_tx,
             participant_reset_rx: tokio::sync::Mutex::new(participant_reset_rx),
+            message_backlog_size: params.message_backlog_size,
         }
     }
 
@@ -393,66 +353,80 @@ impl RemoteAccessSession {
         }
     }
 
-    /// Enqueue a control plane message for a specific participant.
-    /// Blocks the thread if the queue is full.
-    fn send_control(&self, participant: Arc<Participant>, data: Bytes) {
-        let msg = ControlPlaneMessage { participant, data };
-        if let Err(e) = self.control_plane_tx.send(msg) {
-            warn!("control plane queue disconnected, dropping message: {e}");
+    /// Send a control plane message to a participant. If the queue is full,
+    /// the participant is disconnected (reset requested).
+    fn send_control(&self, participant: &Participant, data: Bytes) {
+        if !participant.try_queue_control(data) {
+            let _ = self
+                .participant_reset_tx
+                .send(participant.participant_id().clone());
         }
     }
 
     /// Send an error status message to a participant.
-    fn send_error(&self, participant: &Arc<Participant>, message: String) {
+    ///
+    /// Best-effort: if the participant's queue is full, the message is dropped
+    /// (the participant may already be disconnecting).
+    fn send_error(&self, participant: &Participant, message: String) {
         debug!("Sending error to {participant}: {message}");
         let status = Status::error(message);
-        self.send_control(participant.clone(), encode_json_message(&status));
+        participant.try_queue_control(encode_json_message(&status));
     }
 
     /// Send a warning status message to a participant.
-    fn send_warning(&self, participant: &Arc<Participant>, message: String) {
+    ///
+    /// Best-effort: if the participant's queue is full, the message is dropped
+    /// (the participant may already be disconnecting).
+    fn send_warning(&self, participant: &Participant, message: String) {
         debug!("Sending warning to {participant}: {message}");
         let status = Status::warning(message);
-        self.send_control(participant.clone(), encode_json_message(&status));
+        participant.try_queue_control(encode_json_message(&status));
     }
 
     /// Enqueue a control plane message for all currently connected participants.
+    /// If a participant's queue is full, a reset is requested for that participant.
     fn broadcast_control(&self, data: Bytes) {
         let participants = self.state.read().collect_participants();
-        send_control_to_all(&self.control_plane_tx, &participants, data);
+        for participant in participants {
+            self.send_control(&participant, data.clone());
+        }
     }
 
-    /// Reads from the control plane queue and sends messages to participants.
+    /// Watches for video metadata changes and re-advertises affected channels.
     ///
-    /// Control plane messages are sent to the targeted participant via its per-participant writer.
-    pub(crate) async fn run_sender(session: Arc<Self>) {
+    /// Runs until the cancellation token fires.
+    pub(crate) async fn run_video_metadata_watcher(session: Arc<Self>) {
         let mut video_metadata: HashMap<ChannelId, VideoMetadata> = HashMap::new();
         let mut video_metadata_rx = session.video_metadata_rx.clone();
-        let mut poisoned_participants: HashSet<ClientId> = HashSet::new();
         loop {
             tokio::select! {
                 biased;
                 () = session.cancellation_token.cancelled() => break,
-                msg = session.control_plane_rx.recv_async() => {
-                    let Ok(msg) = msg else { break };
-                    if poisoned_participants.contains(&msg.participant.client_id()) {
-                        continue;
-                    }
-                    if let Err(e) = msg.participant.send(&msg.data).await {
-                        warn!(
-                            "control write failed for {:?}, requesting reset: {e:?}",
-                            msg.participant,
-                        );
-                        poisoned_participants.insert(msg.participant.client_id());
-                        let _ = session.participant_reset_tx.send(
-                            msg.participant.participant_id().clone(),
-                        );
-                    }
-                }
                 Ok(()) = video_metadata_rx.changed() => {
                     session.republish_video_metadata(&mut video_metadata);
                 }
             }
+        }
+    }
+
+    /// Shut down the session: await all per-participant flush tasks, then close
+    /// the LiveKit room.
+    ///
+    /// The caller must ensure that `handle_room_events` has stopped (so no new
+    /// `remove_participant` / `reset_participant` calls can race with the flush
+    /// handle drain) and that the `CancellationToken` has fired (so flush tasks
+    /// exit promptly).
+    pub(crate) async fn close(&self) {
+        let flush_handles = self.state.write().take_flush_handles();
+        for handle in flush_handles {
+            let _ = handle.await;
+        }
+        if let Err(e) = self.room.close().await {
+            error!(
+                remote_access_session_id = self.remote_access_session_id(),
+                error = %e,
+                "failed to close room: {e}",
+            );
         }
     }
 
@@ -603,7 +577,7 @@ impl RemoteAccessSession {
                 pong_payload.extend_from_slice(&millis_since_epoch().to_le_bytes());
                 let pong = Pong::new(&pong_payload);
                 let framed = encode_binary_message(&pong);
-                self.send_control(participant, framed);
+                self.send_control(&participant, framed);
             }
             ClientMessage::PingAck(ack) => {
                 let now = millis_since_epoch();
@@ -971,18 +945,45 @@ impl RemoteAccessSession {
             }
         };
 
+        // Create a per-participant control plane channel and spawn a flush task
+        // that drains it into the byte stream writer.
+        let (control_tx, control_rx) = flume::bounded::<Bytes>(self.message_backlog_size);
+        let writer = ParticipantWriter::Livekit(stream);
+        let participant_id_for_task = participant_id.clone();
+        let reset_tx = self.participant_reset_tx.clone();
+        let cancel = self.cancellation_token.clone();
+
+        let flush_handle = tokio::spawn(async move {
+            loop {
+                let data = tokio::select! {
+                    () = cancel.cancelled() => break,
+                    msg = control_rx.recv_async() => match msg {
+                        Ok(data) => data,
+                        Err(_) => break,
+                    },
+                };
+                if let Err(e) = writer.write(&data).await {
+                    warn!(
+                        "control write failed for {:?}, requesting reset: {e:?}",
+                        participant_id_for_task,
+                    );
+                    let _ = reset_tx.send(participant_id_for_task.clone());
+                    break;
+                }
+            }
+        });
+
         let participant = Arc::new(Participant::new(
             participant_id.clone(),
             protocol_version,
-            ParticipantWriter::Livekit(stream),
-            self.control_plane_tx.clone(),
+            control_tx,
         ));
 
         // Send initial messages prior to adding the participant to the state map, to ensure that
         // these are the first messages delivered to the participant. This is safe to do without
-        // holding the write lock, because this is a new participant - see below.
+        // holding the write lock, because this is a new participant — see below.
         info!("sending server info and advertisements to participant {participant:?}");
-        self.send_control(participant.clone(), encode_json_message(&self.server_info));
+        participant.try_queue_control(encode_json_message(&self.server_info));
         self.send_channel_advertisements(participant.clone());
         self.send_service_advertisements(participant.clone());
 
@@ -990,11 +991,10 @@ impl RemoteAccessSession {
         // we validated that it did not exist in the map at the top of this function, and the
         // caller is responsible for ensuring this function is not called concurrently for the same
         // participant identity.
-        let did_insert = self
-            .state
-            .write()
-            .insert_participant(participant_id, participant);
+        let mut state = self.state.write();
+        let did_insert = state.insert_participant(participant_id.clone(), participant);
         assert!(did_insert);
+        state.insert_flush_handle(participant_id, flush_handle);
         Ok(())
     }
 
@@ -1426,14 +1426,14 @@ impl RemoteAccessSession {
             return;
         };
 
-        self.send_control(participant, encode_json_message(&advertise_msg));
+        participant.try_queue_control(encode_json_message(&advertise_msg));
     }
 
     /// Enqueue service advertisements for delivery to a single participant.
     fn send_service_advertisements(&self, participant: Arc<Participant>) {
         let services: Vec<_> = self.services.read().values().cloned().collect();
         if let Some(msg) = build_advertise_services_msg(&services) {
-            self.send_control(participant, encode_json_message(&msg));
+            participant.try_queue_control(encode_json_message(&msg));
         }
     }
 
@@ -1505,14 +1505,8 @@ impl RemoteAccessSession {
             .unwrap_or(req.encoding.as_ref())
             .to_string();
 
-        let responder = super::service::new_responder(
-            participant.clone(),
-            service_id,
-            call_id,
-            encoding,
-            participant.control_plane_tx().clone(),
-            guard,
-        );
+        let responder =
+            super::service::new_responder(participant, service_id, call_id, encoding, guard);
         let request = crate::remote_common::service::Request::new(
             service.clone(),
             participant.client_id(),
@@ -1537,7 +1531,7 @@ impl RemoteAccessSession {
             call_id: call_id.into(),
             message: message.to_string(),
         };
-        self.send_control(participant.clone(), encode_json_message(&failure));
+        self.send_control(participant, encode_json_message(&failure));
     }
 
     /// Handle a fetch asset request from a client.
@@ -1688,7 +1682,7 @@ impl RemoteAccessSession {
         if let Some(id) = request_id {
             msg = msg.with_id(id);
         }
-        self.send_control(participant.clone(), encode_json_message(&msg));
+        self.send_control(participant, encode_json_message(&msg));
     }
 
     /// Publish parameter values to all participants subscribed to those parameters.
@@ -1698,24 +1692,38 @@ impl RemoteAccessSession {
             return;
         }
 
-        let state = self.state.read();
-        let participants = state.collect_participants();
-        for participant in &participants {
-            // Filter parameters by this participant's subscriptions.
-            let filtered: Vec<_> = parameters
-                .iter()
-                .filter(|p| {
-                    state
-                        .parameter_subscribers(&p.name)
-                        .is_some_and(|ids| ids.contains(participant.participant_id()))
-                })
-                .cloned()
-                .collect();
+        // Collect the per-participant messages while holding the read lock, then
+        // send them after the lock is released to avoid holding a parking_lot guard
+        // across a potentially-blocking `queue_control` call.
+        let to_send: Vec<(Arc<Participant>, Bytes)> = {
+            let state = self.state.read();
+            let participants = state.collect_participants();
+            participants
+                .into_iter()
+                .filter_map(|participant| {
+                    let filtered: Vec<_> = parameters
+                        .iter()
+                        .filter(|p| {
+                            state
+                                .parameter_subscribers(&p.name)
+                                .is_some_and(|ids| ids.contains(participant.participant_id()))
+                        })
+                        .cloned()
+                        .collect();
 
-            if !filtered.is_empty() {
-                let no_request_id = None;
-                self.send_parameter_values(participant, filtered, no_request_id);
-            }
+                    if filtered.is_empty() {
+                        return None;
+                    }
+
+                    let msg =
+                        ParameterValues::new(filtered.into_iter().filter(|p| p.value.is_some()));
+                    Some((participant, encode_json_message(&msg)))
+                })
+                .collect()
+        };
+
+        for (participant, data) in to_send {
+            self.send_control(&participant, data);
         }
     }
 
@@ -1740,24 +1748,27 @@ impl RemoteAccessSession {
             return;
         }
 
-        let mut graph = self.connection_graph.lock();
-        let first = !graph.has_subscribers();
-        if !graph.add_subscriber(participant.client_id()) {
-            debug!(
-                "Participant {} is already subscribed to connection graph updates",
-                participant,
-            );
-            return;
-        }
-
-        if first {
-            if let Some(listener) = &self.listener {
-                listener.on_connection_graph_subscribe();
+        let encoded = {
+            let mut graph = self.connection_graph.lock();
+            let first = !graph.has_subscribers();
+            if !graph.add_subscriber(participant.client_id()) {
+                debug!(
+                    "Participant {} is already subscribed to connection graph updates",
+                    participant,
+                );
+                return;
             }
-        }
 
-        let initial_update = graph.as_initial_update();
-        self.send_control(participant.clone(), encode_json_message(&initial_update));
+            if first {
+                if let Some(listener) = &self.listener {
+                    listener.on_connection_graph_subscribe();
+                }
+            }
+
+            encode_json_message(&graph.as_initial_update())
+        };
+
+        self.send_control(participant, encoded);
     }
 
     /// Handle an `UnsubscribeConnectionGraph` message from a client.
@@ -1794,14 +1805,14 @@ impl RemoteAccessSession {
         let participants = self.state.read().collect_participants();
         for participant in participants {
             if graph.is_subscriber(participant.client_id()) {
-                self.send_control(participant, encoded.clone());
+                self.send_control(&participant, encoded.clone());
             }
         }
     }
 
     /// Check video publishers for metadata changes and re-advertise affected channels.
     ///
-    /// Called from `run_sender` when `video_metadata_rx` signals a change. Compares each
+    /// Called from `run_video_metadata_watcher` when `video_metadata_rx` signals a change. Compares each
     /// publisher's current metadata against what was last advertised, updates session state for
     /// any changes, and broadcasts re-advertise messages to participants.
     fn republish_video_metadata(&self, advertised: &mut HashMap<ChannelId, VideoMetadata>) {
@@ -1997,24 +2008,15 @@ impl RemoteAccessSession {
 mod tests {
     use super::*;
     use crate::protocol::v2::server::FetchAssetResponse;
-    use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter};
     use crate::remote_common::fetch_asset::{
         AssetHandler, AsyncAssetHandlerFn, BlockingAssetHandlerFn,
     };
 
-    fn make_participant_with_rx(
-        name: &str,
-    ) -> (Arc<Participant>, flume::Receiver<ControlPlaneMessage>) {
+    fn make_participant_with_rx(name: &str) -> (Arc<Participant>, flume::Receiver<Bytes>) {
         let identity = ParticipantIdentity(name.to_string());
-        let writer = Arc::new(TestByteStreamWriter::default());
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
-        let participant = Arc::new(Participant::new(
-            identity,
-            version,
-            ParticipantWriter::Test(writer),
-            tx,
-        ));
+        let participant = Arc::new(Participant::new(identity, version, tx));
         (participant, rx)
     }
 
@@ -2037,7 +2039,7 @@ mod tests {
 
         let msg = rx.try_recv().unwrap();
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::asset_data(42, &b"hello world"[..]))
         );
     }
@@ -2051,7 +2053,7 @@ mod tests {
 
         let msg = rx.try_recv().unwrap();
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::error_message(
                 42,
                 "something went wrong"
@@ -2068,7 +2070,7 @@ mod tests {
 
         let msg = rx.try_recv().unwrap();
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::error_message(
                 42,
                 "Internal server error: asset handler failed to send a response"
@@ -2089,7 +2091,7 @@ mod tests {
 
         let msg = rx.try_recv().unwrap();
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::error_message(
                 99,
                 "Too many concurrent fetch asset requests"
@@ -2137,7 +2139,7 @@ mod tests {
 
         let msg = rx.try_recv().unwrap();
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::error_message(
                 42,
                 "Server does not have a fetch asset handler"
@@ -2161,7 +2163,7 @@ mod tests {
             .expect("timed out waiting for asset response")
             .expect("channel closed");
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::asset_data(7, &b"<robot/>"[..]))
         );
     }
@@ -2182,7 +2184,7 @@ mod tests {
             .expect("timed out waiting for asset response")
             .expect("channel closed");
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::error_message(9, "not found"))
         );
     }
@@ -2203,8 +2205,140 @@ mod tests {
             .expect("timed out waiting for asset response")
             .expect("channel closed");
         assert_eq!(
-            msg.data,
+            msg,
             encode_binary_message(&FetchAssetResponse::asset_data(8, &b"PNG data"[..]))
         );
+    }
+
+    // ---- flush task tests ----
+
+    /// Spawns a flush task identical to the one in `add_participant`, using a test writer.
+    /// Returns the control channel sender, the test writer (for inspecting writes), and
+    /// the task's `JoinHandle`.
+    fn spawn_test_flush_task(
+        cancel: CancellationToken,
+    ) -> (
+        flume::Sender<Bytes>,
+        Arc<crate::remote_access::participant::TestByteStreamWriter>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter};
+
+        let (control_tx, control_rx) = flume::bounded::<Bytes>(DEFAULT_CONTROL_QUEUE_SIZE);
+        let writer = Arc::new(TestByteStreamWriter::default());
+        let writer_for_task = writer.clone();
+        let handle = tokio::spawn(async move {
+            let writer = ParticipantWriter::Test(writer_for_task);
+            loop {
+                let data = tokio::select! {
+                    () = cancel.cancelled() => break,
+                    msg = control_rx.recv_async() => match msg {
+                        Ok(data) => data,
+                        Err(_) => break,
+                    },
+                };
+                if let Err(e) = writer.write(&data).await {
+                    warn!("test flush task write failed: {e:?}");
+                    break;
+                }
+            }
+        });
+        (control_tx, writer, handle)
+    }
+
+    #[tokio::test]
+    async fn flush_task_delivers_messages() {
+        let cancel = CancellationToken::new();
+        let (tx, writer, handle) = spawn_test_flush_task(cancel.clone());
+
+        tx.send(Bytes::from_static(b"hello")).unwrap();
+        tx.send(Bytes::from_static(b"world")).unwrap();
+
+        // Drop the sender to signal the flush task to exit.
+        drop(tx);
+        handle.await.unwrap();
+
+        let writes = writer.writes();
+        assert_eq!(writes.len(), 2);
+        assert_eq!(writes[0], Bytes::from_static(b"hello"));
+        assert_eq!(writes[1], Bytes::from_static(b"world"));
+    }
+
+    #[tokio::test]
+    async fn flush_task_stops_on_sender_drop() {
+        let cancel = CancellationToken::new();
+        let (tx, _writer, handle) = spawn_test_flush_task(cancel.clone());
+
+        // Drop the sender without cancelling — task should exit because recv returns Err.
+        drop(tx);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
+        assert!(result.is_ok(), "flush task did not exit after sender drop");
+    }
+
+    #[tokio::test]
+    async fn flush_task_stops_on_cancellation() {
+        let cancel = CancellationToken::new();
+        let (_tx, _writer, handle) = spawn_test_flush_task(cancel.clone());
+
+        // Cancel without dropping the sender — task should exit via the select! arm.
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
+        assert!(result.is_ok(), "flush task did not exit after cancellation");
+    }
+
+    #[tokio::test]
+    async fn flush_tasks_are_independent() {
+        // Two flush tasks: task A is blocked by a Notify, task B should still make progress.
+        let cancel = CancellationToken::new();
+        let gate = Arc::new(tokio::sync::Notify::new());
+
+        // Task A: uses a custom writer that blocks on the gate before completing.
+        let (tx_a, control_rx_a) = flume::bounded::<Bytes>(DEFAULT_CONTROL_QUEUE_SIZE);
+        let gate_for_a = gate.clone();
+        let cancel_a = cancel.clone();
+        let writer_a = Arc::new(crate::remote_access::participant::TestByteStreamWriter::default());
+        let writer_a_for_task = writer_a.clone();
+        let handle_a = tokio::spawn(async move {
+            loop {
+                let data = tokio::select! {
+                    () = cancel_a.cancelled() => break,
+                    msg = control_rx_a.recv_async() => match msg {
+                        Ok(data) => data,
+                        Err(_) => break,
+                    },
+                };
+                // Wait for the gate before "writing".
+                gate_for_a.notified().await;
+                writer_a_for_task.record(&data);
+            }
+        });
+
+        // Task B: normal flush task, no blocking.
+        let (tx_b, writer_b, handle_b) = spawn_test_flush_task(cancel.clone());
+
+        // Send a message to both.
+        tx_a.send(Bytes::from_static(b"msg_a")).unwrap();
+        tx_b.send(Bytes::from_static(b"msg_b")).unwrap();
+
+        // Drop B's sender so it flushes and exits.
+        drop(tx_b);
+        let result = tokio::time::timeout(Duration::from_secs(1), handle_b).await;
+        assert!(
+            result.is_ok(),
+            "task B should complete even though task A is blocked"
+        );
+        assert_eq!(writer_b.writes(), vec![Bytes::from_static(b"msg_b")]);
+
+        // Task A hasn't written yet — still blocked on the gate.
+        assert!(writer_a.writes().is_empty());
+
+        // Release A.
+        gate.notify_one();
+        drop(tx_a);
+        let result = tokio::time::timeout(Duration::from_secs(1), handle_a).await;
+        assert!(result.is_ok(), "task A should complete after gate release");
+        assert_eq!(writer_a.writes(), vec![Bytes::from_static(b"msg_a")]);
     }
 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1700,8 +1700,7 @@ impl RemoteAccessSession {
         }
 
         // Collect the per-participant messages while holding the read lock, then
-        // send them after the lock is released to avoid holding a parking_lot guard
-        // across a potentially-blocking `queue_control` call.
+        // send them after the lock is released to minimize lock scope.
         let to_send: Vec<(Arc<Participant>, Bytes)> = {
             let state = self.state.read();
             let participants = state.collect_participants();

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -155,13 +155,13 @@ pub(crate) struct RemoteAccessSession {
     connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
     /// Immutable `ServerInfo` message sent to each participant on connect and reset.
     server_info: ServerInfo,
-    /// Channel used by per-participant flush tasks to request participant resets
-    /// when a control stream write fails. `handle_room_events` receives identities
-    /// and calls `reset_participant`. Using `mpsc` rather than `Notify` because
-    /// `Notify` is not cancel-safe in `select!`.
-    participant_reset_tx: tokio::sync::mpsc::UnboundedSender<ParticipantIdentity>,
-    participant_reset_rx:
-        tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<ParticipantIdentity>>,
+    /// Set of participant identities pending a reset (disconnect + reconnect).
+    /// Populated by `Participant::send_control` on queue overflow and by flush
+    /// tasks on write failure. Drained by `handle_room_events`.
+    /// Using a set deduplicates multiple reset requests for the same participant.
+    pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+    /// Wakes `handle_room_events` when a new reset is added to `pending_resets`.
+    reset_notify: Arc<tokio::sync::Notify>,
     /// Size of the per-participant control plane queue.
     message_backlog_size: usize,
 }
@@ -296,7 +296,8 @@ pub(crate) struct SessionParams {
 impl RemoteAccessSession {
     pub(crate) fn new(params: SessionParams) -> Self {
         let (video_metadata_tx, video_metadata_rx) = tokio::sync::watch::channel(());
-        let (participant_reset_tx, participant_reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
         Self {
             sink_id: SinkId::next(),
             room: params.room,
@@ -318,8 +319,8 @@ impl RemoteAccessSession {
             ice_rtt_tracker: parking_lot::Mutex::new(RttTracker::new("ICE")),
             connection_graph: params.connection_graph,
             server_info: params.server_info,
-            participant_reset_tx,
-            participant_reset_rx: tokio::sync::Mutex::new(participant_reset_rx),
+            pending_resets,
+            reset_notify,
             message_backlog_size: params.message_backlog_size,
         }
     }
@@ -938,7 +939,8 @@ impl RemoteAccessSession {
             protocol_version,
             ParticipantWriter::Livekit(stream),
             self.message_backlog_size,
-            self.participant_reset_tx.clone(),
+            self.pending_resets.clone(),
+            self.reset_notify.clone(),
             &self.cancellation_token,
         );
 
@@ -1021,7 +1023,6 @@ impl RemoteAccessSession {
         mut room_events: tokio::sync::mpsc::UnboundedReceiver<RoomEvent>,
     ) {
         let remote_access_session_id = self.remote_access_session_id();
-        let mut participant_reset_rx = self.participant_reset_rx.lock().await;
         loop {
             tokio::select! {
                 event = room_events.recv() => {
@@ -1030,11 +1031,17 @@ impl RemoteAccessSession {
                         return;
                     }
                 }
-                // Reset participants whose control streams have broken. This is
-                // the same flow as disconnect + reconnect: remove the old state,
-                // then re-add with a fresh stream and fresh advertisements.
-                Some(participant_id) = participant_reset_rx.recv() => {
-                    self.reset_participant(participant_id).await;
+                // Reset participants whose control queues overflowed or whose
+                // flush tasks encountered a write error. Drain the entire set
+                // atomically to deduplicate multiple reset requests.
+                () = self.reset_notify.notified() => {
+                    let identities: Vec<_> = {
+                        let mut set = self.pending_resets.lock();
+                        set.drain().collect()
+                    };
+                    for participant_id in identities {
+                        self.reset_participant(participant_id).await;
+                    }
                 }
             }
         }
@@ -1984,9 +1991,17 @@ mod tests {
         let identity = ParticipantIdentity(name.to_string());
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
-        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
         let cancel = CancellationToken::new();
-        let participant = Arc::new(Participant::new(identity, version, tx, reset_tx, cancel));
+        let participant = Arc::new(Participant::new(
+            identity,
+            version,
+            tx,
+            pending_resets,
+            reset_notify,
+            cancel,
+        ));
         (participant, rx)
     }
 
@@ -2312,19 +2327,26 @@ mod tests {
         assert_eq!(writer_a.writes(), vec![Bytes::from_static(b"msg_a")]);
     }
 
-    #[test]
-    fn try_queue_control_returns_false_when_full() {
+    fn make_test_participant(queue_size: usize) -> (Participant, flume::Receiver<Bytes>) {
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
-        let (tx, _rx) = flume::bounded::<Bytes>(1);
-        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = flume::bounded::<Bytes>(queue_size);
+        let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
         let cancel = CancellationToken::new();
         let participant = Participant::new(
             ParticipantIdentity("alice".to_string()),
             version,
             tx,
-            reset_tx,
+            pending_resets,
+            reset_notify,
             cancel,
         );
+        (participant, rx)
+    }
+
+    #[test]
+    fn try_queue_control_returns_false_when_full() {
+        let (participant, _rx) = make_test_participant(1);
 
         // First message fits.
         assert!(participant.try_queue_control(Bytes::from_static(b"first")));
@@ -2334,17 +2356,7 @@ mod tests {
 
     #[test]
     fn try_queue_control_returns_true_when_disconnected() {
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
-        let (tx, rx) = flume::bounded::<Bytes>(1);
-        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
-        let cancel = CancellationToken::new();
-        let participant = Participant::new(
-            ParticipantIdentity("alice".to_string()),
-            version,
-            tx,
-            reset_tx,
-            cancel,
-        );
+        let (participant, rx) = make_test_participant(1);
 
         // Drop the receiver — channel disconnected.
         drop(rx);

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2272,13 +2272,9 @@ mod tests {
 
     #[tokio::test]
     async fn flush_tasks_are_independent() {
-        // Two flush tasks spawned via Participant::spawn. Task A gets a slow
-        // writer (delayed by a Notify gate), task B gets a normal writer.
-        // B should complete even while A is blocked.
+        // Two participants spawned independently. Dropping one and awaiting its
+        // flush task should not affect the other.
         let cancel = CancellationToken::new();
-
-        // Task A: normal Participant::spawn, but we'll send and then verify
-        // it completes independently of B's timing.
         let (participant_a, writer_a, handle_a) = spawn_test_participant(&cancel);
         let (participant_b, writer_b, handle_b) = spawn_test_participant(&cancel);
 

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -121,6 +121,10 @@ impl SessionState {
     /// Removes all participants, dropping their `Arc<Participant>` references.
     /// This causes per-participant `control_tx` senders to drop, which signals
     /// flush tasks to exit.
+    ///
+    /// For use during session teardown only — does not clean up subscriptions,
+    /// video subscribers, client channels, or parameter subscriptions (the room
+    /// is closing immediately after).
     pub fn clear_participants(&mut self) {
         self.participants.clear();
     }

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -679,7 +679,14 @@ mod tests {
             crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
         let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
-        let participant = Arc::new(Participant::new(identity.clone(), version, tx, reset_tx));
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let participant = Arc::new(Participant::new(
+            identity.clone(),
+            version,
+            tx,
+            reset_tx,
+            cancel,
+        ));
         (identity, participant)
     }
 

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -678,7 +678,8 @@ mod tests {
         let version =
             crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
-        let participant = Arc::new(Participant::new(identity.clone(), version, tx));
+        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let participant = Arc::new(Participant::new(identity.clone(), version, tx, reset_tx));
         (identity, participant)
     }
 

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -107,11 +107,6 @@ impl SessionState {
         self.flush_handles.insert(identity, handle);
     }
 
-    /// Drains all flush task handles, returning them for awaiting during teardown.
-    pub fn take_flush_handles(&mut self) -> Vec<JoinHandle<()>> {
-        self.flush_handles.drain().map(|(_, h)| h).collect()
-    }
-
     /// Removes and returns the flush handle for a participant, if one was registered.
     pub fn remove_flush_handle(
         &mut self,
@@ -120,15 +115,16 @@ impl SessionState {
         self.flush_handles.remove(identity)
     }
 
-    /// Removes all participants, dropping their `Arc<Participant>` references.
-    /// This causes per-participant `control_tx` senders to drop, which signals
-    /// flush tasks to exit.
+    /// Removes all participants and their flush handles atomically, returning both.
     ///
     /// For use during session teardown only — does not clean up subscriptions,
     /// video subscribers, client channels, or parameter subscriptions (the room
-    /// is closing immediately after).
-    pub fn clear_participants(&mut self) {
-        self.participants.clear();
+    /// is closing immediately after). Does not fire listener callbacks
+    /// (`on_unsubscribe`, `on_client_unadvertise`, etc.).
+    pub fn take_participants(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
+        let participants: Vec<_> = self.participants.drain().map(|(_, p)| p).collect();
+        let handles: Vec<_> = self.flush_handles.drain().map(|(_, h)| h).collect();
+        (participants, handles)
     }
 
     /// Inserts a participant if not already present.

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -118,6 +118,13 @@ impl SessionState {
         self.flush_handles.drain().map(|(_, h)| h).collect()
     }
 
+    /// Removes all participants, dropping their `Arc<Participant>` references.
+    /// This causes per-participant `control_tx` senders to drop, which signals
+    /// flush tasks to exit.
+    pub fn clear_participants(&mut self) {
+        self.participants.clear();
+    }
+
     /// Inserts a participant if not already present.
     ///
     /// Returns true if this is a new participant, or false if there was already a participant

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -28,12 +28,6 @@ pub(crate) struct RemovedSubscriptions {
     pub client_channels: Vec<ChannelDescriptor>,
     /// Parameter names that lost their last subscriber.
     pub last_param_unsubscribed: Vec<String>,
-    /// The flush task handle for the removed participant, if one was registered.
-    /// Intentionally dropped (detached) by callers. The flush task drains naturally
-    /// once all `Arc<Participant>` refs are dropped (which drops `control_tx`). The
-    /// session-level `CancellationToken` is the backstop for prompt shutdown.
-    #[allow(dead_code)]
-    pub flush_handle: Option<JoinHandle<()>>,
 }
 
 /// Result of subscribing a participant to channels.
@@ -118,6 +112,14 @@ impl SessionState {
         self.flush_handles.drain().map(|(_, h)| h).collect()
     }
 
+    /// Removes and returns the flush handle for a participant, if one was registered.
+    pub fn remove_flush_handle(
+        &mut self,
+        identity: &ParticipantIdentity,
+    ) -> Option<JoinHandle<()>> {
+        self.flush_handles.remove(identity)
+    }
+
     /// Removes all participants, dropping their `Arc<Participant>` references.
     /// This causes per-participant `control_tx` senders to drop, which signals
     /// flush tasks to exit.
@@ -161,7 +163,6 @@ impl SessionState {
                 subscribed_descriptors: SmallVec::new(),
                 client_channels: Vec::new(),
                 last_param_unsubscribed: Vec::new(),
-                flush_handle: None,
             };
         };
         let client_id = participant.client_id();
@@ -213,8 +214,6 @@ impl SessionState {
             }
         });
 
-        let flush_handle = self.flush_handles.remove(identity);
-
         RemovedSubscriptions {
             client_id: Some(client_id),
             last_unsubscribed,
@@ -222,7 +221,6 @@ impl SessionState {
             subscribed_descriptors,
             client_channels,
             last_param_unsubscribed,
-            flush_handle,
         }
     }
 

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use livekit::id::{ParticipantIdentity, TrackSid};
 use smallvec::SmallVec;
+use tokio::task::JoinHandle;
 use tracing::{debug, info};
 
 use crate::protocol::v2::server::advertise;
@@ -27,6 +28,12 @@ pub(crate) struct RemovedSubscriptions {
     pub client_channels: Vec<ChannelDescriptor>,
     /// Parameter names that lost their last subscriber.
     pub last_param_unsubscribed: Vec<String>,
+    /// The flush task handle for the removed participant, if one was registered.
+    /// Intentionally dropped (detached) by callers. The flush task drains naturally
+    /// once all `Arc<Participant>` refs are dropped (which drops `control_tx`). The
+    /// session-level `CancellationToken` is the backstop for prompt shutdown.
+    #[allow(dead_code)]
+    pub flush_handle: Option<JoinHandle<()>>,
 }
 
 /// Result of subscribing a participant to channels.
@@ -79,6 +86,8 @@ pub(crate) struct SessionState {
     client_channels: HashMap<ParticipantIdentity, HashMap<ChannelId, ChannelDescriptor>>,
     /// Parameters subscribed to by participants, keyed by parameter name.
     subscribed_parameters: HashMap<String, HashSet<ParticipantIdentity>>,
+    /// Per-participant flush task handles, for teardown awaiting.
+    flush_handles: HashMap<ParticipantIdentity, JoinHandle<()>>,
 }
 
 impl SessionState {
@@ -95,7 +104,18 @@ impl SessionState {
             video_metadata: HashMap::new(),
             client_channels: HashMap::new(),
             subscribed_parameters: HashMap::new(),
+            flush_handles: HashMap::new(),
         }
+    }
+
+    /// Stores the flush task handle for a participant.
+    pub fn insert_flush_handle(&mut self, identity: ParticipantIdentity, handle: JoinHandle<()>) {
+        self.flush_handles.insert(identity, handle);
+    }
+
+    /// Drains all flush task handles, returning them for awaiting during teardown.
+    pub fn take_flush_handles(&mut self) -> Vec<JoinHandle<()>> {
+        self.flush_handles.drain().map(|(_, h)| h).collect()
     }
 
     /// Inserts a participant if not already present.
@@ -130,6 +150,7 @@ impl SessionState {
                 subscribed_descriptors: SmallVec::new(),
                 client_channels: Vec::new(),
                 last_param_unsubscribed: Vec::new(),
+                flush_handle: None,
             };
         };
         let client_id = participant.client_id();
@@ -181,6 +202,8 @@ impl SessionState {
             }
         });
 
+        let flush_handle = self.flush_handles.remove(identity);
+
         RemovedSubscriptions {
             client_id: Some(client_id),
             last_unsubscribed,
@@ -188,6 +211,7 @@ impl SessionState {
             subscribed_descriptors,
             client_channels,
             last_param_unsubscribed,
+            flush_handle,
         }
     }
 
@@ -639,20 +663,13 @@ impl SessionState {
 mod tests {
     use super::*;
     use crate::img2yuv::{ImageEncoding, RawImageEncoding};
-    use crate::remote_access::participant::ParticipantWriter;
 
     fn make_participant(name: &str) -> (ParticipantIdentity, Arc<Participant>) {
         let identity = ParticipantIdentity(name.to_string());
-        let writer = Arc::new(crate::remote_access::participant::TestByteStreamWriter::default());
         let version =
             crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
-        let participant = Arc::new(Participant::new(
-            identity.clone(),
-            version,
-            ParticipantWriter::Test(writer),
-            tx,
-        ));
+        let participant = Arc::new(Participant::new(identity.clone(), version, tx));
         (identity, participant)
     }
 

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -678,13 +678,15 @@ mod tests {
         let version =
             crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
-        let (reset_tx, _reset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let pending_resets = Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
         let cancel = tokio_util::sync::CancellationToken::new();
         let participant = Arc::new(Participant::new(
             identity.clone(),
             version,
             tx,
-            reset_tx,
+            pending_resets,
+            reset_notify,
             cancel,
         ));
         (identity, participant)


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

**Problem:** The control plane in `run_sender` processed messages serially — each
`participant.send().await` blocked until the receiver acked. This created
head-of-line blocking where a slow participant stalled control messages for all
other participants.

**Approach:** Replace the shared control plane queue (`control_plane_tx/rx`) with
a per-participant `flume::bounded` channel (sized by `message_backlog_size`,
default 1024), each drained by a dedicated tokio flush task. Each participant now
has its own mailbox and worker. When a participant's queue is full, it is
disconnected (reset requested) rather than exerting backpressure — the entire
send path is non-blocking and sync.

Key changes:
- `Participant::spawn()` encapsulates channel creation, cancellation token,
  writer ownership, and flush task spawning. The flush task uses biased select
  and cancel-aware write (writer.write wrapped in a cancel select).
- `try_queue_control()` (#[must_use], non-blocking try_send) and
  `send_control()` (try_send + cancel token + reset on full).
- Per-participant `CancellationToken` (child of session token) — cancelled on
  queue overflow so the flush task stops immediately.
- Participant reset requests use a shared `HashSet` + `Notify` instead of an
  unbounded mpsc channel, deduplicating multiple resets for the same participant.
- `run_sender` renamed to `run_video_metadata_watcher` — control plane arm
  removed entirely.
- `ResponseSender` (service.rs) changed to `Weak<Participant>` so in-flight
  service calls don't extend participant lifetime past removal.
- `RemoteAccessSession::close()` encapsulates teardown: cancels all participants
  via `take_participants()`, awaits flush handles, closes room.
- `remove_participant` cancels the participant's token and detaches the flush
  handle.

Fixes: [FLE-427](https://linear.app/foxglove/issue/FLE-427)