### PR TITLE
remote_access: Key pending_resets by ClientId

### DIFF
--- a/rust/foxglove/src/remote_access.rs
+++ b/rust/foxglove/src/remote_access.rs
@@ -7,6 +7,7 @@ mod credentials_provider;
 mod gateway;
 mod listener;
 mod participant;
+mod participants;
 pub(super) mod protocol_version;
 mod qos;
 mod rtt_tracker;

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -36,9 +36,13 @@ pub(crate) struct Participant {
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush task.
     control_tx: flume::Sender<Bytes>,
-    /// Shared set of participant identities pending a reset. Inserting into this
-    /// set + notifying is how we signal `handle_room_events` to disconnect us.
-    pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+    /// Shared set of `ClientId`s pending a reset. Inserting into this set +
+    /// notifying is how we signal `handle_room_events` to disconnect us.
+    /// Keyed by `ClientId` (unique per physical connection) rather than
+    /// `ParticipantIdentity` (stable across disconnect/reconnect) so that a
+    /// stale reset request doesn't fire against a reconnected participant
+    /// that happens to reuse the same identity.
+    pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
     /// Wakes `handle_room_events` when we add ourselves to `pending_resets`.
     reset_notify: Arc<tokio::sync::Notify>,
     /// Per-participant cancellation token. Cancelled when the control queue
@@ -64,13 +68,14 @@ impl Participant {
         protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
-        pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+        pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
         reset_notify: Arc<tokio::sync::Notify>,
         session_cancel: &CancellationToken,
     ) -> (Arc<Self>, tokio::task::JoinHandle<()>) {
         let (control_tx, control_rx) = flume::bounded::<Bytes>(queue_size);
         let cancel = session_cancel.child_token();
         let cancel_for_task = cancel.clone();
+        let client_id = ClientId::next();
         let identity_for_task = identity.clone();
         let pending_resets_for_task = pending_resets.clone();
         let reset_notify_for_task = reset_notify.clone();
@@ -97,9 +102,7 @@ impl Participant {
                         "control write failed for {:?}, requesting reset: {e:?}",
                         identity_for_task,
                     );
-                    pending_resets_for_task
-                        .lock()
-                        .insert(identity_for_task.clone());
+                    pending_resets_for_task.lock().insert(client_id);
                     reset_notify_for_task.notify_one();
                     break;
                 }
@@ -107,7 +110,7 @@ impl Participant {
         });
 
         let participant = Arc::new(Self {
-            client_id: ClientId::next(),
+            client_id,
             participant_id: identity,
             protocol_version,
             control_tx,
@@ -128,7 +131,7 @@ impl Participant {
         identity: ParticipantIdentity,
         protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
-        pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+        pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
         reset_notify: Arc<tokio::sync::Notify>,
         cancel: CancellationToken,
     ) -> Self {
@@ -199,9 +202,7 @@ impl Participant {
     pub(crate) fn send_control(&self, data: Bytes) {
         if !self.try_queue_control(data) {
             self.cancel.cancel();
-            self.pending_resets
-                .lock()
-                .insert(self.participant_id.clone());
+            self.pending_resets.lock().insert(self.client_id);
             self.reset_notify.notify_one();
         }
     }

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -1,0 +1,195 @@
+//! Two-key lookup table for connected participants.
+//!
+//! Maintains both `ParticipantIdentity` → `Arc<Participant>` and
+//! `ClientId` → `Arc<Participant>` indexes. Both reference the same
+//! `Arc<Participant>` values and are kept in sync by construction —
+//! mutation is only possible through the inherent methods on [`Participants`],
+//! all of which update both indexes together.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::sync::Arc;
+
+use livekit::id::ParticipantIdentity;
+
+use crate::remote_access::participant::Participant;
+use crate::remote_common::ClientId;
+
+/// Collection of connected participants, indexed by both `ParticipantIdentity`
+/// and `ClientId`.
+#[derive(Default)]
+pub(crate) struct Participants {
+    by_identity: HashMap<ParticipantIdentity, Arc<Participant>>,
+    by_client_id: HashMap<ClientId, Arc<Participant>>,
+}
+
+impl Participants {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts `participant` if no participant with the same identity is present.
+    ///
+    /// Returns `true` on insert, `false` if the identity was already occupied —
+    /// in the latter case neither index is modified.
+    pub fn insert(&mut self, participant: Arc<Participant>) -> bool {
+        let identity = participant.participant_id().clone();
+        let Entry::Vacant(v) = self.by_identity.entry(identity) else {
+            return false;
+        };
+        self.by_client_id
+            .insert(participant.client_id(), participant.clone());
+        v.insert(participant);
+        true
+    }
+
+    /// Removes and returns the participant for the given identity, if present.
+    pub fn remove_by_identity(
+        &mut self,
+        identity: &ParticipantIdentity,
+    ) -> Option<Arc<Participant>> {
+        let participant = self.by_identity.remove(identity)?;
+        self.by_client_id.remove(&participant.client_id());
+        Some(participant)
+    }
+
+    /// Returns the participant for the given identity, if present.
+    pub fn get_by_identity(&self, identity: &ParticipantIdentity) -> Option<&Arc<Participant>> {
+        self.by_identity.get(identity)
+    }
+
+    /// Returns the participant for the given `client_id`, if present.
+    #[allow(dead_code)]
+    pub fn get_by_client_id(&self, client_id: ClientId) -> Option<&Arc<Participant>> {
+        self.by_client_id.get(&client_id)
+    }
+
+    /// Returns `true` if a participant with this identity is registered.
+    pub fn contains_identity(&self, identity: &ParticipantIdentity) -> bool {
+        self.by_identity.contains_key(identity)
+    }
+
+    /// Iterates over all registered participants.
+    pub fn iter(&self) -> impl Iterator<Item = &Arc<Participant>> {
+        self.by_identity.values()
+    }
+
+    /// Returns the number of registered participants.
+    pub fn len(&self) -> usize {
+        self.by_identity.len()
+    }
+
+    /// Removes all participants and returns them.
+    pub fn drain(&mut self) -> Vec<Arc<Participant>> {
+        self.by_client_id.clear();
+        self.by_identity.drain().map(|(_, p)| p).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    fn make_participant(name: &str) -> Arc<Participant> {
+        let identity = ParticipantIdentity(name.to_string());
+        let version =
+            crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let (tx, _rx) = flume::bounded(16);
+        let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
+        let cancel = tokio_util::sync::CancellationToken::new();
+        Arc::new(Participant::new(
+            identity,
+            version,
+            tx,
+            pending_resets,
+            reset_notify,
+            cancel,
+        ))
+    }
+
+    #[test]
+    fn insert_returns_true_for_new_identity() {
+        let mut ps = Participants::new();
+        assert!(ps.insert(make_participant("alice")));
+        assert_eq!(ps.len(), 1);
+    }
+
+    #[test]
+    fn insert_returns_false_for_duplicate_identity() {
+        let mut ps = Participants::new();
+        assert!(ps.insert(make_participant("alice")));
+        assert!(!ps.insert(make_participant("alice")));
+        assert_eq!(ps.len(), 1);
+    }
+
+    #[test]
+    fn insert_populates_both_indexes() {
+        let mut ps = Participants::new();
+        let p = make_participant("alice");
+        let identity = p.participant_id().clone();
+        let client_id = p.client_id();
+        assert!(ps.insert(p));
+        assert!(ps.get_by_identity(&identity).is_some());
+        assert!(ps.get_by_client_id(client_id).is_some());
+    }
+
+    #[test]
+    fn remove_by_identity_clears_both_indexes() {
+        let mut ps = Participants::new();
+        let p = make_participant("alice");
+        let identity = p.participant_id().clone();
+        let client_id = p.client_id();
+        ps.insert(p);
+        assert!(ps.remove_by_identity(&identity).is_some());
+        assert!(ps.get_by_identity(&identity).is_none());
+        assert!(ps.get_by_client_id(client_id).is_none());
+        assert_eq!(ps.len(), 0);
+    }
+
+    #[test]
+    fn remove_by_identity_returns_none_for_missing() {
+        let mut ps = Participants::new();
+        let missing = ParticipantIdentity("nobody".to_string());
+        assert!(ps.remove_by_identity(&missing).is_none());
+    }
+
+    #[test]
+    fn duplicate_insert_does_not_disturb_existing_entry() {
+        let mut ps = Participants::new();
+        let first = make_participant("alice");
+        let first_client_id = first.client_id();
+        ps.insert(first);
+        // Second participant has the same identity but a distinct client_id.
+        let second = make_participant("alice");
+        let second_client_id = second.client_id();
+        assert_ne!(first_client_id, second_client_id);
+        assert!(!ps.insert(second));
+        // Secondary index must not contain the rejected participant's client_id.
+        assert!(ps.get_by_client_id(first_client_id).is_some());
+        assert!(ps.get_by_client_id(second_client_id).is_none());
+    }
+
+    #[test]
+    fn drain_clears_both_indexes_and_returns_all() {
+        let mut ps = Participants::new();
+        let alice = make_participant("alice");
+        let alice_client_id = alice.client_id();
+        ps.insert(alice);
+        ps.insert(make_participant("bob"));
+        let drained = ps.drain();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(ps.len(), 0);
+        assert!(ps.get_by_client_id(alice_client_id).is_none());
+    }
+
+    #[test]
+    fn iter_yields_all_registered_participants() {
+        let mut ps = Participants::new();
+        ps.insert(make_participant("alice"));
+        ps.insert(make_participant("bob"));
+        assert_eq!(ps.iter().count(), 2);
+    }
+}

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -79,7 +79,7 @@ impl Participants {
     }
 
     /// Removes all participants and returns them.
-    pub fn drain(&mut self) -> Vec<Arc<Participant>> {
+    pub fn take(&mut self) -> Vec<Arc<Participant>> {
         self.by_client_id.clear();
         self.by_identity.drain().map(|(_, p)| p).collect()
     }
@@ -172,14 +172,14 @@ mod tests {
     }
 
     #[test]
-    fn drain_clears_both_indexes_and_returns_all() {
+    fn take_clears_both_indexes_and_returns_all() {
         let mut ps = Participants::new();
         let alice = make_participant("alice");
         let alice_client_id = alice.client_id();
         ps.insert(alice);
         ps.insert(make_participant("bob"));
-        let drained = ps.drain();
-        assert_eq!(drained.len(), 2);
+        let taken = ps.take();
+        assert_eq!(taken.len(), 2);
         assert_eq!(ps.len(), 0);
         assert!(ps.get_by_client_id(alice_client_id).is_none());
     }

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -59,7 +59,6 @@ impl Participants {
     }
 
     /// Returns the participant for the given `client_id`, if present.
-    #[allow(dead_code)]
     pub fn get_by_client_id(&self, client_id: ClientId) -> Option<&Arc<Participant>> {
         self.by_client_id.get(&client_id)
     }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -160,12 +160,8 @@ pub(crate) struct RemoteAccessSession {
     server_info: ServerInfo,
     /// Set of `ClientId`s pending a reset (disconnect + reconnect).
     /// Populated by `Participant::send_control` on queue overflow and by flush
-    /// tasks on write failure. Drained by `handle_room_events`.
-    /// Keyed by `ClientId` (unique per physical connection) rather than
-    /// `ParticipantIdentity` (stable across reconnect) so a stale reset doesn't
-    /// fire against a reconnected participant reusing the same identity — the
-    /// drain-time lookup skips any `ClientId` no longer in `SessionState`.
-    /// Using a set deduplicates multiple reset requests for the same participant.
+    /// tasks on write failure. Drained by `handle_room_events`. See
+    /// [`Participant::pending_resets`] for why this is keyed by `ClientId`.
     pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
     /// Wakes `handle_room_events` when a new reset is added to `pending_resets`.
     reset_notify: Arc<tokio::sync::Notify>,
@@ -993,7 +989,7 @@ impl RemoteAccessSession {
         // caller is responsible for ensuring this function is not called concurrently for the same
         // participant identity.
         let mut state = self.state.write();
-        let did_insert = state.insert_participant(participant_id.clone(), participant);
+        let did_insert = state.insert_participant(participant);
         assert!(did_insert);
         state.insert_flush_handle(participant_id, flush_handle);
         Ok(())
@@ -1072,14 +1068,14 @@ impl RemoteAccessSession {
                 let mut set = self.pending_resets.lock();
                 set.drain().collect()
             };
+            // `handle_room_events` is the single task driving participant
+            // membership during the session lifecycle, so the lookup below
+            // cannot be invalidated before `reset_participant` runs. A
+            // `ClientId` no longer registered means the request is stale —
+            // the participant was already removed and may have been replaced
+            // by a reconnection reusing the same identity; skipping avoids
+            // spuriously tearing down that replacement.
             for client_id in client_ids {
-                // Look up the current participant by `ClientId`. If the id is
-                // no longer in `SessionState`, this reset request is stale —
-                // the participant was already removed (likely via the normal
-                // `ParticipantDisconnected` path) and may even have been
-                // replaced by a reconnected participant reusing the same
-                // identity but with a fresh `ClientId`. Skipping avoids
-                // spuriously tearing down the replacement.
                 let Some(participant) = self.state.read().get_participant_by_client_id(client_id)
                 else {
                     continue;

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -20,6 +20,7 @@ use tracing::{debug, error, info, trace, warn};
 use crate::protocol::v2::DecodeError;
 use crate::protocol::v2::parameter::Parameter;
 use crate::protocol::v2::server::ParameterValues;
+use crate::remote_common::ClientId;
 use crate::remote_common::connection_graph::ConnectionGraph;
 use crate::remote_common::{
     fetch_asset::AssetResponder,
@@ -157,11 +158,15 @@ pub(crate) struct RemoteAccessSession {
     connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
     /// Immutable `ServerInfo` message sent to each participant on connect and reset.
     server_info: ServerInfo,
-    /// Set of participant identities pending a reset (disconnect + reconnect).
+    /// Set of `ClientId`s pending a reset (disconnect + reconnect).
     /// Populated by `Participant::send_control` on queue overflow and by flush
     /// tasks on write failure. Drained by `handle_room_events`.
+    /// Keyed by `ClientId` (unique per physical connection) rather than
+    /// `ParticipantIdentity` (stable across reconnect) so a stale reset doesn't
+    /// fire against a reconnected participant reusing the same identity — the
+    /// drain-time lookup skips any `ClientId` no longer in `SessionState`.
     /// Using a set deduplicates multiple reset requests for the same participant.
-    pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantIdentity>>>,
+    pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
     /// Wakes `handle_room_events` when a new reset is added to `pending_resets`.
     reset_notify: Arc<tokio::sync::Notify>,
     /// Size of the per-participant control plane queue.
@@ -1061,14 +1066,26 @@ impl RemoteAccessSession {
         loop {
             // Drain pending resets before waiting for events. This covers the case
             // where a `Notify::notified()` wakeup was lost due to `select!`
-            // cancellation — the identities are still in the set even if the
+            // cancellation — the client ids are still in the set even if the
             // notification was consumed by a dropped future.
-            let identities: Vec<_> = {
+            let client_ids: Vec<ClientId> = {
                 let mut set = self.pending_resets.lock();
                 set.drain().collect()
             };
-            for participant_id in identities {
-                self.reset_participant(participant_id).await;
+            for client_id in client_ids {
+                // Look up the current participant by `ClientId`. If the id is
+                // no longer in `SessionState`, this reset request is stale —
+                // the participant was already removed (likely via the normal
+                // `ParticipantDisconnected` path) and may even have been
+                // replaced by a reconnected participant reusing the same
+                // identity but with a fresh `ClientId`. Skipping avoids
+                // spuriously tearing down the replacement.
+                let Some(participant) = self.state.read().get_participant_by_client_id(client_id)
+                else {
+                    continue;
+                };
+                self.reset_participant(participant.participant_id().clone())
+                    .await;
             }
 
             tokio::select! {

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -136,13 +136,7 @@ impl SessionState {
     ///
     /// Returns true if this is a new participant, or false if there was already a participant
     /// registered with this identity.
-    pub fn insert_participant(
-        &mut self,
-        identity: ParticipantIdentity,
-        participant: Arc<Participant>,
-    ) -> bool {
-        debug_assert_eq!(&identity, participant.participant_id());
-        let _ = identity;
+    pub fn insert_participant(&mut self, participant: Arc<Participant>) -> bool {
         self.participants.insert(participant)
     }
 
@@ -744,24 +738,24 @@ mod tests {
     #[test]
     fn insert_new_participant() {
         let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        assert!(state.insert_participant(id.clone(), p));
+        let (_, p) = make_participant("alice");
+        assert!(state.insert_participant(p));
     }
 
     #[test]
     fn insert_existing_participant() {
         let mut state = SessionState::new();
-        let (id, p1) = make_participant("alice");
-        assert!(state.insert_participant(id.clone(), p1));
+        let (_, p1) = make_participant("alice");
+        assert!(state.insert_participant(p1));
         let (_, p2) = make_participant("alice");
-        assert!(!state.insert_participant(id, p2));
+        assert!(!state.insert_participant(p2));
     }
 
     #[test]
     fn get_participant_returns_existing() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
         assert!(state.get_participant(&id).is_some());
     }
 
@@ -782,12 +776,12 @@ mod tests {
         let mut state = SessionState::new();
         let (id, original) = make_participant("alice");
         let original_client_id = original.client_id();
-        state.insert_participant(id.clone(), original);
+        state.insert_participant(original);
         let _ = state.remove_participant(&id);
         let (_, replacement) = make_participant("alice");
         let replacement_client_id = replacement.client_id();
         assert_ne!(original_client_id, replacement_client_id);
-        state.insert_participant(id, replacement);
+        state.insert_participant(replacement);
         assert!(
             state
                 .get_participant_by_client_id(original_client_id)
@@ -815,7 +809,7 @@ mod tests {
     fn remove_participant_cleans_up_subscriptions() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p.clone());
+        state.insert_participant(p.clone());
 
         let ch = make_channel("/topic1");
         let ch_id = ch.id();
@@ -831,9 +825,9 @@ mod tests {
     fn remove_participant_reports_only_last_unsubscribed_channels() {
         let mut state = SessionState::new();
         let (id_a, pa) = make_participant("alice");
-        let (id_b, pb) = make_participant("bob");
-        state.insert_participant(id_a.clone(), pa.clone());
-        state.insert_participant(id_b.clone(), pb.clone());
+        let (_, pb) = make_participant("bob");
+        state.insert_participant(pa.clone());
+        state.insert_participant(pb.clone());
 
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
@@ -856,7 +850,7 @@ mod tests {
     fn remove_participant_cleans_up_video_subscriptions() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p.clone());
+        state.insert_participant(p.clone());
 
         let ch = make_channel("/topic1");
         let ch_id = ch.id();
@@ -903,8 +897,8 @@ mod tests {
         let mut state = SessionState::new();
         let (id_a, pa) = make_participant("alice");
         let (id_b, pb) = make_participant("bob");
-        state.insert_participant(id_a.clone(), pa.clone());
-        state.insert_participant(id_b.clone(), pb.clone());
+        state.insert_participant(pa.clone());
+        state.insert_participant(pb.clone());
 
         let ch = make_channel("/topic1");
         let ch_id = ch.id();
@@ -923,8 +917,8 @@ mod tests {
     fn channel_subscriber_clients_empty_after_remove_channel() {
         let mut state = SessionState::new();
         let ch = make_channel("/topic1");
-        let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p.clone());
+        let (_, p) = make_participant("alice");
+        state.insert_participant(p.clone());
         state.insert_channel(&ch);
         let _ = state.subscribe(&p, &[ch.id()]);
 
@@ -1063,10 +1057,10 @@ mod tests {
     #[test]
     fn collect_participants_yields_all() {
         let mut state = SessionState::new();
-        let (id_a, pa) = make_participant("alice");
-        let (id_b, pb) = make_participant("bob");
-        state.insert_participant(id_a, pa);
-        state.insert_participant(id_b, pb);
+        let (_, pa) = make_participant("alice");
+        let (_, pb) = make_participant("bob");
+        state.insert_participant(pa);
+        state.insert_participant(pb);
         assert_eq!(state.collect_participants().len(), 2);
     }
 
@@ -1225,9 +1219,9 @@ mod tests {
     fn remove_participant_with_mixed_video_preferences() {
         let mut state = SessionState::new();
         let (id_a, pa) = make_participant("alice");
-        let (id_b, pb) = make_participant("bob");
-        state.insert_participant(id_a.clone(), pa.clone());
-        state.insert_participant(id_b.clone(), pb.clone());
+        let (_, pb) = make_participant("bob");
+        state.insert_participant(pa.clone());
+        state.insert_participant(pb.clone());
 
         let ch = make_channel("/topic1");
         let ch_id = ch.id();
@@ -1357,9 +1351,9 @@ mod tests {
     fn remove_participant_video_subscriber_while_other_video_remains() {
         let mut state = SessionState::new();
         let (id_a, pa) = make_participant("alice");
-        let (id_b, pb) = make_participant("bob");
-        state.insert_participant(id_a.clone(), pa.clone());
-        state.insert_participant(id_b.clone(), pb.clone());
+        let (_, pb) = make_participant("bob");
+        state.insert_participant(pa.clone());
+        state.insert_participant(pb.clone());
 
         let ch = make_channel("/topic1");
         let ch_id = ch.id();
@@ -1390,7 +1384,7 @@ mod tests {
     fn insert_client_channel_succeeds_for_new_channel() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
         let ch = make_client_channel(1, "/cmd");
 
         assert!(state.insert_client_channel(&id, ch));
@@ -1400,7 +1394,7 @@ mod tests {
     fn insert_client_channel_returns_false_for_duplicate() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
         let ch = make_client_channel(1, "/cmd");
 
         assert!(state.insert_client_channel(&id, ch.clone()));
@@ -1411,7 +1405,7 @@ mod tests {
     fn remove_client_channel_returns_descriptor() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
         let ch = make_client_channel(1, "/cmd");
 
         state.insert_client_channel(&id, ch);
@@ -1436,7 +1430,7 @@ mod tests {
     fn remove_participant_returns_subscribed_descriptors() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p.clone());
+        state.insert_participant(p.clone());
 
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
@@ -1459,7 +1453,7 @@ mod tests {
     fn remove_participant_cleans_up_client_channels() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
 
         state.insert_client_channel(&id, make_client_channel(1, "/cmd_vel"));
         state.insert_client_channel(&id, make_client_channel(2, "/joy"));
@@ -1478,7 +1472,7 @@ mod tests {
     fn remove_participant_with_no_client_channels_yields_empty_vec() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
 
         let removed = state.remove_participant(&id);
         assert!(removed.client_channels.is_empty());
@@ -1488,7 +1482,7 @@ mod tests {
     fn get_client_channel_returns_channel() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
         let ch = make_client_channel(1, "/cmd");
 
         state.insert_client_channel(&id, ch);
@@ -1509,7 +1503,7 @@ mod tests {
     fn get_client_channel_returns_none_for_unknown_channel() {
         let mut state = SessionState::new();
         let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p);
+        state.insert_participant(p);
         state.insert_client_channel(&id, make_client_channel(1, "/cmd"));
         assert!(state.get_client_channel(&id, ChannelId::new(99)).is_none());
     }
@@ -1595,9 +1589,9 @@ mod tests {
     fn data_subscriber_participants_returns_data_only_subscribers() {
         let mut state = SessionState::new();
         let (id_a, pa) = make_participant("alice");
-        let (id_b, pb) = make_participant("bob");
-        state.insert_participant(id_a.clone(), pa.clone());
-        state.insert_participant(id_b.clone(), pb.clone());
+        let (_, pb) = make_participant("bob");
+        state.insert_participant(pa.clone());
+        state.insert_participant(pb.clone());
 
         let ch = make_channel("/data");
         let ch_id = ch.id();
@@ -1617,8 +1611,8 @@ mod tests {
     #[test]
     fn data_subscriber_participants_empty_when_all_are_video() {
         let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(id.clone(), p.clone());
+        let (_, p) = make_participant("alice");
+        state.insert_participant(p.clone());
 
         let ch = make_channel("/cam");
         let ch_id = ch.id();

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -10,6 +10,7 @@ use tracing::{debug, info};
 use crate::protocol::v2::server::advertise;
 
 use crate::remote_access::participant::Participant;
+use crate::remote_access::participants::Participants;
 use crate::remote_access::qos::{QosProfile, Reliability};
 use crate::remote_access::session::{DataTrack, VideoInputSchema, VideoMetadata, VideoPublisher};
 use crate::remote_common::ClientId;
@@ -59,7 +60,7 @@ pub(crate) struct UnsubscribeResult {
 /// A subscriber is a "data subscriber" if they appear in `subscriptions` but not in
 /// `video_subscribers`. See [`Self::has_data_subscribers`].
 pub(crate) struct SessionState {
-    participants: HashMap<ParticipantIdentity, Arc<Participant>>,
+    participants: Participants,
     /// Channels that have been advertised to participants.
     channels: HashMap<ChannelId, Arc<RawChannel>>,
     /// QoS profile per channel.
@@ -90,7 +91,7 @@ pub(crate) struct SessionState {
 impl SessionState {
     pub fn new() -> Self {
         Self {
-            participants: HashMap::new(),
+            participants: Participants::new(),
             channels: HashMap::new(),
             qos_profiles: HashMap::new(),
             subscriptions: HashMap::new(),
@@ -126,7 +127,7 @@ impl SessionState {
     /// is closing immediately after). Does not fire listener callbacks
     /// (`on_unsubscribe`, `on_client_unadvertise`, etc.).
     pub fn take_participants(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
-        let participants: Vec<_> = self.participants.drain().map(|(_, p)| p).collect();
+        let participants = self.participants.drain();
         let handles: Vec<_> = self.flush_handles.drain().map(|(_, h)| h).collect();
         (participants, handles)
     }
@@ -140,13 +141,9 @@ impl SessionState {
         identity: ParticipantIdentity,
         participant: Arc<Participant>,
     ) -> bool {
-        use std::collections::hash_map::Entry;
-        if let Entry::Vacant(v) = self.participants.entry(identity) {
-            v.insert(participant);
-            true
-        } else {
-            false
-        }
+        debug_assert_eq!(&identity, participant.participant_id());
+        let _ = identity;
+        self.participants.insert(participant)
     }
 
     /// Removes a participant and all of its subscriptions.
@@ -155,7 +152,7 @@ impl SessionState {
     /// and any client channels that were advertised by the participant.
     #[must_use]
     pub fn remove_participant(&mut self, identity: &ParticipantIdentity) -> RemovedSubscriptions {
-        let Some(participant) = self.participants.remove(identity) else {
+        let Some(participant) = self.participants.remove_by_identity(identity) else {
             return RemovedSubscriptions {
                 client_id: None,
                 last_unsubscribed: SmallVec::new(),
@@ -226,17 +223,17 @@ impl SessionState {
 
     /// Returns the participant for the given identity, if present.
     pub fn get_participant(&self, identity: &ParticipantIdentity) -> Option<Arc<Participant>> {
-        self.participants.get(identity).cloned()
+        self.participants.get_by_identity(identity).cloned()
     }
 
     /// Returns true if there is a participant for the given identity.
     pub fn has_participant(&self, identity: &ParticipantIdentity) -> bool {
-        self.participants.contains_key(identity)
+        self.participants.contains_identity(identity)
     }
 
     /// Collects and returns all current participants.
     pub fn collect_participants(&self) -> SmallVec<[Arc<Participant>; 8]> {
-        self.participants.values().cloned().collect()
+        self.participants.iter().cloned().collect()
     }
 
     /// Records a client-advertised channel for a participant.
@@ -249,10 +246,10 @@ impl SessionState {
         channel: ChannelDescriptor,
     ) -> bool {
         debug_assert!(
-            self.participants.contains_key(identity),
+            self.participants.contains_identity(identity),
             "Participant does not exist for identity: {identity:?}"
         );
-        if !self.participants.contains_key(identity) {
+        if !self.participants.contains_identity(identity) {
             return false;
         }
         let map = self.client_channels.entry(identity.clone()).or_default();
@@ -304,7 +301,7 @@ impl SessionState {
         subscribers
             .iter()
             .filter_map(|identity| {
-                let participant = self.participants.get(identity)?;
+                let participant = self.participants.get_by_identity(identity)?;
                 Some((participant.client_id(), identity.clone()))
             })
             .collect()
@@ -342,7 +339,7 @@ impl SessionState {
         subscribers
             .iter()
             .filter(|identity| !video_subs.is_some_and(|vs| vs.contains(identity)))
-            .filter_map(|identity| self.participants.get(identity).cloned())
+            .filter_map(|identity| self.participants.get_by_identity(identity).cloned())
             .collect()
     }
 
@@ -751,7 +748,7 @@ mod tests {
         let mut state = SessionState::new();
         let (id, p1) = make_participant("alice");
         assert!(state.insert_participant(id.clone(), p1));
-        let (_, p2) = make_participant("bob");
+        let (_, p2) = make_participant("alice");
         assert!(!state.insert_participant(id, p2));
     }
 

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -127,7 +127,7 @@ impl SessionState {
     /// is closing immediately after). Does not fire listener callbacks
     /// (`on_unsubscribe`, `on_client_unadvertise`, etc.).
     pub fn take_participants(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
-        let participants = self.participants.drain();
+        let participants = self.participants.take();
         let handles: Vec<_> = self.flush_handles.drain().map(|(_, h)| h).collect();
         (participants, handles)
     }

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -226,6 +226,11 @@ impl SessionState {
         self.participants.get_by_identity(identity).cloned()
     }
 
+    /// Returns the participant for the given `client_id`, if present.
+    pub fn get_participant_by_client_id(&self, client_id: ClientId) -> Option<Arc<Participant>> {
+        self.participants.get_by_client_id(client_id).cloned()
+    }
+
     /// Returns true if there is a participant for the given identity.
     pub fn has_participant(&self, identity: &ParticipantIdentity) -> bool {
         self.participants.contains_identity(identity)
@@ -765,6 +770,36 @@ mod tests {
         let state = SessionState::new();
         let id = ParticipantIdentity("nobody".to_string());
         assert!(state.get_participant(&id).is_none());
+    }
+
+    /// Protects the drain-time staleness check for `pending_resets`: after a
+    /// participant is removed and replaced (e.g. disconnect + reconnect), a
+    /// stale `ClientId` from the previous connection must not match the
+    /// replacement. If this ever returns `Some`, a stale reset request would
+    /// tear down a healthy reconnected participant.
+    #[test]
+    fn get_participant_by_client_id_does_not_match_replaced_participant() {
+        let mut state = SessionState::new();
+        let (id, original) = make_participant("alice");
+        let original_client_id = original.client_id();
+        state.insert_participant(id.clone(), original);
+        let _ = state.remove_participant(&id);
+        let (_, replacement) = make_participant("alice");
+        let replacement_client_id = replacement.client_id();
+        assert_ne!(original_client_id, replacement_client_id);
+        state.insert_participant(id, replacement);
+        assert!(
+            state
+                .get_participant_by_client_id(original_client_id)
+                .is_none(),
+            "stale ClientId must not resolve to the replacement participant",
+        );
+        assert!(
+            state
+                .get_participant_by_client_id(replacement_client_id)
+                .is_some(),
+            "fresh ClientId must resolve to the current participant",
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

**Problem.** The `pending_resets` set in the remote-access session was keyed by `ParticipantIdentity`, which LiveKit reuses across disconnect/reconnect for the same logical client. A reset request queued for one physical connection could fire against a different, healthy connection that reconnected under the same identity before the drain ran — spuriously tearing down the replacement.

Flagged as a post-merge follow-up by @gasmith in the review of #1160:
https://github.com/foxglove/foxglove-sdk/pull/1160#pullrequestreview-4124702297

**Approach.** Rekey `pending_resets` by `ClientId` — a crate-local `u32` assigned once per physical connection and never reused. The drain in `handle_room_events` looks up each `ClientId` via `SessionState::get_participant_by_client_id`; when the id is no longer registered the request is stale (either the participant was removed, or it was already replaced by a reconnection with a fresh `ClientId`) and the drain skips it.

To support `ClientId` lookups alongside the existing identity-keyed access, participant storage on `SessionState` is encapsulated behind a new `Participants` type that maintains both indexes in sync by construction. The invariant is local to that type rather than spread across every mutator of `SessionState`.

The three commits are separated by responsibility:

1. `Encapsulate participant storage in Participants type` — pure refactor behind the dual-key wrapper. No semantic change.
2. `Key pending_resets by ClientId instead of ParticipantIdentity` — the actual fix. Adds a test `get_participant_by_client_id_does_not_match_replaced_participant` that locks in the staleness-rejection property.
3. `Tighten insert_participant signature and dedupe pending_resets rationale` — post-review cleanup: drops a redundant `identity` parameter, consolidates the `ClientId`-vs-identity rationale (previously duplicated across three doc/comment locations), and adds a drain-site comment capturing the single-task invariant the lookup relies on.

**Tradeoffs considered.**

- **Tuple `(ClientId, ParticipantIdentity)` in the set** vs. `HashSet<ClientId>` + secondary index: the tuple approach has a single load-bearing staleness check at the drain site and no permanent secondary index. The secondary-index approach (chosen here) pays a small always-on memory cost (8 bytes per participant for the extra `Arc` pointer) but makes `ClientId` → `Participant` a first-class access path, which fits the codebase's direction — `connection_graph` already keys by `ClientId`. Encapsulating both indexes in a single `Participants` type keeps the sync invariant local, removing 1b's main downside (distributed invariant across mutators).
- **Other identity-keyed maps on `SessionState`** (`subscriptions`, `video_subscribers`, `client_channels`, `subscribed_parameters`, `flush_handles`) were audited and kept as-is. None share `pending_resets`' producer/consumer decoupling — they're mutated synchronously with `add_participant` / `remove_participant` under `subscription_lock`, and `SessionState::remove_participant` sweeps all of them atomically. No stale-key window exists.

**Testing.**

Unit tests in `participants.rs` cover every method on the new type, including the dual-identity / distinct-`ClientId` rejection case. The core staleness-rejection property is tested at `SessionState` level (`get_participant_by_client_id_does_not_match_replaced_participant`), which exercises remove + replace under the same identity and asserts the original `ClientId` no longer resolves. Full-suite `cargo test -p foxglove --all-features` (476 pass) and `cargo test -p foxglove --no-default-features` (56 pass) both clean. `cargo clippy --no-deps --all-targets --tests -- -D warnings` clean. `cargo doc` clean.

No live LiveKit testing required — the staleness behavior is deterministic at `SessionState` level and exercised by the unit tests.

Fixes: [FLE-427](https://linear.app/foxglove/issue/FLE-427)
