### PR TITLE
remote_access: Enable ros1/ros2 message support by default

### DIFF
--- a/rust/examples/remote_access_stream_mcap/Cargo.toml
+++ b/rust/examples/remote_access_stream_mcap/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 workspace = true
 
 [dependencies]
-foxglove = { path = "../../foxglove", features = ["remote-access", "img2yuv-ros1", "img2yuv-ros2"] }
+foxglove = { path = "../../foxglove", features = ["remote-access"] }
 tokio = { version = "1.47", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -53,7 +53,7 @@ img2yuv-core = ["dep:image", "dep:yuv"]
 img2yuv-png = ["img2yuv-core", "image/png"]
 img2yuv-jpeg = ["img2yuv-core", "image/jpeg"]
 img2yuv-webp = ["img2yuv-core", "image/webp"]
-img2yuv = ["img2yuv-png", "img2yuv-jpeg", "img2yuv-webp"]
+img2yuv = ["img2yuv-png", "img2yuv-jpeg", "img2yuv-webp", "img2yuv-ros1", "img2yuv-ros2"]
 img2yuv-ros1 = ["img2yuv-core", "dep:regex"]
 img2yuv-ros2 = ["img2yuv-core", "dep:cdr", "dep:regex"]
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Might be part of the reason our foxglove bridge experiments have been struggling...