### PR TITLE
foxglove_bridge: Send ROS_DISTRO via gateway ServerInfo

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2485,6 +2485,8 @@ typedef struct foxglove_qos_profile {
  *   `FOXGLOVE_DEVICE_TOKEN` environment variable.
  * - If `supported_encodings` is supplied, all entries must contain valid UTF-8, and
  *   `supported_encodings` must have length equal to `supported_encodings_count`.
+ * - If `server_info` is supplied, all entries must contain valid UTF-8, and `server_info` must
+ *   have length equal to `server_info_count`.
  */
 typedef struct foxglove_gateway_options {
   /**
@@ -2498,6 +2500,16 @@ typedef struct foxglove_gateway_options {
   foxglove_gateway_capability capabilities;
   const struct foxglove_string *supported_encodings;
   size_t supported_encodings_count;
+  /**
+   * Optional information about the gateway, which is shared with clients via the ServerInfo
+   * message.
+   *
+   * # Safety
+   * - If provided, the `server_info` must be a valid pointer to an array of valid
+   *   `FoxgloveKeyValue`s with `server_info_count` elements.
+   */
+  const struct foxglove_key_value *server_info;
+  size_t server_info_count;
   /**
    * Context provided to the `sink_channel_filter` callback.
    */
@@ -5541,6 +5553,8 @@ void foxglove_fetch_asset_respond_error(struct foxglove_fetch_asset_responder *r
  * # Safety
  * - `options` must be a valid pointer to a `FoxgloveGatewayOptions` struct with all fields
  *   satisfying the documented safety requirements.
+ * - If `server_info` is supplied in options, all `server_info` must contain valid UTF8, and
+ *   `server_info` must have length equal to `server_info_count`.
  * - `gateway` must be a valid pointer to a `*mut FoxgloveGateway`.
  */
 foxglove_error foxglove_gateway_start(const struct foxglove_gateway_options *FOXGLOVE_NONNULL options,

--- a/c/src/gateway.rs
+++ b/c/src/gateway.rs
@@ -12,7 +12,10 @@ use crate::parameter::FoxgloveParameterArray;
 use crate::server::FoxgloveServerStatusLevel;
 use crate::service::FoxgloveService;
 use crate::sink_channel_filter::ChannelFilter;
-use crate::{FoxgloveContext, FoxgloveError, FoxgloveSinkId, FoxgloveString, result_to_c};
+use crate::util::parse_key_value_array;
+use crate::{
+    FoxgloveContext, FoxgloveError, FoxgloveKeyValue, FoxgloveSinkId, FoxgloveString, result_to_c,
+};
 
 /// The reliability policy for a channel's data delivery.
 #[repr(u8)]
@@ -497,6 +500,8 @@ impl foxglove::remote_access::Listener for FoxgloveGatewayCallbacks {
 ///   `FOXGLOVE_DEVICE_TOKEN` environment variable.
 /// - If `supported_encodings` is supplied, all entries must contain valid UTF-8, and
 ///   `supported_encodings` must have length equal to `supported_encodings_count`.
+/// - If `server_info` is supplied, all entries must contain valid UTF-8, and `server_info` must
+///   have length equal to `server_info_count`.
 #[repr(C)]
 pub struct FoxgloveGatewayOptions<'a> {
     /// `context` can be null, or a valid pointer to a context created via `foxglove_context_new`.
@@ -508,6 +513,15 @@ pub struct FoxgloveGatewayOptions<'a> {
     pub capabilities: FoxgloveGatewayCapability,
     pub supported_encodings: *const FoxgloveString,
     pub supported_encodings_count: usize,
+
+    /// Optional information about the gateway, which is shared with clients via the ServerInfo
+    /// message.
+    ///
+    /// # Safety
+    /// - If provided, the `server_info` must be a valid pointer to an array of valid
+    ///   `FoxgloveKeyValue`s with `server_info_count` elements.
+    pub server_info: *const FoxgloveKeyValue,
+    pub server_info_count: usize,
 
     /// Context provided to the `sink_channel_filter` callback.
     pub sink_channel_filter_context: *const c_void,
@@ -604,6 +618,8 @@ impl FoxgloveGateway {
 /// # Safety
 /// - `options` must be a valid pointer to a `FoxgloveGatewayOptions` struct with all fields
 ///   satisfying the documented safety requirements.
+/// - If `server_info` is supplied in options, all `server_info` must contain valid UTF8, and
+///   `server_info` must have length equal to `server_info_count`.
 /// - `gateway` must be a valid pointer to a `*mut FoxgloveGateway`.
 #[unsafe(no_mangle)]
 #[must_use]
@@ -667,6 +683,17 @@ unsafe fn do_foxglove_gateway_start(
             })
             .collect::<Result<Vec<_>, _>>()?,
         );
+    }
+
+    if options.server_info_count > 0 {
+        let server_info = unsafe {
+            parse_key_value_array(
+                options.server_info,
+                options.server_info_count,
+                "server_info",
+            )?
+        };
+        gateway = gateway.server_info(server_info);
     }
 
     // Callbacks

--- a/c/src/server.rs
+++ b/c/src/server.rs
@@ -3,8 +3,8 @@ use crate::connection_graph::FoxgloveConnectionGraph;
 use crate::fetch_asset::{FetchAssetHandler, FoxgloveFetchAssetResponder};
 use crate::service::FoxgloveService;
 use crate::sink_channel_filter::ChannelFilter;
+use crate::util::parse_key_value_array;
 use bitflags::bitflags;
-use std::collections::HashMap;
 use std::ffi::{CString, c_char, c_void};
 use std::mem::ManuallyDrop;
 use std::sync::Arc;
@@ -466,24 +466,13 @@ unsafe fn do_foxglove_server_start(
         server = server.tls(tls_identity);
     }
     if options.server_info_count > 0 {
-        if options.server_info.is_null() {
-            return Err(foxglove::FoxgloveError::ValueError(
-                "server_info is null".to_string(),
-            ));
-        }
-        let opts_info = options.server_info;
-        let mut server_info = HashMap::new();
-        for i in 0..options.server_info_count {
-            let kv = unsafe { &*opts_info.add(i) };
-            if kv.key.data.is_null() || kv.value.data.is_null() {
-                return Err(foxglove::FoxgloveError::ValueError(
-                    "null key or value in server_info".to_string(),
-                ));
-            }
-            let key = unsafe { kv.key.as_utf8_str() }?;
-            let value = unsafe { kv.value.as_utf8_str() }?;
-            server_info.insert(key.to_string(), value.to_string());
-        }
+        let server_info = unsafe {
+            parse_key_value_array(
+                options.server_info,
+                options.server_info_count,
+                "server_info",
+            )?
+        };
         server = server.server_info(server_info);
     }
 

--- a/c/src/util.rs
+++ b/c/src/util.rs
@@ -2,6 +2,12 @@ use foxglove::FoxgloveError;
 use foxglove::bytes::Bytes;
 use std::mem::ManuallyDrop;
 
+#[cfg(not(target_family = "wasm"))]
+use std::collections::HashMap;
+
+#[cfg(not(target_family = "wasm"))]
+use crate::FoxgloveKeyValue;
+
 /// Create a borrowed Bytes from a raw pointer and length.
 ///
 /// # Safety
@@ -51,4 +57,34 @@ pub(crate) unsafe fn vec_from_raw<T>(ptr: *const T, len: usize) -> ManuallyDrop<
         return ManuallyDrop::new(Vec::new());
     }
     unsafe { ManuallyDrop::new(Vec::from_raw_parts(ptr as *mut _, len, len)) }
+}
+
+/// Parse a C array of [`FoxgloveKeyValue`] into a `HashMap<String, String>`.
+///
+/// # Safety
+///
+/// If `count > 0`, `ptr` must be a valid pointer to `count` initialized elements. Each key
+/// and value must contain valid UTF-8.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) unsafe fn parse_key_value_array(
+    ptr: *const FoxgloveKeyValue,
+    count: usize,
+    field_name: &str,
+) -> Result<HashMap<String, String>, FoxgloveError> {
+    if ptr.is_null() {
+        return Err(FoxgloveError::ValueError(format!("{field_name} is null")));
+    }
+    let mut map = HashMap::with_capacity(count);
+    for i in 0..count {
+        let kv = unsafe { &*ptr.add(i) };
+        if kv.key.data.is_null() || kv.value.data.is_null() {
+            return Err(FoxgloveError::ValueError(format!(
+                "null key or value in {field_name}"
+            )));
+        }
+        let key = unsafe { kv.key.as_utf8_str() }?;
+        let value = unsafe { kv.value.as_utf8_str() }?;
+        map.insert(key.to_string(), value.to_string());
+    }
+    Ok(map)
 }

