### PR TITLE
remote access: rename video tracks

### DIFF
--- a/rust/foxglove/src/remote_access/protocol_version.rs
+++ b/rust/foxglove/src/remote_access/protocol_version.rs
@@ -9,14 +9,14 @@ use tracing::error;
 pub(crate) const PROTOCOL_VERSION_ATTRIBUTE: &str = "protocolVersion";
 
 /// The remote access protocol version supported by this SDK build.
-pub(crate) const REMOTE_ACCESS_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 1, 0);
+pub(crate) const REMOTE_ACCESS_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
 
 /// The minimum remote access protocol version this SDK will accept from a connecting participant.
 pub(crate) const REMOTE_ACCESS_MIN_SUPPORTED_PROTOCOL_VERSION: semver::Version =
-    semver::Version::new(2, 1, 0);
+    semver::Version::new(2, 2, 0);
 
 /// The protocol version assumed when a participant does not advertise one.
-pub(crate) const DEFAULT_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 1, 0);
+pub(crate) const DEFAULT_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
 
 /// Parse the remote access protocol version from a LiveKit participant's attributes.
 ///
@@ -96,14 +96,14 @@ mod tests {
 
     #[test]
     fn parse_valid_version() {
-        let result = parse_participant_protocol_version(&attrs("2.1.0"));
-        assert_eq!(result, Some(semver::Version::new(2, 1, 0)));
+        let result = parse_participant_protocol_version(&attrs("2.2.0"));
+        assert_eq!(result, Some(semver::Version::new(2, 2, 0)));
     }
 
     #[test]
-    fn parse_missing_attribute_defaults_to_2_1_0() {
+    fn parse_missing_attribute_defaults_to_current() {
         let result = parse_participant_protocol_version(&HashMap::new());
-        assert_eq!(result, Some(semver::Version::new(2, 1, 0)));
+        assert_eq!(result, Some(semver::Version::new(2, 2, 0)));
     }
 
     #[test]
@@ -122,26 +122,26 @@ mod tests {
 
     #[test]
     fn check_valid_version_at_minimum_returns_some() {
-        let result = check_participant_protocol_version(&identity(), &attrs("2.1.0"), None);
-        assert_eq!(result, Some(semver::Version::new(2, 1, 0)));
+        let result = check_participant_protocol_version(&identity(), &attrs("2.2.0"), None);
+        assert_eq!(result, Some(semver::Version::new(2, 2, 0)));
     }
 
     #[test]
     fn check_valid_version_above_minimum_returns_some() {
-        let result = check_participant_protocol_version(&identity(), &attrs("2.1.1"), Some("sess"));
-        assert_eq!(result, Some(semver::Version::new(2, 1, 1)));
+        let result = check_participant_protocol_version(&identity(), &attrs("2.2.1"), Some("sess"));
+        assert_eq!(result, Some(semver::Version::new(2, 2, 1)));
     }
 
     #[test]
     fn check_missing_attribute_defaults_and_passes() {
-        // DEFAULT_PROTOCOL_VERSION == REMOTE_ACCESS_MIN_SUPPORTED_PROTOCOL_VERSION == 2.1.0
+        // DEFAULT_PROTOCOL_VERSION == REMOTE_ACCESS_MIN_SUPPORTED_PROTOCOL_VERSION == 2.2.0
         let result = check_participant_protocol_version(&identity(), &HashMap::new(), None);
-        assert_eq!(result, Some(semver::Version::new(2, 1, 0)));
+        assert_eq!(result, Some(semver::Version::new(2, 2, 0)));
     }
 
     #[test]
     fn check_version_below_minimum_returns_none() {
-        let result = check_participant_protocol_version(&identity(), &attrs("1.9.9"), None);
+        let result = check_participant_protocol_version(&identity(), &attrs("2.1.9"), None);
         assert_eq!(result, None);
     }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1858,27 +1858,18 @@ impl RemoteAccessSession {
     ///
     /// Caller must hold `subscription_lock`.
     fn start_video_tracks(self: &Arc<Self>, first_subscribed: &[ChannelId]) {
-        // Collect video-capable channels and their topics while holding the read lock.
-        let to_start: SmallVec<[(ChannelId, VideoInputSchema, String); 4]> = {
+        let to_start: SmallVec<[(ChannelId, VideoInputSchema); 4]> = {
             let state = self.state.read();
-            state
-                .with_channels(|channels| {
-                    first_subscribed
-                        .iter()
-                        .filter_map(|&channel_id| {
-                            let input_schema = state.get_video_schema(&channel_id)?;
-                            let topic = channels
-                                .get(&channel_id)
-                                .map(|ch| ch.topic().to_string())
-                                .unwrap_or_default();
-                            Some((channel_id, input_schema, topic))
-                        })
-                        .collect()
+            first_subscribed
+                .iter()
+                .filter_map(|&channel_id| {
+                    let input_schema = state.get_video_schema(&channel_id)?;
+                    Some((channel_id, input_schema))
                 })
-                .unwrap_or_default()
+                .collect()
         };
 
-        for (channel_id, input_schema, topic) in to_start {
+        for (channel_id, input_schema) in to_start {
             let video_source = NativeVideoSource::default();
             let publisher = Arc::new(VideoPublisher::new(
                 video_source.clone(),
@@ -1891,8 +1882,9 @@ impl RemoteAccessSession {
                 .write()
                 .insert_video_publisher(channel_id, publisher);
 
+            let track_name = format!("video-ch-{}", u64::from(channel_id));
             let track =
-                LocalVideoTrack::create_video_track(&topic, RtcVideoSource::Native(video_source));
+                LocalVideoTrack::create_video_track(&track_name, RtcVideoSource::Native(video_source));
 
             let local_participant = self.room.local_participant().clone();
             let session = self.clone();

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1855,6 +1855,7 @@ impl RemoteAccessSession {
     }
 
     /// Start video tracks for first-subscribed channels that have video schemas.
+    /// Each track is named video-ch-{channel_id}.
     ///
     /// Caller must hold `subscription_lock`.
     fn start_video_tracks(self: &Arc<Self>, first_subscribed: &[ChannelId]) {
@@ -1883,8 +1884,10 @@ impl RemoteAccessSession {
                 .insert_video_publisher(channel_id, publisher);
 
             let track_name = format!("video-ch-{}", u64::from(channel_id));
-            let track =
-                LocalVideoTrack::create_video_track(&track_name, RtcVideoSource::Native(video_source));
+            let track = LocalVideoTrack::create_video_track(
+                &track_name,
+                RtcVideoSource::Native(video_source),
+            );
 
             let local_participant = self.room.local_participant().clone();
             let session = self.clone();

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -517,14 +517,15 @@ async fn livekit_video_track_lifecycle() -> Result<()> {
     viewer
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
+    let expected_track_name = format!("video-ch-{channel_id}");
     let track_name = viewer.expect_track_subscribed().await?;
-    assert_eq!(track_name, "/camera", "video track name should match topic");
+    assert_eq!(track_name, expected_track_name, "video track name should match video-ch-{{channelId}}");
     info!("video track published on subscribe: {track_name}");
 
     // Unsubscribe — the gateway should unpublish the video track.
     viewer.send_unsubscribe(&[channel_id]).await?;
     let track_name = viewer.expect_track_unsubscribed().await?;
-    assert_eq!(track_name, "/camera");
+    assert_eq!(track_name, expected_track_name);
     info!("video track torn down on unsubscribe: {track_name}");
 
     viewer.close().await?;
@@ -555,18 +556,20 @@ async fn livekit_video_track_resubscribe() -> Result<()> {
     let advertise = viewer.expect_advertise().await?;
     let channel_id = advertise.channels[0].id;
 
+    let expected_track_name = format!("video-ch-{channel_id}");
+
     // First subscribe with requestVideoTrack — video track should be published.
     viewer
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
     let track_name = viewer.expect_track_subscribed().await?;
-    assert_eq!(track_name, "/camera");
+    assert_eq!(track_name, expected_track_name);
     info!("first subscribe: video track published");
 
     // Unsubscribe — video track should be torn down.
     viewer.send_unsubscribe(&[channel_id]).await?;
     let track_name = viewer.expect_track_unsubscribed().await?;
-    assert_eq!(track_name, "/camera");
+    assert_eq!(track_name, expected_track_name);
     info!("unsubscribe: video track torn down");
 
     // Resubscribe with requestVideoTrack — video track should come back.
@@ -577,7 +580,7 @@ async fn livekit_video_track_resubscribe() -> Result<()> {
         }])
         .await?;
     let track_name = viewer.expect_track_subscribed().await?;
-    assert_eq!(track_name, "/camera");
+    assert_eq!(track_name, expected_track_name);
     info!("resubscribe: video track re-established");
 
     viewer.close().await?;
@@ -705,12 +708,14 @@ async fn livekit_video_resubscribe_switches_to_data_plane() -> Result<()> {
     let advertise = viewer.expect_advertise().await?;
     let channel_id = advertise.channels[0].id;
 
+    let expected_track_name = format!("video-ch-{channel_id}");
+
     // First subscribe with requestVideoTrack: true — video track should be published.
     viewer
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
     let track_name = viewer.expect_track_subscribed().await?;
-    assert_eq!(track_name, "/camera");
+    assert_eq!(track_name, expected_track_name);
     info!("video track published");
 
     // Re-subscribe with requestVideoTrack: false — video track should be torn down.
@@ -721,7 +726,7 @@ async fn livekit_video_resubscribe_switches_to_data_plane() -> Result<()> {
         }])
         .await?;
     let track_name = viewer.expect_track_unsubscribed().await?;
-    assert_eq!(track_name, "/camera");
+    assert_eq!(track_name, expected_track_name);
     info!("video track torn down after re-subscribe with requestVideoTrack: false");
 
     // Wait for the device data track to be published and subscribe.

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -519,7 +519,10 @@ async fn livekit_video_track_lifecycle() -> Result<()> {
         .await?;
     let expected_track_name = format!("video-ch-{channel_id}");
     let track_name = viewer.expect_track_subscribed().await?;
-    assert_eq!(track_name, expected_track_name, "video track name should match video-ch-{{channelId}}");
+    assert_eq!(
+        track_name, expected_track_name,
+        "video track name should match video-ch-{{channelId}}"
+    );
     info!("video track published on subscribe: {track_name}");
 
     // Unsubscribe — the gateway should unpublish the video track.


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Video tracks were named with the topic name, while data tracks are named with the channelId. Using the topic name adds more complexity in mapping things on both sides. This is just a little cleanup PR to make the naming of video tracks consistent with data tracks, as it will be hard to do after we've released the beta.

The app side PR: [13920](https://github.com/foxglove/app/pull/13920)

This changes unreleased  functionality, so no changelog needed.

### Testing

- [x] Spin up the example_remote_access and verify video works as before