### PR TITLE
remote_access: Fix same-identity reconnect race

### DIFF
--- a/rust/foxglove/src/remote_access.rs
+++ b/rust/foxglove/src/remote_access.rs
@@ -7,6 +7,7 @@ mod credentials_provider;
 mod gateway;
 mod listener;
 mod participant;
+mod participant_registry;
 mod participants;
 pub(super) mod protocol_version;
 mod qos;

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -406,7 +406,11 @@ impl RemoteAccessConnection {
                 version = %version,
                 "adding existing participant"
             );
-            if let Err(e) = session.add_participant(identity.clone(), version).await {
+            let sid = participant.sid();
+            if let Err(e) = session
+                .add_participant(identity.clone(), sid, version)
+                .await
+            {
                 error!(
                     remote_access_session_id,
                     error = %e,

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -407,7 +407,10 @@ impl RemoteAccessConnection {
                 "adding existing participant"
             );
             let sid = participant.sid();
-            if let Err(e) = session.add_participant(identity.clone(), sid).await {
+            if let Err(e) = session
+                .add_participant(identity.clone(), sid, version)
+                .await
+            {
                 error!(
                     remote_access_session_id,
                     error = %e,

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -407,10 +407,7 @@ impl RemoteAccessConnection {
                 "adding existing participant"
             );
             let sid = participant.sid();
-            if let Err(e) = session
-                .add_participant(identity.clone(), sid, version)
-                .await
-            {
+            if let Err(e) = session.add_participant(identity.clone(), sid).await {
                 error!(
                     remote_access_session_id,
                     error = %e,

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -8,7 +8,6 @@ use livekit::{
     ByteStreamWriter, StreamWriter,
     id::{ParticipantIdentity, ParticipantSid},
 };
-use semver::Version;
 use tokio_util::sync::CancellationToken;
 
 use crate::protocol::v2::server::FetchAssetResponse;
@@ -39,11 +38,6 @@ pub(crate) struct Participant {
     /// (for a prior instance) apart from a legitimate disconnect of the
     /// current instance.
     participant_sid: ParticipantSid,
-    /// The remote access protocol version advertised by this participant.
-    /// Captured at `add_participant` time and reused on reset so we don't have to
-    /// re-query the LiveKit room (which would race with reconnection under the
-    /// same identity).
-    protocol_version: Version,
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush-task.
     control_tx: flume::Sender<Bytes>,
@@ -81,7 +75,6 @@ impl Participant {
     pub fn spawn(
         identity: ParticipantIdentity,
         participant_sid: ParticipantSid,
-        protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
         pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
@@ -130,7 +123,6 @@ impl Participant {
             client_id,
             participant_id: identity,
             participant_sid,
-            protocol_version,
             control_tx,
             pending_resets,
             reset_notify,
@@ -152,7 +144,6 @@ impl Participant {
     pub fn new(
         identity: ParticipantIdentity,
         participant_sid: ParticipantSid,
-        protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
         pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
         reset_notify: Arc<tokio::sync::Notify>,
@@ -162,7 +153,6 @@ impl Participant {
             client_id: ClientId::next(),
             participant_id: identity,
             participant_sid,
-            protocol_version,
             control_tx,
             pending_resets,
             reset_notify,
@@ -196,11 +186,6 @@ impl Participant {
     /// Returns the participant's identity.
     pub fn participant_id(&self) -> &ParticipantIdentity {
         &self.participant_id
-    }
-
-    /// Returns the protocol version advertised by this participant.
-    pub(crate) fn protocol_version(&self) -> &Version {
-        &self.protocol_version
     }
 
     /// Returns the LiveKit session ID this participant was added with. Unique

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -8,6 +8,7 @@ use livekit::{
     ByteStreamWriter, StreamWriter,
     id::{ParticipantIdentity, ParticipantSid},
 };
+use semver::Version;
 use tokio_util::sync::CancellationToken;
 
 use crate::protocol::v2::server::FetchAssetResponse;
@@ -38,6 +39,15 @@ pub(crate) struct Participant {
     /// one specific instance: `ParticipantDisconnected` event handling,
     /// SID-keyed `remove_participant`, and `pending_resets` bookkeeping.
     participant_sid: ParticipantSid,
+    /// The remote access protocol version advertised by this participant.
+    /// Stored for future use when branching protocol behavior based on the
+    /// participant's version. Captured at registration and refreshed on
+    /// reset: `reset_participant` re-validates the freshly-queried
+    /// attributes and the new participant is registered with that fresh
+    /// version, so the stored value reflects the current connection
+    /// instance's advertised version even across same-identity reconnects.
+    #[expect(dead_code)]
+    protocol_version: Version,
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush-task.
     control_tx: flume::Sender<Bytes>,
@@ -76,6 +86,7 @@ impl Participant {
     pub fn spawn(
         identity: ParticipantIdentity,
         participant_sid: ParticipantSid,
+        protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
         pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
@@ -124,6 +135,7 @@ impl Participant {
             client_id,
             participant_id: identity,
             participant_sid,
+            protocol_version,
             control_tx,
             pending_resets,
             reset_notify,
@@ -145,6 +157,7 @@ impl Participant {
     pub fn new(
         identity: ParticipantIdentity,
         participant_sid: ParticipantSid,
+        protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
         pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
         reset_notify: Arc<tokio::sync::Notify>,
@@ -154,6 +167,7 @@ impl Participant {
             client_id: ClientId::next(),
             participant_id: identity,
             participant_sid,
+            protocol_version,
             control_tx,
             pending_resets,
             reset_notify,

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -34,9 +34,9 @@ pub(crate) struct Participant {
     /// LiveKit session ID for this specific connection instance. Unique per
     /// physical connection — unlike `participant_id`, it changes when a
     /// participant disconnects and reconnects under the same identity. Used
-    /// by the `ParticipantDisconnected` handler to tell a stale disconnect
-    /// (for a prior instance) apart from a legitimate disconnect of the
-    /// current instance.
+    /// to disambiguate connection instances on every operation that targets
+    /// one specific instance: `ParticipantDisconnected` event handling,
+    /// SID-keyed `remove_participant`, and `pending_resets` bookkeeping.
     participant_sid: ParticipantSid,
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush-task.
@@ -46,10 +46,11 @@ pub(crate) struct Participant {
     /// us. Keyed by `ParticipantSid` (unique per physical connection) rather
     /// than `ParticipantIdentity` (stable across disconnect/reconnect) so a
     /// stale reset request doesn't fire against a reconnected participant
-    /// that happens to reuse the same identity. `ClientId` would also work
-    /// (per-instance), but keeping internal bookkeeping on `ParticipantSid`
-    /// matches the SID-keyed `remove_participant` path and reserves
-    /// `ClientId` for the user-facing `Listener` API.
+    /// that happens to reuse the same identity. `ClientId` is also
+    /// per-instance and would work for staleness disambiguation, but keying
+    /// on `ParticipantSid` matches the SID-keyed `remove_participant` path
+    /// directly; `ClientId` stays the identifier exposed through `Listener`
+    /// callbacks and the connection-graph subscriber index.
     pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
     /// Wakes `handle_room_events` when we add ourselves to `pending_resets`.
     reset_notify: Arc<tokio::sync::Notify>,

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -4,7 +4,10 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use livekit::{ByteStreamWriter, StreamWriter, id::ParticipantIdentity};
+use livekit::{
+    ByteStreamWriter, StreamWriter,
+    id::{ParticipantIdentity, ParticipantSid},
+};
 use semver::Version;
 use tokio_util::sync::CancellationToken;
 
@@ -27,11 +30,19 @@ const DEFAULT_FETCH_ASSET_PER_PARTICIPANT: usize = 32;
 pub(crate) struct Participant {
     /// Locally-significant identifier for this particular instance of this participant.
     client_id: ClientId,
-    /// LiveKit participant ID.
+    /// LiveKit participant identity (stable across disconnect + reconnect).
     participant_id: ParticipantIdentity,
+    /// LiveKit session ID for this specific connection instance. Unique per
+    /// physical connection — unlike `participant_id`, it changes when a
+    /// participant disconnects and reconnects under the same identity. Used
+    /// by the `ParticipantDisconnected` handler to tell a stale disconnect
+    /// (for a prior instance) apart from a legitimate disconnect of the
+    /// current instance.
+    livekit_sid: ParticipantSid,
     /// The remote access protocol version advertised by this participant.
-    /// Stored for future use when branching protocol behavior based on the participant's version.
-    #[expect(dead_code)]
+    /// Captured at `add_participant` time and reused on reset so we don't have to
+    /// re-query the LiveKit room (which would race with reconnection under the
+    /// same identity).
     protocol_version: Version,
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush task.
@@ -63,8 +74,10 @@ impl Participant {
     ///
     /// Returns the participant (wrapped in `Arc` for shared ownership) and the
     /// flush task's `JoinHandle` (for teardown awaiting).
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         identity: ParticipantIdentity,
+        livekit_sid: ParticipantSid,
         protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
@@ -112,6 +125,7 @@ impl Participant {
         let participant = Arc::new(Self {
             client_id,
             participant_id: identity,
+            livekit_sid,
             protocol_version,
             control_tx,
             pending_resets,
@@ -126,6 +140,8 @@ impl Participant {
     /// Creates a new participant without spawning a flush task.
     ///
     /// For use in tests that only need a participant with a pre-created channel.
+    /// The stored `livekit_sid` is a fixed placeholder; the race-disambiguation
+    /// tests that depend on distinct SIDs go through [`Participant::spawn`].
     #[cfg(test)]
     pub fn new(
         identity: ParticipantIdentity,
@@ -138,6 +154,8 @@ impl Participant {
         Self {
             client_id: ClientId::next(),
             participant_id: identity,
+            livekit_sid: ParticipantSid::try_from("PA_test".to_string())
+                .expect("valid LiveKit SID prefix"),
             protocol_version,
             control_tx,
             pending_resets,
@@ -172,6 +190,19 @@ impl Participant {
     /// Returns the participant's identity.
     pub fn participant_id(&self) -> &ParticipantIdentity {
         &self.participant_id
+    }
+
+    /// Returns the protocol version advertised by this participant.
+    pub(crate) fn protocol_version(&self) -> &Version {
+        &self.protocol_version
+    }
+
+    /// Returns the LiveKit session ID this participant was added with. Unique
+    /// per physical connection instance — used to disambiguate a stale
+    /// `ParticipantDisconnected` from a legitimate disconnect when the same
+    /// identity has reconnected.
+    pub(crate) fn livekit_sid(&self) -> &ParticipantSid {
+        &self.livekit_sid
     }
 
     /// Try to queue a control plane message. Returns `false` if the queue is
@@ -260,6 +291,14 @@ impl ParticipantWriter {
             }
         }
     }
+}
+
+/// Constructs a `ParticipantSid` for tests. LiveKit requires the `PA_`
+/// prefix; anything stable+unique works for identifying distinct instances.
+#[cfg(test)]
+pub(crate) fn test_sid(label: &str) -> ParticipantSid {
+    ParticipantSid::try_from(format!("PA_{label}"))
+        .expect("test_sid label should form a valid ParticipantSid")
 }
 
 #[cfg(test)]

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -47,13 +47,16 @@ pub(crate) struct Participant {
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush-task.
     control_tx: flume::Sender<Bytes>,
-    /// Shared set of `ClientId`s pending a reset. Inserting into this set +
-    /// notifying is how we signal `handle_room_events` to disconnect us.
-    /// Keyed by `ClientId` (unique per physical connection) rather than
-    /// `ParticipantIdentity` (stable across disconnect/reconnect) so that a
+    /// Shared set of `ParticipantSid`s pending a reset. Inserting into this
+    /// set and notifying is how we signal `handle_room_events` to disconnect
+    /// us. Keyed by `ParticipantSid` (unique per physical connection) rather
+    /// than `ParticipantIdentity` (stable across disconnect/reconnect) so a
     /// stale reset request doesn't fire against a reconnected participant
-    /// that happens to reuse the same identity.
-    pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
+    /// that happens to reuse the same identity. `ClientId` would also work
+    /// (per-instance), but keeping internal bookkeeping on `ParticipantSid`
+    /// matches the SID-keyed `remove_participant` path and reserves
+    /// `ClientId` for the user-facing `Listener` API.
+    pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
     /// Wakes `handle_room_events` when we add ourselves to `pending_resets`.
     reset_notify: Arc<tokio::sync::Notify>,
     /// Per-participant cancellation token. Cancelled when the control queue
@@ -81,7 +84,7 @@ impl Participant {
         protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
-        pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
+        pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
         reset_notify: Arc<tokio::sync::Notify>,
         session_cancel: &CancellationToken,
     ) -> (Arc<Self>, tokio::task::JoinHandle<()>) {
@@ -90,6 +93,7 @@ impl Participant {
         let cancel_for_task = cancel.clone();
         let client_id = ClientId::next();
         let identity_for_task = identity.clone();
+        let sid_for_task = participant_sid.clone();
         let pending_resets_for_task = pending_resets.clone();
         let reset_notify_for_task = reset_notify.clone();
 
@@ -115,7 +119,7 @@ impl Participant {
                         "control write failed for {:?}, requesting reset: {e:?}",
                         identity_for_task,
                     );
-                    pending_resets_for_task.lock().insert(client_id);
+                    pending_resets_for_task.lock().insert(sid_for_task);
                     reset_notify_for_task.notify_one();
                     break;
                 }
@@ -150,7 +154,7 @@ impl Participant {
         participant_sid: ParticipantSid,
         protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
-        pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
+        pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
         reset_notify: Arc<tokio::sync::Notify>,
         cancel: CancellationToken,
     ) -> Self {
@@ -235,7 +239,9 @@ impl Participant {
     pub(crate) fn send_control(&self, data: Bytes) {
         if !self.try_queue_control(data) {
             self.cancel.cancel();
-            self.pending_resets.lock().insert(self.client_id);
+            self.pending_resets
+                .lock()
+                .insert(self.participant_sid.clone());
             self.reset_notify.notify_one();
         }
     }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -26,7 +26,7 @@ const DEFAULT_FETCH_ASSET_PER_PARTICIPANT: usize = 32;
 ///
 /// Each participant has an identity, a per-participant control plane queue, and
 /// rate-limiting semaphores. The actual byte-stream writer lives in a dedicated
-/// flush task (spawned by `Participant::spawn`), not in this struct.
+/// flush-task (spawned by `Participant::spawn`), not in this struct.
 pub(crate) struct Participant {
     /// Locally-significant identifier for this particular instance of this participant.
     client_id: ClientId,
@@ -38,14 +38,14 @@ pub(crate) struct Participant {
     /// by the `ParticipantDisconnected` handler to tell a stale disconnect
     /// (for a prior instance) apart from a legitimate disconnect of the
     /// current instance.
-    livekit_sid: ParticipantSid,
+    participant_sid: ParticipantSid,
     /// The remote access protocol version advertised by this participant.
     /// Captured at `add_participant` time and reused on reset so we don't have to
     /// re-query the LiveKit room (which would race with reconnection under the
     /// same identity).
     protocol_version: Version,
     /// Per-participant control plane queue. The receiving end is owned by the
-    /// flush task.
+    /// flush-task.
     control_tx: flume::Sender<Bytes>,
     /// Shared set of `ClientId`s pending a reset. Inserting into this set +
     /// notifying is how we signal `handle_room_events` to disconnect us.
@@ -57,7 +57,7 @@ pub(crate) struct Participant {
     /// Wakes `handle_room_events` when we add ourselves to `pending_resets`.
     reset_notify: Arc<tokio::sync::Notify>,
     /// Per-participant cancellation token. Cancelled when the control queue
-    /// overflows, signaling the flush task to stop immediately.
+    /// overflows, signaling the flush-task to stop immediately.
     cancel: CancellationToken,
     /// Limits concurrent service calls from this participant.
     service_call_sem: Semaphore,
@@ -66,18 +66,18 @@ pub(crate) struct Participant {
 }
 
 impl Participant {
-    /// Creates a new participant with its own control plane channel and flush task.
+    /// Creates a new participant with its own control plane channel and flush-task.
     ///
-    /// The flush task drains the bounded channel into the `writer`. It exits when
+    /// The flush-task drains the bounded channel into the `writer`. It exits when
     /// the per-participant cancellation token fires (queue overflow or session
     /// shutdown) or when all `control_tx` senders are dropped.
     ///
     /// Returns the participant (wrapped in `Arc` for shared ownership) and the
-    /// flush task's `JoinHandle` (for teardown awaiting).
+    /// flush-task's `JoinHandle` (for teardown awaiting).
     #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         identity: ParticipantIdentity,
-        livekit_sid: ParticipantSid,
+        participant_sid: ParticipantSid,
         protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
@@ -125,7 +125,7 @@ impl Participant {
         let participant = Arc::new(Self {
             client_id,
             participant_id: identity,
-            livekit_sid,
+            participant_sid,
             protocol_version,
             control_tx,
             pending_resets,
@@ -137,14 +137,17 @@ impl Participant {
         (participant, flush_handle)
     }
 
-    /// Creates a new participant without spawning a flush task.
+    /// Creates a new participant without spawning a flush-task.
     ///
-    /// For use in tests that only need a participant with a pre-created channel.
-    /// The stored `livekit_sid` is a fixed placeholder; the race-disambiguation
-    /// tests that depend on distinct SIDs go through [`Participant::spawn`].
+    /// For use in tests that only need a participant with a pre-created
+    /// channel. Callers must supply a `participant_sid` — typically via
+    /// [`test_sid`] — so a test that builds two participants under the same
+    /// identity gets distinct SIDs and the SID-keyed `remove_participant`
+    /// path behaves the same as in production.
     #[cfg(test)]
     pub fn new(
         identity: ParticipantIdentity,
+        participant_sid: ParticipantSid,
         protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
         pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
@@ -154,8 +157,7 @@ impl Participant {
         Self {
             client_id: ClientId::next(),
             participant_id: identity,
-            livekit_sid: ParticipantSid::try_from("PA_test".to_string())
-                .expect("valid LiveKit SID prefix"),
+            participant_sid,
             protocol_version,
             control_tx,
             pending_resets,
@@ -181,7 +183,7 @@ impl Participant {
         &self.fetch_asset_sem
     }
 
-    /// Cancel this participant's flush task. The task will exit at the next
+    /// Cancel this participant's flush-task. The task will exit at the next
     /// `select!` iteration.
     pub(crate) fn cancel(&self) {
         self.cancel.cancel();
@@ -201,8 +203,8 @@ impl Participant {
     /// per physical connection instance — used to disambiguate a stale
     /// `ParticipantDisconnected` from a legitimate disconnect when the same
     /// identity has reconnected.
-    pub(crate) fn livekit_sid(&self) -> &ParticipantSid {
-        &self.livekit_sid
+    pub(crate) fn participant_sid(&self) -> &ParticipantSid {
+        &self.participant_sid
     }
 
     /// Try to queue a control plane message. Returns `false` if the queue is
@@ -220,7 +222,7 @@ impl Participant {
                     "control queue disconnected for {}, dropping message",
                     self.participant_id
                 );
-                // Queue already disconnected — flush task has exited. A reset is
+                // Queue already disconnected — flush-task has exited. A reset is
                 // likely already in progress, so don't trigger another one.
                 true
             }
@@ -228,7 +230,7 @@ impl Participant {
     }
 
     /// Queue a control plane message, requesting a participant reset if the
-    /// queue is full. Also cancels the per-participant token so the flush task
+    /// queue is full. Also cancels the per-participant token so the flush-task
     /// stops immediately — no point draining messages for a client being disconnected.
     pub(crate) fn send_control(&self, data: Bytes) {
         if !self.try_queue_control(data) {
@@ -270,7 +272,7 @@ impl std::fmt::Display for Participant {
 /// A writer for a participant's control plane byte stream.
 ///
 /// Wraps an ordered, reliable byte stream to one specific participant.
-/// Owned by the per-participant flush task, not by `Participant` itself.
+/// Owned by the per-participant flush-task, not by `Participant` itself.
 ///
 /// Mocked with a `TestByteStreamWriter` for tests.
 pub(crate) enum ParticipantWriter {

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use livekit::id::{ParticipantIdentity, ParticipantSid};
 use parking_lot::{Mutex, RwLock};
+use semver::Version;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
@@ -77,6 +78,7 @@ impl ParticipantRegistry {
         &self,
         id: ParticipantIdentity,
         participant_sid: ParticipantSid,
+        protocol_version: Version,
         writer: ParticipantWriter,
         session_cancel: &CancellationToken,
         initial_messages: I,
@@ -91,6 +93,7 @@ impl ParticipantRegistry {
         let (participant, flush_handle) = Participant::spawn(
             id,
             participant_sid,
+            protocol_version,
             writer,
             self.message_backlog_size,
             self.pending_resets.clone(),
@@ -198,6 +201,7 @@ mod tests {
     use super::*;
 
     use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter, test_sid};
+    use crate::remote_access::protocol_version;
 
     fn make_registry() -> ParticipantRegistry {
         ParticipantRegistry::new(16)
@@ -212,11 +216,13 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
 
         let sid = test_sid("alice-1");
         let inserted = registry.register_participant(
             id.clone(),
             sid.clone(),
+            version,
             test_writer(),
             &cancel,
             [],
@@ -233,10 +239,12 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
 
         assert!(registry.register_participant(
             id.clone(),
             test_sid("alice-1"),
+            version.clone(),
             test_writer(),
             &cancel,
             [],
@@ -244,6 +252,7 @@ mod tests {
         assert!(!registry.register_participant(
             id.clone(),
             test_sid("alice-2"),
+            version,
             test_writer(),
             &cancel,
             [],
@@ -272,6 +281,7 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("viewer-1".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid_1 = test_sid("viewer-1-attempt-1");
         let sid_2 = test_sid("viewer-1-attempt-2");
 
@@ -279,6 +289,7 @@ mod tests {
         assert!(registry.register_participant(
             id.clone(),
             sid_1.clone(),
+            version.clone(),
             test_writer(),
             &cancel,
             [],
@@ -297,6 +308,7 @@ mod tests {
         assert!(registry.register_participant(
             id.clone(),
             sid_2.clone(),
+            version,
             test_writer(),
             &cancel,
             [],

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -188,10 +188,7 @@ impl ParticipantRegistry {
     /// `register_participant` / `remove_participant` / `reset_participant`
     /// calls can race with this one.
     pub(crate) async fn shutdown(&self) {
-        let (participants, handles) = self.participants.write().drain();
-        for p in &participants {
-            p.cancel();
-        }
+        let handles = self.participants.write().drain();
         let _ = futures_util::future::join_all(handles).await;
     }
 }

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -106,34 +106,24 @@ impl ParticipantRegistry {
         self.participants.write().insert(participant, flush_handle)
     }
 
-    /// Removes the participant registered under `id` if — and only if — its
-    /// stored `participant_sid` matches `expected_sid`. Returns the removed
-    /// participant (for its `ClientId`) or `None` if no match (either the
-    /// identity isn't registered, or the stored SID belongs to a later
-    /// connection instance that must not be torn down).
+    /// Removes the participant whose stored `ParticipantSid` matches
+    /// `target_sid`. Returns the removed participant or `None` if no
+    /// participant with this SID is registered.
     ///
-    /// Identity alone is ambiguous: a `ParticipantDisconnected` for a prior
-    /// instance can arrive after a same-identity reconnect has replaced it.
-    /// Requiring the SID at the call site means the caller has already
-    /// committed to which *specific* instance it's removing — the event
-    /// handler uses the disconnected participant's SID; `reset_participant`
-    /// uses the stored participant's SID.
+    /// SID-keyed: a `ParticipantDisconnected` for a prior instance can arrive
+    /// after a same-identity reconnect has replaced it, but the reconnected
+    /// instance has a *different* SID, so a stale removal misses here rather
+    /// than tearing down the replacement.
     ///
-    /// `Participants::remove_by_identity` cancels the flush-task and detaches
-    /// its handle as part of the removal; the caller is responsible for any
+    /// `Participants::remove_by_sid` cancels the flush-task and detaches its
+    /// handle as part of the removal; the caller is responsible for any
     /// further cleanup (subscription sweep, listener callbacks) via
     /// [`SessionState::cleanup_for_removed_identity`].
     pub(crate) fn remove_participant(
         &self,
-        id: &ParticipantIdentity,
-        expected_sid: &ParticipantSid,
+        target_sid: &ParticipantSid,
     ) -> Option<Arc<Participant>> {
-        let mut participants = self.participants.write();
-        let current = participants.get_by_identity(id)?;
-        if current.participant_sid() != expected_sid {
-            return None;
-        }
-        participants.remove_by_identity(id)
+        self.participants.write().remove_by_sid(target_sid)
     }
 
     /// Returns the participant for the given identity, if any.
@@ -154,14 +144,6 @@ impl ParticipantRegistry {
             .into_iter()
             .filter_map(|id| participants.get_by_identity(&id).cloned())
             .collect()
-    }
-
-    /// Returns the participant matching the given `ParticipantSid`, if any.
-    pub(crate) fn get_participant_by_sid(
-        &self,
-        sid: &ParticipantSid,
-    ) -> Option<Arc<Participant>> {
-        self.participants.read().get_by_sid(sid).cloned()
     }
 
     /// Returns true if a participant exists for the given identity.
@@ -249,7 +231,7 @@ mod tests {
         assert!(inserted);
         assert!(registry.has_participant(&id));
 
-        assert!(registry.remove_participant(&id, &sid).is_some());
+        assert!(registry.remove_participant(&sid).is_some());
         assert!(!registry.has_participant(&id));
     }
 
@@ -290,10 +272,11 @@ mod tests {
     ///    2 with `S2`.
     /// 4. A `ParticipantDisconnected(viewer-1, sid=S1)` event — queued by
     ///    LiveKit for *attempt 1* before it dropped — is then dispatched to
-    ///    `remove_participant(viewer-1, S1)`.
+    ///    `remove_participant(S1)`.
     ///
-    /// Because the currently-stored `Participant` has `participant_sid = S2`, the
-    /// SID-keyed remove is a no-op. Attempt 2 stays registered.
+    /// Because no participant has `participant_sid = S1` anymore (attempt 1
+    /// was removed in step 3, and attempt 2 has S2), the SID-keyed remove is
+    /// a no-op. Attempt 2 stays registered.
     #[tokio::test]
     async fn stale_disconnect_must_not_remove_reconnected_participant() {
         let registry = make_registry();
@@ -322,12 +305,11 @@ mod tests {
         // re-insert under the new SID.
         let drained = registry.drain_pending_resets();
         assert_eq!(drained, vec![sid_1.clone()]);
-        let reset_target = registry
-            .get_participant_by_sid(&sid_1)
-            .expect("attempt 1 resolves from drained sid");
-        let stored_version = reset_target.protocol_version().clone();
-        let stored_id = reset_target.participant_id().clone();
-        registry.remove_participant(&stored_id, &sid_1);
+        let removed = registry
+            .remove_participant(&sid_1)
+            .expect("attempt 1 removes via its SID");
+        let stored_version = removed.protocol_version().clone();
+        drop(removed);
         assert!(registry.register_participant(
             id.clone(),
             sid_2.clone(),
@@ -342,7 +324,7 @@ mod tests {
         assert_eq!(attempt_2.participant_sid(), &sid_2);
 
         // Step 4: stale disconnect carries attempt 1's SID. No-op.
-        let removed = registry.remove_participant(&id, &sid_1);
+        let removed = registry.remove_participant(&sid_1);
         assert!(removed.is_none());
         assert!(
             registry.has_participant(&id),
@@ -350,7 +332,7 @@ mod tests {
         );
 
         // Sanity: matching SID does remove.
-        let removed = registry.remove_participant(&id, &sid_2);
+        let removed = registry.remove_participant(&sid_2);
         assert!(removed.is_some());
         assert!(!registry.has_participant(&id));
     }

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -1,7 +1,7 @@
 //! Participant-lifecycle state machine for a remote access session.
 //!
 //! Owns the participant map + per-participant flush-task handles, and the
-//! `pending_resets` / `reset_notify` signalling surfaces that let a flush task
+//! `pending_resets` / `reset_notify` signalling surfaces that let a flush-task
 //! request its own reset. Deliberately knows nothing about LiveKit
 //! [`livekit::Room`]s: the caller (which *does* know about the Room) opens
 //! the control-plane stream and hands the resulting writer in. Tests build
@@ -25,12 +25,12 @@ use crate::remote_access::participants::Participants;
 use crate::remote_common::ClientId;
 
 /// Owns the participant membership state machine: add / remove / lookup, plus
-/// the `pending_resets` channel that lets a flush task request its own reset.
+/// the `pending_resets` channel that lets a flush-task request its own reset.
 pub(crate) struct ParticipantRegistry {
     /// Map of connected participants and their flush-task join handles.
     participants: RwLock<Participants>,
     /// Set of `ClientId`s pending a reset (disconnect + reconnect). Populated by
-    /// [`Participant::send_control`] on queue overflow and by flush tasks on
+    /// [`Participant::send_control`] on queue overflow and by flush-tasks on
     /// write failure.
     pending_resets: Arc<Mutex<HashSet<ClientId>>>,
     /// Notified when a new reset is inserted into `pending_resets`.
@@ -49,31 +49,34 @@ impl ParticipantRegistry {
         }
     }
 
-    /// Spawns a [`Participant`] and its flush task against the supplied
+    /// Spawns a [`Participant`] and its flush-task against the supplied
     /// `writer` and inserts it into the registry.
     ///
     /// Each byte slice in `initial_messages` is queued on the participant's
-    /// control-plane channel after the flush task is spawned but before the
+    /// control-plane channel after the flush-task is spawned but before the
     /// participant is visible in the registry. This preserves the invariant
     /// that these bytes (typically `ServerInfo` + channel/service
-    /// advertisements) are the first the flush task delivers to the viewer,
+    /// advertisements) are the first the flush-task delivers to the viewer,
     /// ahead of any broadcast that reaches the participant after registration.
     ///
-    /// `livekit_sid` is stored on the new [`Participant`] so a later
+    /// `participant_sid` is stored on the new [`Participant`] so a later
     /// `ParticipantDisconnected` event can be matched against this specific
     /// connection instance rather than the identity alone.
     ///
     /// `session_cancel` is the session's cancellation token; the spawned
-    /// flush task takes a child of it so the task exits on session close.
+    /// flush-task takes a child of it so the task exits on session close.
     ///
     /// Returns `false` without spawning or inserting if a participant already
     /// exists for this identity. Callers that want to avoid opening a stream
     /// in that case should gate on [`has_participant`] before opening the
-    /// writer.
+    /// writer; this gate is only a backstop.
+    #[must_use = "register_participant returns false on a same-identity collision; \
+                  callers must check (or debug_assert) the result to catch \
+                  contract violations of the no-concurrent-call rule"]
     pub(crate) fn register_participant<I>(
         &self,
         id: ParticipantIdentity,
-        livekit_sid: ParticipantSid,
+        participant_sid: ParticipantSid,
         version: Version,
         writer: ParticipantWriter,
         session_cancel: &CancellationToken,
@@ -82,9 +85,13 @@ impl ParticipantRegistry {
     where
         I: IntoIterator<Item = Bytes>,
     {
+        if self.participants.read().contains_identity(&id) {
+            return false;
+        }
+
         let (participant, flush_handle) = Participant::spawn(
             id,
-            livekit_sid,
+            participant_sid,
             version,
             writer,
             self.message_backlog_size,
@@ -101,7 +108,7 @@ impl ParticipantRegistry {
     }
 
     /// Removes the participant registered under `id` if — and only if — its
-    /// stored `livekit_sid` matches `expected_sid`. Returns the removed
+    /// stored `participant_sid` matches `expected_sid`. Returns the removed
     /// participant (for its `ClientId`) or `None` if no match (either the
     /// identity isn't registered, or the stored SID belongs to a later
     /// connection instance that must not be torn down).
@@ -113,7 +120,7 @@ impl ParticipantRegistry {
     /// handler uses the disconnected participant's SID; `reset_participant`
     /// uses the stored participant's SID.
     ///
-    /// The flush task is cancelled and its handle detached; the caller is
+    /// The flush-task is cancelled and its handle detached; the caller is
     /// responsible for any further cleanup (subscription sweep, listener
     /// callbacks) via [`SessionState::cleanup_for_removed_identity`].
     pub(crate) fn remove_participant(
@@ -123,7 +130,7 @@ impl ParticipantRegistry {
     ) -> Option<Arc<Participant>> {
         let mut participants = self.participants.write();
         let current = participants.get_by_identity(id)?;
-        if current.livekit_sid() != expected_sid {
+        if current.participant_sid() != expected_sid {
             return None;
         }
         let removed = participants.remove_by_identity(id)?;
@@ -185,7 +192,7 @@ impl ParticipantRegistry {
 
     /// Test-only hook to simulate a flush-task failure by directly inserting
     /// a `ClientId` into the pending-reset set. In production this set is
-    /// only written by flush tasks on write failure and by
+    /// only written by flush-tasks on write failure and by
     /// `Participant::send_control` on queue overflow.
     #[cfg(test)]
     pub(crate) fn pending_resets(&self) -> &Arc<Mutex<HashSet<ClientId>>> {
@@ -198,7 +205,7 @@ impl ParticipantRegistry {
         &self.reset_notify
     }
 
-    /// Cancels every registered participant's flush task and awaits their
+    /// Cancels every registered participant's flush-task and awaits their
     /// completion. After this call the registry is empty.
     ///
     /// For use at session teardown only — the caller must ensure no further
@@ -279,7 +286,7 @@ mod tests {
     /// Regression test for the same-identity reconnect race:
     ///
     /// 1. Attempt 1 (`viewer-1`, LiveKit SID `S1`) is in the registry.
-    /// 2. Its flush task fails its first write and inserts its `ClientId`
+    /// 2. Its flush-task fails its first write and inserts its `ClientId`
     ///    into `pending_resets` (simulated here by calling the set directly).
     /// 3. The reset loop drains `pending_resets` and runs a reset: remove
     ///    attempt 1 (with `S1`), look up the current `RemoteParticipant` from
@@ -289,7 +296,7 @@ mod tests {
     ///    LiveKit for *attempt 1* before it dropped — is then dispatched to
     ///    `remove_participant(viewer-1, S1)`.
     ///
-    /// Because the currently-stored `Participant` has `livekit_sid = S2`, the
+    /// Because the currently-stored `Participant` has `participant_sid = S2`, the
     /// SID-keyed remove is a no-op. Attempt 2 stays registered.
     #[tokio::test]
     async fn stale_disconnect_must_not_remove_reconnected_participant() {
@@ -301,19 +308,19 @@ mod tests {
         let sid_2 = test_sid("viewer-1-attempt-2");
 
         // Step 1: attempt 1 joins.
-        registry.register_participant(
+        assert!(registry.register_participant(
             id.clone(),
             sid_1.clone(),
             version.clone(),
             test_writer(),
             &cancel,
             [],
-        );
+        ));
         let attempt_1 = registry.get_participant(&id).expect("attempt 1 present");
         let client_id_1 = attempt_1.client_id();
-        assert_eq!(attempt_1.livekit_sid(), &sid_1);
+        assert_eq!(attempt_1.participant_sid(), &sid_1);
 
-        // Step 2: simulate attempt 1's flush task failing its first write.
+        // Step 2: simulate attempt 1's flush-task failing its first write.
         registry.pending_resets().lock().insert(client_id_1);
 
         // Step 3: drain + reset. Reset = remove (with the stored SID) +
@@ -324,20 +331,20 @@ mod tests {
             .get_participant_by_client_id(client_id_1)
             .expect("attempt 1 resolves from drained client_id");
         let stored_version = reset_target.protocol_version().clone();
-        let stored_sid = reset_target.livekit_sid().clone();
+        let stored_sid = reset_target.participant_sid().clone();
         registry.remove_participant(reset_target.participant_id(), &stored_sid);
-        registry.register_participant(
+        assert!(registry.register_participant(
             id.clone(),
             sid_2.clone(),
             stored_version,
             test_writer(),
             &cancel,
             [],
-        );
+        ));
 
         let attempt_2 = registry.get_participant(&id).expect("attempt 2 present");
         assert_ne!(attempt_2.client_id(), client_id_1);
-        assert_eq!(attempt_2.livekit_sid(), &sid_2);
+        assert_eq!(attempt_2.participant_sid(), &sid_2);
 
         // Step 4: stale disconnect carries attempt 1's SID. No-op.
         let removed = registry.remove_participant(&id, &sid_1);

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -22,17 +22,16 @@ use tokio_util::sync::CancellationToken;
 
 use crate::remote_access::participant::{Participant, ParticipantWriter};
 use crate::remote_access::participants::Participants;
-use crate::remote_common::ClientId;
 
 /// Owns the participant membership state machine: add / remove / lookup, plus
 /// the `pending_resets` channel that lets a flush-task request its own reset.
 pub(crate) struct ParticipantRegistry {
     /// Map of connected participants and their flush-task join handles.
     participants: RwLock<Participants>,
-    /// Set of `ClientId`s pending a reset (disconnect + reconnect). Populated by
-    /// [`Participant::send_control`] on queue overflow and by flush-tasks on
-    /// write failure.
-    pending_resets: Arc<Mutex<HashSet<ClientId>>>,
+    /// Set of `ParticipantSid`s pending a reset (disconnect + reconnect).
+    /// Populated by [`Participant::send_control`] on queue overflow and by
+    /// flush-tasks on write failure.
+    pending_resets: Arc<Mutex<HashSet<ParticipantSid>>>,
     /// Notified when a new reset is inserted into `pending_resets`.
     reset_notify: Arc<Notify>,
     /// Size of the per-participant control-plane queue.
@@ -157,15 +156,12 @@ impl ParticipantRegistry {
             .collect()
     }
 
-    /// Returns the participant matching the given `ClientId`, if any.
-    pub(crate) fn get_participant_by_client_id(
+    /// Returns the participant matching the given `ParticipantSid`, if any.
+    pub(crate) fn get_participant_by_sid(
         &self,
-        client_id: ClientId,
+        sid: &ParticipantSid,
     ) -> Option<Arc<Participant>> {
-        self.participants
-            .read()
-            .get_by_client_id(client_id)
-            .cloned()
+        self.participants.read().get_by_sid(sid).cloned()
     }
 
     /// Returns true if a participant exists for the given identity.
@@ -185,16 +181,16 @@ impl ParticipantRegistry {
     }
 
     /// Drains the pending-reset set and returns its contents.
-    pub(crate) fn drain_pending_resets(&self) -> Vec<ClientId> {
+    pub(crate) fn drain_pending_resets(&self) -> Vec<ParticipantSid> {
         self.pending_resets.lock().drain().collect()
     }
 
     /// Test-only hook to simulate a flush-task failure by directly inserting
-    /// a `ClientId` into the pending-reset set. In production this set is
-    /// only written by flush-tasks on write failure and by
+    /// a `ParticipantSid` into the pending-reset set. In production this set
+    /// is only written by flush-tasks on write failure and by
     /// `Participant::send_control` on queue overflow.
     #[cfg(test)]
-    pub(crate) fn pending_resets(&self) -> &Arc<Mutex<HashSet<ClientId>>> {
+    pub(crate) fn pending_resets(&self) -> &Arc<Mutex<HashSet<ParticipantSid>>> {
         &self.pending_resets
     }
 
@@ -285,8 +281,9 @@ mod tests {
     /// Regression test for the same-identity reconnect race:
     ///
     /// 1. Attempt 1 (`viewer-1`, LiveKit SID `S1`) is in the registry.
-    /// 2. Its flush-task fails its first write and inserts its `ClientId`
-    ///    into `pending_resets` (simulated here by calling the set directly).
+    /// 2. Its flush-task fails its first write and inserts its
+    ///    `ParticipantSid` into `pending_resets` (simulated here by calling
+    ///    the set directly).
     /// 3. The reset loop drains `pending_resets` and runs a reset: remove
     ///    attempt 1 (with `S1`), look up the current `RemoteParticipant` from
     ///    LiveKit (attempt 2, SID `S2`, already reconnected), insert attempt
@@ -316,22 +313,21 @@ mod tests {
             [],
         ));
         let attempt_1 = registry.get_participant(&id).expect("attempt 1 present");
-        let client_id_1 = attempt_1.client_id();
         assert_eq!(attempt_1.participant_sid(), &sid_1);
 
         // Step 2: simulate attempt 1's flush-task failing its first write.
-        registry.pending_resets().lock().insert(client_id_1);
+        registry.pending_resets().lock().insert(sid_1.clone());
 
         // Step 3: drain + reset. Reset = remove (with the stored SID) +
         // re-insert under the new SID.
         let drained = registry.drain_pending_resets();
-        assert_eq!(drained, vec![client_id_1]);
+        assert_eq!(drained, vec![sid_1.clone()]);
         let reset_target = registry
-            .get_participant_by_client_id(client_id_1)
-            .expect("attempt 1 resolves from drained client_id");
+            .get_participant_by_sid(&sid_1)
+            .expect("attempt 1 resolves from drained sid");
         let stored_version = reset_target.protocol_version().clone();
-        let stored_sid = reset_target.participant_sid().clone();
-        registry.remove_participant(reset_target.participant_id(), &stored_sid);
+        let stored_id = reset_target.participant_id().clone();
+        registry.remove_participant(&stored_id, &sid_1);
         assert!(registry.register_participant(
             id.clone(),
             sid_2.clone(),
@@ -342,7 +338,7 @@ mod tests {
         ));
 
         let attempt_2 = registry.get_participant(&id).expect("attempt 2 present");
-        assert_ne!(attempt_2.client_id(), client_id_1);
+        assert_ne!(attempt_2.participant_sid(), &sid_1);
         assert_eq!(attempt_2.participant_sid(), &sid_2);
 
         // Step 4: stale disconnect carries attempt 1's SID. No-op.

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -57,9 +57,11 @@ impl ParticipantRegistry {
     /// advertisements) are the first the flush-task delivers to the viewer,
     /// ahead of any broadcast that reaches the participant after registration.
     ///
-    /// `participant_sid` is stored on the new [`Participant`] so a later
-    /// `ParticipantDisconnected` event can be matched against this specific
-    /// connection instance rather than the identity alone.
+    /// `participant_sid` is stored on the new [`Participant`] and indexed in
+    /// the registry so any later operation that targets a specific connection
+    /// instance — a `ParticipantDisconnected` event, or a queued reset from a
+    /// flush-task write failure — matches this exact instance rather than
+    /// some other connection that happens to share the identity.
     ///
     /// `session_cancel` is the session's cancellation token; the spawned
     /// flush-task takes a child of it so the task exits on session close.

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -1,0 +1,355 @@
+//! Participant-lifecycle state machine for a remote access session.
+//!
+//! Owns the participant map + per-participant flush-task handles, and the
+//! `pending_resets` / `reset_notify` signalling surfaces that let a flush task
+//! request its own reset. Deliberately knows nothing about LiveKit
+//! [`livekit::Room`]s: the caller (which *does* know about the Room) opens
+//! the control-plane stream and hands the resulting writer in. Tests build
+//! writers directly and never construct a `Room`.
+//!
+//! [`RemoteAccessSession`] wraps this registry and holds its own
+//! [`SessionState`] for channel/subscription/video bookkeeping.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use livekit::id::{ParticipantIdentity, ParticipantSid};
+use parking_lot::{Mutex, RwLock};
+use semver::Version;
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+use crate::remote_access::participant::{Participant, ParticipantWriter};
+use crate::remote_access::participants::Participants;
+use crate::remote_common::ClientId;
+
+/// Owns the participant membership state machine: add / remove / lookup, plus
+/// the `pending_resets` channel that lets a flush task request its own reset.
+pub(crate) struct ParticipantRegistry {
+    /// Map of connected participants and their flush-task join handles.
+    participants: RwLock<Participants>,
+    /// Set of `ClientId`s pending a reset (disconnect + reconnect). Populated by
+    /// [`Participant::send_control`] on queue overflow and by flush tasks on
+    /// write failure.
+    pending_resets: Arc<Mutex<HashSet<ClientId>>>,
+    /// Notified when a new reset is inserted into `pending_resets`.
+    reset_notify: Arc<Notify>,
+    /// Size of the per-participant control-plane queue.
+    message_backlog_size: usize,
+}
+
+impl ParticipantRegistry {
+    pub(crate) fn new(message_backlog_size: usize) -> Self {
+        Self {
+            participants: RwLock::new(Participants::new()),
+            pending_resets: Arc::new(Mutex::new(HashSet::new())),
+            reset_notify: Arc::new(Notify::new()),
+            message_backlog_size,
+        }
+    }
+
+    /// Spawns a [`Participant`] and its flush task against the supplied
+    /// `writer` and inserts it into the registry.
+    ///
+    /// Each byte slice in `initial_messages` is queued on the participant's
+    /// control-plane channel after the flush task is spawned but before the
+    /// participant is visible in the registry. This preserves the invariant
+    /// that these bytes (typically `ServerInfo` + channel/service
+    /// advertisements) are the first the flush task delivers to the viewer,
+    /// ahead of any broadcast that reaches the participant after registration.
+    ///
+    /// `livekit_sid` is stored on the new [`Participant`] so a later
+    /// `ParticipantDisconnected` event can be matched against this specific
+    /// connection instance rather than the identity alone.
+    ///
+    /// `session_cancel` is the session's cancellation token; the spawned
+    /// flush task takes a child of it so the task exits on session close.
+    ///
+    /// Returns `false` without spawning or inserting if a participant already
+    /// exists for this identity. Callers that want to avoid opening a stream
+    /// in that case should gate on [`has_participant`] before opening the
+    /// writer.
+    pub(crate) fn register_participant<I>(
+        &self,
+        id: ParticipantIdentity,
+        livekit_sid: ParticipantSid,
+        version: Version,
+        writer: ParticipantWriter,
+        session_cancel: &CancellationToken,
+        initial_messages: I,
+    ) -> bool
+    where
+        I: IntoIterator<Item = Bytes>,
+    {
+        let (participant, flush_handle) = Participant::spawn(
+            id,
+            livekit_sid,
+            version,
+            writer,
+            self.message_backlog_size,
+            self.pending_resets.clone(),
+            self.reset_notify.clone(),
+            session_cancel,
+        );
+
+        for msg in initial_messages {
+            participant.send_control(msg);
+        }
+
+        self.participants.write().insert(participant, flush_handle)
+    }
+
+    /// Removes the participant registered under `id` if — and only if — its
+    /// stored `livekit_sid` matches `expected_sid`. Returns the removed
+    /// participant (for its `ClientId`) or `None` if no match (either the
+    /// identity isn't registered, or the stored SID belongs to a later
+    /// connection instance that must not be torn down).
+    ///
+    /// Identity alone is ambiguous: a `ParticipantDisconnected` for a prior
+    /// instance can arrive after a same-identity reconnect has replaced it.
+    /// Requiring the SID at the call site means the caller has already
+    /// committed to which *specific* instance it's removing — the event
+    /// handler uses the disconnected participant's SID; `reset_participant`
+    /// uses the stored participant's SID.
+    ///
+    /// The flush task is cancelled and its handle detached; the caller is
+    /// responsible for any further cleanup (subscription sweep, listener
+    /// callbacks) via [`SessionState::cleanup_for_removed_identity`].
+    pub(crate) fn remove_participant(
+        &self,
+        id: &ParticipantIdentity,
+        expected_sid: &ParticipantSid,
+    ) -> Option<Arc<Participant>> {
+        let mut participants = self.participants.write();
+        let current = participants.get_by_identity(id)?;
+        if current.livekit_sid() != expected_sid {
+            return None;
+        }
+        let removed = participants.remove_by_identity(id)?;
+        removed.cancel();
+        Some(removed)
+    }
+
+    /// Returns the participant for the given identity, if any.
+    pub(crate) fn get_participant(&self, id: &ParticipantIdentity) -> Option<Arc<Participant>> {
+        self.participants.read().get_by_identity(id).cloned()
+    }
+
+    /// Resolves a batch of identities to `Arc<Participant>`s under a single
+    /// read lock. Identities with no matching registration are silently
+    /// skipped (a participant may have been removed between the identity
+    /// snapshot and this call; the missed send is harmless).
+    pub(crate) fn resolve_identities<I>(&self, identities: I) -> Vec<Arc<Participant>>
+    where
+        I: IntoIterator<Item = ParticipantIdentity>,
+    {
+        let participants = self.participants.read();
+        identities
+            .into_iter()
+            .filter_map(|id| participants.get_by_identity(&id).cloned())
+            .collect()
+    }
+
+    /// Returns the participant matching the given `ClientId`, if any.
+    pub(crate) fn get_participant_by_client_id(
+        &self,
+        client_id: ClientId,
+    ) -> Option<Arc<Participant>> {
+        self.participants
+            .read()
+            .get_by_client_id(client_id)
+            .cloned()
+    }
+
+    /// Returns true if a participant exists for the given identity.
+    pub(crate) fn has_participant(&self, id: &ParticipantIdentity) -> bool {
+        self.participants.read().contains_identity(id)
+    }
+
+    /// Returns the number of registered participants.
+    pub(crate) fn participant_count(&self) -> usize {
+        self.participants.read().len()
+    }
+
+    /// Clones every currently-registered participant into a `Vec`. Useful for
+    /// iterating at broadcast points without holding the read lock.
+    pub(crate) fn collect_participants(&self) -> Vec<Arc<Participant>> {
+        self.participants.read().iter().cloned().collect()
+    }
+
+    /// Drains the pending-reset set and returns its contents.
+    pub(crate) fn drain_pending_resets(&self) -> Vec<ClientId> {
+        self.pending_resets.lock().drain().collect()
+    }
+
+    /// Test-only hook to simulate a flush-task failure by directly inserting
+    /// a `ClientId` into the pending-reset set. In production this set is
+    /// only written by flush tasks on write failure and by
+    /// `Participant::send_control` on queue overflow.
+    #[cfg(test)]
+    pub(crate) fn pending_resets(&self) -> &Arc<Mutex<HashSet<ClientId>>> {
+        &self.pending_resets
+    }
+
+    /// Shared reference to the reset notifier, for use by the session's event
+    /// loop `select!`.
+    pub(crate) fn reset_notify(&self) -> &Arc<Notify> {
+        &self.reset_notify
+    }
+
+    /// Cancels every registered participant's flush task and awaits their
+    /// completion. After this call the registry is empty.
+    ///
+    /// For use at session teardown only — the caller must ensure no further
+    /// `register_participant` / `remove_participant` / `reset_participant`
+    /// calls can race with this one.
+    pub(crate) async fn shutdown(&self) {
+        let (participants, handles) = self.participants.write().drain();
+        for p in &participants {
+            p.cancel();
+        }
+        let _ = futures_util::future::join_all(handles).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter, test_sid};
+    use crate::remote_access::protocol_version;
+
+    fn make_registry() -> ParticipantRegistry {
+        ParticipantRegistry::new(16)
+    }
+
+    fn test_writer() -> ParticipantWriter {
+        ParticipantWriter::Test(Arc::new(TestByteStreamWriter::default()))
+    }
+
+    #[tokio::test]
+    async fn insert_then_remove_roundtrip() {
+        let registry = make_registry();
+        let cancel = CancellationToken::new();
+        let id = ParticipantIdentity("alice".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+
+        let sid = test_sid("alice-1");
+        let inserted = registry.register_participant(
+            id.clone(),
+            sid.clone(),
+            version,
+            test_writer(),
+            &cancel,
+            [],
+        );
+        assert!(inserted);
+        assert!(registry.has_participant(&id));
+
+        assert!(registry.remove_participant(&id, &sid).is_some());
+        assert!(!registry.has_participant(&id));
+    }
+
+    #[tokio::test]
+    async fn insert_is_noop_when_identity_already_present() {
+        let registry = make_registry();
+        let cancel = CancellationToken::new();
+        let id = ParticipantIdentity("alice".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+
+        assert!(registry.register_participant(
+            id.clone(),
+            test_sid("alice-1"),
+            version.clone(),
+            test_writer(),
+            &cancel,
+            [],
+        ));
+        assert!(!registry.register_participant(
+            id.clone(),
+            test_sid("alice-2"),
+            version,
+            test_writer(),
+            &cancel,
+            [],
+        ));
+    }
+
+    /// Regression test for the same-identity reconnect race:
+    ///
+    /// 1. Attempt 1 (`viewer-1`, LiveKit SID `S1`) is in the registry.
+    /// 2. Its flush task fails its first write and inserts its `ClientId`
+    ///    into `pending_resets` (simulated here by calling the set directly).
+    /// 3. The reset loop drains `pending_resets` and runs a reset: remove
+    ///    attempt 1 (with `S1`), look up the current `RemoteParticipant` from
+    ///    LiveKit (attempt 2, SID `S2`, already reconnected), insert attempt
+    ///    2 with `S2`.
+    /// 4. A `ParticipantDisconnected(viewer-1, sid=S1)` event — queued by
+    ///    LiveKit for *attempt 1* before it dropped — is then dispatched to
+    ///    `remove_participant(viewer-1, S1)`.
+    ///
+    /// Because the currently-stored `Participant` has `livekit_sid = S2`, the
+    /// SID-keyed remove is a no-op. Attempt 2 stays registered.
+    #[tokio::test]
+    async fn stale_disconnect_must_not_remove_reconnected_participant() {
+        let registry = make_registry();
+        let cancel = CancellationToken::new();
+        let id = ParticipantIdentity("viewer-1".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let sid_1 = test_sid("viewer-1-attempt-1");
+        let sid_2 = test_sid("viewer-1-attempt-2");
+
+        // Step 1: attempt 1 joins.
+        registry.register_participant(
+            id.clone(),
+            sid_1.clone(),
+            version.clone(),
+            test_writer(),
+            &cancel,
+            [],
+        );
+        let attempt_1 = registry.get_participant(&id).expect("attempt 1 present");
+        let client_id_1 = attempt_1.client_id();
+        assert_eq!(attempt_1.livekit_sid(), &sid_1);
+
+        // Step 2: simulate attempt 1's flush task failing its first write.
+        registry.pending_resets().lock().insert(client_id_1);
+
+        // Step 3: drain + reset. Reset = remove (with the stored SID) +
+        // re-insert under the new SID.
+        let drained = registry.drain_pending_resets();
+        assert_eq!(drained, vec![client_id_1]);
+        let reset_target = registry
+            .get_participant_by_client_id(client_id_1)
+            .expect("attempt 1 resolves from drained client_id");
+        let stored_version = reset_target.protocol_version().clone();
+        let stored_sid = reset_target.livekit_sid().clone();
+        registry.remove_participant(reset_target.participant_id(), &stored_sid);
+        registry.register_participant(
+            id.clone(),
+            sid_2.clone(),
+            stored_version,
+            test_writer(),
+            &cancel,
+            [],
+        );
+
+        let attempt_2 = registry.get_participant(&id).expect("attempt 2 present");
+        assert_ne!(attempt_2.client_id(), client_id_1);
+        assert_eq!(attempt_2.livekit_sid(), &sid_2);
+
+        // Step 4: stale disconnect carries attempt 1's SID. No-op.
+        let removed = registry.remove_participant(&id, &sid_1);
+        assert!(removed.is_none());
+        assert!(
+            registry.has_participant(&id),
+            "attempt 2 must still be registered after stale disconnect was ignored",
+        );
+
+        // Sanity: matching SID does remove.
+        let removed = registry.remove_participant(&id, &sid_2);
+        assert!(removed.is_some());
+        assert!(!registry.has_participant(&id));
+    }
+}

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use bytes::Bytes;
 use livekit::id::{ParticipantIdentity, ParticipantSid};
 use parking_lot::{Mutex, RwLock};
-use semver::Version;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
@@ -76,7 +75,6 @@ impl ParticipantRegistry {
         &self,
         id: ParticipantIdentity,
         participant_sid: ParticipantSid,
-        version: Version,
         writer: ParticipantWriter,
         session_cancel: &CancellationToken,
         initial_messages: I,
@@ -91,7 +89,6 @@ impl ParticipantRegistry {
         let (participant, flush_handle) = Participant::spawn(
             id,
             participant_sid,
-            version,
             writer,
             self.message_backlog_size,
             self.pending_resets.clone(),
@@ -202,7 +199,6 @@ mod tests {
     use super::*;
 
     use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter, test_sid};
-    use crate::remote_access::protocol_version;
 
     fn make_registry() -> ParticipantRegistry {
         ParticipantRegistry::new(16)
@@ -217,13 +213,11 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
 
         let sid = test_sid("alice-1");
         let inserted = registry.register_participant(
             id.clone(),
             sid.clone(),
-            version,
             test_writer(),
             &cancel,
             [],
@@ -240,12 +234,10 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
 
         assert!(registry.register_participant(
             id.clone(),
             test_sid("alice-1"),
-            version.clone(),
             test_writer(),
             &cancel,
             [],
@@ -253,7 +245,6 @@ mod tests {
         assert!(!registry.register_participant(
             id.clone(),
             test_sid("alice-2"),
-            version,
             test_writer(),
             &cancel,
             [],
@@ -282,7 +273,6 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("viewer-1".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid_1 = test_sid("viewer-1-attempt-1");
         let sid_2 = test_sid("viewer-1-attempt-2");
 
@@ -290,7 +280,6 @@ mod tests {
         assert!(registry.register_participant(
             id.clone(),
             sid_1.clone(),
-            version.clone(),
             test_writer(),
             &cancel,
             [],
@@ -305,15 +294,10 @@ mod tests {
         // re-insert under the new SID.
         let drained = registry.drain_pending_resets();
         assert_eq!(drained, vec![sid_1.clone()]);
-        let removed = registry
-            .remove_participant(&sid_1)
-            .expect("attempt 1 removes via its SID");
-        let stored_version = removed.protocol_version().clone();
-        drop(removed);
+        assert!(registry.remove_participant(&sid_1).is_some());
         assert!(registry.register_participant(
             id.clone(),
             sid_2.clone(),
-            stored_version,
             test_writer(),
             &cancel,
             [],

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -120,9 +120,10 @@ impl ParticipantRegistry {
     /// handler uses the disconnected participant's SID; `reset_participant`
     /// uses the stored participant's SID.
     ///
-    /// The flush-task is cancelled and its handle detached; the caller is
-    /// responsible for any further cleanup (subscription sweep, listener
-    /// callbacks) via [`SessionState::cleanup_for_removed_identity`].
+    /// `Participants::remove_by_identity` cancels the flush-task and detaches
+    /// its handle as part of the removal; the caller is responsible for any
+    /// further cleanup (subscription sweep, listener callbacks) via
+    /// [`SessionState::cleanup_for_removed_identity`].
     pub(crate) fn remove_participant(
         &self,
         id: &ParticipantIdentity,
@@ -133,9 +134,7 @@ impl ParticipantRegistry {
         if current.participant_sid() != expected_sid {
             return None;
         }
-        let removed = participants.remove_by_identity(id)?;
-        removed.cancel();
-        Some(removed)
+        participants.remove_by_identity(id)
     }
 
     /// Returns the participant for the given identity, if any.

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -1,26 +1,30 @@
-//! Two-key lookup table for connected participants.
+//! Two-key lookup table for connected participants, plus their flush-task
+//! join handles.
 //!
-//! Maintains both `ParticipantIdentity` → `Arc<Participant>` and
-//! `ClientId` → `Arc<Participant>` indexes. Both reference the same
-//! `Arc<Participant>` values and are kept in sync by construction —
-//! mutation is only possible through the inherent methods on [`Participants`],
-//! all of which update both indexes together.
+//! Maintains `ParticipantIdentity` → `Arc<Participant>` and
+//! `ClientId` → `Arc<Participant>` indexes over the same `Arc<Participant>`
+//! values, and a parallel `ParticipantIdentity` → `JoinHandle<()>` map for
+//! each participant's flush task. All three are kept in sync by construction
+//! — mutation is only possible through the inherent methods on [`Participants`].
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use livekit::id::ParticipantIdentity;
+use tokio::task::JoinHandle;
 
 use crate::remote_access::participant::Participant;
 use crate::remote_common::ClientId;
 
 /// Collection of connected participants, indexed by both `ParticipantIdentity`
-/// and `ClientId`.
+/// and `ClientId`, with each participant's flush-task `JoinHandle` stored
+/// alongside.
 #[derive(Default)]
 pub(crate) struct Participants {
     by_identity: HashMap<ParticipantIdentity, Arc<Participant>>,
     by_client_id: HashMap<ClientId, Arc<Participant>>,
+    flush_handles: HashMap<ParticipantIdentity, JoinHandle<()>>,
 }
 
 impl Participants {
@@ -28,28 +32,35 @@ impl Participants {
         Self::default()
     }
 
-    /// Inserts `participant` if no participant with the same identity is present.
+    /// Inserts `participant` and its flush-task handle if no participant
+    /// with the same identity is present.
     ///
-    /// Returns `true` on insert, `false` if the identity was already occupied —
-    /// in the latter case neither index is modified.
-    pub fn insert(&mut self, participant: Arc<Participant>) -> bool {
+    /// Returns `true` on insert, `false` if the identity was already occupied
+    /// — in the latter case no index is modified and `flush_handle` is
+    /// dropped.
+    pub fn insert(&mut self, participant: Arc<Participant>, flush_handle: JoinHandle<()>) -> bool {
         let identity = participant.participant_id().clone();
-        let Entry::Vacant(v) = self.by_identity.entry(identity) else {
+        let Entry::Vacant(v) = self.by_identity.entry(identity.clone()) else {
             return false;
         };
         self.by_client_id
             .insert(participant.client_id(), participant.clone());
+        self.flush_handles.insert(identity, flush_handle);
         v.insert(participant);
         true
     }
 
-    /// Removes and returns the participant for the given identity, if present.
+    /// Removes the participant for the given identity, along with its flush
+    /// handle. Returns the participant; the flush handle is detached and
+    /// dropped so the task exits when its control-plane channel senders are
+    /// all gone (or earlier, if the caller cancels the participant).
     pub fn remove_by_identity(
         &mut self,
         identity: &ParticipantIdentity,
     ) -> Option<Arc<Participant>> {
         let participant = self.by_identity.remove(identity)?;
         self.by_client_id.remove(&participant.client_id());
+        drop(self.flush_handles.remove(identity));
         Some(participant)
     }
 
@@ -78,10 +89,12 @@ impl Participants {
         self.by_identity.len()
     }
 
-    /// Removes all participants and returns them.
-    pub fn take(&mut self) -> Vec<Arc<Participant>> {
+    /// Removes all participants and their flush handles, returning both.
+    pub fn drain(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
         self.by_client_id.clear();
-        self.by_identity.drain().map(|(_, p)| p).collect()
+        let participants = self.by_identity.drain().map(|(_, p)| p).collect();
+        let handles = self.flush_handles.drain().map(|(_, h)| h).collect();
+        (participants, handles)
     }
 }
 
@@ -109,39 +122,45 @@ mod tests {
         ))
     }
 
-    #[test]
-    fn insert_returns_true_for_new_identity() {
+    /// Builds a trivial `JoinHandle<()>` for tests. Must be called from within
+    /// a tokio runtime context (provided by `#[tokio::test]`).
+    fn dummy_handle() -> JoinHandle<()> {
+        tokio::spawn(async {})
+    }
+
+    #[tokio::test]
+    async fn insert_returns_true_for_new_identity() {
         let mut ps = Participants::new();
-        assert!(ps.insert(make_participant("alice")));
+        assert!(ps.insert(make_participant("alice"), dummy_handle()));
         assert_eq!(ps.len(), 1);
     }
 
-    #[test]
-    fn insert_returns_false_for_duplicate_identity() {
+    #[tokio::test]
+    async fn insert_returns_false_for_duplicate_identity() {
         let mut ps = Participants::new();
-        assert!(ps.insert(make_participant("alice")));
-        assert!(!ps.insert(make_participant("alice")));
+        assert!(ps.insert(make_participant("alice"), dummy_handle()));
+        assert!(!ps.insert(make_participant("alice"), dummy_handle()));
         assert_eq!(ps.len(), 1);
     }
 
-    #[test]
-    fn insert_populates_both_indexes() {
+    #[tokio::test]
+    async fn insert_populates_both_indexes() {
         let mut ps = Participants::new();
         let p = make_participant("alice");
         let identity = p.participant_id().clone();
         let client_id = p.client_id();
-        assert!(ps.insert(p));
+        assert!(ps.insert(p, dummy_handle()));
         assert!(ps.get_by_identity(&identity).is_some());
         assert!(ps.get_by_client_id(client_id).is_some());
     }
 
-    #[test]
-    fn remove_by_identity_clears_both_indexes() {
+    #[tokio::test]
+    async fn remove_by_identity_clears_both_indexes() {
         let mut ps = Participants::new();
         let p = make_participant("alice");
         let identity = p.participant_id().clone();
         let client_id = p.client_id();
-        ps.insert(p);
+        ps.insert(p, dummy_handle());
         assert!(ps.remove_by_identity(&identity).is_some());
         assert!(ps.get_by_identity(&identity).is_none());
         assert!(ps.get_by_client_id(client_id).is_none());
@@ -155,40 +174,70 @@ mod tests {
         assert!(ps.remove_by_identity(&missing).is_none());
     }
 
-    #[test]
-    fn duplicate_insert_does_not_disturb_existing_entry() {
+    #[tokio::test]
+    async fn duplicate_insert_does_not_disturb_existing_entry() {
         let mut ps = Participants::new();
         let first = make_participant("alice");
         let first_client_id = first.client_id();
-        ps.insert(first);
+        ps.insert(first, dummy_handle());
         // Second participant has the same identity but a distinct client_id.
         let second = make_participant("alice");
         let second_client_id = second.client_id();
         assert_ne!(first_client_id, second_client_id);
-        assert!(!ps.insert(second));
+        assert!(!ps.insert(second, dummy_handle()));
         // Secondary index must not contain the rejected participant's client_id.
         assert!(ps.get_by_client_id(first_client_id).is_some());
         assert!(ps.get_by_client_id(second_client_id).is_none());
     }
 
-    #[test]
-    fn take_clears_both_indexes_and_returns_all() {
+    /// Load-bearing invariant for the reset-drain loop: after a participant
+    /// is removed and a new one is inserted under the same identity, the old
+    /// `ClientId` must not resolve to the replacement. If it did,
+    /// `handle_room_events`' drain would spuriously reset the reconnected
+    /// participant on a stale flush-failure notification.
+    #[tokio::test]
+    async fn get_by_client_id_does_not_match_replaced_participant() {
+        let mut ps = Participants::new();
+        let original = make_participant("alice");
+        let identity = original.participant_id().clone();
+        let original_client_id = original.client_id();
+        ps.insert(original, dummy_handle());
+        ps.remove_by_identity(&identity);
+
+        let replacement = make_participant("alice");
+        let replacement_client_id = replacement.client_id();
+        assert_ne!(original_client_id, replacement_client_id);
+        ps.insert(replacement, dummy_handle());
+
+        assert!(
+            ps.get_by_client_id(original_client_id).is_none(),
+            "stale ClientId must not resolve to the replacement participant",
+        );
+        assert!(
+            ps.get_by_client_id(replacement_client_id).is_some(),
+            "fresh ClientId must resolve to the current participant",
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_clears_both_indexes_and_returns_all() {
         let mut ps = Participants::new();
         let alice = make_participant("alice");
         let alice_client_id = alice.client_id();
-        ps.insert(alice);
-        ps.insert(make_participant("bob"));
-        let taken = ps.take();
+        ps.insert(alice, dummy_handle());
+        ps.insert(make_participant("bob"), dummy_handle());
+        let (taken, handles) = ps.drain();
         assert_eq!(taken.len(), 2);
+        assert_eq!(handles.len(), 2);
         assert_eq!(ps.len(), 0);
         assert!(ps.get_by_client_id(alice_client_id).is_none());
     }
 
-    #[test]
-    fn iter_yields_all_registered_participants() {
+    #[tokio::test]
+    async fn iter_yields_all_registered_participants() {
         let mut ps = Participants::new();
-        ps.insert(make_participant("alice"));
-        ps.insert(make_participant("bob"));
+        ps.insert(make_participant("alice"), dummy_handle());
+        ps.insert(make_participant("bob"), dummy_handle());
         assert_eq!(ps.iter().count(), 2);
     }
 }

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -2,28 +2,28 @@
 //! join handles.
 //!
 //! Maintains `ParticipantIdentity` → `Arc<Participant>` and
-//! `ClientId` → `Arc<Participant>` indexes over the same `Arc<Participant>`
-//! values, and a parallel `ParticipantIdentity` → `JoinHandle<()>` map for
-//! each participant's flush-task. All three are kept in sync by construction
-//! — mutation is only possible through the inherent methods on [`Participants`].
+//! `ParticipantSid` → `Arc<Participant>` indexes over the same
+//! `Arc<Participant>` values, and a parallel `ParticipantIdentity` →
+//! `JoinHandle<()>` map for each participant's flush-task. All three are kept
+//! in sync by construction — mutation is only possible through the inherent
+//! methods on [`Participants`].
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use livekit::id::ParticipantIdentity;
+use livekit::id::{ParticipantIdentity, ParticipantSid};
 use tokio::task::JoinHandle;
 
 use crate::remote_access::participant::Participant;
-use crate::remote_common::ClientId;
 
 /// Collection of connected participants, indexed by both `ParticipantIdentity`
-/// and `ClientId`, with each participant's flush-task `JoinHandle` stored
-/// alongside.
+/// and `ParticipantSid`, with each participant's flush-task `JoinHandle`
+/// stored alongside.
 #[derive(Default)]
 pub(crate) struct Participants {
     by_identity: HashMap<ParticipantIdentity, Arc<Participant>>,
-    by_client_id: HashMap<ClientId, Arc<Participant>>,
+    by_sid: HashMap<ParticipantSid, Arc<Participant>>,
     flush_handles: HashMap<ParticipantIdentity, JoinHandle<()>>,
 }
 
@@ -43,8 +43,8 @@ impl Participants {
         let Entry::Vacant(v) = self.by_identity.entry(identity.clone()) else {
             return false;
         };
-        self.by_client_id
-            .insert(participant.client_id(), participant.clone());
+        self.by_sid
+            .insert(participant.participant_sid().clone(), participant.clone());
         self.flush_handles.insert(identity, flush_handle);
         v.insert(participant);
         true
@@ -60,7 +60,7 @@ impl Participants {
         identity: &ParticipantIdentity,
     ) -> Option<Arc<Participant>> {
         let participant = self.by_identity.remove(identity)?;
-        self.by_client_id.remove(&participant.client_id());
+        self.by_sid.remove(participant.participant_sid());
         drop(self.flush_handles.remove(identity));
         participant.cancel();
         Some(participant)
@@ -71,9 +71,9 @@ impl Participants {
         self.by_identity.get(identity)
     }
 
-    /// Returns the participant for the given `client_id`, if present.
-    pub fn get_by_client_id(&self, client_id: ClientId) -> Option<&Arc<Participant>> {
-        self.by_client_id.get(&client_id)
+    /// Returns the participant for the given `ParticipantSid`, if present.
+    pub fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
+        self.by_sid.get(sid)
     }
 
     /// Returns `true` if a participant with this identity is registered.
@@ -93,7 +93,7 @@ impl Participants {
 
     /// Removes all participants and their flush handles, returning both.
     pub fn drain(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
-        self.by_client_id.clear();
+        self.by_sid.clear();
         let participants = self.by_identity.drain().map(|(_, p)| p).collect();
         let handles = self.flush_handles.drain().map(|(_, h)| h).collect();
         (participants, handles)
@@ -155,10 +155,10 @@ mod tests {
         let mut ps = Participants::new();
         let p = make_participant("alice");
         let identity = p.participant_id().clone();
-        let client_id = p.client_id();
+        let sid = p.participant_sid().clone();
         assert!(ps.insert(p, dummy_handle()));
         assert!(ps.get_by_identity(&identity).is_some());
-        assert!(ps.get_by_client_id(client_id).is_some());
+        assert!(ps.get_by_sid(&sid).is_some());
     }
 
     #[tokio::test]
@@ -166,11 +166,11 @@ mod tests {
         let mut ps = Participants::new();
         let p = make_participant("alice");
         let identity = p.participant_id().clone();
-        let client_id = p.client_id();
+        let sid = p.participant_sid().clone();
         ps.insert(p, dummy_handle());
         assert!(ps.remove_by_identity(&identity).is_some());
         assert!(ps.get_by_identity(&identity).is_none());
-        assert!(ps.get_by_client_id(client_id).is_none());
+        assert!(ps.get_by_sid(&sid).is_none());
         assert_eq!(ps.len(), 0);
     }
 
@@ -185,44 +185,44 @@ mod tests {
     async fn duplicate_insert_does_not_disturb_existing_entry() {
         let mut ps = Participants::new();
         let first = make_participant("alice");
-        let first_client_id = first.client_id();
+        let first_sid = first.participant_sid().clone();
         ps.insert(first, dummy_handle());
-        // Second participant has the same identity but a distinct client_id.
+        // Second participant has the same identity but a distinct SID.
         let second = make_participant("alice");
-        let second_client_id = second.client_id();
-        assert_ne!(first_client_id, second_client_id);
+        let second_sid = second.participant_sid().clone();
+        assert_ne!(first_sid, second_sid);
         assert!(!ps.insert(second, dummy_handle()));
-        // Secondary index must not contain the rejected participant's client_id.
-        assert!(ps.get_by_client_id(first_client_id).is_some());
-        assert!(ps.get_by_client_id(second_client_id).is_none());
+        // Secondary index must not contain the rejected participant's SID.
+        assert!(ps.get_by_sid(&first_sid).is_some());
+        assert!(ps.get_by_sid(&second_sid).is_none());
     }
 
     /// Load-bearing invariant for the reset-drain loop: after a participant
     /// is removed and a new one is inserted under the same identity, the old
-    /// `ClientId` must not resolve to the replacement. If it did,
+    /// `ParticipantSid` must not resolve to the replacement. If it did,
     /// `handle_room_events`' drain would spuriously reset the reconnected
     /// participant on a stale flush-failure notification.
     #[tokio::test]
-    async fn get_by_client_id_does_not_match_replaced_participant() {
+    async fn get_by_sid_does_not_match_replaced_participant() {
         let mut ps = Participants::new();
         let original = make_participant("alice");
         let identity = original.participant_id().clone();
-        let original_client_id = original.client_id();
+        let original_sid = original.participant_sid().clone();
         ps.insert(original, dummy_handle());
         ps.remove_by_identity(&identity);
 
         let replacement = make_participant("alice");
-        let replacement_client_id = replacement.client_id();
-        assert_ne!(original_client_id, replacement_client_id);
+        let replacement_sid = replacement.participant_sid().clone();
+        assert_ne!(original_sid, replacement_sid);
         ps.insert(replacement, dummy_handle());
 
         assert!(
-            ps.get_by_client_id(original_client_id).is_none(),
-            "stale ClientId must not resolve to the replacement participant",
+            ps.get_by_sid(&original_sid).is_none(),
+            "stale ParticipantSid must not resolve to the replacement participant",
         );
         assert!(
-            ps.get_by_client_id(replacement_client_id).is_some(),
-            "fresh ClientId must resolve to the current participant",
+            ps.get_by_sid(&replacement_sid).is_some(),
+            "fresh ParticipantSid must resolve to the current participant",
         );
     }
 
@@ -230,14 +230,14 @@ mod tests {
     async fn drain_clears_both_indexes_and_returns_all() {
         let mut ps = Participants::new();
         let alice = make_participant("alice");
-        let alice_client_id = alice.client_id();
+        let alice_sid = alice.participant_sid().clone();
         ps.insert(alice, dummy_handle());
         ps.insert(make_participant("bob"), dummy_handle());
         let (taken, handles) = ps.drain();
         assert_eq!(taken.len(), 2);
         assert_eq!(handles.len(), 2);
         assert_eq!(ps.len(), 0);
-        assert!(ps.get_by_client_id(alice_client_id).is_none());
+        assert!(ps.get_by_sid(&alice_sid).is_none());
     }
 
     #[tokio::test]

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -50,10 +50,11 @@ impl Participants {
         true
     }
 
-    /// Removes the participant for the given identity, along with its flush
-    /// handle. Returns the participant; the flush handle is detached and
-    /// dropped so the task exits when its control-plane channel senders are
-    /// all gone (or earlier, if the caller cancels the participant).
+    /// Removes the participant for the given identity, cancels its flush-task,
+    /// and detaches the task handle. Returns the participant. Cancellation
+    /// makes the task exit at its next `select!` iteration rather than when
+    /// senders eventually drop; the detached handle is then dropped without
+    /// being awaited.
     pub fn remove_by_identity(
         &mut self,
         identity: &ParticipantIdentity,
@@ -61,6 +62,7 @@ impl Participants {
         let participant = self.by_identity.remove(identity)?;
         self.by_client_id.remove(&participant.client_id());
         drop(self.flush_handles.remove(identity));
+        participant.cancel();
         Some(participant)
     }
 

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -61,7 +61,7 @@ impl Participants {
     /// already been removed, will not match here because each connection
     /// instance gets a unique `ParticipantSid` (a same-identity reconnect
     /// has a *different* SID).
-    pub fn remove_by_sid(&mut self, sid: &ParticipantSid) -> Option<Arc<Participant>> {
+    pub(crate) fn remove_by_sid(&mut self, sid: &ParticipantSid) -> Option<Arc<Participant>> {
         let participant = self.by_sid.remove(sid)?;
         let identity = participant.participant_id();
         self.by_identity.remove(identity);
@@ -79,7 +79,7 @@ impl Participants {
     /// Test-only accessor — production reads the index implicitly via
     /// [`remove_by_sid`].
     #[cfg(test)]
-    pub fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
+    pub(crate) fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
         self.by_sid.get(sid)
     }
 
@@ -99,7 +99,7 @@ impl Participants {
     }
 
     /// Removes all participants and their flush handles, returning both.
-    pub fn drain(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
+    pub(crate) fn drain(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
         self.by_sid.clear();
         let participants = self.by_identity.drain().map(|(_, p)| p).collect();
         let handles = self.flush_handles.drain().map(|(_, h)| h).collect();

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -4,7 +4,7 @@
 //! Maintains `ParticipantIdentity` → `Arc<Participant>` and
 //! `ClientId` → `Arc<Participant>` indexes over the same `Arc<Participant>`
 //! values, and a parallel `ParticipantIdentity` → `JoinHandle<()>` map for
-//! each participant's flush task. All three are kept in sync by construction
+//! each participant's flush-task. All three are kept in sync by construction
 //! — mutation is only possible through the inherent methods on [`Participants`].
 
 use std::collections::HashMap;
@@ -105,7 +105,11 @@ mod tests {
     use super::*;
 
     fn make_participant(name: &str) -> Arc<Participant> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
+        let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
         let version =
             crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
@@ -114,6 +118,7 @@ mod tests {
         let cancel = tokio_util::sync::CancellationToken::new();
         Arc::new(Participant::new(
             identity,
+            sid,
             version,
             tx,
             pending_resets,

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -124,6 +124,8 @@ mod tests {
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
         let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
+        let version =
+            crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -131,6 +133,7 @@ mod tests {
         Arc::new(Participant::new(
             identity,
             sid,
+            version,
             tx,
             pending_resets,
             reset_notify,

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -98,12 +98,17 @@ impl Participants {
         self.by_identity.len()
     }
 
-    /// Removes all participants and their flush handles, returning both.
-    pub(crate) fn drain(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
+    /// Cancels every participant's flush-task, clears all indexes, and
+    /// returns the detached `JoinHandle`s for the caller to await. After
+    /// this returns the registry is empty. Parallels [`remove_by_sid`] in
+    /// owning the cancel-then-detach lifecycle internally.
+    pub(crate) fn drain(&mut self) -> Vec<JoinHandle<()>> {
+        for p in self.by_identity.values() {
+            p.cancel();
+        }
+        self.by_identity.clear();
         self.by_sid.clear();
-        let participants = self.by_identity.drain().map(|(_, p)| p).collect();
-        let handles = self.flush_handles.drain().map(|(_, h)| h).collect();
-        (participants, handles)
+        self.flush_handles.drain().map(|(_, h)| h).collect()
     }
 }
 
@@ -230,14 +235,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drain_clears_both_indexes_and_returns_all() {
+    async fn drain_clears_indexes_and_returns_handles() {
         let mut ps = Participants::new();
         let alice = make_participant("alice");
         let alice_sid = alice.participant_sid().clone();
         ps.insert(alice, dummy_handle());
         ps.insert(make_participant("bob"), dummy_handle());
-        let (taken, handles) = ps.drain();
-        assert_eq!(taken.len(), 2);
+        let handles = ps.drain();
         assert_eq!(handles.len(), 2);
         assert_eq!(ps.len(), 0);
         assert!(ps.get_by_sid(&alice_sid).is_none());

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -50,17 +50,21 @@ impl Participants {
         true
     }
 
-    /// Removes the participant for the given identity, cancels its flush-task,
-    /// and detaches the task handle. Returns the participant. Cancellation
-    /// makes the task exit at its next `select!` iteration rather than when
-    /// senders eventually drop; the detached handle is then dropped without
-    /// being awaited.
-    pub fn remove_by_identity(
-        &mut self,
-        identity: &ParticipantIdentity,
-    ) -> Option<Arc<Participant>> {
-        let participant = self.by_identity.remove(identity)?;
-        self.by_sid.remove(participant.participant_sid());
+    /// Removes the participant matching `sid`, cancels its flush-task, and
+    /// detaches the task handle. Cancellation makes the task exit at its next
+    /// `select!` iteration rather than when senders eventually drop; the
+    /// detached handle is then dropped without being awaited.
+    ///
+    /// Returns `None` if no participant with this SID is registered. A miss
+    /// is the staleness filter: a `ParticipantDisconnected` for a prior
+    /// connection instance, or a queued reset for a participant that's
+    /// already been removed, will not match here because each connection
+    /// instance gets a unique `ParticipantSid` (a same-identity reconnect
+    /// has a *different* SID).
+    pub fn remove_by_sid(&mut self, sid: &ParticipantSid) -> Option<Arc<Participant>> {
+        let participant = self.by_sid.remove(sid)?;
+        let identity = participant.participant_id();
+        self.by_identity.remove(identity);
         drop(self.flush_handles.remove(identity));
         participant.cancel();
         Some(participant)
@@ -72,6 +76,9 @@ impl Participants {
     }
 
     /// Returns the participant for the given `ParticipantSid`, if present.
+    /// Test-only accessor — production reads the index implicitly via
+    /// [`remove_by_sid`].
+    #[cfg(test)]
     pub fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
         self.by_sid.get(sid)
     }
@@ -162,23 +169,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remove_by_identity_clears_both_indexes() {
+    async fn remove_by_sid_clears_both_indexes() {
         let mut ps = Participants::new();
         let p = make_participant("alice");
         let identity = p.participant_id().clone();
         let sid = p.participant_sid().clone();
         ps.insert(p, dummy_handle());
-        assert!(ps.remove_by_identity(&identity).is_some());
+        assert!(ps.remove_by_sid(&sid).is_some());
         assert!(ps.get_by_identity(&identity).is_none());
         assert!(ps.get_by_sid(&sid).is_none());
         assert_eq!(ps.len(), 0);
     }
 
     #[test]
-    fn remove_by_identity_returns_none_for_missing() {
+    fn remove_by_sid_returns_none_for_missing() {
         let mut ps = Participants::new();
-        let missing = ParticipantIdentity("nobody".to_string());
-        assert!(ps.remove_by_identity(&missing).is_none());
+        let missing = crate::remote_access::participant::test_sid("nobody");
+        assert!(ps.remove_by_sid(&missing).is_none());
     }
 
     #[tokio::test]
@@ -206,10 +213,9 @@ mod tests {
     async fn get_by_sid_does_not_match_replaced_participant() {
         let mut ps = Participants::new();
         let original = make_participant("alice");
-        let identity = original.participant_id().clone();
         let original_sid = original.participant_sid().clone();
         ps.insert(original, dummy_handle());
-        ps.remove_by_identity(&identity);
+        ps.remove_by_sid(&original_sid);
 
         let replacement = make_participant("alice");
         let replacement_sid = replacement.participant_sid().clone();

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -119,8 +119,6 @@ mod tests {
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
         let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
-        let version =
-            crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -128,7 +126,6 @@ mod tests {
         Arc::new(Participant::new(
             identity,
             sid,
-            version,
             tx,
             pending_resets,
             reset_notify,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -142,7 +142,7 @@ pub(crate) struct RemoteAccessSession {
     remote_access_session_id: Option<String>,
     /// Session-level state: channels, subscriptions, video publishers, client
     /// channels, parameter subscriptions. Participant membership lives on
-    /// [`registry`] instead.
+    /// [`participant_registry`] instead.
     state: RwLock<SessionState>,
     channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     qos_classifier: Option<Arc<dyn QosClassifier>>,
@@ -168,7 +168,7 @@ pub(crate) struct RemoteAccessSession {
     /// Immutable `ServerInfo` message sent to each participant on connect and reset.
     server_info: ServerInfo,
     /// Participant membership and flush-task lifecycle.
-    registry: ParticipantRegistry,
+    participant_registry: ParticipantRegistry,
 }
 
 impl Sink for RemoteAccessSession {
@@ -217,7 +217,7 @@ impl Sink for RemoteAccessSession {
         if let Some(subscribers) = reliable_subscribers {
             let message = MessageData::new(u64::from(channel_id), metadata.log_time, msg);
             let encoded = encode_binary_message(&message);
-            for participant in self.registry.resolve_identities(subscribers) {
+            for participant in self.participant_registry.resolve_identities(subscribers) {
                 participant.send_control(encoded.clone());
             }
         }
@@ -314,7 +314,10 @@ impl Sink for RemoteAccessSession {
         // Fire on_unsubscribe callbacks for subscribers of the removed channel.
         if let Some(listener) = &self.listener {
             let descriptor = channel.descriptor();
-            for participant in self.registry.resolve_identities(subscriber_identities) {
+            for participant in self
+                .participant_registry
+                .resolve_identities(subscriber_identities)
+            {
                 let client = Client::new(
                     participant.client_id(),
                     participant.participant_id().clone(),
@@ -350,7 +353,7 @@ pub(crate) struct SessionParams {
 impl RemoteAccessSession {
     pub(crate) fn new(params: SessionParams) -> Self {
         let (video_metadata_tx, video_metadata_rx) = tokio::sync::watch::channel(());
-        let registry = ParticipantRegistry::new(params.message_backlog_size);
+        let participant_registry = ParticipantRegistry::new(params.message_backlog_size);
         Self {
             sink_id: SinkId::next(),
             room: params.room,
@@ -373,7 +376,7 @@ impl RemoteAccessSession {
             ice_rtt_tracker: parking_lot::Mutex::new(RttTracker::new("ICE")),
             connection_graph: params.connection_graph,
             server_info: params.server_info,
-            registry,
+            participant_registry,
         }
     }
 
@@ -397,7 +400,7 @@ impl RemoteAccessSession {
     pub(crate) fn stats(&self) -> SessionStats {
         let state = self.state.read();
         SessionStats {
-            participants: self.registry.participant_count(),
+            participants: self.participant_registry.participant_count(),
             subscriptions: state.subscription_count(),
             video_tracks: state.video_track_count(),
         }
@@ -420,7 +423,7 @@ impl RemoteAccessSession {
     /// Enqueue a control plane message for all currently connected participants.
     /// If a participant's queue is full, a reset is requested for that participant.
     fn broadcast_control(&self, data: Bytes) {
-        for participant in self.registry.collect_participants() {
+        for participant in self.participant_registry.collect_participants() {
             participant.send_control(data.clone());
         }
     }
@@ -456,7 +459,7 @@ impl RemoteAccessSession {
     pub(crate) async fn close(&self) {
         // Cancel flush-tasks and await them before tearing down the transport.
         // In-flight writes either complete or fail once `room.close()` runs.
-        self.registry.shutdown().await;
+        self.participant_registry.shutdown().await;
         if let Err(e) = self.room.close().await {
             error!(
                 remote_access_session_id = self.remote_access_session_id(),
@@ -567,7 +570,10 @@ impl RemoteAccessSession {
             }
         };
 
-        let Some(participant) = self.registry.get_participant(participant_identity) else {
+        let Some(participant) = self
+            .participant_registry
+            .get_participant(participant_identity)
+        else {
             error!("Unknown participant identity: {:?}", participant_identity);
             return false;
         };
@@ -969,7 +975,7 @@ impl RemoteAccessSession {
     ) -> Result<(), Box<RemoteAccessError>> {
         // Gate on the registry *before* opening the stream: `stream_bytes` is
         // an RPC that should not be wasted on an already-registered identity.
-        if self.registry.has_participant(&participant_id) {
+        if self.participant_registry.has_participant(&participant_id) {
             return Ok(());
         }
 
@@ -999,7 +1005,7 @@ impl RemoteAccessSession {
             "registering participant {participant_id:?} with {} initial messages",
             initial_messages.len()
         );
-        let inserted = self.registry.register_participant(
+        let inserted = self.participant_registry.register_participant(
             participant_id.clone(),
             participant_sid,
             protocol_version,
@@ -1032,7 +1038,7 @@ impl RemoteAccessSession {
     ) {
         let _guard = self.subscription_lock.lock();
         let Some(participant) = self
-            .registry
+            .participant_registry
             .remove_participant(participant_id, expected_sid)
         else {
             info!(
@@ -1108,7 +1114,7 @@ impl RemoteAccessSession {
             // replaced by a reconnection that, by definition, has a different
             // SID; the staleness check inside `reset_participant` skips
             // those, avoiding a spurious teardown of the replacement.
-            for sid in self.registry.drain_pending_resets() {
+            for sid in self.participant_registry.drain_pending_resets() {
                 self.reset_participant(sid).await;
             }
 
@@ -1120,7 +1126,7 @@ impl RemoteAccessSession {
                     }
                 }
                 // Wake when new reset requests arrive.
-                () = self.registry.reset_notify().notified() => {}
+                () = self.participant_registry.reset_notify().notified() => {}
             }
         }
         warn!(
@@ -1376,7 +1382,7 @@ impl RemoteAccessSession {
         // (which has a different SID) won't match here — that's the
         // staleness filter, and avoids tearing down a replacement that has
         // already taken over.
-        let (participant_id, version) = match self.registry.get_participant_by_sid(&target_sid) {
+        let (participant_id, version) = match self.participant_registry.get_participant_by_sid(&target_sid) {
             Some(p) => (p.participant_id().clone(), p.protocol_version().clone()),
             None => {
                 info!(
@@ -1766,7 +1772,7 @@ impl RemoteAccessSession {
 
         // Collect the per-participant messages, then send them after the locks
         // are released to minimize lock scope.
-        let participants = self.registry.collect_participants();
+        let participants = self.participant_registry.collect_participants();
         let to_send: Vec<(Arc<Participant>, Bytes)> = {
             let state = self.state.read();
             participants
@@ -1873,7 +1879,7 @@ impl RemoteAccessSession {
         let mut graph = self.connection_graph.lock();
         let update = graph.update(replacement_graph);
         let encoded = encode_json_message(&update);
-        for participant in self.registry.collect_participants() {
+        for participant in self.participant_registry.collect_participants() {
             if graph.is_subscriber(participant.client_id()) {
                 participant.send_control(encoded.clone());
             }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -7,7 +7,10 @@ use futures_util::StreamExt;
 use indexmap::IndexSet;
 use libwebrtc::video_source::{RtcVideoSource, native::NativeVideoSource};
 use livekit::options::{TrackPublishOptions, VideoCodec};
-use livekit::{ByteStreamReader, Room, StreamByteOptions, id::ParticipantIdentity};
+use livekit::{
+    ByteStreamReader, Room, StreamByteOptions,
+    id::{ParticipantIdentity, ParticipantSid},
+};
 use livekit::{StreamWriter, prelude::*};
 use parking_lot::RwLock;
 use semver::Version;
@@ -20,7 +23,6 @@ use tracing::{debug, error, info, trace, warn};
 use crate::protocol::v2::DecodeError;
 use crate::protocol::v2::parameter::Parameter;
 use crate::protocol::v2::server::ParameterValues;
-use crate::remote_common::ClientId;
 use crate::remote_common::connection_graph::ConnectionGraph;
 use crate::remote_common::{
     fetch_asset::AssetResponder,
@@ -40,8 +42,12 @@ use crate::{
     },
     remote_access::qos::{QosClassifier, Reliability},
     remote_access::{
-        AssetHandler, Capability, Listener, RemoteAccessError, client::Client,
-        participant::Participant, protocol_version, rtt_tracker::RttTracker,
+        AssetHandler, Capability, Listener, RemoteAccessError,
+        client::Client,
+        participant::{Participant, ParticipantWriter},
+        participant_registry::ParticipantRegistry,
+        protocol_version,
+        rtt_tracker::RttTracker,
         session_state::SessionState,
     },
 };
@@ -134,6 +140,9 @@ pub(crate) struct RemoteAccessSession {
     room: Room,
     context: Weak<Context>,
     remote_access_session_id: Option<String>,
+    /// Session-level state: channels, subscriptions, video publishers, client
+    /// channels, parameter subscriptions. Participant membership lives on
+    /// [`registry`] instead.
     state: RwLock<SessionState>,
     channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     qos_classifier: Option<Arc<dyn QosClassifier>>,
@@ -158,15 +167,8 @@ pub(crate) struct RemoteAccessSession {
     connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
     /// Immutable `ServerInfo` message sent to each participant on connect and reset.
     server_info: ServerInfo,
-    /// Set of `ClientId`s pending a reset (disconnect + reconnect).
-    /// Populated by `Participant::send_control` on queue overflow and by flush
-    /// tasks on write failure. Drained by `handle_room_events`. See
-    /// [`Participant::pending_resets`] for why this is keyed by `ClientId`.
-    pending_resets: Arc<parking_lot::Mutex<HashSet<ClientId>>>,
-    /// Wakes `handle_room_events` when a new reset is added to `pending_resets`.
-    reset_notify: Arc<tokio::sync::Notify>,
-    /// Size of the per-participant control plane queue.
-    message_backlog_size: usize,
+    /// Participant membership and flush-task lifecycle.
+    registry: ParticipantRegistry,
 }
 
 impl Sink for RemoteAccessSession {
@@ -182,26 +184,41 @@ impl Sink for RemoteAccessSession {
     ) -> std::result::Result<(), FoxgloveError> {
         let channel_id = channel.id();
 
-        let state = self.state.read();
+        // Collect subscriber identities under the session-state lock and
+        // release it before broadcasting. A participant removed between the
+        // collect and the registry resolve is a benign miss — their control
+        // queue has already been drained.
+        let reliable_subscribers = {
+            let state = self.state.read();
 
-        // Send to video publisher if any subscribers requested a video track.
-        if let Some(publisher) = state.get_video_publisher(&channel_id) {
-            publisher.send(Bytes::copy_from_slice(msg), metadata.log_time);
-        }
+            // Video track publisher: stays inside the state lock since the
+            // publisher handle is not cloneable out of the map.
+            if let Some(publisher) = state.get_video_publisher(&channel_id) {
+                publisher.send(Bytes::copy_from_slice(msg), metadata.log_time);
+            }
 
-        // Send to data subscribers.
-        if state.has_data_subscribers(&channel_id) {
-            if state.qos_profile(&channel_id).reliability == Reliability::Reliable {
-                // Reliable channels: send MessageData via the control bytestream
-                // to each subscribed participant.
-                let message = MessageData::new(u64::from(channel_id), metadata.log_time, msg);
-                let encoded = encode_binary_message(&message);
-                for participant in state.data_subscriber_participants(&channel_id) {
-                    participant.send_control(encoded.clone());
+            if !state.has_data_subscribers(&channel_id) {
+                None
+            } else if state.qos_profile(&channel_id).reliability == Reliability::Reliable {
+                Some(state.data_subscriber_identities(&channel_id))
+            } else {
+                // Lossy channels: send via the eagerly-published data track
+                // inline, while we still hold the state read lock.
+                if let Some(track) = state.get_subscribed_data_track(&channel_id) {
+                    track.log(channel_id, msg, metadata);
                 }
-            } else if let Some(track) = state.get_subscribed_data_track(&channel_id) {
-                // Lossy channels: send via the eagerly-published data track.
-                track.log(channel_id, msg, metadata);
+                None
+            }
+        };
+
+        // Reliable channels: send MessageData via the control bytestream.
+        // Batch-resolve identities so we take the registry lock once rather
+        // than per-subscriber.
+        if let Some(subscribers) = reliable_subscribers {
+            let message = MessageData::new(u64::from(channel_id), metadata.log_time, msg);
+            let encoded = encode_binary_message(&message);
+            for participant in self.registry.resolve_identities(subscribers) {
+                participant.send_control(encoded.clone());
             }
         }
 
@@ -279,8 +296,9 @@ impl Sink for RemoteAccessSession {
         let _guard = self.subscription_lock.lock();
         let channel_id = channel.id();
 
-        // Collect subscriber info before removal for on_unsubscribe callbacks.
-        let subscriber_clients = self.state.read().channel_subscriber_clients(&channel_id);
+        // Collect subscriber identities before removal; we'll resolve them to
+        // `Client`s after via the registry.
+        let subscriber_identities = self.state.read().channel_subscriber_identities(&channel_id);
 
         if !self.state.write().remove_channel(channel_id) {
             return;
@@ -296,8 +314,11 @@ impl Sink for RemoteAccessSession {
         // Fire on_unsubscribe callbacks for subscribers of the removed channel.
         if let Some(listener) = &self.listener {
             let descriptor = channel.descriptor();
-            for (client_id, participant_id) in subscriber_clients {
-                let client = Client::new(client_id, participant_id);
+            for participant in self.registry.resolve_identities(subscriber_identities) {
+                let client = Client::new(
+                    participant.client_id(),
+                    participant.participant_id().clone(),
+                );
                 listener.on_unsubscribe(&client, descriptor);
             }
         }
@@ -329,8 +350,7 @@ pub(crate) struct SessionParams {
 impl RemoteAccessSession {
     pub(crate) fn new(params: SessionParams) -> Self {
         let (video_metadata_tx, video_metadata_rx) = tokio::sync::watch::channel(());
-        let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
-        let reset_notify = Arc::new(tokio::sync::Notify::new());
+        let registry = ParticipantRegistry::new(params.message_backlog_size);
         Self {
             sink_id: SinkId::next(),
             room: params.room,
@@ -353,9 +373,7 @@ impl RemoteAccessSession {
             ice_rtt_tracker: parking_lot::Mutex::new(RttTracker::new("ICE")),
             connection_graph: params.connection_graph,
             server_info: params.server_info,
-            pending_resets,
-            reset_notify,
-            message_backlog_size: params.message_backlog_size,
+            registry,
         }
     }
 
@@ -379,7 +397,7 @@ impl RemoteAccessSession {
     pub(crate) fn stats(&self) -> SessionStats {
         let state = self.state.read();
         SessionStats {
-            participants: state.participant_count(),
+            participants: self.registry.participant_count(),
             subscriptions: state.subscription_count(),
             video_tracks: state.video_track_count(),
         }
@@ -402,8 +420,7 @@ impl RemoteAccessSession {
     /// Enqueue a control plane message for all currently connected participants.
     /// If a participant's queue is full, a reset is requested for that participant.
     fn broadcast_control(&self, data: Bytes) {
-        let participants = self.state.read().collect_participants();
-        for participant in participants {
+        for participant in self.registry.collect_participants() {
             participant.send_control(data.clone());
         }
     }
@@ -431,23 +448,15 @@ impl RemoteAccessSession {
         self.cancellation_token.cancel();
     }
 
-    /// Shut down the session: clear all participants (dropping their control
-    /// queue senders so flush tasks exit), await the flush task handles, then
-    /// close the LiveKit room.
+    /// Shut down the session: cancel every participant's flush task, await
+    /// their completion, then close the LiveKit room.
     ///
     /// The caller must ensure that `handle_room_events` has stopped so no new
     /// `remove_participant` / `reset_participant` calls can race with us.
     pub(crate) async fn close(&self) {
-        let (participants, flush_handles) = self.state.write().take_participants();
-        // Cancel each participant's flush task so it breaks out of the recv/write
-        // select! and doesn't pick up new messages. In-flight writes will complete
-        // or fail once room.close() tears down the transport.
-        for participant in participants {
-            participant.cancel();
-        }
-        for handle in flush_handles {
-            let _ = handle.await;
-        }
+        // Cancel flush tasks and await them before tearing down the transport.
+        // In-flight writes either complete or fail once `room.close()` runs.
+        self.registry.shutdown().await;
         if let Err(e) = self.room.close().await {
             error!(
                 remote_access_session_id = self.remote_access_session_id(),
@@ -558,7 +567,7 @@ impl RemoteAccessSession {
             }
         };
 
-        let Some(participant) = self.state.read().get_participant(participant_identity) else {
+        let Some(participant) = self.registry.get_participant(participant_identity) else {
             error!("Unknown participant identity: {:?}", participant_identity);
             return false;
         };
@@ -666,9 +675,11 @@ impl RemoteAccessSession {
         drop(state);
 
         let mut state = self.state.write();
-        let subscribe_result = state.subscribe(participant, &channel_ids);
-        let first_video_subscribed = state.subscribe_video(participant, &video_channel_ids);
-        let last_video_unsubscribed = state.unsubscribe_video(participant, &data_channel_ids);
+        let subscribe_result = state.subscribe(participant.participant_id(), &channel_ids);
+        let first_video_subscribed =
+            state.subscribe_video(participant.participant_id(), &video_channel_ids);
+        let last_video_unsubscribed =
+            state.unsubscribe_video(participant.participant_id(), &data_channel_ids);
         drop(state);
 
         if !subscribe_result.first_subscribed.is_empty() {
@@ -710,8 +721,9 @@ impl RemoteAccessSession {
             .collect();
 
         let mut state = self.state.write();
-        let unsubscribe_result = state.unsubscribe(participant, &channel_ids);
-        let last_video_unsubscribed = state.unsubscribe_video(participant, &channel_ids);
+        let unsubscribe_result = state.unsubscribe(participant.participant_id(), &channel_ids);
+        let last_video_unsubscribed =
+            state.unsubscribe_video(participant.participant_id(), &channel_ids);
         drop(state);
 
         if !unsubscribe_result.last_unsubscribed.is_empty() {
@@ -942,20 +954,26 @@ impl RemoteAccessSession {
     /// The caller is responsible for ensuring that this method is not called concurrently for the
     /// same participant identity.
     ///
+    /// `livekit_sid` is the LiveKit session ID of the specific connection
+    /// instance being registered; it's stored on the `Participant` so a later
+    /// `ParticipantDisconnected` event can be matched against this instance
+    /// rather than the identity alone.
+    ///
     /// When a participant is added, a ServerInfo message and channel Advertisement messages are
     /// immediately queued for transmission.
     pub(crate) async fn add_participant(
         &self,
         participant_id: ParticipantIdentity,
+        livekit_sid: ParticipantSid,
         protocol_version: Version,
     ) -> Result<(), Box<RemoteAccessError>> {
-        use crate::remote_access::participant::ParticipantWriter;
-
-        if self.state.read().has_participant(&participant_id) {
+        // Gate on the registry *before* opening the stream: `stream_bytes` is
+        // an RPC that should not be wasted on an already-registered identity.
+        if self.registry.has_participant(&participant_id) {
             return Ok(());
         }
 
-        let stream = match self
+        let stream = self
             .room
             .local_participant()
             .stream_bytes(StreamByteOptions {
@@ -964,61 +982,68 @@ impl RemoteAccessSession {
                 ..StreamByteOptions::default()
             })
             .await
-        {
-            Ok(stream) => stream,
-            Err(e) => {
-                error!("failed to create stream for participant {participant_id}: {e:?}");
-                return Err(e.into());
-            }
-        };
+            .inspect_err(|e| {
+                error!("failed to open control stream for {participant_id}: {e:?}");
+            })?;
 
-        let (participant, flush_handle) = Participant::spawn(
-            participant_id.clone(),
+        // Encode the initial messages (server info + channel / service
+        // advertisements) up front. The registry queues them on the
+        // participant's control-plane channel before inserting the
+        // participant into state, so these are the first bytes the viewer
+        // receives.
+        let mut initial_messages = vec![encode_json_message(&self.server_info)];
+        initial_messages.extend(self.encode_channel_advertisements());
+        initial_messages.extend(self.encode_service_advertisements());
+
+        info!(
+            "registering participant {participant_id:?} with {} initial messages",
+            initial_messages.len()
+        );
+        self.registry.register_participant(
+            participant_id,
+            livekit_sid,
             protocol_version,
             ParticipantWriter::Livekit(stream),
-            self.message_backlog_size,
-            self.pending_resets.clone(),
-            self.reset_notify.clone(),
             &self.cancellation_token,
+            initial_messages,
         );
-
-        // Send initial messages prior to adding the participant to the state map, to ensure that
-        // these are the first messages delivered to the participant. This is safe to do without
-        // holding the write lock, because this is a new participant — see below.
-        info!("sending server info and advertisements to participant {participant:?}");
-        participant.send_control(encode_json_message(&self.server_info));
-        self.send_channel_advertisements(participant.clone());
-        self.send_service_advertisements(participant.clone());
-
-        // Add the participant to the state map. We assert that this is a new participant, because
-        // we validated that it did not exist in the map at the top of this function, and the
-        // caller is responsible for ensuring this function is not called concurrently for the same
-        // participant identity.
-        let mut state = self.state.write();
-        let did_insert = state.insert_participant(participant);
-        assert!(did_insert);
-        state.insert_flush_handle(participant_id, flush_handle);
         Ok(())
     }
 
-    /// Remove a participant from the session, cleaning up its subscriptions.
+    /// Removes the participant registered under `participant_id` if — and only
+    /// if — its stored LiveKit SID matches `expected_sid`. Runs the full
+    /// cleanup (listener callbacks, context unsubscribe, video track teardown,
+    /// connection-graph update) when removal happens.
     ///
-    /// Channels that lose their last subscriber are unsubscribed from the context.
-    pub(crate) fn remove_participant(self: &Arc<Self>, participant_id: &ParticipantIdentity) {
+    /// Callers: `handle_room_event::ParticipantDisconnected` passes the
+    /// event's SID; `reset_participant` passes the stored participant's SID.
+    /// Requiring the SID filters out stale disconnects for a prior connection
+    /// instance that has already been superseded by a same-identity reconnect.
+    pub(crate) fn remove_participant(
+        self: &Arc<Self>,
+        participant_id: &ParticipantIdentity,
+        expected_sid: &ParticipantSid,
+    ) {
         let _guard = self.subscription_lock.lock();
-
-        let removed = {
-            let mut state = self.state.write();
-            // Cancel the flush task so it doesn't linger on a dead write.
-            if let Some(p) = state.get_participant(participant_id) {
-                p.cancel();
-            }
-            let removed = state.remove_participant(participant_id);
-            // Detach the flush handle — task exits via cancel or channel close.
-            drop(state.remove_flush_handle(participant_id));
-            removed
+        let Some(participant) = self
+            .registry
+            .remove_participant(participant_id, expected_sid)
+        else {
+            info!(
+                remote_access_session_id = self.remote_access_session_id(),
+                participant_identity = %participant_id,
+                sid = %expected_sid,
+                "ignoring remove for stale participant SID (current registration is for a different instance)",
+            );
+            return;
         };
+        let client_id = participant.client_id();
+        let removed = self
+            .state
+            .write()
+            .cleanup_for_removed_identity(participant_id);
 
+        // Listener / context / video-track / connection-graph aftercare.
         if !removed.last_unsubscribed.is_empty() {
             if let Some(context) = self.context.upgrade() {
                 context.unsubscribe_channels(self.sink_id, &removed.last_unsubscribed);
@@ -1033,18 +1058,16 @@ impl RemoteAccessSession {
             }
         }
 
-        if let Some(client_id) = removed.client_id {
-            if self.has_capability(Capability::ConnectionGraph) {
-                let mut graph = self.connection_graph.lock();
-                if graph.remove_subscriber(client_id) && !graph.has_subscribers() {
-                    if let Some(listener) = &self.listener {
-                        listener.on_connection_graph_unsubscribe();
-                    }
+        if self.has_capability(Capability::ConnectionGraph) {
+            let mut graph = self.connection_graph.lock();
+            if graph.remove_subscriber(client_id) && !graph.has_subscribers() {
+                if let Some(listener) = &self.listener {
+                    listener.on_connection_graph_unsubscribe();
                 }
             }
         }
 
-        if let Some((listener, client_id)) = self.listener.as_ref().zip(removed.client_id) {
+        if let Some(listener) = &self.listener {
             let client = Client::new(client_id, participant_id.clone());
 
             for descriptor in &removed.subscribed_descriptors {
@@ -1070,10 +1093,7 @@ impl RemoteAccessSession {
             // where a `Notify::notified()` wakeup was lost due to `select!`
             // cancellation — the client ids are still in the set even if the
             // notification was consumed by a dropped future.
-            let client_ids: Vec<ClientId> = {
-                let mut set = self.pending_resets.lock();
-                set.drain().collect()
-            };
+            //
             // `handle_room_events` is the single task driving participant
             // membership during the session lifecycle, so the lookup below
             // cannot be invalidated before `reset_participant` runs. A
@@ -1081,8 +1101,8 @@ impl RemoteAccessSession {
             // the participant was already removed and may have been replaced
             // by a reconnection reusing the same identity; skipping avoids
             // spuriously tearing down that replacement.
-            for client_id in client_ids {
-                let Some(participant) = self.state.read().get_participant_by_client_id(client_id)
+            for client_id in self.registry.drain_pending_resets() {
+                let Some(participant) = self.registry.get_participant_by_client_id(client_id)
                 else {
                     continue;
                 };
@@ -1098,7 +1118,7 @@ impl RemoteAccessSession {
                     }
                 }
                 // Wake when new reset requests arrive.
-                () = self.reset_notify.notified() => {}
+                () = self.registry.reset_notify().notified() => {}
             }
         }
         warn!(
@@ -1133,23 +1153,36 @@ impl RemoteAccessSession {
                     .await;
                     return true;
                 };
+                let sid = participant.sid();
                 info!(
                     remote_access_session_id,
                     participant_identity = %participant_identity,
+                    sid = %sid,
                     version = %version,
                     "participant active in room"
                 );
-                if let Err(e) = self.add_participant(participant.identity(), version).await {
+                if let Err(e) = self
+                    .add_participant(participant_identity, sid, version)
+                    .await
+                {
                     error!(remote_access_session_id, error = %e, "failed to add participant: {e}");
                 }
             }
             RoomEvent::ParticipantDisconnected(participant) => {
+                let participant_identity = participant.identity();
+                let sid = participant.sid();
                 info!(
                     remote_access_session_id,
-                    participant_identity = %participant.identity(),
+                    participant_identity = %participant_identity,
+                    sid = %sid,
                     "participant disconnected from room"
                 );
-                self.remove_participant(&participant.identity());
+                // Match the disconnect against the specific LiveKit connection
+                // instance we registered. If the stored `Participant` was added
+                // for a *later* instance (same identity, different SID — a
+                // reconnect we already reset to), skip the removal: this event
+                // is stale and its target is already gone.
+                self.remove_participant(&participant_identity, &sid);
             }
             RoomEvent::DataReceived {
                 payload: _,
@@ -1322,9 +1355,11 @@ impl RemoteAccessSession {
     ///
     /// Write failures often coincide with participant disconnection. When that happens,
     /// both a reset notification and a `ParticipantDisconnected` event may be in flight.
-    /// We guard against the common case by checking `remote_participants()` before
-    /// re-adding: if LiveKit has already removed the participant, we skip the re-add
+    /// We guard against the common case by checking `remote_participants()` after
+    /// removing: if LiveKit has already removed the participant, we skip the re-add
     /// and let the normal `ParticipantConnected` flow handle any future reconnection.
+    /// Without this guard, re-adding would open a fresh stream whose first write would
+    /// also fail, re-triggering the reset in an infinite loop.
     ///
     /// This is a best-effort check (TOCTOU): the participant could disconnect between
     /// the check and the `stream_bytes` call inside `add_participant`. In that narrow
@@ -1334,18 +1369,41 @@ impl RemoteAccessSession {
     async fn reset_participant(self: &Arc<Self>, participant_id: ParticipantIdentity) {
         let remote_access_session_id = self.remote_access_session_id();
 
-        self.remove_participant(&participant_id);
+        // Capture the protocol version and stored SID from the current
+        // participant before we remove them. Reusing the stored version
+        // avoids a second lookup into LiveKit's identity-keyed
+        // `remote_participants()` map, which can return a *different*
+        // instance if the same identity has already reconnected. The stored
+        // SID identifies the exact instance we intend to remove.
+        let (version, stored_sid) = match self.registry.get_participant(&participant_id) {
+            Some(p) => (p.protocol_version().clone(), p.livekit_sid().clone()),
+            None => {
+                info!(
+                    remote_access_session_id,
+                    participant_identity = %participant_id,
+                    "reset requested for already-removed participant; skipping",
+                );
+                return;
+            }
+        };
+
+        self.remove_participant(&participant_id, &stored_sid);
 
         // Best-effort guard: skip re-add if LiveKit has already removed the participant
         // (e.g., because the underlying WebRTC connection dropped). In that case, the
         // `ParticipantDisconnected` event is already queued and a future reconnect will
         // go through the normal `ParticipantConnected` → `add_participant` path.
-        let remote_participant = self
+        //
+        // If a new instance has already reconnected under the same identity,
+        // its SID is what we re-register with — so that a later stale
+        // `ParticipantDisconnected` for the *old* instance's SID won't match
+        // and tear down this re-registration.
+        let Some(sid) = self
             .room
             .remote_participants()
             .get(&participant_id)
-            .cloned();
-        let Some(remote_participant) = remote_participant else {
+            .map(|p| p.sid())
+        else {
             info!(
                 remote_access_session_id,
                 participant_identity = %participant_id,
@@ -1354,25 +1412,13 @@ impl RemoteAccessSession {
             return;
         };
 
-        let Some(version) = protocol_version::check_participant_protocol_version(
-            &participant_id,
-            &remote_participant.attributes(),
-            remote_access_session_id,
-        ) else {
-            warn!(
-                remote_access_session_id,
-                participant_identity = %participant_id,
-                "skipping reset for participant with incompatible protocol version",
-            );
-            return;
-        };
-
         warn!(
             remote_access_session_id,
             participant_identity = %participant_id,
+            sid = %sid,
             "resetting participant after control stream failure",
         );
-        if let Err(e) = self.add_participant(participant_id, version).await {
+        if let Err(e) = self.add_participant(participant_id, sid, version).await {
             error!(
                 remote_access_session_id,
                 error = %e,
@@ -1439,34 +1485,27 @@ impl RemoteAccessSession {
         }
     }
 
-    /// Enqueue all currently cached channel advertisements for delivery to a single participant.
-    fn send_channel_advertisements(&self, participant: Arc<Participant>) {
-        let Some(advertise_msg) = ({
-            let state = self.state.read();
-            state
-                .with_channels(|channels| {
-                    let msg = advertise::advertise_channels(channels.values());
-                    if msg.channels.is_empty() {
-                        return None;
-                    }
-                    let mut msg = msg.into_owned();
-                    state.add_metadata_to_advertisement(&mut msg);
-                    Some(msg)
-                })
-                .flatten()
-        }) else {
-            return;
-        };
-
-        participant.send_control(encode_json_message(&advertise_msg));
+    /// Returns the currently-cached channel advertisements encoded as a single
+    /// framed control-plane message, or `None` if no channels are advertised.
+    fn encode_channel_advertisements(&self) -> Option<Bytes> {
+        let state = self.state.read();
+        let msg = state.with_channels(|channels| {
+            let msg = advertise::advertise_channels(channels.values());
+            if msg.channels.is_empty() {
+                return None;
+            }
+            let mut msg = msg.into_owned();
+            state.add_metadata_to_advertisement(&mut msg);
+            Some(msg)
+        })??;
+        Some(encode_json_message(&msg))
     }
 
-    /// Enqueue service advertisements for delivery to a single participant.
-    fn send_service_advertisements(&self, participant: Arc<Participant>) {
+    /// Returns the currently-cached service advertisements encoded as a single
+    /// framed control-plane message, or `None` if no services are registered.
+    fn encode_service_advertisements(&self) -> Option<Bytes> {
         let services: Vec<_> = self.services.read().values().cloned().collect();
-        if let Some(msg) = build_advertise_services_msg(&services) {
-            participant.send_control(encode_json_message(&msg));
-        }
+        build_advertise_services_msg(&services).map(|msg| encode_json_message(&msg))
     }
 
     /// Broadcasts service advertisements for the given service IDs to all connected participants.
@@ -1724,11 +1763,11 @@ impl RemoteAccessSession {
             return;
         }
 
-        // Collect the per-participant messages while holding the read lock, then
-        // send them after the lock is released to minimize lock scope.
+        // Collect the per-participant messages, then send them after the locks
+        // are released to minimize lock scope.
+        let participants = self.registry.collect_participants();
         let to_send: Vec<(Arc<Participant>, Bytes)> = {
             let state = self.state.read();
-            let participants = state.collect_participants();
             participants
                 .into_iter()
                 .filter_map(|participant| {
@@ -1833,8 +1872,7 @@ impl RemoteAccessSession {
         let mut graph = self.connection_graph.lock();
         let update = graph.update(replacement_graph);
         let encoded = encode_json_message(&update);
-        let participants = self.state.read().collect_participants();
-        for participant in participants {
+        for participant in self.registry.collect_participants() {
             if graph.is_subscriber(participant.client_id()) {
                 participant.send_control(encoded.clone());
             }
@@ -2042,6 +2080,8 @@ impl RemoteAccessSession {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
     use crate::protocol::v2::server::FetchAssetResponse;
     use crate::remote_common::fetch_asset::{
@@ -2268,13 +2308,16 @@ mod tests {
         Arc<crate::remote_access::participant::TestByteStreamWriter>,
         tokio::task::JoinHandle<()>,
     ) {
-        use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter};
+        use crate::remote_access::participant::{
+            ParticipantWriter, TestByteStreamWriter, test_sid,
+        };
 
         let writer = Arc::new(TestByteStreamWriter::default());
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
         let (participant, handle) = Participant::spawn(
             ParticipantIdentity("test".to_string()),
+            test_sid("flush-test"),
             protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone(),
             ParticipantWriter::Test(writer.clone()),
             DEFAULT_MESSAGE_BACKLOG_SIZE,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1097,23 +1097,19 @@ impl RemoteAccessSession {
         loop {
             // Drain pending resets before waiting for events. This covers the case
             // where a `Notify::notified()` wakeup was lost due to `select!`
-            // cancellation — the client ids are still in the set even if the
+            // cancellation — the SIDs are still in the set even if the
             // notification was consumed by a dropped future.
             //
             // `handle_room_events` is the single task driving participant
-            // membership during the session lifecycle, so the lookup below
-            // cannot be invalidated before `reset_participant` runs. A
-            // `ClientId` no longer registered means the request is stale —
-            // the participant was already removed and may have been replaced
-            // by a reconnection reusing the same identity; skipping avoids
-            // spuriously tearing down that replacement.
-            for client_id in self.registry.drain_pending_resets() {
-                let Some(participant) = self.registry.get_participant_by_client_id(client_id)
-                else {
-                    continue;
-                };
-                self.reset_participant(participant.participant_id().clone())
-                    .await;
+            // membership during the session lifecycle, so the lookup inside
+            // `reset_participant` cannot be invalidated before it runs. A
+            // `ParticipantSid` no longer registered means the request is
+            // stale — the participant was already removed and may have been
+            // replaced by a reconnection that, by definition, has a different
+            // SID; the staleness check inside `reset_participant` skips
+            // those, avoiding a spurious teardown of the replacement.
+            for sid in self.registry.drain_pending_resets() {
+                self.reset_participant(sid).await;
             }
 
             tokio::select! {
@@ -1372,28 +1368,27 @@ impl RemoteAccessSession {
     /// window, `add_participant` may open a dead stream, but the subsequent
     /// `ParticipantDisconnected` event will clean it up. This is harmless — just a
     /// wasted `stream_bytes` call and a log line.
-    async fn reset_participant(self: &Arc<Self>, participant_id: ParticipantIdentity) {
+    async fn reset_participant(self: &Arc<Self>, target_sid: ParticipantSid) {
         let remote_access_session_id = self.remote_access_session_id();
 
-        // Capture the protocol version and stored SID from the current
-        // participant before we remove them. Reusing the stored version
-        // avoids a second lookup into LiveKit's identity-keyed
-        // `remote_participants()` map, which can return a *different*
-        // instance if the same identity has already reconnected. The stored
-        // SID identifies the exact instance we intend to remove.
-        let (version, stored_sid) = match self.registry.get_participant(&participant_id) {
-            Some(p) => (p.protocol_version().clone(), p.participant_sid().clone()),
+        // Look the participant up by SID. The SID identifies the exact
+        // instance that requested the reset, so a same-identity reconnect
+        // (which has a different SID) won't match here — that's the
+        // staleness filter, and avoids tearing down a replacement that has
+        // already taken over.
+        let (participant_id, version) = match self.registry.get_participant_by_sid(&target_sid) {
+            Some(p) => (p.participant_id().clone(), p.protocol_version().clone()),
             None => {
                 info!(
                     remote_access_session_id,
-                    participant_identity = %participant_id,
+                    participant_sid = %target_sid,
                     "reset requested for already-removed participant; skipping",
                 );
                 return;
             }
         };
 
-        self.remove_participant(&participant_id, &stored_sid);
+        self.remove_participant(&participant_id, &target_sid);
 
         // Best-effort guard: skip re-add if LiveKit has already removed the participant
         // (e.g., because the underlying WebRTC connection dropped). In that case, the

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -13,7 +13,6 @@ use livekit::{
 };
 use livekit::{StreamWriter, prelude::*};
 use parking_lot::RwLock;
-use semver::Version;
 use smallvec::SmallVec;
 use tokio::io::AsyncReadExt;
 use tokio::runtime::Handle;
@@ -962,8 +961,8 @@ impl RemoteAccessSession {
     ///
     /// `participant_sid` is the LiveKit session ID of the specific connection
     /// instance being registered; it's stored on the `Participant` so a later
-    /// `ParticipantDisconnected` event can be matched against this instance
-    /// rather than the identity alone.
+    /// `ParticipantDisconnected` event (or a flush-task failure) can be matched
+    /// against this instance rather than the identity alone.
     ///
     /// When a participant is added, a ServerInfo message and channel Advertisement messages are
     /// immediately queued for transmission.
@@ -971,7 +970,6 @@ impl RemoteAccessSession {
         &self,
         participant_id: ParticipantIdentity,
         participant_sid: ParticipantSid,
-        protocol_version: Version,
     ) -> Result<(), Box<RemoteAccessError>> {
         // Gate on the registry *before* opening the stream: `stream_bytes` is
         // an RPC that should not be wasted on an already-registered identity.
@@ -1008,7 +1006,6 @@ impl RemoteAccessSession {
         let inserted = self.participant_registry.register_participant(
             participant_id.clone(),
             participant_sid,
-            protocol_version,
             ParticipantWriter::Livekit(stream),
             &self.cancellation_token,
             initial_messages,
@@ -1163,10 +1160,7 @@ impl RemoteAccessSession {
                     version = %version,
                     "participant active in room"
                 );
-                if let Err(e) = self
-                    .add_participant(participant_identity, sid, version)
-                    .await
-                {
+                if let Err(e) = self.add_participant(participant_identity, sid).await {
                     error!(remote_access_session_id, error = %e, "failed to add participant: {e}");
                 }
             }
@@ -1372,10 +1366,10 @@ impl RemoteAccessSession {
     async fn reset_participant(self: &Arc<Self>, target_sid: ParticipantSid) {
         let remote_access_session_id = self.remote_access_session_id();
 
-        // Remove by SID and capture identity / protocol version from the
-        // returned participant. The SID identifies the exact instance that
-        // requested the reset, so a same-identity reconnect (which has a
-        // different SID) won't match — `None` is the staleness filter.
+        // Remove by SID and capture identity from the returned participant.
+        // The SID identifies the exact instance that requested the reset, so
+        // a same-identity reconnect (which has a different SID) won't match
+        // — `None` is the staleness filter.
         let Some(participant) = self.remove_participant(&target_sid) else {
             info!(
                 remote_access_session_id,
@@ -1385,7 +1379,6 @@ impl RemoteAccessSession {
             return;
         };
         let participant_id = participant.participant_id().clone();
-        let version = participant.protocol_version().clone();
         drop(participant);
 
         // Best-effort guard: skip re-add if LiveKit has already removed the participant
@@ -1394,14 +1387,16 @@ impl RemoteAccessSession {
         // go through the normal `ParticipantConnected` → `add_participant` path.
         //
         // If a new instance has already reconnected under the same identity,
-        // its SID is what we re-register with — so that a later stale
-        // `ParticipantDisconnected` for the *old* instance's SID won't match
-        // and tear down this re-registration.
-        let Some(sid) = self
+        // its SID and attributes are what we re-register with — so that (a) a
+        // later stale `ParticipantDisconnected` for the *old* instance's SID
+        // won't match and tear down this re-registration, and (b) a
+        // protocol-version change between instances is honoured rather than
+        // assumed-unchanged.
+        let Some((sid, attributes)) = self
             .room
             .remote_participants()
             .get(&participant_id)
-            .map(|p| p.sid())
+            .map(|p| (p.sid(), p.attributes()))
         else {
             info!(
                 remote_access_session_id,
@@ -1411,13 +1406,28 @@ impl RemoteAccessSession {
             return;
         };
 
+        // Re-validate the protocol version against the freshly-queried
+        // attributes. A same-identity reconnect could in principle bring a
+        // different protocol version; trust the fresh value, just like we
+        // trust the fresh SID.
+        let Some(version) = protocol_version::check_participant_protocol_version(
+            &participant_id,
+            &attributes,
+            remote_access_session_id,
+        ) else {
+            self.send_incompatible_version_error(&participant_id, &attributes)
+                .await;
+            return;
+        };
+
         warn!(
             remote_access_session_id,
             participant_identity = %participant_id,
             sid = %sid,
+            version = %version,
             "resetting participant after control stream failure",
         );
-        if let Err(e) = self.add_participant(participant_id, sid, version).await {
+        if let Err(e) = self.add_participant(participant_id, sid).await {
             error!(
                 remote_access_session_id,
                 error = %e,
@@ -2093,7 +2103,6 @@ mod tests {
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
         let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -2101,7 +2110,6 @@ mod tests {
         let participant = Arc::new(Participant::new(
             identity,
             sid,
-            version,
             tx,
             pending_resets,
             reset_notify,
@@ -2322,7 +2330,6 @@ mod tests {
         let (participant, handle) = Participant::spawn(
             ParticipantIdentity("test".to_string()),
             test_sid("flush-test"),
-            protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone(),
             ParticipantWriter::Test(writer.clone()),
             DEFAULT_MESSAGE_BACKLOG_SIZE,
             pending_resets,
@@ -2403,7 +2410,6 @@ mod tests {
     }
 
     fn make_test_participant(queue_size: usize) -> (Participant, flume::Receiver<Bytes>) {
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded::<Bytes>(queue_size);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -2411,7 +2417,6 @@ mod tests {
         let participant = Participant::new(
             ParticipantIdentity("alice".to_string()),
             crate::remote_access::participant::test_sid("alice"),
-            version,
             tx,
             pending_resets,
             reset_notify,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -13,6 +13,7 @@ use livekit::{
 };
 use livekit::{StreamWriter, prelude::*};
 use parking_lot::RwLock;
+use semver::Version;
 use smallvec::SmallVec;
 use tokio::io::AsyncReadExt;
 use tokio::runtime::Handle;
@@ -970,6 +971,7 @@ impl RemoteAccessSession {
         &self,
         participant_id: ParticipantIdentity,
         participant_sid: ParticipantSid,
+        protocol_version: Version,
     ) -> Result<(), Box<RemoteAccessError>> {
         // Gate on the registry *before* opening the stream: `stream_bytes` is
         // an RPC that should not be wasted on an already-registered identity.
@@ -1006,6 +1008,7 @@ impl RemoteAccessSession {
         let inserted = self.participant_registry.register_participant(
             participant_id.clone(),
             participant_sid,
+            protocol_version,
             ParticipantWriter::Livekit(stream),
             &self.cancellation_token,
             initial_messages,
@@ -1160,7 +1163,10 @@ impl RemoteAccessSession {
                     version = %version,
                     "participant active in room"
                 );
-                if let Err(e) = self.add_participant(participant_identity, sid).await {
+                if let Err(e) = self
+                    .add_participant(participant_identity, sid, version)
+                    .await
+                {
                     error!(remote_access_session_id, error = %e, "failed to add participant: {e}");
                 }
             }
@@ -1427,7 +1433,7 @@ impl RemoteAccessSession {
             version = %version,
             "resetting participant after control-plane failure",
         );
-        if let Err(e) = self.add_participant(participant_id, sid).await {
+        if let Err(e) = self.add_participant(participant_id, sid, version).await {
             error!(
                 remote_access_session_id,
                 error = %e,
@@ -2103,6 +2109,7 @@ mod tests {
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
         let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -2110,6 +2117,7 @@ mod tests {
         let participant = Arc::new(Participant::new(
             identity,
             sid,
+            version,
             tx,
             pending_resets,
             reset_notify,
@@ -2330,6 +2338,7 @@ mod tests {
         let (participant, handle) = Participant::spawn(
             ParticipantIdentity("test".to_string()),
             test_sid("flush-test"),
+            protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone(),
             ParticipantWriter::Test(writer.clone()),
             DEFAULT_MESSAGE_BACKLOG_SIZE,
             pending_resets,
@@ -2410,6 +2419,7 @@ mod tests {
     }
 
     fn make_test_participant(queue_size: usize) -> (Participant, flume::Receiver<Bytes>) {
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded::<Bytes>(queue_size);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -2417,6 +2427,7 @@ mod tests {
         let participant = Participant::new(
             ParticipantIdentity("alice".to_string()),
             crate::remote_access::participant::test_sid("alice"),
+            version,
             tx,
             pending_resets,
             reset_notify,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -185,9 +185,19 @@ impl Sink for RemoteAccessSession {
         let channel_id = channel.id();
 
         // Collect subscriber identities under the session-state lock and
-        // release it before broadcasting. A participant removed between the
-        // collect and the registry resolve is a benign miss — their control
-        // queue has already been drained.
+        // release it before broadcasting. Two races are possible between the
+        // collect and the registry resolve, both benign:
+        //   1. The participant has been removed and not replaced — the resolve
+        //      misses and the message is dropped (their control queue has
+        //      already been drained anyway).
+        //   2. The participant has been removed and a same-identity reconnect
+        //      has registered in their place. The resolve returns the new
+        //      attempt, which receives a MessageData for a channel it never
+        //      subscribed to. The channel ID is session-scoped (already
+        //      advertised on this session), so the viewer drops the unknown
+        //      subscription and continues. Resolution is keyed on
+        //      ParticipantIdentity, so this can never deliver data across
+        //      identities — only the same logical user across a reconnect.
         let reliable_subscribers = {
             let state = self.state.read();
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -448,13 +448,13 @@ impl RemoteAccessSession {
         self.cancellation_token.cancel();
     }
 
-    /// Shut down the session: cancel every participant's flush task, await
+    /// Shut down the session: cancel every participant's flush-task, await
     /// their completion, then close the LiveKit room.
     ///
     /// The caller must ensure that `handle_room_events` has stopped so no new
     /// `remove_participant` / `reset_participant` calls can race with us.
     pub(crate) async fn close(&self) {
-        // Cancel flush tasks and await them before tearing down the transport.
+        // Cancel flush-tasks and await them before tearing down the transport.
         // In-flight writes either complete or fail once `room.close()` runs.
         self.registry.shutdown().await;
         if let Err(e) = self.room.close().await {
@@ -954,7 +954,7 @@ impl RemoteAccessSession {
     /// The caller is responsible for ensuring that this method is not called concurrently for the
     /// same participant identity.
     ///
-    /// `livekit_sid` is the LiveKit session ID of the specific connection
+    /// `participant_sid` is the LiveKit session ID of the specific connection
     /// instance being registered; it's stored on the `Participant` so a later
     /// `ParticipantDisconnected` event can be matched against this instance
     /// rather than the identity alone.
@@ -964,7 +964,7 @@ impl RemoteAccessSession {
     pub(crate) async fn add_participant(
         &self,
         participant_id: ParticipantIdentity,
-        livekit_sid: ParticipantSid,
+        participant_sid: ParticipantSid,
         protocol_version: Version,
     ) -> Result<(), Box<RemoteAccessError>> {
         // Gate on the registry *before* opening the stream: `stream_bytes` is
@@ -999,13 +999,19 @@ impl RemoteAccessSession {
             "registering participant {participant_id:?} with {} initial messages",
             initial_messages.len()
         );
-        self.registry.register_participant(
-            participant_id,
-            livekit_sid,
+        let inserted = self.registry.register_participant(
+            participant_id.clone(),
+            participant_sid,
             protocol_version,
             ParticipantWriter::Livekit(stream),
             &self.cancellation_token,
             initial_messages,
+        );
+        debug_assert!(
+            inserted,
+            "register_participant returned false for {participant_id:?}; \
+             concurrent add_participant for the same identity violates the \
+             caller-serialization contract",
         );
         Ok(())
     }
@@ -1376,7 +1382,7 @@ impl RemoteAccessSession {
         // instance if the same identity has already reconnected. The stored
         // SID identifies the exact instance we intend to remove.
         let (version, stored_sid) = match self.registry.get_participant(&participant_id) {
-            Some(p) => (p.protocol_version().clone(), p.livekit_sid().clone()),
+            Some(p) => (p.protocol_version().clone(), p.participant_sid().clone()),
             None => {
                 info!(
                     remote_access_session_id,
@@ -2089,7 +2095,11 @@ mod tests {
     };
 
     fn make_participant_with_rx(name: &str) -> (Arc<Participant>, flume::Receiver<Bytes>) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
+        let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
@@ -2097,6 +2107,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let participant = Arc::new(Participant::new(
             identity,
+            sid,
             version,
             tx,
             pending_resets,
@@ -2296,11 +2307,11 @@ mod tests {
         );
     }
 
-    // ---- flush task tests ----
+    // ---- flush-task tests ----
 
     /// Spawns a participant with a test writer via `Participant::spawn`.
     /// Returns the participant (for sending), the test writer (for inspecting
-    /// writes), and the flush task's `JoinHandle`.
+    /// writes), and the flush-task's `JoinHandle`.
     fn spawn_test_participant(
         session_cancel: &CancellationToken,
     ) -> (
@@ -2336,7 +2347,7 @@ mod tests {
         participant.send_control(Bytes::from_static(b"hello"));
         participant.send_control(Bytes::from_static(b"world"));
 
-        // Drop the participant to signal the flush task to exit.
+        // Drop the participant to signal the flush-task to exit.
         drop(participant);
         handle.await.unwrap();
 
@@ -2355,7 +2366,7 @@ mod tests {
         drop(participant);
 
         let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
-        assert!(result.is_ok(), "flush task did not exit after sender drop");
+        assert!(result.is_ok(), "flush-task did not exit after sender drop");
     }
 
     #[tokio::test]
@@ -2367,13 +2378,13 @@ mod tests {
         cancel.cancel();
 
         let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
-        assert!(result.is_ok(), "flush task did not exit after cancellation");
+        assert!(result.is_ok(), "flush-task did not exit after cancellation");
     }
 
     #[tokio::test]
     async fn flush_tasks_are_independent() {
         // Two participants spawned independently. Dropping one and awaiting its
-        // flush task should not affect the other.
+        // flush-task should not affect the other.
         let cancel = CancellationToken::new();
         let (participant_a, writer_a, handle_a) = spawn_test_participant(&cancel);
         let (participant_b, writer_b, handle_b) = spawn_test_participant(&cancel);
@@ -2406,6 +2417,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let participant = Participant::new(
             ParticipantIdentity("alice".to_string()),
+            crate::remote_access::participant::test_sid("alice"),
             version,
             tx,
             pending_resets,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1022,34 +1022,26 @@ impl RemoteAccessSession {
         Ok(())
     }
 
-    /// Removes the participant registered under `participant_id` if — and only
-    /// if — its stored LiveKit SID matches `expected_sid`. Runs the full
-    /// cleanup (listener callbacks, context unsubscribe, video track teardown,
-    /// connection-graph update) when removal happens.
+    /// Removes the participant whose stored LiveKit SID matches `target_sid`,
+    /// running the full cleanup (listener callbacks, context unsubscribe,
+    /// video track teardown, connection-graph update) when removal happens.
+    /// Returns the removed `Arc<Participant>` (so callers can capture
+    /// identity / protocol version for re-registration), or `None` if no
+    /// participant with this SID is registered.
     ///
-    /// Callers: `handle_room_event::ParticipantDisconnected` passes the
-    /// event's SID; `reset_participant` passes the stored participant's SID.
-    /// Requiring the SID filters out stale disconnects for a prior connection
-    /// instance that has already been superseded by a same-identity reconnect.
+    /// SID-keyed: a `ParticipantDisconnected` for a prior instance can arrive
+    /// after a same-identity reconnect has replaced it, but the reconnected
+    /// instance has a *different* SID, so a stale removal misses here rather
+    /// than tearing down the replacement. Callers handle the `None` case
+    /// according to their context.
     pub(crate) fn remove_participant(
         self: &Arc<Self>,
-        participant_id: &ParticipantIdentity,
-        expected_sid: &ParticipantSid,
-    ) {
+        target_sid: &ParticipantSid,
+    ) -> Option<Arc<Participant>> {
         let _guard = self.subscription_lock.lock();
-        let Some(participant) = self
-            .participant_registry
-            .remove_participant(participant_id, expected_sid)
-        else {
-            info!(
-                remote_access_session_id = self.remote_access_session_id(),
-                participant_identity = %participant_id,
-                sid = %expected_sid,
-                "ignoring remove for stale participant SID (current registration is for a different instance)",
-            );
-            return;
-        };
+        let participant = self.participant_registry.remove_participant(target_sid)?;
         let client_id = participant.client_id();
+        let participant_id = participant.participant_id();
         let removed = self
             .state
             .write()
@@ -1090,6 +1082,8 @@ impl RemoteAccessSession {
                 listener.on_client_unadvertise(&client, descriptor);
             }
         }
+
+        Some(participant)
     }
 
     /// Listen for room events and dispatch them.
@@ -1188,9 +1182,10 @@ impl RemoteAccessSession {
                 // Match the disconnect against the specific LiveKit connection
                 // instance we registered. If the stored `Participant` was added
                 // for a *later* instance (same identity, different SID — a
-                // reconnect we already reset to), skip the removal: this event
-                // is stale and its target is already gone.
-                self.remove_participant(&participant_identity, &sid);
+                // reconnect we already reset to), the SID-keyed remove misses
+                // and returns `None`: this event is stale and its target is
+                // already gone.
+                self.remove_participant(&sid);
             }
             RoomEvent::DataReceived {
                 payload: _,
@@ -1377,24 +1372,21 @@ impl RemoteAccessSession {
     async fn reset_participant(self: &Arc<Self>, target_sid: ParticipantSid) {
         let remote_access_session_id = self.remote_access_session_id();
 
-        // Look the participant up by SID. The SID identifies the exact
-        // instance that requested the reset, so a same-identity reconnect
-        // (which has a different SID) won't match here — that's the
-        // staleness filter, and avoids tearing down a replacement that has
-        // already taken over.
-        let (participant_id, version) = match self.participant_registry.get_participant_by_sid(&target_sid) {
-            Some(p) => (p.participant_id().clone(), p.protocol_version().clone()),
-            None => {
-                info!(
-                    remote_access_session_id,
-                    participant_sid = %target_sid,
-                    "reset requested for already-removed participant; skipping",
-                );
-                return;
-            }
+        // Remove by SID and capture identity / protocol version from the
+        // returned participant. The SID identifies the exact instance that
+        // requested the reset, so a same-identity reconnect (which has a
+        // different SID) won't match — `None` is the staleness filter.
+        let Some(participant) = self.remove_participant(&target_sid) else {
+            info!(
+                remote_access_session_id,
+                participant_sid = %target_sid,
+                "reset requested for already-removed participant; skipping",
+            );
+            return;
         };
-
-        self.remove_participant(&participant_id, &target_sid);
+        let participant_id = participant.participant_id().clone();
+        let version = participant.protocol_version().clone();
+        drop(participant);
 
         // Best-effort guard: skip re-add if LiveKit has already removed the participant
         // (e.g., because the underlying WebRTC connection dropped). In that case, the

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1022,9 +1022,9 @@ impl RemoteAccessSession {
     /// Removes the participant whose stored LiveKit SID matches `target_sid`,
     /// running the full cleanup (listener callbacks, context unsubscribe,
     /// video track teardown, connection-graph update) when removal happens.
-    /// Returns the removed `Arc<Participant>` (so callers can capture
-    /// identity / protocol version for re-registration), or `None` if no
-    /// participant with this SID is registered.
+    /// Returns the removed `Arc<Participant>` (so callers can capture the
+    /// identity for re-registration), or `None` if no participant with this
+    /// SID is registered.
     ///
     /// SID-keyed: a `ParticipantDisconnected` for a prior instance can arrive
     /// after a same-identity reconnect has replaced it, but the reconnected
@@ -1401,7 +1401,7 @@ impl RemoteAccessSession {
             info!(
                 remote_access_session_id,
                 participant_identity = %participant_id,
-                "participant already left room, skipping re-add after control stream failure",
+                "participant already left room, skipping re-add after control-plane failure",
             );
             return;
         };
@@ -1425,7 +1425,7 @@ impl RemoteAccessSession {
             participant_identity = %participant_id,
             sid = %sid,
             version = %version,
-            "resetting participant after control stream failure",
+            "resetting participant after control-plane failure",
         );
         if let Err(e) = self.add_participant(participant_id, sid).await {
             error!(

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -4,22 +4,16 @@ use std::sync::Arc;
 
 use livekit::id::{ParticipantIdentity, TrackSid};
 use smallvec::SmallVec;
-use tokio::task::JoinHandle;
 use tracing::{debug, info};
 
 use crate::protocol::v2::server::advertise;
 
-use crate::remote_access::participant::Participant;
-use crate::remote_access::participants::Participants;
 use crate::remote_access::qos::{QosProfile, Reliability};
 use crate::remote_access::session::{DataTrack, VideoInputSchema, VideoMetadata, VideoPublisher};
-use crate::remote_common::ClientId;
 use crate::{ChannelDescriptor, ChannelId, RawChannel};
 
 /// Channels and parameters that lost their last subscriber when a participant was removed.
 pub(crate) struct RemovedSubscriptions {
-    /// The locally-significant client ID of the removed participant.
-    pub client_id: Option<ClientId>,
     /// Channel IDs that lost their last subscriber (of any type).
     pub last_unsubscribed: SmallVec<[ChannelId; 4]>,
     /// Channel IDs that lost their last video subscriber.
@@ -60,7 +54,6 @@ pub(crate) struct UnsubscribeResult {
 /// A subscriber is a "data subscriber" if they appear in `subscriptions` but not in
 /// `video_subscribers`. See [`Self::has_data_subscribers`].
 pub(crate) struct SessionState {
-    participants: Participants,
     /// Channels that have been advertised to participants.
     channels: HashMap<ChannelId, Arc<RawChannel>>,
     /// QoS profile per channel.
@@ -84,14 +77,11 @@ pub(crate) struct SessionState {
     client_channels: HashMap<ParticipantIdentity, HashMap<ChannelId, ChannelDescriptor>>,
     /// Parameters subscribed to by participants, keyed by parameter name.
     subscribed_parameters: HashMap<String, HashSet<ParticipantIdentity>>,
-    /// Per-participant flush task handles, for teardown awaiting.
-    flush_handles: HashMap<ParticipantIdentity, JoinHandle<()>>,
 }
 
 impl SessionState {
     pub fn new() -> Self {
         Self {
-            participants: Participants::new(),
             channels: HashMap::new(),
             qos_profiles: HashMap::new(),
             subscriptions: HashMap::new(),
@@ -103,61 +93,22 @@ impl SessionState {
             video_metadata: HashMap::new(),
             client_channels: HashMap::new(),
             subscribed_parameters: HashMap::new(),
-            flush_handles: HashMap::new(),
         }
     }
 
-    /// Stores the flush task handle for a participant.
-    pub fn insert_flush_handle(&mut self, identity: ParticipantIdentity, handle: JoinHandle<()>) {
-        self.flush_handles.insert(identity, handle);
-    }
-
-    /// Removes and returns the flush handle for a participant, if one was registered.
-    pub fn remove_flush_handle(
+    /// Sweeps `identity` out of every subscription map and returns the
+    /// descriptors of channels that lost their last subscriber (and other
+    /// aftercare info) for the caller to fire listener callbacks on.
+    ///
+    /// Does not touch the participant registry — the caller is expected to
+    /// have already removed the participant entry there. No-op if `identity`
+    /// has no subscriptions or client channels.
+    #[must_use]
+    pub fn cleanup_for_removed_identity(
         &mut self,
         identity: &ParticipantIdentity,
-    ) -> Option<JoinHandle<()>> {
-        self.flush_handles.remove(identity)
-    }
-
-    /// Removes all participants and their flush handles atomically, returning both.
-    ///
-    /// For use during session teardown only — does not clean up subscriptions,
-    /// video subscribers, client channels, or parameter subscriptions (the room
-    /// is closing immediately after). Does not fire listener callbacks
-    /// (`on_unsubscribe`, `on_client_unadvertise`, etc.).
-    pub fn take_participants(&mut self) -> (Vec<Arc<Participant>>, Vec<JoinHandle<()>>) {
-        let participants = self.participants.take();
-        let handles: Vec<_> = self.flush_handles.drain().map(|(_, h)| h).collect();
-        (participants, handles)
-    }
-
-    /// Inserts a participant if not already present.
-    ///
-    /// Returns true if this is a new participant, or false if there was already a participant
-    /// registered with this identity.
-    pub fn insert_participant(&mut self, participant: Arc<Participant>) -> bool {
-        self.participants.insert(participant)
-    }
-
-    /// Removes a participant and all of its subscriptions.
-    ///
-    /// Returns the channels that lost their last subscriber or video subscriber,
-    /// and any client channels that were advertised by the participant.
-    #[must_use]
-    pub fn remove_participant(&mut self, identity: &ParticipantIdentity) -> RemovedSubscriptions {
-        let Some(participant) = self.participants.remove_by_identity(identity) else {
-            return RemovedSubscriptions {
-                client_id: None,
-                last_unsubscribed: SmallVec::new(),
-                last_video_unsubscribed: SmallVec::new(),
-                subscribed_descriptors: SmallVec::new(),
-                client_channels: Vec::new(),
-                last_param_unsubscribed: Vec::new(),
-            };
-        };
-        let client_id = participant.client_id();
-        info!("removed participant {identity:?}");
+    ) -> RemovedSubscriptions {
+        info!("cleaning up state for removed identity {identity:?}");
 
         let mut last_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         let mut subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]> = SmallVec::new();
@@ -206,33 +157,12 @@ impl SessionState {
         });
 
         RemovedSubscriptions {
-            client_id: Some(client_id),
             last_unsubscribed,
             last_video_unsubscribed,
             subscribed_descriptors,
             client_channels,
             last_param_unsubscribed,
         }
-    }
-
-    /// Returns the participant for the given identity, if present.
-    pub fn get_participant(&self, identity: &ParticipantIdentity) -> Option<Arc<Participant>> {
-        self.participants.get_by_identity(identity).cloned()
-    }
-
-    /// Returns the participant for the given `client_id`, if present.
-    pub fn get_participant_by_client_id(&self, client_id: ClientId) -> Option<Arc<Participant>> {
-        self.participants.get_by_client_id(client_id).cloned()
-    }
-
-    /// Returns true if there is a participant for the given identity.
-    pub fn has_participant(&self, identity: &ParticipantIdentity) -> bool {
-        self.participants.contains_identity(identity)
-    }
-
-    /// Collects and returns all current participants.
-    pub fn collect_participants(&self) -> SmallVec<[Arc<Participant>; 8]> {
-        self.participants.iter().cloned().collect()
     }
 
     /// Records a client-advertised channel for a participant.
@@ -244,13 +174,6 @@ impl SessionState {
         identity: &ParticipantIdentity,
         channel: ChannelDescriptor,
     ) -> bool {
-        debug_assert!(
-            self.participants.contains_identity(identity),
-            "Participant does not exist for identity: {identity:?}"
-        );
-        if !self.participants.contains_identity(identity) {
-            return false;
-        }
         let map = self.client_channels.entry(identity.clone()).or_default();
         match map.entry(channel.id()) {
             Entry::Occupied(_) => false,
@@ -289,21 +212,15 @@ impl SessionState {
         self.channels.get(channel_id).map(|ch| ch.descriptor())
     }
 
-    /// Returns (client_id, participant_identity) for all subscribers of the given channel.
-    pub fn channel_subscriber_clients(
+    /// Returns all subscriber identities for the given channel.
+    pub fn channel_subscriber_identities(
         &self,
         channel_id: &ChannelId,
-    ) -> SmallVec<[(ClientId, ParticipantIdentity); 4]> {
-        let Some(subscribers) = self.subscriptions.get(channel_id) else {
-            return SmallVec::new();
-        };
-        subscribers
-            .iter()
-            .filter_map(|identity| {
-                let participant = self.participants.get_by_identity(identity)?;
-                Some((participant.client_id(), identity.clone()))
-            })
-            .collect()
+    ) -> SmallVec<[ParticipantIdentity; 4]> {
+        self.subscriptions
+            .get(channel_id)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// Records a channel as advertised.
@@ -324,13 +241,13 @@ impl SessionState {
             .unwrap_or_default()
     }
 
-    /// Returns participants that have data subscriptions for a channel.
+    /// Returns identities of participants that have data subscriptions for a channel.
     ///
     /// A "data subscriber" is one in `subscriptions` but not `video_subscribers`.
-    pub fn data_subscriber_participants(
+    pub fn data_subscriber_identities(
         &self,
         channel_id: &ChannelId,
-    ) -> SmallVec<[Arc<Participant>; 4]> {
+    ) -> SmallVec<[ParticipantIdentity; 4]> {
         let Some(subscribers) = self.subscriptions.get(channel_id) else {
             return SmallVec::new();
         };
@@ -338,7 +255,7 @@ impl SessionState {
         subscribers
             .iter()
             .filter(|identity| !video_subs.is_some_and(|vs| vs.contains(identity)))
-            .filter_map(|identity| self.participants.get_by_identity(identity).cloned())
+            .cloned()
             .collect()
     }
 
@@ -470,20 +387,20 @@ impl SessionState {
     #[must_use]
     pub fn subscribe(
         &mut self,
-        participant: &Participant,
+        identity: &ParticipantIdentity,
         channel_ids: &[ChannelId],
     ) -> SubscribeResult {
         let mut first_subscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         let mut newly_subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]> = SmallVec::new();
         for &channel_id in channel_ids {
             let subscribers = self.subscriptions.entry(channel_id).or_default();
-            if subscribers.contains(participant.participant_id()) {
-                info!("{participant} is already subscribed to channel {channel_id:?}; ignoring");
+            if subscribers.contains(identity) {
+                info!("{identity:?} is already subscribed to channel {channel_id:?}; ignoring");
                 continue;
             }
             let is_first = subscribers.is_empty();
-            subscribers.push(participant.participant_id().clone());
-            debug!("{participant} subscribed to channel {channel_id:?}");
+            subscribers.push(identity.clone());
+            debug!("{identity:?} subscribed to channel {channel_id:?}");
             debug_assert!(
                 self.channels.contains_key(&channel_id),
                 "Subscribing to channel {channel_id:?} which is not advertised"
@@ -510,7 +427,7 @@ impl SessionState {
     #[must_use]
     pub fn unsubscribe(
         &mut self,
-        participant: &Participant,
+        identity: &ParticipantIdentity,
         channel_ids: &[ChannelId],
     ) -> UnsubscribeResult {
         let mut last_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
@@ -518,18 +435,15 @@ impl SessionState {
             SmallVec::new();
         for &channel_id in channel_ids {
             let Some(subscribers) = self.subscriptions.get_mut(&channel_id) else {
-                info!("{participant} is not subscribed to channel {channel_id:?}; ignoring");
+                info!("{identity:?} is not subscribed to channel {channel_id:?}; ignoring");
                 continue;
             };
-            let Some(pos) = subscribers
-                .iter()
-                .position(|id| id == participant.participant_id())
-            else {
-                info!("{participant} is not subscribed to channel {channel_id:?}; ignoring");
+            let Some(pos) = subscribers.iter().position(|id| id == identity) else {
+                info!("{identity:?} is not subscribed to channel {channel_id:?}; ignoring");
                 continue;
             };
             subscribers.swap_remove(pos);
-            debug!("{participant} unsubscribed from channel {channel_id:?}");
+            debug!("{identity:?} unsubscribed from channel {channel_id:?}");
             debug_assert!(
                 self.channels.contains_key(&channel_id),
                 "Unsubscribing from channel {channel_id:?} which is not advertised"
@@ -545,11 +459,6 @@ impl SessionState {
             last_unsubscribed,
             actually_unsubscribed_descriptors,
         }
-    }
-
-    /// Returns the number of connected participants.
-    pub fn participant_count(&self) -> usize {
-        self.participants.len()
     }
 
     /// Returns the total number of active participant subscriptions across all channels.
@@ -570,17 +479,17 @@ impl SessionState {
     #[must_use]
     pub fn subscribe_video(
         &mut self,
-        participant: &Participant,
+        identity: &ParticipantIdentity,
         channel_ids: &[ChannelId],
     ) -> SmallVec<[ChannelId; 4]> {
         let mut first_subscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         for &channel_id in channel_ids {
             let subscribers = self.video_subscribers.entry(channel_id).or_default();
-            if subscribers.contains(participant.participant_id()) {
+            if subscribers.contains(identity) {
                 continue;
             }
             let is_first = subscribers.is_empty();
-            subscribers.push(participant.participant_id().clone());
+            subscribers.push(identity.clone());
             if is_first {
                 first_subscribed.push(channel_id);
             }
@@ -596,7 +505,7 @@ impl SessionState {
     #[must_use]
     pub fn unsubscribe_video(
         &mut self,
-        participant: &Participant,
+        identity: &ParticipantIdentity,
         channel_ids: &[ChannelId],
     ) -> SmallVec<[ChannelId; 4]> {
         let mut last_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
@@ -604,10 +513,7 @@ impl SessionState {
             let Some(subscribers) = self.video_subscribers.get_mut(&channel_id) else {
                 continue;
             };
-            let Some(pos) = subscribers
-                .iter()
-                .position(|id| id == participant.participant_id())
-            else {
+            let Some(pos) = subscribers.iter().position(|id| id == identity) else {
                 continue;
             };
             subscribers.swap_remove(pos);
@@ -705,23 +611,8 @@ mod tests {
     use super::*;
     use crate::img2yuv::{ImageEncoding, RawImageEncoding};
 
-    fn make_participant(name: &str) -> (ParticipantIdentity, Arc<Participant>) {
-        let identity = ParticipantIdentity(name.to_string());
-        let version =
-            crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
-        let (tx, _rx) = flume::bounded(16);
-        let pending_resets = Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
-        let reset_notify = Arc::new(tokio::sync::Notify::new());
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let participant = Arc::new(Participant::new(
-            identity.clone(),
-            version,
-            tx,
-            pending_resets,
-            reset_notify,
-            cancel,
-        ));
-        (identity, participant)
+    fn make_identity(name: &str) -> ParticipantIdentity {
+        ParticipantIdentity(name.to_string())
     }
 
     fn make_channel(topic: &str) -> Arc<RawChannel> {
@@ -735,133 +626,331 @@ mod tests {
             .unwrap()
     }
 
-    #[test]
-    fn insert_new_participant() {
-        let mut state = SessionState::new();
-        let (_, p) = make_participant("alice");
-        assert!(state.insert_participant(p));
+    fn make_client_channel(channel_id: u64, topic: &str) -> ChannelDescriptor {
+        ChannelDescriptor::new(
+            ChannelId::new(channel_id),
+            topic.to_string(),
+            "json".to_string(),
+            Default::default(),
+            None,
+        )
     }
 
+    // ---- subscribe / unsubscribe ----
+
     #[test]
-    fn insert_existing_participant() {
+    fn first_subscriber_is_reported() {
         let mut state = SessionState::new();
-        let (_, p1) = make_participant("alice");
-        assert!(state.insert_participant(p1));
-        let (_, p2) = make_participant("alice");
-        assert!(!state.insert_participant(p2));
-    }
-
-    #[test]
-    fn get_participant_returns_existing() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-        assert!(state.get_participant(&id).is_some());
-    }
-
-    #[test]
-    fn get_participant_returns_none_for_missing() {
-        let state = SessionState::new();
-        let id = ParticipantIdentity("nobody".to_string());
-        assert!(state.get_participant(&id).is_none());
-    }
-
-    /// Protects the drain-time staleness check for `pending_resets`: after a
-    /// participant is removed and replaced (e.g. disconnect + reconnect), a
-    /// stale `ClientId` from the previous connection must not match the
-    /// replacement. If this ever returns `Some`, a stale reset request would
-    /// tear down a healthy reconnected participant.
-    #[test]
-    fn get_participant_by_client_id_does_not_match_replaced_participant() {
-        let mut state = SessionState::new();
-        let (id, original) = make_participant("alice");
-        let original_client_id = original.client_id();
-        state.insert_participant(original);
-        let _ = state.remove_participant(&id);
-        let (_, replacement) = make_participant("alice");
-        let replacement_client_id = replacement.client_id();
-        assert_ne!(original_client_id, replacement_client_id);
-        state.insert_participant(replacement);
-        assert!(
-            state
-                .get_participant_by_client_id(original_client_id)
-                .is_none(),
-            "stale ClientId must not resolve to the replacement participant",
-        );
-        assert!(
-            state
-                .get_participant_by_client_id(replacement_client_id)
-                .is_some(),
-            "fresh ClientId must resolve to the current participant",
-        );
-    }
-
-    #[test]
-    fn remove_missing_participant_is_noop() {
-        let mut state = SessionState::new();
-        let id = ParticipantIdentity("nobody".to_string());
-        let removed = state.remove_participant(&id);
-        assert!(removed.last_unsubscribed.is_empty());
-        assert!(removed.last_video_unsubscribed.is_empty());
-    }
-
-    #[test]
-    fn remove_participant_cleans_up_subscriptions() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p.clone());
-
+        let id = make_identity("alice");
         let ch = make_channel("/topic1");
-        let ch_id = ch.id();
         state.insert_channel(&ch);
-        let _ = state.subscribe(&p, &[ch_id]);
 
-        let removed = state.remove_participant(&id);
-        assert_eq!(removed.last_unsubscribed.as_slice(), &[ch_id]);
-        assert!(!state.has_data_subscribers(&ch_id));
+        let result = state.subscribe(&id, &[ch.id()]);
+        assert_eq!(result.first_subscribed.as_slice(), &[ch.id()]);
+        assert_eq!(result.newly_subscribed_descriptors.len(), 1);
+        assert_eq!(result.newly_subscribed_descriptors[0].id(), ch.id());
     }
 
     #[test]
-    fn remove_participant_reports_only_last_unsubscribed_channels() {
+    fn second_subscriber_is_not_reported_as_first() {
         let mut state = SessionState::new();
-        let (id_a, pa) = make_participant("alice");
-        let (_, pb) = make_participant("bob");
-        state.insert_participant(pa.clone());
-        state.insert_participant(pb.clone());
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
 
+        let _ = state.subscribe(&id_a, &[ch.id()]);
+        let result = state.subscribe(&id_b, &[ch.id()]);
+        assert!(result.first_subscribed.is_empty());
+        assert_eq!(result.newly_subscribed_descriptors.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_subscribe_is_idempotent() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+
+        let _ = state.subscribe(&id, &[ch.id()]);
+        let result = state.subscribe(&id, &[ch.id()]);
+        assert!(result.first_subscribed.is_empty());
+        assert!(result.newly_subscribed_descriptors.is_empty());
+        assert_eq!(state.subscriptions[&ch.id()].len(), 1);
+    }
+
+    #[test]
+    fn subscribe_multiple_channels_at_once() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
-        let ch1_id = ch1.id();
-        let ch2_id = ch2.id();
         state.insert_channel(&ch1);
         state.insert_channel(&ch2);
 
-        // Both subscribe to ch1; only alice subscribes to ch2.
-        let _ = state.subscribe(&pa, &[ch1_id, ch2_id]);
-        let _ = state.subscribe(&pb, &[ch1_id]);
-
-        let removed = state.remove_participant(&id_a);
-        // ch1 still has bob, so only ch2 should be reported.
-        assert_eq!(removed.last_unsubscribed.as_slice(), &[ch2_id]);
-        assert_eq!(state.subscriptions[&ch1_id].len(), 1);
+        let result = state.subscribe(&id, &[ch1.id(), ch2.id()]);
+        assert_eq!(result.first_subscribed.len(), 2);
+        assert_eq!(result.newly_subscribed_descriptors.len(), 2);
     }
 
     #[test]
-    fn remove_participant_cleans_up_video_subscriptions() {
+    fn last_unsubscriber_is_reported() {
         let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p.clone());
-
+        let id = make_identity("alice");
         let ch = make_channel("/topic1");
-        let ch_id = ch.id();
         state.insert_channel(&ch);
-        let _ = state.subscribe(&p, &[ch_id]);
-        let _ = state.subscribe_video(&p, &[ch_id]);
 
-        let removed = state.remove_participant(&id);
-        assert_eq!(removed.last_unsubscribed.as_slice(), &[ch_id]);
-        assert_eq!(removed.last_video_unsubscribed.as_slice(), &[ch_id]);
+        let _ = state.subscribe(&id, &[ch.id()]);
+        let result = state.unsubscribe(&id, &[ch.id()]);
+        assert_eq!(result.last_unsubscribed.as_slice(), &[ch.id()]);
+        assert_eq!(result.actually_unsubscribed_descriptors.len(), 1);
     }
+
+    #[test]
+    fn unsubscribe_with_remaining_subscribers_is_not_reported() {
+        let mut state = SessionState::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+
+        let _ = state.subscribe(&id_a, &[ch.id()]);
+        let _ = state.subscribe(&id_b, &[ch.id()]);
+
+        let result = state.unsubscribe(&id_a, &[ch.id()]);
+        assert!(result.last_unsubscribed.is_empty());
+        assert_eq!(state.subscriptions[&ch.id()].len(), 1);
+    }
+
+    #[test]
+    fn unsubscribe_when_not_subscribed_is_noop() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let result = state.unsubscribe(&id, &[ChannelId::new(1)]);
+        assert!(result.last_unsubscribed.is_empty());
+    }
+
+    // ---- video subscribers ----
+
+    #[test]
+    fn first_video_subscriber_is_reported() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let first = state.subscribe_video(&id, &[ChannelId::new(1)]);
+        assert_eq!(first.as_slice(), &[ChannelId::new(1)]);
+    }
+
+    #[test]
+    fn last_video_unsubscriber_is_reported() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let _ = state.subscribe_video(&id, &[ChannelId::new(1)]);
+        let last = state.unsubscribe_video(&id, &[ChannelId::new(1)]);
+        assert_eq!(last.as_slice(), &[ChannelId::new(1)]);
+    }
+
+    #[test]
+    fn video_only_subscriber_is_not_a_data_subscriber() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+        let _ = state.subscribe(&id, &[ch.id()]);
+        let _ = state.subscribe_video(&id, &[ch.id()]);
+        assert!(!state.has_data_subscribers(&ch.id()));
+    }
+
+    #[test]
+    fn switching_from_video_to_data() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+        let _ = state.subscribe(&id, &[ch.id()]);
+        let _ = state.subscribe_video(&id, &[ch.id()]);
+        assert!(!state.has_data_subscribers(&ch.id()));
+        let _ = state.unsubscribe_video(&id, &[ch.id()]);
+        assert!(state.has_data_subscribers(&ch.id()));
+    }
+
+    // ---- cleanup_for_removed_identity ----
+
+    #[test]
+    fn cleanup_missing_identity_is_noop() {
+        let mut state = SessionState::new();
+        let cleanup = state.cleanup_for_removed_identity(&make_identity("nobody"));
+        assert!(cleanup.last_unsubscribed.is_empty());
+        assert!(cleanup.last_video_unsubscribed.is_empty());
+        assert!(cleanup.subscribed_descriptors.is_empty());
+        assert!(cleanup.client_channels.is_empty());
+        assert!(cleanup.last_param_unsubscribed.is_empty());
+    }
+
+    #[test]
+    fn cleanup_sweeps_subscriptions() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+        let _ = state.subscribe(&id, &[ch.id()]);
+
+        let cleanup = state.cleanup_for_removed_identity(&id);
+        assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch.id()]);
+        assert!(!state.has_data_subscribers(&ch.id()));
+    }
+
+    #[test]
+    fn cleanup_reports_only_last_unsubscribed_channels() {
+        let mut state = SessionState::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+        let ch1 = make_channel("/topic1");
+        let ch2 = make_channel("/topic2");
+        state.insert_channel(&ch1);
+        state.insert_channel(&ch2);
+
+        let _ = state.subscribe(&id_a, &[ch1.id(), ch2.id()]);
+        let _ = state.subscribe(&id_b, &[ch1.id()]);
+
+        let cleanup = state.cleanup_for_removed_identity(&id_a);
+        // ch1 still has bob, so only ch2 should be reported.
+        assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch2.id()]);
+        assert_eq!(state.subscriptions[&ch1.id()].len(), 1);
+    }
+
+    #[test]
+    fn cleanup_sweeps_video_subscriptions() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+        let _ = state.subscribe(&id, &[ch.id()]);
+        let _ = state.subscribe_video(&id, &[ch.id()]);
+
+        let cleanup = state.cleanup_for_removed_identity(&id);
+        assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch.id()]);
+        assert_eq!(cleanup.last_video_unsubscribed.as_slice(), &[ch.id()]);
+    }
+
+    #[test]
+    fn cleanup_returns_subscribed_descriptors() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch1 = make_channel("/topic1");
+        let ch2 = make_channel("/topic2");
+        state.insert_channel(&ch1);
+        state.insert_channel(&ch2);
+        let _ = state.subscribe(&id, &[ch1.id(), ch2.id()]);
+
+        let cleanup = state.cleanup_for_removed_identity(&id);
+        assert_eq!(cleanup.subscribed_descriptors.len(), 2);
+    }
+
+    #[test]
+    fn cleanup_sweeps_client_channels() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        state.insert_client_channel(&id, make_client_channel(1, "/cmd_vel"));
+        state.insert_client_channel(&id, make_client_channel(2, "/joy"));
+
+        let cleanup = state.cleanup_for_removed_identity(&id);
+        assert_eq!(cleanup.client_channels.len(), 2);
+        assert!(
+            state
+                .remove_client_channel(&id, ChannelId::new(1))
+                .is_none(),
+            "map entry must be gone",
+        );
+    }
+
+    #[test]
+    fn cleanup_for_mixed_video_preferences() {
+        let mut state = SessionState::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+        let _ = state.subscribe(&id_a, &[ch.id()]);
+        let _ = state.subscribe(&id_b, &[ch.id()]);
+        let _ = state.subscribe_video(&id_a, &[ch.id()]);
+
+        // Remove alice: channel keeps bob, loses its last video subscriber.
+        let cleanup = state.cleanup_for_removed_identity(&id_a);
+        assert!(cleanup.last_unsubscribed.is_empty());
+        assert_eq!(cleanup.last_video_unsubscribed.as_slice(), &[ch.id()]);
+        assert!(state.has_data_subscribers(&ch.id()));
+    }
+
+    // ---- channel + client-channel lookups ----
+
+    #[test]
+    fn channel_subscriber_identities_empty_for_unknown_channel() {
+        let state = SessionState::new();
+        assert!(
+            state
+                .channel_subscriber_identities(&ChannelId::new(999))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn channel_subscriber_identities_returns_subscribers() {
+        let mut state = SessionState::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+        let _ = state.subscribe(&id_a, &[ch.id()]);
+        let _ = state.subscribe(&id_b, &[ch.id()]);
+
+        let result = state.channel_subscriber_identities(&ch.id());
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&id_a));
+        assert!(result.contains(&id_b));
+    }
+
+    #[test]
+    fn channel_subscriber_identities_empty_after_remove_channel() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch = make_channel("/topic1");
+        state.insert_channel(&ch);
+        let _ = state.subscribe(&id, &[ch.id()]);
+        assert_eq!(state.channel_subscriber_identities(&ch.id()).len(), 1);
+
+        state.remove_channel(ch.id());
+        assert!(state.channel_subscriber_identities(&ch.id()).is_empty());
+    }
+
+    #[test]
+    fn insert_client_channel_is_noop_for_duplicate() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        let ch = make_client_channel(1, "/cmd");
+        assert!(state.insert_client_channel(&id, ch.clone()));
+        assert!(!state.insert_client_channel(&id, ch));
+    }
+
+    #[test]
+    fn remove_client_channel_returns_descriptor() {
+        let mut state = SessionState::new();
+        let id = make_identity("alice");
+        state.insert_client_channel(&id, make_client_channel(1, "/cmd"));
+        let removed = state.remove_client_channel(&id, ChannelId::new(1));
+        assert_eq!(removed.unwrap().topic(), "/cmd");
+    }
+
+    #[test]
+    fn get_client_channel_returns_none_for_unknown() {
+        let state = SessionState::new();
+        assert!(
+            state
+                .get_client_channel(&make_identity("nobody"), ChannelId::new(1))
+                .is_none()
+        );
+    }
+
+    // ---- channels / qos ----
 
     #[test]
     fn insert_and_query_channel() {
@@ -886,359 +975,74 @@ mod tests {
     }
 
     #[test]
-    fn channel_subscriber_clients_empty_for_unknown_channel() {
+    fn qos_profile_defaults_to_lossy() {
         let state = SessionState::new();
-        let result = state.channel_subscriber_clients(&ChannelId::new(999));
-        assert!(result.is_empty());
+        assert_eq!(
+            state.qos_profile(&ChannelId::new(42)).reliability,
+            Reliability::Lossy,
+        );
     }
 
     #[test]
-    fn channel_subscriber_clients_returns_subscribers() {
+    fn insert_and_retrieve_qos_profile() {
         let mut state = SessionState::new();
-        let (id_a, pa) = make_participant("alice");
-        let (id_b, pb) = make_participant("bob");
-        state.insert_participant(pa.clone());
-        state.insert_participant(pb.clone());
-
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
+        let ch = make_channel("/config");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&pa, &[ch_id]);
-        let _ = state.subscribe(&pb, &[ch_id]);
-
-        let result = state.channel_subscriber_clients(&ch_id);
-        assert_eq!(result.len(), 2);
-        let identities: Vec<_> = result.iter().map(|(_, id)| id.clone()).collect();
-        assert!(identities.contains(&id_a));
-        assert!(identities.contains(&id_b));
+        let qos = QosProfile::builder()
+            .reliability(Reliability::Reliable)
+            .build();
+        state.insert_qos_profile(ch.id(), qos);
+        assert_eq!(
+            state.qos_profile(&ch.id()).reliability,
+            Reliability::Reliable
+        );
     }
 
     #[test]
-    fn channel_subscriber_clients_empty_after_remove_channel() {
+    fn remove_channel_cleans_up_qos_profile() {
         let mut state = SessionState::new();
-        let ch = make_channel("/topic1");
-        let (_, p) = make_participant("alice");
-        state.insert_participant(p.clone());
+        let ch = make_channel("/config");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&p, &[ch.id()]);
-
-        assert_eq!(state.channel_subscriber_clients(&ch.id()).len(), 1);
+        state.insert_qos_profile(
+            ch.id(),
+            QosProfile::builder()
+                .reliability(Reliability::Reliable)
+                .build(),
+        );
         state.remove_channel(ch.id());
-        assert!(state.channel_subscriber_clients(&ch.id()).is_empty());
+        assert_eq!(state.qos_profile(&ch.id()).reliability, Reliability::Lossy);
     }
 
-    #[test]
-    fn first_subscriber_is_reported() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let result = state.subscribe(&p, &[ch_id]);
-        assert_eq!(result.first_subscribed.as_slice(), &[ch_id]);
-        assert_eq!(result.newly_subscribed_descriptors.len(), 1);
-        assert_eq!(result.newly_subscribed_descriptors[0].id(), ch_id);
-    }
+    // ---- data_subscriber_identities ----
 
     #[test]
-    fn second_subscriber_is_not_reported_as_first() {
-        let mut state = SessionState::new();
-        let (_id_a, pa) = make_participant("alice");
-        let (_id_b, pb) = make_participant("bob");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&pa, &[ch_id]);
-        let result = state.subscribe(&pb, &[ch_id]);
-        assert!(result.first_subscribed.is_empty());
-        assert_eq!(result.newly_subscribed_descriptors.len(), 1);
-        assert_eq!(result.newly_subscribed_descriptors[0].id(), ch_id);
-    }
-
-    #[test]
-    fn duplicate_subscribe_is_idempotent() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&p, &[ch_id]);
-        let result = state.subscribe(&p, &[ch_id]);
-        assert!(result.first_subscribed.is_empty());
-        assert!(result.newly_subscribed_descriptors.is_empty());
-        assert_eq!(state.subscriptions[&ch_id].len(), 1);
-    }
-
-    #[test]
-    fn subscribe_multiple_channels_at_once() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch1 = make_channel("/topic1");
-        let ch2 = make_channel("/topic2");
-        let ch1_id = ch1.id();
-        let ch2_id = ch2.id();
-        state.insert_channel(&ch1);
-        state.insert_channel(&ch2);
-
-        let result = state.subscribe(&p, &[ch1_id, ch2_id]);
-        assert_eq!(result.first_subscribed.len(), 2);
-        assert!(result.first_subscribed.contains(&ch1_id));
-        assert!(result.first_subscribed.contains(&ch2_id));
-        assert_eq!(result.newly_subscribed_descriptors.len(), 2);
-    }
-
-    #[test]
-    fn last_unsubscriber_is_reported() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&p, &[ch_id]);
-        let result = state.unsubscribe(&p, &[ch_id]);
-        assert_eq!(result.last_unsubscribed.as_slice(), &[ch_id]);
-        assert_eq!(result.actually_unsubscribed_descriptors.len(), 1);
-        assert_eq!(result.actually_unsubscribed_descriptors[0].id(), ch_id);
-    }
-
-    #[test]
-    fn unsubscribe_with_remaining_subscribers_is_not_reported() {
-        let mut state = SessionState::new();
-        let (_id_a, pa) = make_participant("alice");
-        let (_id_b, pb) = make_participant("bob");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&pa, &[ch_id]);
-        let _ = state.subscribe(&pb, &[ch_id]);
-
-        let result = state.unsubscribe(&pa, &[ch_id]);
-        assert!(result.last_unsubscribed.is_empty());
-        assert_eq!(result.actually_unsubscribed_descriptors.len(), 1);
-        assert_eq!(result.actually_unsubscribed_descriptors[0].id(), ch_id);
-        assert_eq!(state.subscriptions[&ch_id].len(), 1);
-    }
-
-    #[test]
-    fn unsubscribe_when_not_subscribed_is_noop() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch_id = ChannelId::new(1);
-
-        let result = state.unsubscribe(&p, &[ch_id]);
-        assert!(result.last_unsubscribed.is_empty());
-        assert!(result.actually_unsubscribed_descriptors.is_empty());
-    }
-
-    #[test]
-    fn unsubscribe_multiple_channels_at_once() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch1 = make_channel("/topic1");
-        let ch2 = make_channel("/topic2");
-        let ch1_id = ch1.id();
-        let ch2_id = ch2.id();
-        state.insert_channel(&ch1);
-        state.insert_channel(&ch2);
-
-        let _ = state.subscribe(&p, &[ch1_id, ch2_id]);
-        let result = state.unsubscribe(&p, &[ch1_id, ch2_id]);
-        assert_eq!(result.last_unsubscribed.len(), 2);
-        assert!(result.last_unsubscribed.contains(&ch1_id));
-        assert!(result.last_unsubscribed.contains(&ch2_id));
-        assert_eq!(result.actually_unsubscribed_descriptors.len(), 2);
-    }
-
-    #[test]
-    fn collect_participants_yields_all() {
-        let mut state = SessionState::new();
-        let (_, pa) = make_participant("alice");
-        let (_, pb) = make_participant("bob");
-        state.insert_participant(pa);
-        state.insert_participant(pb);
-        assert_eq!(state.collect_participants().len(), 2);
-    }
-
-    #[test]
-    fn first_video_subscriber_is_reported() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = ChannelId::new(1);
-
-        let first = state.subscribe_video(&p, &[ch]);
-        assert_eq!(first.as_slice(), &[ch]);
-    }
-
-    #[test]
-    fn second_video_subscriber_is_not_reported_as_first() {
-        let mut state = SessionState::new();
-        let (_id_a, pa) = make_participant("alice");
-        let (_id_b, pb) = make_participant("bob");
-        let ch = ChannelId::new(1);
-
-        let _ = state.subscribe_video(&pa, &[ch]);
-        let first = state.subscribe_video(&pb, &[ch]);
-        assert!(first.is_empty());
-    }
-
-    #[test]
-    fn duplicate_video_subscribe_is_idempotent() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = ChannelId::new(1);
-
-        let _ = state.subscribe_video(&p, &[ch]);
-        let first = state.subscribe_video(&p, &[ch]);
-        assert!(first.is_empty());
-    }
-
-    #[test]
-    fn last_video_unsubscriber_is_reported() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = ChannelId::new(1);
-
-        let _ = state.subscribe_video(&p, &[ch]);
-        let last = state.unsubscribe_video(&p, &[ch]);
-        assert_eq!(last.as_slice(), &[ch]);
-    }
-
-    #[test]
-    fn video_unsubscribe_with_remaining_is_not_reported() {
-        let mut state = SessionState::new();
-        let (_id_a, pa) = make_participant("alice");
-        let (_id_b, pb) = make_participant("bob");
-        let ch = ChannelId::new(1);
-
-        let _ = state.subscribe_video(&pa, &[ch]);
-        let _ = state.subscribe_video(&pb, &[ch]);
-
-        let last = state.unsubscribe_video(&pa, &[ch]);
-        assert!(last.is_empty());
-    }
-
-    #[test]
-    fn video_unsubscribe_when_not_subscribed_is_noop() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = ChannelId::new(1);
-
-        let last = state.unsubscribe_video(&p, &[ch]);
-        assert!(last.is_empty());
-    }
-
-    #[test]
-    fn no_subscribers_means_no_data_subscribers() {
+    fn data_subscriber_identities_empty_when_no_subscribers() {
         let state = SessionState::new();
-        let ch = ChannelId::new(1);
-        assert!(!state.has_data_subscribers(&ch));
+        assert!(
+            state
+                .data_subscriber_identities(&ChannelId::new(1))
+                .is_empty()
+        );
     }
 
     #[test]
-    fn non_video_subscriber_is_data_subscriber() {
+    fn data_subscriber_identities_returns_data_only_subscribers() {
         let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+        let ch = make_channel("/data");
         state.insert_channel(&ch);
+        // Both subscribe (data). Bob also subscribes to video.
+        let _ = state.subscribe(&id_a, &[ch.id()]);
+        let _ = state.subscribe(&id_b, &[ch.id()]);
+        let _ = state.subscribe_video(&id_b, &[ch.id()]);
 
-        let _ = state.subscribe(&p, &[ch_id]);
-        assert!(state.has_data_subscribers(&ch_id));
+        let subs = state.data_subscriber_identities(&ch.id());
+        assert_eq!(subs.len(), 1);
+        assert_eq!(&subs[0], &id_a);
     }
 
-    #[test]
-    fn video_only_subscriber_is_not_a_data_subscriber() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&p, &[ch_id]);
-        let _ = state.subscribe_video(&p, &[ch_id]);
-        assert!(!state.has_data_subscribers(&ch_id));
-    }
-
-    #[test]
-    fn mixed_subscribers_data_and_video() {
-        let mut state = SessionState::new();
-        let (_id_a, pa) = make_participant("alice");
-        let (_id_b, pb) = make_participant("bob");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        // Both subscribe; Alice wants video, Bob wants data (no video sub).
-        let _ = state.subscribe(&pa, &[ch_id]);
-        let _ = state.subscribe(&pb, &[ch_id]);
-        let _ = state.subscribe_video(&pa, &[ch_id]);
-
-        assert!(state.has_data_subscribers(&ch_id));
-    }
-
-    #[test]
-    fn switching_from_video_to_data() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&p, &[ch_id]);
-        let _ = state.subscribe_video(&p, &[ch_id]);
-        assert!(!state.has_data_subscribers(&ch_id));
-
-        // Alice switches to data.
-        let _ = state.unsubscribe_video(&p, &[ch_id]);
-        assert!(state.has_data_subscribers(&ch_id));
-    }
-
-    #[test]
-    fn switching_from_data_to_video() {
-        let mut state = SessionState::new();
-        let (_id, p) = make_participant("alice");
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&p, &[ch_id]);
-        assert!(state.has_data_subscribers(&ch_id));
-
-        // Alice switches to video.
-        let _ = state.subscribe_video(&p, &[ch_id]);
-        assert!(!state.has_data_subscribers(&ch_id));
-        assert!(state.video_subscribers.contains_key(&ch_id));
-    }
-
-    #[test]
-    fn remove_participant_with_mixed_video_preferences() {
-        let mut state = SessionState::new();
-        let (id_a, pa) = make_participant("alice");
-        let (_, pb) = make_participant("bob");
-        state.insert_participant(pa.clone());
-        state.insert_participant(pb.clone());
-
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-        // alice=video, bob=data — both in the unified map.
-        let _ = state.subscribe(&pa, &[ch_id]);
-        let _ = state.subscribe(&pb, &[ch_id]);
-        let _ = state.subscribe_video(&pa, &[ch_id]);
-
-        // Remove alice: channel keeps bob, but loses its last video subscriber.
-        let removed = state.remove_participant(&id_a);
-        assert!(removed.last_unsubscribed.is_empty(), "bob still subscribed");
-        assert_eq!(removed.last_video_unsubscribed.as_slice(), &[ch_id]);
-
-        // Bob is the only subscriber and he's a data subscriber.
-        assert!(state.has_data_subscribers(&ch_id));
-    }
+    // ---- advertise-metadata rendering ----
 
     #[test]
     fn add_metadata_to_advertisement_injects_video_metadata() {
@@ -1247,26 +1051,13 @@ mod tests {
         state.insert_channel(&ch);
         state.insert_video_schema(ch.id(), VideoInputSchema::FoxgloveRawImage);
 
-        // Before any video metadata, only hasVideoTrack should be present.
         let mut msg = advertise::advertise_channels(std::iter::once(&ch)).into_owned();
         state.add_metadata_to_advertisement(&mut msg);
-        assert_eq!(msg.channels.len(), 1);
         assert_eq!(
             msg.channels[0].metadata.get("foxglove.hasVideoTrack"),
             Some(&"true".to_string()),
         );
-        assert!(
-            !msg.channels[0]
-                .metadata
-                .contains_key("foxglove.videoSourceEncoding")
-        );
-        assert!(
-            !msg.channels[0]
-                .metadata
-                .contains_key("foxglove.videoFrameId")
-        );
 
-        // After inserting video metadata, encoding and frame_id should appear.
         state.insert_video_metadata(
             ch.id(),
             VideoMetadata {
@@ -1301,15 +1092,11 @@ mod tests {
         );
         let mut msg = advertise::advertise_channels(std::iter::once(&ch)).into_owned();
         state.add_metadata_to_advertisement(&mut msg);
-        assert_eq!(
-            msg.channels[0].metadata.get("foxglove.videoSourceEncoding"),
-            Some(&"mono8".to_string()),
-        );
         assert!(
             !msg.channels[0]
                 .metadata
                 .contains_key("foxglove.videoFrameId"),
-            "empty frame_id should not be advertised"
+            "empty frame_id should not be advertised",
         );
     }
 
@@ -1330,7 +1117,6 @@ mod tests {
 
         let mut msg = advertise::advertise_channels(std::iter::once(&ch)).into_owned();
         state.add_metadata_to_advertisement(&mut msg);
-        // hasVideoTrack should still be present (schema persists), but metadata should be gone.
         assert_eq!(
             msg.channels[0].metadata.get("foxglove.hasVideoTrack"),
             Some(&"true".to_string()),
@@ -1340,287 +1126,5 @@ mod tests {
                 .metadata
                 .contains_key("foxglove.videoSourceEncoding")
         );
-        assert!(
-            !msg.channels[0]
-                .metadata
-                .contains_key("foxglove.videoFrameId")
-        );
-    }
-
-    #[test]
-    fn remove_participant_video_subscriber_while_other_video_remains() {
-        let mut state = SessionState::new();
-        let (id_a, pa) = make_participant("alice");
-        let (_, pb) = make_participant("bob");
-        state.insert_participant(pa.clone());
-        state.insert_participant(pb.clone());
-
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-        let _ = state.subscribe(&pa, &[ch_id]);
-        let _ = state.subscribe(&pb, &[ch_id]);
-        let _ = state.subscribe_video(&pa, &[ch_id]);
-        let _ = state.subscribe_video(&pb, &[ch_id]);
-
-        // Remove alice: bob still has video.
-        let removed = state.remove_participant(&id_a);
-        assert!(removed.last_unsubscribed.is_empty());
-        assert!(removed.last_video_unsubscribed.is_empty());
-        assert!(!state.has_data_subscribers(&ch_id));
-    }
-
-    fn make_client_channel(channel_id: u64, topic: &str) -> ChannelDescriptor {
-        ChannelDescriptor::new(
-            ChannelId::new(channel_id),
-            topic.to_string(),
-            "json".to_string(),
-            Default::default(),
-            None,
-        )
-    }
-
-    #[test]
-    fn insert_client_channel_succeeds_for_new_channel() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-        let ch = make_client_channel(1, "/cmd");
-
-        assert!(state.insert_client_channel(&id, ch));
-    }
-
-    #[test]
-    fn insert_client_channel_returns_false_for_duplicate() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-        let ch = make_client_channel(1, "/cmd");
-
-        assert!(state.insert_client_channel(&id, ch.clone()));
-        assert!(!state.insert_client_channel(&id, ch));
-    }
-
-    #[test]
-    fn remove_client_channel_returns_descriptor() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-        let ch = make_client_channel(1, "/cmd");
-
-        state.insert_client_channel(&id, ch);
-        let removed = state.remove_client_channel(&id, ChannelId::new(1));
-        assert!(removed.is_some());
-        assert_eq!(removed.unwrap().topic(), "/cmd");
-    }
-
-    #[test]
-    fn remove_client_channel_returns_none_for_unknown_channel() {
-        let mut state = SessionState::new();
-        let (id, _) = make_participant("alice");
-
-        assert!(
-            state
-                .remove_client_channel(&id, ChannelId::new(99))
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn remove_participant_returns_subscribed_descriptors() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p.clone());
-
-        let ch1 = make_channel("/topic1");
-        let ch2 = make_channel("/topic2");
-        state.insert_channel(&ch1);
-        state.insert_channel(&ch2);
-        let _ = state.subscribe(&p, &[ch1.id(), ch2.id()]);
-
-        let removed = state.remove_participant(&id);
-        assert_eq!(removed.subscribed_descriptors.len(), 2);
-        let topics: Vec<&str> = removed
-            .subscribed_descriptors
-            .iter()
-            .map(|d| d.topic())
-            .collect();
-        assert!(topics.contains(&"/topic1"));
-        assert!(topics.contains(&"/topic2"));
-    }
-
-    #[test]
-    fn remove_participant_cleans_up_client_channels() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-
-        state.insert_client_channel(&id, make_client_channel(1, "/cmd_vel"));
-        state.insert_client_channel(&id, make_client_channel(2, "/joy"));
-
-        let removed = state.remove_participant(&id);
-        assert_eq!(removed.client_channels.len(), 2);
-        // Channel map entry should be cleaned up.
-        assert!(
-            state
-                .remove_client_channel(&id, ChannelId::new(1))
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn remove_participant_with_no_client_channels_yields_empty_vec() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-
-        let removed = state.remove_participant(&id);
-        assert!(removed.client_channels.is_empty());
-    }
-
-    #[test]
-    fn get_client_channel_returns_channel() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-        let ch = make_client_channel(1, "/cmd");
-
-        state.insert_client_channel(&id, ch);
-
-        let result = state.get_client_channel(&id, ChannelId::new(1));
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().topic(), "/cmd");
-    }
-
-    #[test]
-    fn get_client_channel_returns_none_for_unknown_participant() {
-        let state = SessionState::new();
-        let id = ParticipantIdentity("nobody".to_string());
-        assert!(state.get_client_channel(&id, ChannelId::new(1)).is_none());
-    }
-
-    #[test]
-    fn get_client_channel_returns_none_for_unknown_channel() {
-        let mut state = SessionState::new();
-        let (id, p) = make_participant("alice");
-        state.insert_participant(p);
-        state.insert_client_channel(&id, make_client_channel(1, "/cmd"));
-        assert!(state.get_client_channel(&id, ChannelId::new(99)).is_none());
-    }
-
-    #[test]
-    fn get_channel_descriptor_returns_descriptor() {
-        let mut state = SessionState::new();
-        let ch = make_channel("/topic1");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let result = state.get_channel_descriptor(&ch_id);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().topic(), "/topic1");
-    }
-
-    #[test]
-    fn get_channel_descriptor_returns_none_for_unknown() {
-        let state = SessionState::new();
-        assert!(state.get_channel_descriptor(&ChannelId::new(999)).is_none());
-    }
-
-    // -----------------------------------------------------------------------
-    // QoS profile tests
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn qos_profile_defaults_to_lossy() {
-        let state = SessionState::new();
-        let qos = state.qos_profile(&ChannelId::new(42));
-        assert_eq!(qos.reliability, Reliability::Lossy);
-    }
-
-    #[test]
-    fn insert_and_retrieve_qos_profile() {
-        let mut state = SessionState::new();
-        let ch = make_channel("/config");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let qos = QosProfile::builder()
-            .reliability(Reliability::Reliable)
-            .build();
-        state.insert_qos_profile(ch_id, qos);
-
-        assert_eq!(state.qos_profile(&ch_id).reliability, Reliability::Reliable);
-    }
-
-    #[test]
-    fn remove_channel_cleans_up_qos_profile() {
-        let mut state = SessionState::new();
-        let ch = make_channel("/config");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-        state.insert_qos_profile(
-            ch_id,
-            QosProfile::builder()
-                .reliability(Reliability::Reliable)
-                .build(),
-        );
-
-        state.remove_channel(ch_id);
-
-        // Should fall back to default after removal.
-        assert_eq!(state.qos_profile(&ch_id).reliability, Reliability::Lossy);
-    }
-
-    // -----------------------------------------------------------------------
-    // data_subscriber_participants tests
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn data_subscriber_participants_empty_when_no_subscribers() {
-        let state = SessionState::new();
-        assert!(
-            state
-                .data_subscriber_participants(&ChannelId::new(1))
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn data_subscriber_participants_returns_data_only_subscribers() {
-        let mut state = SessionState::new();
-        let (id_a, pa) = make_participant("alice");
-        let (_, pb) = make_participant("bob");
-        state.insert_participant(pa.clone());
-        state.insert_participant(pb.clone());
-
-        let ch = make_channel("/data");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        // Both subscribe (data). Bob also subscribes to video.
-        let _ = state.subscribe(&pa, &[ch_id]);
-        let _ = state.subscribe(&pb, &[ch_id]);
-        let _ = state.subscribe_video(&pb, &[ch_id]);
-
-        let participants = state.data_subscriber_participants(&ch_id);
-        // Only alice should be returned — bob is a video subscriber.
-        assert_eq!(participants.len(), 1);
-        assert_eq!(participants[0].participant_id(), &id_a);
-    }
-
-    #[test]
-    fn data_subscriber_participants_empty_when_all_are_video() {
-        let mut state = SessionState::new();
-        let (_, p) = make_participant("alice");
-        state.insert_participant(p.clone());
-
-        let ch = make_channel("/cam");
-        let ch_id = ch.id();
-        state.insert_channel(&ch);
-
-        let _ = state.subscribe(&p, &[ch_id]);
-        let _ = state.subscribe_video(&p, &[ch_id]);
-
-        assert!(state.data_subscriber_participants(&ch_id).is_empty());
     }
 }


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

This saga started when a few days ago I noticed that the netem test on one of my PRs failed.  That has happened (very) sporadically before, so I decided to dig into it.  I ended up finding a race condition.

Under impairment the netem integration test can fail with "byte stream ended unexpectedly" when the viewer's outer connect-retry timer fires (`ViewerConnection::connect_with_timeout` in `test_helpers.rs`, 5s). The test reuses a hardcoded `"viewer-1"` identity across retries, so the retry joins the room under the same identity as the attempt the gateway is still holding state for. The gateway's reset path (triggered by attempt 1's flush task failing a write) re-opens a stream against that identity, and a queued `ParticipantDisconnected` for attempt 1 then tears down the freshly re-registered attempt 2 — because `remove_participant` keyed on `ParticipantIdentity` alone.
    
Each `Participant` now stores LiveKit's per-connection `ParticipantSid` at registration time, and `remove_participant` takes both the identity and the expected SID; a removal whose SID doesn't match the currently stored one is a no-op. A stale `ParticipantDisconnected` for a prior instance can't remove its replacement. `reset_participant` captures
    the stored participant's SID and `protocol_version` before removing: the stored SID is what's passed to `remove_participant` (identifying which specific instance to tear down), and the `protocol_version` is reused on re-add to avoid a `remote_participants()` lookup that would race with reconnection. The re-add SID itself is still queried fresh from `remote_participants()` — if a same-identity reconnect has already landed, we want to register the *new* instance's SID, not the just-removed one's, so that a later stale `ParticipantDisconnected` for the old SID can't tear down the replacement.
    
Participant membership lives in a new `ParticipantRegistry` that owns the participant map, per-participant flush-task `JoinHandle`s, and the `pending_resets` / `reset_notify` signalling surfaces. It has no LiveKit dependency, so the race is reproducible in a unit test without a real `Room`: the session opens the control-plane stream and passes the resulting `ParticipantWriter` into `registry.register_participant`; tests build writers directly. `SessionState` is now purely session-level state (channels, subscriptions, video publishers, client channels, parameters); subscribe/unsubscribe methods take `&ParticipantIdentity` instead of `&Participant`, so `SessionState` has no dependency on `Participant` at all. Participant-removal cleanup (listener callbacks, context unsubscribe, video track teardown, connection-graph update) runs after registry removal via `run_participant_removal_cleanup`. `Sink::log` and `Sink::remove_channel` resolve subscriber identities through `ParticipantRegistry::resolve_identities`, which takes the registry read lock once per broadcast rather than per subscriber.

Regression test:
`remote_access::participant_registry::tests::stale_disconnect_must_not_remove_reconnected_participant`.

I tested locally with the remote_access example and connecting to it through the app, and it seems to work fine (both before and after this PR)

Coincidentally, I *believe* that this:

Fixes FLE-417

But I'm not certain of that because I don't have exact details on how that failure manifested.