### PR TITLE
Increment foxglove-schemas-{protobuf,flatbuffer} packages and document release steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,16 @@ All SDK languages are versioned and released together.
 2. Manually create a new Release in the GitHub UI. Ensure the tag uses the form `typescript/schemas/vX.Y.Z`.
 3. GitHub Actions will take care of the rest.
 
+### Python schema packages (`foxglove-schemas-protobuf`, `foxglove-schemas-flatbuffer`)
+
+These packages are versioned and released independently from the SDK.
+
+1. Create and merge a PR bumping the `version` in the package's `pyproject.toml` (and the corresponding entry in its `uv.lock`).
+2. From the merged commit on `main`, push a tag of the form:
+   - `python/foxglove-schemas-protobuf/vX.Y.Z`, or
+   - `python/foxglove-schemas-flatbuffer/vX.Y.Z`
+3. The `schemas` job in `.github/workflows/python.yml` will build the package and publish it to PyPI when it sees the matching tag.
+
 ### ROS
 
 For first-time setup, follow the guides for [installing bloom](http://ros-infrastructure.github.io/bloom/) and [authenticating with GitHub](https://wiki.ros.org/bloom/Tutorials/GithubManualAuthorization).

--- a/python/foxglove-schemas-flatbuffer/pyproject.toml
+++ b/python/foxglove-schemas-flatbuffer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "foxglove-schemas-flatbuffer"
-version = "0.3.0"
+version = "0.4.0"
 description = "Precompiled flatbuffer schemas for Foxglove"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 license = { text = "MIT" }

--- a/python/foxglove-schemas-flatbuffer/uv.lock
+++ b/python/foxglove-schemas-flatbuffer/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "foxglove-schemas-flatbuffer"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "flatbuffers" },

--- a/python/foxglove-schemas-protobuf/pyproject.toml
+++ b/python/foxglove-schemas-protobuf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "foxglove-schemas-protobuf"
-version = "0.3.0"
+version = "0.4.0"
 description = "Precompiled protocol buffer schemas for Foxglove"
 authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 license = { text = "MIT" }

--- a/python/foxglove-schemas-protobuf/uv.lock
+++ b/python/foxglove-schemas-protobuf/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "foxglove-schemas-protobuf"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "protobuf" },


### PR DESCRIPTION
### Changelog

Bump `foxglove-schemas-protobuf` and `foxglove-schemas-flatbuffer` to 0.4.0.

### Docs

Added a "Python schema packages" section to `CONTRIBUTING.md` documenting the per-package tag-based release flow (`python/foxglove-schemas-{protobuf,flatbuffer}/vX.Y.Z`), which wasn't previously covered alongside the combined SDK / TypeScript / ROS release instructions.

### Description

These two packages are versioned and published independently from the main `foxglove-sdk` Python package — they ship the generated protobuf and flatbuffer Python bindings for Foxglove schemas, which the Rust-core SDK does not expose. Their version has been pinned at 0.3.0 since the switch from poetry to uv, despite several additive schema changes landing in the meantime (e.g. `CompressedPointCloud`, `JointState`/`JointStates`, new `LocationFix` fields, per-annotation metadata on image annotations), so this PR bumps both to 0.4.0 and documents the release mechanics so future bumps don't require archaeology of the workflow file.

No code changes; only version metadata and docs. Once merged, tagging the commit with `python/foxglove-schemas-protobuf/v0.4.0` and `python/foxglove-schemas-flatbuffer/v0.4.0` will trigger the `schemas` job in `.github/workflows/python.yml` to publish to PyPI.

Manual testing steps for reviewers:

- [ ] After merge, push both tags and confirm the `schemas` job in the Python workflow publishes each package to PyPI.
- [ ] Verify the resulting PyPI releases install cleanly (`uv pip install foxglove-schemas-protobuf==0.4.0`, `uv pip install foxglove-schemas-flatbuffer==0.4.0`).