### PR TITLE
docs: Fix remote data loader example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
     && apt-get install -y \
         cmake \
         curl \
-        doxygen \
         gcc \
         g++ \
         git \
@@ -20,6 +19,14 @@ RUN apt-get update \
         software-properties-common \
         unzip \
     && rm -rf /var/lib/apt/lists/*
+
+# doxygen — pin to match CI (.github/workflows/docs.yml)
+ARG DOXYGEN_VERSION=1.13.2
+RUN curl -fsSL https://github.com/doxygen/doxygen/releases/download/Release_$(echo ${DOXYGEN_VERSION} | tr '.' '_')/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz \
+        -o /tmp/doxygen.tar.gz \
+    && tar -xzf /tmp/doxygen.tar.gz -C /tmp \
+    && cp /tmp/doxygen-${DOXYGEN_VERSION}/bin/doxygen /usr/local/bin/ \
+    && rm -rf /tmp/doxygen.tar.gz /tmp/doxygen-${DOXYGEN_VERSION}
 
 # protoc — pin to match CI (arduino/setup-protoc version in .github/workflows/ci.yml)
 ARG PROTOC_VERSION=29.6

--- a/cpp/foxglove/include/foxglove/remote_data_loader_backend.hpp
+++ b/cpp/foxglove/include/foxglove/remote_data_loader_backend.hpp
@@ -5,36 +5,11 @@
 ///
 /// Use @ref foxglove::remote_data_loader_backend::ChannelSet to declare channels, then construct a
 /// @ref foxglove::remote_data_loader_backend::StreamedSource with the resulting topics and schemas.
+/// See @ref foxglove::remote_data_loader_backend::Manifest for a full example.
 ///
 /// @note This header requires [nlohmann/json](https://github.com/nlohmann/json) and
 /// [tobiaslocker/base64](https://github.com/tobiaslocker/base64) to be available on the include
 /// path.
-///
-/// ## Example
-///
-/// @code{.cpp}
-/// #include <foxglove/remote_data_loader_backend.hpp>
-/// #include <foxglove/messages.hpp>
-///
-/// namespace rdl = foxglove::remote_data_loader_backend;
-///
-/// rdl::ChannelSet channels;
-/// channels.insert<foxglove::messages::Vector3>("/demo");
-///
-/// rdl::StreamedSource source;
-/// source.url = "/v1/data?flightId=ABC123";
-/// source.id = "flight-v1-ABC123";
-/// source.topics = std::move(channels.topics);
-/// source.schemas = std::move(channels.schemas);
-/// source.start_time = "2024-01-01T00:00:00Z";
-/// source.end_time = "2024-01-02T00:00:00Z";
-///
-/// rdl::Manifest manifest;
-/// manifest.name = "Flight ABC123";
-/// manifest.sources = {std::move(source)};
-///
-/// std::string json_str = rdl::toJsonString(manifest);
-/// @endcode
 
 #include <foxglove/schema.hpp>
 
@@ -104,6 +79,30 @@ struct StreamedSource {
 };
 
 /// @brief Manifest of upstream sources returned by the manifest endpoint.
+///
+/// @code{.cpp}
+/// #include <foxglove/remote_data_loader_backend.hpp>
+/// #include <foxglove/messages.hpp>
+///
+/// namespace rdl = foxglove::remote_data_loader_backend;
+///
+/// rdl::ChannelSet channels;
+/// channels.insert<foxglove::messages::Vector3>("/demo");
+///
+/// rdl::StreamedSource source;
+/// source.url = "/v1/data?flightId=ABC123";
+/// source.id = "flight-v1-ABC123";
+/// source.topics = std::move(channels.topics);
+/// source.schemas = std::move(channels.schemas);
+/// source.start_time = "2024-01-01T00:00:00Z";
+/// source.end_time = "2024-01-02T00:00:00Z";
+///
+/// rdl::Manifest manifest;
+/// manifest.name = "Flight ABC123";
+/// manifest.sources = {std::move(source)};
+///
+/// std::string json_str = rdl::toJsonString(manifest);
+/// @endcode
 struct Manifest {
   /// @brief Human-readable display name for this manifest.
   std::optional<std::string> name;


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
The remote data loader backend example was [not rendering properly](https://foxglove-sdk-api-docs.pages.dev/cpp/generated/api/file_foxglove_include_foxglove_remote_data_loader_backend.hpp#detailed-description), due
to a quirk in exhale, which seems to be related to the `@file` section
and `## Example` subheading somehow, but I couldn't find a reasonable
way to fix it. Moved the example to the `Manifest` struct instead, with a
link from the header doc.

I also noticed that I was unable to build the C++ documentation locally
with the build container, because the build container was using doxygen
1.9.1 instead of the 1.13.2 that we're using in CI. Updated the
Dockefile to pin doxygen at 1.13.2.

New docs experience:
- [remote_data_loader_backend.hpp](https://f24432f8.foxglove-sdk-api-docs.pages.dev/cpp/generated/api/file_foxglove_include_foxglove_remote_data_loader_backend.hpp)
- [Example](https://f24432f8.foxglove-sdk-api-docs.pages.dev/cpp/generated/api/structfoxglove_1_1remote__data__loader__backend_1_1Manifest#struct-documentation)