### PR TITLE
remote_access: Revert protocol breakage for livekit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "device-info"
+version = "0.1.1"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "libc",
+ "thiserror 2.0.14",
+ "wasm-bindgen",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,16 +2687,15 @@ dependencies = [
 [[package]]
 name = "libwebrtc"
 version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0c053af35021bc5d2f286b8e6a4f552bc75fdc14e40ebe2d0ef42ffa70a6b4"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "cxx",
  "glib",
  "jni",
  "js-sys",
  "lazy_static",
- "livekit-protocol",
- "livekit-runtime",
+ "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
  "log",
  "parking_lot",
  "rtrb",
@@ -2720,8 +2733,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "livekit"
 version = "0.7.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c38bd12b8cef6b8589d124e20460fd7ccc4cfb08d817de7d9d4b615d8c48e3f"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "base64 0.22.1",
  "bmrng",
@@ -2731,10 +2743,10 @@ dependencies = [
  "lazy_static",
  "libloading",
  "libwebrtc",
- "livekit-api",
+ "livekit-api 0.4.19 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
  "livekit-datatrack",
- "livekit-protocol",
- "livekit-runtime",
+ "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
  "log",
  "parking_lot",
  "prost 0.12.6",
@@ -2751,13 +2763,35 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900451a686a1ce8488c420e81a2135831383b03aade6bc3075cf80463d3dd6a4"
 dependencies = [
+ "device-info 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 1.3.1",
+ "jsonwebtoken",
+ "livekit-protocol 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "os_info",
+ "parking_lot",
+ "pbjson-types",
+ "prost 0.12.6",
+ "rand 0.9.2",
+ "scopeguard",
+ "serde",
+ "sha2",
+ "thiserror 2.0.14",
+ "url",
+]
+
+[[package]]
+name = "livekit-api"
+version = "0.4.19"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
+dependencies = [
  "base64 0.21.7",
- "device-info",
+ "device-info 0.1.1 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
  "futures-util",
  "http 1.3.1",
  "jsonwebtoken",
- "livekit-protocol",
- "livekit-runtime",
+ "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
  "log",
  "os_info",
  "parking_lot",
@@ -2780,16 +2814,15 @@ dependencies = [
 [[package]]
 name = "livekit-datatrack"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dba71a581354a0dcb89e4a396ae08b386b4103e743b22d145711878105aa8d"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "anyhow",
  "bytes",
  "from_variants",
  "futures-core",
  "futures-util",
- "livekit-protocol",
- "livekit-runtime",
+ "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
  "log",
  "rand 0.9.2",
  "thiserror 2.0.14",
@@ -2804,7 +2837,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cf1cc4ab39d7857fb31be648f43aa7068acb54a6960270dccd300dd5c8d0a98"
 dependencies = [
  "futures-util",
- "livekit-runtime",
+ "livekit-runtime 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot",
+ "pbjson",
+ "pbjson-types",
+ "prost 0.12.6",
+ "serde",
+ "thiserror 2.0.14",
+ "tokio",
+]
+
+[[package]]
+name = "livekit-protocol"
+version = "0.7.5"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
+dependencies = [
+ "futures-util",
+ "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
  "parking_lot",
  "pbjson",
  "pbjson-types",
@@ -2819,6 +2868,15 @@ name = "livekit-runtime"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "532e84c6cdc5fe774f2b5d9912597b5f3bea561927a48296d03e24549d21c3f6"
+dependencies = [
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "livekit-runtime"
+version = "0.4.0"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4126,7 +4184,7 @@ dependencies = [
  "foxglove 0.22.0",
  "futures-util",
  "livekit",
- "livekit-api",
+ "livekit-api 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -5837,8 +5895,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys"
 version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda197783d7898f62bc52ea551c113d615c266b866b686f4a627277b0f0928b0"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "cc",
  "cxx",
@@ -5852,8 +5909,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys-build"
 version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9a618b192cc7c7824b0f3bb931876fa7df8ba518ea163bd9f6e6e2d4b485e8"
+source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "anyhow",
  "fs2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,21 +1030,6 @@ dependencies = [
 [[package]]
 name = "device-info"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ca8e71544c1b67dcdbc2699ab258828aff985e5bc8d5f6b486d90d7df2f848"
-dependencies = [
- "core-foundation 0.10.1",
- "jni",
- "libc",
- "thiserror 2.0.14",
- "wasm-bindgen",
- "web-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "device-info"
-version = "0.1.1"
 source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "core-foundation 0.10.1",
@@ -2694,8 +2679,8 @@ dependencies = [
  "jni",
  "js-sys",
  "lazy_static",
- "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
- "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-protocol",
+ "livekit-runtime",
  "log",
  "parking_lot",
  "rtrb",
@@ -2743,10 +2728,10 @@ dependencies = [
  "lazy_static",
  "libloading",
  "libwebrtc",
- "livekit-api 0.4.19 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-api",
  "livekit-datatrack",
- "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
- "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-protocol",
+ "livekit-runtime",
  "log",
  "parking_lot",
  "prost 0.12.6",
@@ -2760,38 +2745,15 @@ dependencies = [
 [[package]]
 name = "livekit-api"
 version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900451a686a1ce8488c420e81a2135831383b03aade6bc3075cf80463d3dd6a4"
-dependencies = [
- "device-info 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 1.3.1",
- "jsonwebtoken",
- "livekit-protocol 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log",
- "os_info",
- "parking_lot",
- "pbjson-types",
- "prost 0.12.6",
- "rand 0.9.2",
- "scopeguard",
- "serde",
- "sha2",
- "thiserror 2.0.14",
- "url",
-]
-
-[[package]]
-name = "livekit-api"
-version = "0.4.19"
 source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "base64 0.21.7",
- "device-info 0.1.1 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "device-info",
  "futures-util",
  "http 1.3.1",
  "jsonwebtoken",
- "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
- "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-protocol",
+ "livekit-runtime",
  "log",
  "os_info",
  "parking_lot",
@@ -2821,8 +2783,8 @@ dependencies = [
  "from_variants",
  "futures-core",
  "futures-util",
- "livekit-protocol 0.7.5 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
- "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-protocol",
+ "livekit-runtime",
  "log",
  "rand 0.9.2",
  "thiserror 2.0.14",
@@ -2833,27 +2795,10 @@ dependencies = [
 [[package]]
 name = "livekit-protocol"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf1cc4ab39d7857fb31be648f43aa7068acb54a6960270dccd300dd5c8d0a98"
-dependencies = [
- "futures-util",
- "livekit-runtime 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot",
- "pbjson",
- "pbjson-types",
- "prost 0.12.6",
- "serde",
- "thiserror 2.0.14",
- "tokio",
-]
-
-[[package]]
-name = "livekit-protocol"
-version = "0.7.5"
 source = "git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change#78345bbe55b4b57ab7bc3a0687beb7dde03a2eca"
 dependencies = [
  "futures-util",
- "livekit-runtime 0.4.0 (git+https://github.com/gasmith/rust-sdks?branch=revert-protocol-change)",
+ "livekit-runtime",
  "parking_lot",
  "pbjson",
  "pbjson-types",
@@ -2861,16 +2806,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.14",
  "tokio",
-]
-
-[[package]]
-name = "livekit-runtime"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532e84c6cdc5fe774f2b5d9912597b5f3bea561927a48296d03e24549d21c3f6"
-dependencies = [
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -4184,7 +4119,7 @@ dependencies = [
  "foxglove 0.22.0",
  "futures-util",
  "livekit",
- "livekit-api 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "livekit-api",
  "reqwest 0.13.2",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,13 @@ license = "MIT"
 [workspace.dependencies]
 bytes = "1.11.1"
 chrono = { version = "0.4.39" }
+insta = { version = "1.42.2", features = ["json"] }
+# In v0.7.37, livekit introduced a breaking change to the data tracks wire
+# protocol. At the time of writing, no version of the javascript SDK knows how
+# to parse the new format. Tracked by FLE-452.
+libwebrtc = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
+livekit = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
+livekit-api = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change", default-features = false }
 log = "0.4.22"
 mcap = { version = "0.24", default-features = false }
 prost = "0.14"
@@ -38,10 +45,6 @@ tokio-tungstenite = "0.28"
 tokio-util = { version = "0.7", features = ["io", "rt"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-test = "0.2.5"
-insta = { version = "1.42.2", features = ["json"] }
-livekit = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
-livekit-api = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change", default-features = false }
-libwebrtc = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
 
 [workspace.lints.clippy]
 assigning_clones = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-test = "0.2.5"
 insta = { version = "1.42.2", features = ["json"] }
 livekit = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
+livekit-api = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change", default-features = false }
 libwebrtc = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
 
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ tokio-util = { version = "0.7", features = ["io", "rt"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-test = "0.2.5"
 insta = { version = "1.42.2", features = ["json"] }
+livekit = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
+libwebrtc = { git = "https://github.com/gasmith/rust-sdks", branch = "revert-protocol-change" }
 
 [workspace.lints.clippy]
 assigning_clones = "warn"

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -73,8 +73,8 @@ indexmap = "2"
 foxglove_derive = { version = "0.22.0", path = "../foxglove_derive", optional = true }
 futures = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3.31", features = ["sink", "std"], optional = true }
-livekit = { version = "0.7.37", optional = true, features = ["rustls-tls-native-roots"] }
-libwebrtc = { version = "0.3.24", optional = true }
+livekit = { workspace = true, optional = true, features = ["rustls-tls-native-roots"] }
+libwebrtc = { workspace = true, optional = true }
 mcap.workspace = true
 parking_lot = "0.12.4"
 prost-types.workspace = true

--- a/rust/remote_access_tests/Cargo.toml
+++ b/rust/remote_access_tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 foxglove = { path = "../foxglove", features = ["remote-access", "_protocol"] }
 livekit = { workspace = true, features = ["rustls-tls-native-roots"] }
-livekit-api = { version = "0.4", default-features = false, features = ["access-token"] }
+livekit-api = { workspace = true, features = ["access-token"] }
 axum = "0.8"
 reqwest = { version = "0.13", features = ["json"] }
 tokio.workspace = true

--- a/rust/remote_access_tests/Cargo.toml
+++ b/rust/remote_access_tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 foxglove = { path = "../foxglove", features = ["remote-access", "_protocol"] }
-livekit = { version = "0.7.36", features = ["rustls-tls-native-roots"] }
+livekit = { workspace = true, features = ["rustls-tls-native-roots"] }
 livekit-api = { version = "0.4", default-features = false, features = ["access-token"] }
 axum = "0.8"
 reqwest = { version = "0.13", features = ["json"] }


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Use a fork of livekit without the recent data tracks protocol breakage
introduced in v0.7.37.

This fork is v0.7.37, minus the breaking change: https://github.com/gasmith/rust-sdks/commits/revert-protocol-change/