### PR TITLE
Fix documentation nits

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2246,7 +2246,7 @@ typedef union foxglove_parameter_value_data {
 
 #if !defined(__wasm__)
 /**
- * A websocket parameter value.
+ * A WebSocket parameter value.
  *
  * Constructed with `foxglove_parameter_value_create_*`.
  */
@@ -2264,7 +2264,7 @@ typedef struct foxglove_parameter_value {
 
 #if !defined(__wasm__)
 /**
- * A websocket parameter.
+ * A WebSocket parameter.
  *
  * Constructed with `foxglove_parameter_create`.
  */
@@ -2286,7 +2286,7 @@ typedef struct foxglove_parameter {
 
 #if !defined(__wasm__)
 /**
- * An array of websocket parameters.
+ * An array of WebSocket parameters.
  *
  * Constructed with `foxglove_parameter_array_create`.
  */
@@ -2800,7 +2800,7 @@ typedef struct foxglove_server_options {
 
 #if !defined(__wasm__)
 /**
- * A schema describing either a websocket service request or response.
+ * A schema describing either a WebSocket service request or response.
  */
 typedef struct foxglove_service_message_schema {
   /**
@@ -2816,7 +2816,7 @@ typedef struct foxglove_service_message_schema {
 
 #if !defined(__wasm__)
 /**
- * A websocket service schema.
+ * A WebSocket service schema.
  */
 typedef struct foxglove_service_schema {
   /**
@@ -2836,7 +2836,7 @@ typedef struct foxglove_service_schema {
 
 #if !defined(__wasm__)
 /**
- * A websocket service request message.
+ * A WebSocket service request message.
  */
 typedef struct foxglove_service_request {
   /**
@@ -5136,7 +5136,7 @@ void foxglove_channel_free(const struct foxglove_channel *channel);
  * # Safety
  * `channel` must be a valid pointer to a `foxglove_channel` created via `foxglove_channel_create`.
  *
- * If the passed channel is null, an invalid id of 0 is returned.
+ * If the passed channel is null, an invalid ID of 0 is returned.
  */
 uint64_t foxglove_channel_get_id(const struct foxglove_channel *channel);
 #endif
@@ -5276,7 +5276,7 @@ void foxglove_context_free(const struct foxglove_context *context);
 
 #if !defined(__wasm__)
 /**
- * Get the id of a channel descriptor.
+ * Get the ID of a channel descriptor.
  *
  * # Safety
  * `channel` must be a valid pointer to a `foxglove_channel_descriptor`.
@@ -6203,9 +6203,9 @@ foxglove_error foxglove_server_remove_status(struct foxglove_websocket_server *s
 
 #if !defined(__wasm__)
 /**
- * Creates a new websocket service.
+ * Creates a new WebSocket service.
  *
- * The service must be registered with a websocket server using `foxglove_server_add_service`, or
+ * The service must be registered with a WebSocket server using `foxglove_server_add_service`, or
  * freed with `foxglove_service_free`.
  *
  * The callback is invoked from the client's main poll loop and must not block. If blocking or
@@ -6239,11 +6239,11 @@ foxglove_error foxglove_service_create(struct foxglove_service **service,
 
 #if !defined(__wasm__)
 /**
- * Frees a service that was never registered to a websocket server.
+ * Frees a service that was never registered to a WebSocket server.
  *
  * # Safety
  * - `service` must be a valid pointer to a service allocated by `foxglove_service_create`. The
- *   service MUST NOT have been previously registered with a websocket server.
+ *   service MUST NOT have been previously registered with a WebSocket server.
  */
 void foxglove_service_free(struct foxglove_service *service);
 #endif

--- a/c/src/channel.rs
+++ b/c/src/channel.rs
@@ -704,7 +704,7 @@ pub extern "C" fn foxglove_channel_free(channel: Option<&FoxgloveChannel>) {
 /// # Safety
 /// `channel` must be a valid pointer to a `foxglove_channel` created via `foxglove_channel_create`.
 ///
-/// If the passed channel is null, an invalid id of 0 is returned.
+/// If the passed channel is null, an invalid ID of 0 is returned.
 #[unsafe(no_mangle)]
 pub extern "C" fn foxglove_channel_get_id(channel: Option<&FoxgloveChannel>) -> u64 {
     let Some(channel) = channel else {

--- a/c/src/channel_descriptor.rs
+++ b/c/src/channel_descriptor.rs
@@ -2,7 +2,7 @@ use crate::{FoxgloveError, FoxgloveKeyValue, FoxgloveSchema, FoxgloveString};
 
 pub struct FoxgloveChannelDescriptor(pub(crate) foxglove::ChannelDescriptor);
 
-/// Get the id of a channel descriptor.
+/// Get the ID of a channel descriptor.
 ///
 /// # Safety
 /// `channel` must be a valid pointer to a `foxglove_channel_descriptor`.

--- a/c/src/fetch_asset.rs
+++ b/c/src/fetch_asset.rs
@@ -80,7 +80,7 @@ impl websocket::AssetHandler<websocket::Client> for FetchAssetHandler {
         let c_responder =
             FoxgloveFetchAssetResponder(AssetResponderVariant::WebSocket(responder)).into_raw();
         // SAFETY: It's the callback implementation's responsibility to ensure that this callback
-        // function pointer remains valid for the lifetime of the websocket server, as described in
+        // function pointer remains valid for the lifetime of the WebSocket server, as described in
         // the safety requirements of `foxglove_server_options.fetch_asset`.
         unsafe { (self.callback)(self.callback_context, &raw const c_uri, c_responder) };
     }

--- a/c/src/parameter.rs
+++ b/c/src/parameter.rs
@@ -32,7 +32,7 @@ unsafe fn raw_vec_clone<T: Clone>(ptr: *const T, len: usize, cap: usize) -> Vec<
         .collect()
 }
 
-/// An array of websocket parameters.
+/// An array of WebSocket parameters.
 ///
 /// Constructed with `foxglove_parameter_array_create`.
 //
@@ -165,7 +165,7 @@ pub unsafe extern "C" fn foxglove_parameter_array_free(array: *mut FoxgloveParam
     }
 }
 
-/// A websocket parameter.
+/// A WebSocket parameter.
 ///
 /// Constructed with `foxglove_parameter_create`.
 #[repr(C)]
@@ -676,7 +676,7 @@ impl FoxgloveParameterType {
     }
 }
 
-/// A websocket parameter value.
+/// A WebSocket parameter value.
 ///
 /// Constructed with `foxglove_parameter_value_create_*`.
 #[repr(C)]

--- a/c/src/service.rs
+++ b/c/src/service.rs
@@ -24,7 +24,7 @@ impl FoxgloveServiceResponder {
     }
 }
 
-/// A websocket service request message.
+/// A WebSocket service request message.
 #[repr(C)]
 pub struct FoxgloveServiceRequest {
     /// The service name.
@@ -74,7 +74,7 @@ impl FoxgloveService {
     }
 }
 
-/// A schema describing either a websocket service request or response.
+/// A schema describing either a WebSocket service request or response.
 #[repr(C)]
 pub struct FoxgloveServiceMessageSchema {
     /// The message encoding.
@@ -95,7 +95,7 @@ impl FoxgloveServiceMessageSchema {
     }
 }
 
-/// A websocket service schema.
+/// A WebSocket service schema.
 #[repr(C)]
 pub struct FoxgloveServiceSchema<'a> {
     /// Service schema name.
@@ -150,9 +150,9 @@ impl Handler for ServiceHandler {
     }
 }
 
-/// Creates a new websocket service.
+/// Creates a new WebSocket service.
 ///
-/// The service must be registered with a websocket server using `foxglove_server_add_service`, or
+/// The service must be registered with a WebSocket server using `foxglove_server_add_service`, or
 /// freed with `foxglove_service_free`.
 ///
 /// The callback is invoked from the client's main poll loop and must not block. If blocking or
@@ -215,11 +215,11 @@ pub unsafe extern "C" fn foxglove_service_create(
     FoxgloveError::Ok
 }
 
-/// Frees a service that was never registered to a websocket server.
+/// Frees a service that was never registered to a WebSocket server.
 ///
 /// # Safety
 /// - `service` must be a valid pointer to a service allocated by `foxglove_service_create`. The
-///   service MUST NOT have been previously registered with a websocket server.
+///   service MUST NOT have been previously registered with a WebSocket server.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn foxglove_service_free(service: *mut FoxgloveService) {
     if !service.is_null() {

--- a/cpp/foxglove/docs/index.rst
+++ b/cpp/foxglove/docs/index.rst
@@ -98,9 +98,8 @@ To create a remote access gateway sink, call :func:`foxglove::RemoteAccessGatewa
 provide a device token to authenticate with the Foxglove API; this can be set via
 :class:`foxglove::RemoteAccessGatewayOptions` or with the ``FOXGLOVE_DEVICE_TOKEN`` environment
 variable. Once started, the gateway connects to the Foxglove platform over WebRTC and makes the
-device available for remote visualization and teleop. Each remote client that connects is its own
-independent sink, dynamically added to the :class:`foxglove::Context` when the client connects and
-removed when it disconnects.
+device available for remote visualization and teleop. The gateway acts as a single sink on the
+:class:`foxglove::Context`, registered when the gateway starts and unregistered when it stops.
 
 
 

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -28,7 +28,7 @@ public:
   explicit ChannelDescriptor(const foxglove_channel_descriptor* channel_descriptor);
   /// @endcond
 
-  /// @brief Get the id of the channel descriptor.
+  /// @brief Get the ID of the channel descriptor.
   [[nodiscard]] uint64_t id() const noexcept;
 
   /// @brief Get the topic of the channel descriptor.

--- a/rust/examples/client_publish/src/main.rs
+++ b/rust/examples/client_publish/src/main.rs
@@ -1,4 +1,4 @@
-//! Example websocket server with client publish
+//! Example WebSocket server with client publish
 //!
 //! This example uses the 'unstable' feature to expose capabilities.
 //!

--- a/rust/examples/ws_server_blocking/src/main.rs
+++ b/rust/examples/ws_server_blocking/src/main.rs
@@ -1,4 +1,4 @@
-//! A websocket server without a #[tokio::main] entrypoint.
+//! A WebSocket server without a #[tokio::main] entrypoint.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/rust/examples/ws_stream_mcap/src/main.rs
+++ b/rust/examples/ws_stream_mcap/src/main.rs
@@ -1,4 +1,4 @@
-//! Streams an mcap file over a websocket.
+//! Streams an mcap file over a WebSocket.
 
 mod mcap_player;
 mod playback_source;

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -289,8 +289,8 @@
 //! the `FOXGLOVE_DEVICE_TOKEN` environment variable.
 //!
 //! Once started, the gateway connects to the Foxglove platform and makes the device available for
-//! remote visualization and teleop. Each remote client that connects is its own independent sink,
-//! dynamically added to the [`Context`] when the client connects and removed when it disconnects.
+//! remote visualization and teleop. The gateway acts as a single sink on the [`Context`], registered
+//! when the gateway starts and unregistered when it stops.
 //!
 //! The gateway handle can safely be dropped and the connection will continue to run. Use
 //! [`stop`](`remote_access::GatewayHandle::stop`) to shut down the gateway explicitly.

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -166,7 +166,7 @@ impl RemoteAccessConnection {
         }
     }
 
-    /// Removes status messages by id from all connected participants.
+    /// Removes status messages by ID from all connected participants.
     ///
     /// If no session is currently active (e.g. while reconnecting), this is a no-op.
     pub fn remove_status(&self, status_ids: Vec<String>) {

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -76,7 +76,7 @@ impl GatewayHandle {
         self.connection.publish_status(status);
     }
 
-    /// Removes status messages by id from all connected participants.
+    /// Removes status messages by ID from all connected participants.
     pub fn remove_status(&self, status_ids: Vec<String>) {
         self.connection.remove_status(status_ids);
     }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1724,7 +1724,7 @@ impl RemoteAccessSession {
         self.broadcast_control(encode_json_message(&status));
     }
 
-    /// Remove status messages by id from all connected participants.
+    /// Remove status messages by ID from all connected participants.
     pub(crate) fn remove_status(&self, status_ids: Vec<String>) {
         let message = RemoveStatus::new(status_ids);
         self.broadcast_control(encode_json_message(&message));

--- a/rust/foxglove/src/remote_common/connection_graph.rs
+++ b/rust/foxglove/src/remote_common/connection_graph.rs
@@ -1,4 +1,4 @@
-//! Connection graph types shared between the websocket and remote access modules.
+//! Connection graph types shared between the WebSocket and remote access modules.
 
 use std::collections::{HashMap, HashSet};
 

--- a/rust/foxglove/src/websocket/connected_client/poller.rs
+++ b/rust/foxglove/src/websocket/connected_client/poller.rs
@@ -56,7 +56,7 @@ impl Poller {
             ShutdownReason::ClientDisconnected
         };
 
-        // Send messages from queues to the websocket.
+        // Send messages from queues to the WebSocket.
         let ws_tx_loop = async {
             while let Ok(msg) = tokio::select! {
                 msg = self.control_plane_rx.recv_async() => msg,

--- a/rust/foxglove/src/websocket/connection_graph.rs
+++ b/rust/foxglove/src/websocket/connection_graph.rs
@@ -1,4 +1,4 @@
-//! Websocket connection graph.
+//! WebSocket connection graph.
 
 // Re-export all public types from the common connection graph module.
 pub use crate::remote_common::connection_graph::ConnectionGraph;

--- a/rust/foxglove/src/websocket/fetch_asset.rs
+++ b/rust/foxglove/src/websocket/fetch_asset.rs
@@ -3,7 +3,7 @@ use crate::remote_common::fetch_asset;
 
 pub use fetch_asset::AssetHandler;
 
-/// Type alias for the websocket-specific asset responder.
+/// Type alias for the WebSocket-specific asset responder.
 pub type AssetResponder = fetch_asset::AssetResponder<Client>;
 
 pub(crate) use fetch_asset::{AsyncAssetHandlerFn, BlockingAssetHandlerFn};

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -563,7 +563,7 @@ impl Server {
         }
     }
 
-    /// Remove status messages by id from all clients.
+    /// Remove status messages by ID from all clients.
     pub fn remove_status(&self, status_ids: Vec<String>) {
         let message = RemoveStatus { status_ids };
         let clients = self.clients.get();

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -357,7 +357,7 @@ impl WebSocketServerHandle {
         self.0.publish_status(status);
     }
 
-    /// Removes status messages by id from all clients.
+    /// Removes status messages by ID from all clients.
     pub fn remove_status(&self, status_ids: Vec<String>) {
         self.0.remove_status(status_ids);
     }

--- a/rust/foxglove_data_loader/src/lib.rs
+++ b/rust/foxglove_data_loader/src/lib.rs
@@ -308,7 +308,7 @@ impl Default for SchemaManager {
 }
 
 impl SchemaManager {
-    /// Find the next available schema id. This method ensures no other schemas are using this id.
+    /// Find the next available schema ID. This method ensures no other schemas are using this ID.
     fn get_free_id(&mut self) -> u16 {
         loop {
             let current_id = self.next_schema_id;
@@ -322,8 +322,8 @@ impl SchemaManager {
         }
     }
 
-    /// Add a [`foxglove::Schema`] to the manager using a certain id, returning a [`LinkedSchema`].
-    /// This method will return None if the id is being used by another schema.
+    /// Add a [`foxglove::Schema`] to the manager using a certain ID, returning a [`LinkedSchema`].
+    /// This method will return None if the ID is being used by another schema.
     fn add_schema(
         &mut self,
         id: u16,


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
This change addresses some inconsistencies in the C++ and rust
documentation:

- ID and WebSocket should be capitalized appropriately
- Remote access gateway is a single sink, not sink-per-client