### PR TITLE
remote_access: Use session-scoped CancellationToken for watcher teardown

### DIFF
--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -301,7 +301,7 @@ impl RemoteAccessConnection {
                         capabilities: self.capabilities.clone(),
                         supported_encodings: self.supported_encodings.clone().unwrap_or_default(),
                         runtime: self.runtime.clone(),
-                        cancellation_token: self.cancellation_token.clone(),
+                        cancellation_token: self.cancellation_token.child_token(),
                         message_backlog_size: self
                             .message_backlog_size
                             .unwrap_or(DEFAULT_MESSAGE_BACKLOG_SIZE),
@@ -442,8 +442,12 @@ impl RemoteAccessConnection {
             }
         }
         context.remove_sink(session.sink_id());
-        video_metadata_task.abort();
-        let _ = video_metadata_task.await;
+        session.cancel();
+        if let Err(e) = video_metadata_task.await
+            && e.is_panic()
+        {
+            error!(remote_access_session_id, error = %e, "video metadata watcher panicked");
+        }
 
         info!(remote_access_session_id, "disconnecting from room");
         // handle_room_events was one arm of the select! above — when the select

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -443,10 +443,8 @@ impl RemoteAccessConnection {
         }
         context.remove_sink(session.sink_id());
         session.cancel();
-        if let Err(e) = video_metadata_task.await
-            && e.is_panic()
-        {
-            error!(remote_access_session_id, error = %e, "video metadata watcher panicked");
+        if let Err(e) = video_metadata_task.await {
+            error!(remote_access_session_id, error = %e, "video metadata watcher failed");
         }
 
         info!(remote_access_session_id, "disconnecting from room");

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -425,10 +425,8 @@ impl RemoteAccessSession {
         }
     }
 
-    /// Signal all session-scoped tasks to stop. This cancels the session's
-    /// `CancellationToken`, which fires the break in `run_video_metadata_watcher`,
-    /// `handle_byte_stream_from_client`, and each participant's flush task (via
-    /// their child tokens).
+    /// Cancel the session's `CancellationToken`, signaling all session-scoped
+    /// tasks to stop.
     pub(crate) fn cancel(&self) {
         self.cancellation_token.cancel();
     }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -425,6 +425,14 @@ impl RemoteAccessSession {
         }
     }
 
+    /// Signal all session-scoped tasks to stop. This cancels the session's
+    /// `CancellationToken`, which fires the break in `run_video_metadata_watcher`,
+    /// `handle_byte_stream_from_client`, and each participant's flush task (via
+    /// their child tokens).
+    pub(crate) fn cancel(&self) {
+        self.cancellation_token.cancel();
+    }
+
     /// Shut down the session: clear all participants (dropping their control
     /// queue senders so flush tasks exit), await the flush task handles, then
     /// close the LiveKit room.


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Follow-up from #1160: the `video_metadata_task.abort()` + `let _ = task.await` (silently discarding the result) in the session teardown was only necessary because the watcher's break arm listened on the same `CancellationToken` as the outer `select!` in `run()`. That token is the connection-level token, so when `handle_room_events` returned from a room disconnect (without the connection being cancelled), nothing fired the break — hence the explicit `abort()`.

This PR makes the session's `CancellationToken` a child of the connection's, via `child_token()` instead of `clone()`, and adds a `RemoteAccessSession::cancel()` method to fire it. The teardown path now calls `session.cancel()` and `await`s the task normally, logging any `JoinError` instead of silently discarding it.

Side effect: the byte-stream readers (`handle_byte_stream_from_client`), data tracks (`publish_data_tracks`), and per-participant flush tasks (via `Participant::spawn`'s child token) also now observe session-scoped cancellation. All three were already semantically session-scoped — the previous behavior only happened to work because the token was cancelled on connection shutdown. The new behavior also cancels them when the session ends mid-connection, which is desirable.

No new tests — the watcher/cancel interaction isn't unit-testable without a real `livekit::Room` (no mock constructor). Regression coverage comes from `remote_access_tests/livekit_test.rs`, whose session lifecycle tests would time out if teardown hung. A follow-up note tracks adding a targeted integration test when we next expand that crate.

Fixes: [FLE-441](https://linear.app/foxglove/issue/FLE-441/remote-access-use-session-scoped-cancellationtoken-for-watcher)