### PR TITLE
Dockerfile.ros: Swap to ros2-testing via ros2-testing-apt-source

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -24,6 +24,7 @@ jobs:
               - 'c/**'
               - 'cpp/**'
               - 'ros/**'
+              - 'Dockerfile.ros'
               - '.github/workflows/ros.yml'
 
   build-cpp-dist:

--- a/Dockerfile.ros
+++ b/Dockerfile.ros
@@ -7,8 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG USE_ROS_TESTING=false
 RUN if [ "$USE_ROS_TESTING" = "true" ]; then \
-      sed -i 's|packages.ros.org/ros2/ubuntu|packages.ros.org/ros2-testing/ubuntu|g' \
-        /etc/apt/sources.list.d/ros2*.sources; \
+      apt-get update && apt-get install -y ros2-testing-apt-source; \
     fi
 
 # The ROS docker images are only updated when the underlying


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The prior sed-based swap editing /etc/apt/sources.list.d/ros2.sources was silently reverted during `apt-get dist-upgrade` when ros2-apt-source was upgraded 1.1.0 -> 1.2.0: the new package replaces the sed'd regular file with a symlink back into /usr/share, pointing at the default ros2/ubuntu URL. The subsequent `apt-get install python3-bloom` then failed with "Unable to locate package" because apt had only fetched the ros2-testing index.

Install the official ros2-testing-apt-source package instead, which Conflicts with ros2-apt-source (so dpkg cleanly swaps them) and configures ros2-testing as the sole ROS source in a way that survives dist-upgrade.

This should fix our currently failing Rolling builds, like in https://github.com/foxglove/foxglove-sdk/actions/runs/24850793861/job/72875771799?pr=1191