### PR TITLE
ros: Release version 3.3.0

### DIFF
--- a/ros/src/foxglove_bridge/CHANGELOG.rst
+++ b/ros/src/foxglove_bridge/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package foxglove_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.3.0 (2026-04-21)
+------------------
+* Add support for remote access
+* Update Foxglove SDK version to 0.22.0
+
 3.2.6 (2026-04-02)
 ------------------
 * Fix ROS rolling build for rclcpp 31.0.0

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -9,7 +9,7 @@ if(POLICY CMP0024)
   set(CMAKE_POLICY_DEFAULT_CMP0024 NEW)
 endif()
 
-project(foxglove_bridge LANGUAGES CXX VERSION 3.2.6)
+project(foxglove_bridge LANGUAGES CXX VERSION 3.3.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -55,15 +55,14 @@ if (ENDIAN)
   add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
 endif()
 
-# FLE-419: Update hashes after v0.22.0 is released.
 set(FOXGLOVE_SDK_VERSION "0.22.0")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   set(FOXGLOVE_SDK_PLATFORM "aarch64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "INVALID")
+  set(FOXGLOVE_SDK_SHA "122b2b3553e1828d23e8728cdf9913be18be8fb63064118491b0313cb29ebea7")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(FOXGLOVE_SDK_PLATFORM "x86_64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "INVALID")
+  set(FOXGLOVE_SDK_SHA "93d4fef56766162d6ac5a866596f09708fc34543c5194595df48f36dfddbc759")
 else()
   message(FATAL_ERROR "Unsupported platform/architecture combination: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
 endif()

--- a/ros/src/foxglove_bridge/package.xml
+++ b/ros/src/foxglove_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>foxglove_bridge</name>
-    <version>3.2.6</version>
+    <version>3.3.0</version>
     <description>ROS Foxglove Bridge</description>
     <license>MIT</license>
     <url type="website">https://github.com/foxglove/foxglove-sdk</url>

--- a/ros/src/foxglove_msgs/CHANGELOG.rst
+++ b/ros/src/foxglove_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package foxglove_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.3.0 (2026-04-21)
+------------------
+* Add Odometry schema
+* Remove Velocity3 schema; LocationFix.velocity now uses Vector3
+
 3.2.6 (2026-04-02)
 ------------------
 * Add CompressedPointCloud schema

--- a/ros/src/foxglove_msgs/package.xml
+++ b/ros/src/foxglove_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>foxglove_msgs</name>
-  <version>3.2.6</version>
+  <version>3.3.0</version>
   <description>
     foxglove_msgs provides visualization messages that are supported by Foxglove.
   </description>


### PR DESCRIPTION
### Changelog
foxglove_bridge:
- Add support for remote access
- Update Foxglove SDK version to 0.22.0

foxglove_msgs:
- Add Odometry schema
- Remove Velocity3 schema; LocationFix.velocity now uses Vector3

### Docs
None

### Description
This change is to release the next version of the bridge, which includes
support for remote access.

### Testing
Mock release build: https://github.com/foxglove/foxglove-sdk/actions/runs/24732192556