### PR TITLE
docs: Update ParameterType documentation

### DIFF
--- a/cpp/foxglove/include/foxglove/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/parameter.hpp
@@ -21,18 +21,33 @@ struct foxglove_parameter_array;
 
 namespace foxglove {
 
-/// @brief A parameter type.
+/// @brief An optional type hint for a `Parameter`, used to disambiguate values whose intended
+/// type cannot be inferred from the wire representation alone.
 ///
-/// This enum is used to disambiguate `Parameter` values, in situations where the
-/// wire representation is ambiguous.
+/// A parameter's type is typically derived directly from its value: integers, booleans, strings,
+/// dicts, and homogeneous arrays of these are unambiguous on the wire. This enum only enumerates
+/// the cases that need an explicit hint:
+///
+/// - `ByteArray`: a byte array is transmitted as a base64-encoded string, so without a type hint
+///   it would be indistinguishable from an ordinary string.
+/// - `Float64`: a whole-valued float (e.g. `1.0`) may be serialized as an integer by some JSON
+///   encoders; the hint preserves the intended floating-point type.
+/// - `Float64Array`: same rationale as `Float64`, for arrays.
+///
+/// Parameters of other types (integer, bool, string, dict, arrays of these) use `None`.
 enum class ParameterType : uint8_t {
-  /// The parameter value can be inferred from the inner parameter value tag.
+  /// The parameter value can be inferred from the inner parameter value tag. Use this for
+  /// parameters whose type is unambiguous on the wire (integer, bool, string, dict, or
+  /// homogeneous arrays of these).
   None,
-  /// An array of bytes.
+  /// A byte array, transmitted on the wire as a base64-encoded string. The type hint
+  /// distinguishes it from an ordinary string value.
   ByteArray,
-  /// A floating-point value that can be represented as a `float64`.
+  /// A floating-point value that can be represented as a `float64`. Used to preserve the
+  /// floating-point type for whole-valued numbers that would otherwise round-trip as integers.
   Float64,
-  /// An array of floating-point values that can be represented as `float64`s.
+  /// An array of floating-point values that can be represented as `float64`s. Used to preserve
+  /// the floating-point type for arrays of whole-valued numbers.
   Float64Array,
 };
 

--- a/cpp/foxglove/include/foxglove/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/parameter.hpp
@@ -30,11 +30,12 @@ namespace foxglove {
 ///
 /// - `ByteArray`: a byte array is transmitted as a base64-encoded string, so without a type hint
 ///   it would be indistinguishable from an ordinary string.
-/// - `Float64`: a whole-valued float (e.g. `1.0`) may be serialized as an integer by some JSON
-///   encoders; the hint preserves the intended floating-point type.
+/// - `Float64`: a whole-valued float (e.g. `1.0`) may be indistinguishable from an integer on
+///   the wire; the hint preserves the intended floating-point type.
 /// - `Float64Array`: same rationale as `Float64`, for arrays.
 ///
-/// Parameters of other types (integer, bool, string, dict, arrays of these) use `None`.
+/// Parameters of other types (integer, bool, string, dict, arrays of these) leave `type()` as
+/// `ParameterType::None`.
 enum class ParameterType : uint8_t {
   /// The parameter value can be inferred from the inner parameter value tag. Use this for
   /// parameters whose type is unambiguous on the wire (integer, bool, string, dict, or

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -251,8 +251,9 @@ class ParameterType(Enum):
 
     - :py:attr:`ParameterType.ByteArray`: a byte array is transmitted as a base64-encoded
       string, so without a type hint it would be indistinguishable from an ordinary string.
-    - :py:attr:`ParameterType.Float64`: a whole-valued float (e.g. ``1.0``) may be serialized
-      as an integer by some JSON encoders; the hint preserves the intended floating-point type.
+    - :py:attr:`ParameterType.Float64`: a whole-valued float (e.g. ``1.0``) may be
+      indistinguishable from an integer on the wire; the hint preserves the intended
+      floating-point type.
     - :py:attr:`ParameterType.Float64Array`: same rationale as ``Float64``, for arrays.
 
     Parameters of other types (integer, bool, string, dict, arrays of these) leave

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -242,17 +242,34 @@ class Parameter:
 
 class ParameterType(Enum):
     """
-    The type of a parameter.
+    An optional type hint for a :py:class:`Parameter`, used to disambiguate values whose
+    intended type cannot be inferred from the wire representation alone.
+
+    A parameter's type is typically derived directly from its value: integers, booleans,
+    strings, dicts, and homogeneous arrays of these are unambiguous on the wire. This enum
+    only enumerates the cases that need an explicit hint:
+
+    - :py:attr:`ParameterType.ByteArray`: a byte array is transmitted as a base64-encoded
+      string, so without a type hint it would be indistinguishable from an ordinary string.
+    - :py:attr:`ParameterType.Float64`: a whole-valued float (e.g. ``1.0``) may be serialized
+      as an integer by some JSON encoders; the hint preserves the intended floating-point type.
+    - :py:attr:`ParameterType.Float64Array`: same rationale as ``Float64``, for arrays.
+
+    Parameters of other types (integer, bool, string, dict, arrays of these) leave
+    :py:attr:`Parameter.type` set to ``None``.
     """
 
     ByteArray = ...
-    """A byte array."""
+    """A byte array, transmitted on the wire as a base64-encoded string. The type hint
+    distinguishes it from an ordinary string value."""
 
     Float64 = ...
-    """A floating-point value that can be represented as a `float64`."""
+    """A floating-point value that can be represented as a ``float64``. Used to preserve the
+    floating-point type for whole-valued numbers that would otherwise round-trip as integers."""
 
     Float64Array = ...
-    """An array of floating-point values that can be represented as `float64`s."""
+    """An array of floating-point values that can be represented as ``float64``s. Used to
+    preserve the floating-point type for arrays of whole-valued numbers."""
 
 class ParameterValue:
     """

--- a/python/foxglove-sdk/src/remote_common.rs
+++ b/python/foxglove-sdk/src/remote_common.rs
@@ -193,8 +193,9 @@ impl PyMessageSchema {
 ///
 /// - :py:attr:`ParameterType.ByteArray`: a byte array is transmitted as a base64-encoded string,
 ///   so without a type hint it would be indistinguishable from an ordinary string.
-/// - :py:attr:`ParameterType.Float64`: a whole-valued float (e.g. ``1.0``) may be serialized as
-///   an integer by some JSON encoders; the hint preserves the intended floating-point type.
+/// - :py:attr:`ParameterType.Float64`: a whole-valued float (e.g. ``1.0``) may be
+///   indistinguishable from an integer on the wire; the hint preserves the intended
+///   floating-point type.
 /// - :py:attr:`ParameterType.Float64Array`: same rationale as ``Float64``, for arrays.
 ///
 /// Parameters of other types (integer, bool, string, dict, arrays of these) leave

--- a/python/foxglove-sdk/src/remote_common.rs
+++ b/python/foxglove-sdk/src/remote_common.rs
@@ -184,15 +184,32 @@ impl PyMessageSchema {
     }
 }
 
-/// A parameter type.
+/// An optional type hint for a :py:class:`Parameter`, used to disambiguate values whose intended
+/// type cannot be inferred from the wire representation alone.
+///
+/// A parameter's type is typically derived directly from its value: integers, booleans, strings,
+/// dicts, and homogeneous arrays of these are unambiguous on the wire. This enum only enumerates
+/// the cases that need an explicit hint:
+///
+/// - :py:attr:`ParameterType.ByteArray`: a byte array is transmitted as a base64-encoded string,
+///   so without a type hint it would be indistinguishable from an ordinary string.
+/// - :py:attr:`ParameterType.Float64`: a whole-valued float (e.g. ``1.0``) may be serialized as
+///   an integer by some JSON encoders; the hint preserves the intended floating-point type.
+/// - :py:attr:`ParameterType.Float64Array`: same rationale as ``Float64``, for arrays.
+///
+/// Parameters of other types (integer, bool, string, dict, arrays of these) leave
+/// :py:attr:`Parameter.type` set to ``None``.
 #[pyclass(name = "ParameterType", module = "foxglove", eq, eq_int)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyParameterType {
-    /// A byte array.
+    /// A byte array, transmitted on the wire as a base64-encoded string. The type hint
+    /// distinguishes it from an ordinary string value.
     ByteArray,
-    /// A floating-point value that can be represented as a `float64`.
+    /// A floating-point value that can be represented as a ``float64``. Used to preserve the
+    /// floating-point type for whole-valued numbers that would otherwise round-trip as integers.
     Float64,
-    /// An array of floating-point values that can be represented as `float64`s.
+    /// An array of floating-point values that can be represented as ``float64``s. Used to
+    /// preserve the floating-point type for arrays of whole-valued numbers.
     Float64Array,
 }
 

--- a/rust/foxglove/src/protocol/common/parameter.rs
+++ b/rust/foxglove/src/protocol/common/parameter.rs
@@ -21,16 +21,16 @@ pub enum DecodeError {
 }
 
 /// An optional type hint for a [`Parameter`], used to disambiguate values whose intended type
-/// cannot be inferred from the JSON representation alone.
+/// cannot be inferred from the wire representation alone.
 ///
-/// A parameter's type is typically derived directly from its [`ParameterValue`]: integers,
-/// booleans, strings, dicts, and homogeneous arrays of these are unambiguous on the wire.
+/// A parameter's type is typically derived directly from its value: integers, booleans, strings,
+/// dicts, and homogeneous arrays of these are unambiguous on the wire.
 /// This enum only enumerates the cases that need an explicit hint:
 ///
 /// - [`ParameterType::ByteArray`]: a byte array is transmitted as a base64-encoded string, so
 ///   without a type hint it would be indistinguishable from an ordinary string.
-/// - [`ParameterType::Float64`]: a whole-valued float (e.g. `1.0`) may be serialized as an
-///   integer by some JSON encoders; the hint preserves the intended floating-point type.
+/// - [`ParameterType::Float64`]: a whole-valued float (e.g. `1.0`) may be indistinguishable from
+///   an integer on the wire; the hint preserves the intended floating-point type.
 /// - [`ParameterType::Float64Array`]: same rationale as `Float64`, for arrays.
 ///
 /// Parameters of other types (integer, bool, string, dict, arrays of these) leave
@@ -38,7 +38,8 @@ pub enum DecodeError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ParameterType {
-    /// A byte array, encoded on the wire as a base64-encoded string.
+    /// A byte array, transmitted on the wire as a base64-encoded string. The type hint
+    /// distinguishes it from an ordinary string value.
     ByteArray,
     /// A floating-point value that can be represented as a `float64`. Used to preserve the
     /// floating-point type for whole-valued numbers that would otherwise round-trip as integers.

--- a/rust/foxglove/src/protocol/common/parameter.rs
+++ b/rust/foxglove/src/protocol/common/parameter.rs
@@ -20,15 +20,31 @@ pub enum DecodeError {
     Base64(#[from] base64::DecodeError),
 }
 
-/// A parameter type.
+/// An optional type hint for a [`Parameter`], used to disambiguate values whose intended type
+/// cannot be inferred from the JSON representation alone.
+///
+/// A parameter's type is typically derived directly from its [`ParameterValue`]: integers,
+/// booleans, strings, dicts, and homogeneous arrays of these are unambiguous on the wire.
+/// This enum only enumerates the cases that need an explicit hint:
+///
+/// - [`ParameterType::ByteArray`]: a byte array is transmitted as a base64-encoded string, so
+///   without a type hint it would be indistinguishable from an ordinary string.
+/// - [`ParameterType::Float64`]: a whole-valued float (e.g. `1.0`) may be serialized as an
+///   integer by some JSON encoders; the hint preserves the intended floating-point type.
+/// - [`ParameterType::Float64Array`]: same rationale as `Float64`, for arrays.
+///
+/// Parameters of other types (integer, bool, string, dict, arrays of these) leave
+/// [`Parameter::type`] set to `None`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ParameterType {
-    /// A byte array, encoded as a base64-encoded string.
+    /// A byte array, encoded on the wire as a base64-encoded string.
     ByteArray,
-    /// A floating-point value that can be represented as a `float64`.
+    /// A floating-point value that can be represented as a `float64`. Used to preserve the
+    /// floating-point type for whole-valued numbers that would otherwise round-trip as integers.
     Float64,
-    /// An array of floating-point values that can be represented as `float64`s.
+    /// An array of floating-point values that can be represented as `float64`s. Used to preserve
+    /// the floating-point type for arrays of whole-valued numbers.
     Float64Array,
 }
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
While plumbing parameter support for remote access, we realized that the
documentation for ParameterType was not very clear. This change expands
the documentation to describe when ParameterType should be specified.

### Links
Fixes: FLE-412