### PR TITLE
remote_access: Prefer H.264

### DIFF
--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use indexmap::IndexSet;
 use libwebrtc::video_source::{RtcVideoSource, native::NativeVideoSource};
-use livekit::options::TrackPublishOptions;
+use livekit::options::{TrackPublishOptions, VideoCodec};
 use livekit::{ByteStreamReader, Room, StreamByteOptions, id::ParticipantIdentity};
 use livekit::{StreamWriter, prelude::*};
 use parking_lot::RwLock;
@@ -1916,8 +1916,15 @@ impl RemoteAccessSession {
             let session = self.clone();
             tokio::spawn(async move {
                 let local_track = LocalTrack::Video(track);
+                // Prefer H.264 so that the libwebrtc VAAPI encoder (H.264-only) can be used
+                // on Linux hosts that have libva + a VA driver available. VP8/VP9/AV1 paths
+                // are software-only in our builds, so H.264 is at worst parity elsewhere.
+                let publish_options = TrackPublishOptions {
+                    video_codec: VideoCodec::H264,
+                    ..Default::default()
+                };
                 match local_participant
-                    .publish_track(local_track, TrackPublishOptions::default())
+                    .publish_track(local_track, publish_options)
                     .await
                 {
                     Ok(publication) => {


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Eventually we want to enable NVENC hardware offloading, but it's going
to take some work to bake CUDA into the toolchain. For now we can take
advantage of VAAPI on the platforms where it is supported simply by
preferring H.264. Sadly, this only makes a difference for Linux x86_64,
because webrtc-sys does not include support for VAAPI on aarch64.

When we eventually support NVENC, we can either stick with H.264, or
offer an opt-in for H.265.

### Testing
Ran the example. Before this change, `intel_gpu_top` does not show the
example. After this change, it does.