### PR TITLE
docs: Remove "LiveKit" from Client docstring

### DIFF
--- a/rust/foxglove/src/remote_access/client.rs
+++ b/rust/foxglove/src/remote_access/client.rs
@@ -6,7 +6,7 @@ use crate::remote_access::participant::Participant;
 use crate::remote_common::ClientId;
 use crate::remote_common::fetch_asset::SendAssetResponse;
 
-/// Represents a connected remote access client (LiveKit participant).
+/// Represents a connected remote access client.
 #[derive(Debug, Clone)]
 pub struct Client {
     /// Locally-significant identifier for this particular instance of this participant.


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Remove an errant LiveKit reference from the Client docstring.