--- a/cpp/foxglove/include/foxglove/remote_access.hpp
+++ b/cpp/foxglove/include/foxglove/remote_access.hpp
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -190,6 +191,12 @@ struct RemoteAccessGatewayOptions {
   /// If set, this callback is invoked for each channel to determine its quality-of-service
   /// profile. If not set, all channels use the default lossy profile.
   QosClassifierFn qos_classifier;
+  /// @cond foxglove_internal
+  /// @brief (internal) Information about the gateway, which is shared with clients.
+  ///
+  /// This option is for internal use only and may change.
+  std::optional<std::map<std::string, std::string>> server_info = std::nullopt;
+  /// @endcond
   /// @brief Override the Foxglove API base URL.
   std::optional<std::string> foxglove_api_url;
   /// @brief Override the Foxglove API timeout (in seconds).

--- a/cpp/foxglove/src/remote_access.cpp
+++ b/cpp/foxglove/src/remote_access.cpp
@@ -332,6 +332,16 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
     c_options.message_backlog_size = &*options.message_backlog_size;
   }
 
+  std::vector<foxglove_key_value> server_info;
+  if (options.server_info) {
+    server_info.reserve(options.server_info->size());
+    for (auto const& [key, value] : *options.server_info) {
+      server_info.push_back({{key.data(), key.length()}, {value.data(), value.length()}});
+    }
+    c_options.server_info = server_info.data();
+    c_options.server_info_count = server_info.size();
+  }
+
   foxglove_gateway* gateway = nullptr;
   foxglove_error error = foxglove_gateway_start(&c_options, &gateway);
   if (error != foxglove_error::FOXGLOVE_ERROR_OK || gateway == nullptr) {

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -102,6 +102,11 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   RCLCPP_INFO(this->get_logger(), "Starting foxglove_bridge (%s, %s@%s)", rosDistro,
               foxglove_bridge::FOXGLOVE_BRIDGE_VERSION, foxglove_bridge::FOXGLOVE_BRIDGE_GIT_HASH);
 
+  std::optional<std::map<std::string, std::string>> rosServerInfo;
+  if (rosDistro && strlen(rosDistro) > 0) {
+    rosServerInfo = std::map<std::string, std::string>{{"ROS_DISTRO", rosDistro}};
+  }
+
   declareParameters(this);
 
   const auto port = static_cast<uint16_t>(this->get_parameter(PARAM_PORT).as_int());
@@ -149,10 +154,7 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   sdkServerOptions.capabilities = _capabilities;
   sdkServerOptions.context = _serverContext;
 
-  if (rosDistro && strlen(rosDistro) > 0) {
-    std::map<std::string, std::string> serverInfo = {{"ROS_DISTRO", rosDistro}};
-    sdkServerOptions.server_info = std::move(serverInfo);
-  }
+  sdkServerOptions.server_info = rosServerInfo;
 
   if (_useSimTime) {
     sdkServerOptions.capabilities =
@@ -285,6 +287,7 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     gatewayOptions.context = _serverContext;
     gatewayOptions.device_token = deviceToken;
     gatewayOptions.supported_encodings = {"cdr", "json"};
+    gatewayOptions.server_info = std::move(rosServerInfo);
 
     const auto foxgloveApiUrl = this->get_parameter(PARAM_FOXGLOVE_API_URL).as_string();
     if (!foxgloveApiUrl.empty()) {


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The WebSocket path already advertises ROS_DISTRO in its ServerInfo metadata, but the remote access gateway did not, which caused clients to fail to resolve well-known ROS message definitions (seen as "Advertise channel failed: Unknown message definition" in the UI, e.g. for /move_base_simple/goal) when connecting over remote access.

Tested together with https://github.com/foxglove/foxglove-sdk/pull/1189 on a ROS 2 Humble machine. I was able to build and connect the foxglove_bridge to my local foxglove instance, then view remote access in the UI. While testing I didn't see any messages about "unknown message definition errors"

Fixes FLE-443