### PR TITLE
remote access: fix race in sdk if ParticipantActive arrives before Disconnected

### DIFF
--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -407,8 +407,9 @@ impl RemoteAccessConnection {
                 "adding existing participant"
             );
             let sid = participant.sid();
+            let joined_at = participant.joined_at();
             if let Err(e) = session
-                .add_participant(identity.clone(), sid, version)
+                .add_participant(identity.clone(), sid, joined_at, version)
                 .await
             {
                 error!(

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -32,13 +32,17 @@ pub(crate) struct Participant {
     client_id: ClientId,
     /// LiveKit participant identity (stable across disconnect + reconnect).
     participant_id: ParticipantIdentity,
-    /// LiveKit session ID for this specific connection instance. Unique per
-    /// physical connection — unlike `participant_id`, it changes when a
-    /// participant disconnects and reconnects under the same identity. Used
     /// to disambiguate connection instances on every operation that targets
     /// one specific instance: `ParticipantDisconnected` event handling,
     /// SID-keyed `remove_participant`, and `pending_resets` bookkeeping.
     participant_sid: ParticipantSid,
+    /// Server-assigned join timestamp (ms since epoch) for this specific
+    /// connection instance, copied from
+    /// [`livekit::participant::RemoteParticipant::joined_at`]. Used by the
+    /// registry to enforce monotonicity when two same-identity registrations
+    /// race: a registration whose `joined_at` is older than the currently
+    /// stored instance is dropped instead of replacing it.
+    joined_at: i64,
     /// The remote access protocol version advertised by this participant.
     /// Stored for future use when branching protocol behavior based on the
     /// participant's version. Captured at registration and refreshed on
@@ -86,6 +90,7 @@ impl Participant {
     pub fn spawn(
         identity: ParticipantIdentity,
         participant_sid: ParticipantSid,
+        joined_at: i64,
         protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
@@ -135,6 +140,7 @@ impl Participant {
             client_id,
             participant_id: identity,
             participant_sid,
+            joined_at,
             protocol_version,
             control_tx,
             pending_resets,
@@ -167,6 +173,7 @@ impl Participant {
             client_id: ClientId::next(),
             participant_id: identity,
             participant_sid,
+            joined_at: 0,
             protocol_version,
             control_tx,
             pending_resets,
@@ -209,6 +216,14 @@ impl Participant {
     /// identity has reconnected.
     pub(crate) fn participant_sid(&self) -> &ParticipantSid {
         &self.participant_sid
+    }
+
+    /// Returns the server-assigned join timestamp (ms since epoch) for this
+    /// connection instance. Used by the participant registry to reject a
+    /// stale same-identity registration whose `joined_at` precedes the
+    /// currently stored instance.
+    pub(crate) fn joined_at(&self) -> i64 {
+        self.joined_at
     }
 
     /// Try to queue a control plane message. Returns `false` if the queue is

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -32,6 +32,9 @@ pub(crate) struct Participant {
     client_id: ClientId,
     /// LiveKit participant identity (stable across disconnect + reconnect).
     participant_id: ParticipantIdentity,
+    /// LiveKit session ID for this specific connection instance. Unique per
+    /// physical connection — unlike `participant_id`, it changes when a
+    /// participant disconnects and reconnects under the same identity. Used
     /// to disambiguate connection instances on every operation that targets
     /// one specific instance: `ParticipantDisconnected` event handling,
     /// SID-keyed `remove_participant`, and `pending_resets` bookkeeping.

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -513,9 +513,9 @@ mod tests {
         assert!(registry.remove_participant(&sid_1).is_none());
 
         // Step 4: attempt 2 must still be registered.
-        let current = registry
-            .get_participant(&id)
-            .expect("attempt 2 must remain registered after a late stale Disconnected for the prior SID");
+        let current = registry.get_participant(&id).expect(
+            "attempt 2 must remain registered after a late stale Disconnected for the prior SID",
+        );
         assert_eq!(current.participant_sid(), &sid_2);
         assert_ne!(current.client_id(), client_id_1);
     }

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -49,14 +49,17 @@ impl ParticipantRegistry {
     }
 
     /// Spawns a [`Participant`] and its flush-task against the supplied
-    /// `writer` and inserts it into the registry.
+    /// `writer` and inserts it into the registry, atomically replacing any
+    /// prior registration for the same identity that has a **different**
+    /// `ParticipantSid`.
     ///
-    /// Each byte slice in `initial_messages` is queued on the participant's
-    /// control-plane channel after the flush-task is spawned but before the
-    /// participant is visible in the registry. This preserves the invariant
-    /// that these bytes (typically `ServerInfo` + channel/service
-    /// advertisements) are the first the flush-task delivers to the viewer,
-    /// ahead of any broadcast that reaches the participant after registration.
+    /// Each byte slice in `initial_messages` is queued on the new
+    /// participant's control-plane channel after the flush-task is spawned
+    /// but before the participant is visible in the registry. This preserves
+    /// the invariant that these bytes (typically `ServerInfo` +
+    /// channel/service advertisements) are the first the flush-task delivers
+    /// to the viewer, ahead of any broadcast that reaches the participant
+    /// after registration.
     ///
     /// `participant_sid` is stored on the new [`Participant`] and indexed in
     /// the registry so any later operation that targets a specific connection
@@ -67,13 +70,29 @@ impl ParticipantRegistry {
     /// `session_cancel` is the session's cancellation token; the spawned
     /// flush-task takes a child of it so the task exits on session close.
     ///
-    /// Returns `false` without spawning or inserting if a participant already
-    /// exists for this identity. Callers that want to avoid opening a stream
-    /// in that case should gate on [`has_participant`] before opening the
-    /// writer; this gate is only a backstop.
-    #[must_use = "register_participant returns false on a same-identity collision; \
-                  callers must check (or debug_assert) the result to catch \
-                  contract violations of the no-concurrent-call rule"]
+    /// # Replacement semantics
+    ///
+    /// LiveKit assigns a fresh [`ParticipantSid`] to each connection
+    /// instance, so a same-identity reconnect arrives with a different SID:
+    ///
+    /// - If no participant is registered for `id`, the new one is inserted
+    ///   and `None` is returned.
+    /// - If a participant is registered with a **different** `participant_sid`,
+    ///   it is removed (its flush-task is cancelled by `Participants`'
+    ///   removal path) and the new one is inserted in its place; the prior
+    ///   `Arc<Participant>` is returned so the caller can run any
+    ///   session-level cleanup (subscription sweep, listener callbacks).
+    ///   This handles the case where LiveKit emits the reconnect's
+    ///   `ParticipantActive` *before* the prior instance's
+    ///   `ParticipantDisconnected`; without atomic replacement the new
+    ///   instance would be silently dropped and the late `Disconnected`
+    ///   would then evict the only registration, stranding the live viewer.
+    /// - If a participant is registered with the **same** `participant_sid`,
+    ///   the existing registration is left untouched, the freshly-spawned
+    ///   participant is cancelled and dropped, and `None` is returned. This
+    ///   path is defensive: in practice LiveKit never reuses a SID across
+    ///   instances, so re-registering an identical `(identity, sid)` pair
+    ///   indicates a redundant call rather than a true reconnect.
     pub(crate) fn register_participant<I>(
         &self,
         id: ParticipantIdentity,
@@ -82,14 +101,10 @@ impl ParticipantRegistry {
         writer: ParticipantWriter,
         session_cancel: &CancellationToken,
         initial_messages: I,
-    ) -> bool
+    ) -> Option<Arc<Participant>>
     where
         I: IntoIterator<Item = Bytes>,
     {
-        if self.participants.read().contains_identity(&id) {
-            return false;
-        }
-
         let (participant, flush_handle) = Participant::spawn(
             id,
             participant_sid,
@@ -105,7 +120,35 @@ impl ParticipantRegistry {
             participant.send_control(msg);
         }
 
-        self.participants.write().insert(participant, flush_handle)
+        let mut participants = self.participants.write();
+
+        // Same-identity reconnect (different SID): atomically remove the prior
+        // registration so this `register_participant` call cannot lose a
+        // race with a late `ParticipantDisconnected` for the prior instance.
+        let prior =
+            if let Some(existing) = participants.get_by_identity(participant.participant_id()) {
+                if existing.participant_sid() == participant.participant_sid() {
+                    // Defensive no-op: same instance is already registered. Drop
+                    // the freshly-spawned participant (and its writer); cancel
+                    // its flush-task so it exits promptly.
+                    participant.cancel();
+                    return None;
+                }
+                let prior_sid = existing.participant_sid().clone();
+                let prior = participants
+                    .remove_by_sid(&prior_sid)
+                    .expect("get_by_identity returned Some; remove must succeed");
+                Some(prior)
+            } else {
+                None
+            };
+
+        let inserted = participants.insert(participant, flush_handle);
+        debug_assert!(
+            inserted,
+            "identity slot is vacant after the conditional remove above; insert must succeed",
+        );
+        prior
     }
 
     /// Removes the participant whose stored `ParticipantSid` matches
@@ -146,11 +189,6 @@ impl ParticipantRegistry {
             .into_iter()
             .filter_map(|id| participants.get_by_identity(&id).cloned())
             .collect()
-    }
-
-    /// Returns true if a participant exists for the given identity.
-    pub(crate) fn has_participant(&self, id: &ParticipantIdentity) -> bool {
-        self.participants.read().contains_identity(id)
     }
 
     /// Returns the number of registered participants.
@@ -219,7 +257,7 @@ mod tests {
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
 
         let sid = test_sid("alice-1");
-        let inserted = registry.register_participant(
+        let prior = registry.register_participant(
             id.clone(),
             sid.clone(),
             version,
@@ -227,36 +265,105 @@ mod tests {
             &cancel,
             [],
         );
-        assert!(inserted);
-        assert!(registry.has_participant(&id));
+        assert!(prior.is_none(), "no prior registration expected");
+        assert!(registry.get_participant(&id).is_some());
 
         assert!(registry.remove_participant(&sid).is_some());
-        assert!(!registry.has_participant(&id));
+        assert!(registry.get_participant(&id).is_none());
     }
 
+    /// `register_participant` for a same-identity, **different**-SID call must
+    /// atomically replace the prior registration and return the prior
+    /// participant for caller-side cleanup.
     #[tokio::test]
-    async fn insert_is_noop_when_identity_already_present() {
+    async fn register_replaces_prior_participant_with_different_sid() {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
         let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let sid_1 = test_sid("alice-1");
+        let sid_2 = test_sid("alice-2");
 
-        assert!(registry.register_participant(
+        assert!(
+            registry
+                .register_participant(
+                    id.clone(),
+                    sid_1.clone(),
+                    version.clone(),
+                    test_writer(),
+                    &cancel,
+                    [],
+                )
+                .is_none()
+        );
+        let original = registry.get_participant(&id).expect("first present");
+        let original_client_id = original.client_id();
+        drop(original);
+
+        let prior = registry
+            .register_participant(
+                id.clone(),
+                sid_2.clone(),
+                version,
+                test_writer(),
+                &cancel,
+                [],
+            )
+            .expect("prior registration must be returned for cleanup");
+        assert_eq!(prior.client_id(), original_client_id);
+        assert_eq!(prior.participant_sid(), &sid_1);
+
+        let current = registry.get_participant(&id).expect("replacement present");
+        assert_eq!(current.participant_sid(), &sid_2);
+        assert_ne!(current.client_id(), original_client_id);
+    }
+
+    /// `register_participant` for a same-identity, **same**-SID call is a
+    /// defensive no-op: the existing registration is preserved and the call
+    /// returns `None`.
+    #[tokio::test]
+    async fn register_is_noop_when_same_identity_and_sid_already_present() {
+        let registry = make_registry();
+        let cancel = CancellationToken::new();
+        let id = ParticipantIdentity("alice".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let sid = test_sid("alice-1");
+
+        assert!(
+            registry
+                .register_participant(
+                    id.clone(),
+                    sid.clone(),
+                    version.clone(),
+                    test_writer(),
+                    &cancel,
+                    [],
+                )
+                .is_none()
+        );
+        let original = registry.get_participant(&id).expect("first present");
+        let original_client_id = original.client_id();
+        drop(original);
+
+        let prior = registry.register_participant(
             id.clone(),
-            test_sid("alice-1"),
-            version.clone(),
-            test_writer(),
-            &cancel,
-            [],
-        ));
-        assert!(!registry.register_participant(
-            id.clone(),
-            test_sid("alice-2"),
+            sid.clone(),
             version,
             test_writer(),
             &cancel,
             [],
-        ));
+        );
+        assert!(
+            prior.is_none(),
+            "same-(identity, sid) re-register must be a no-op",
+        );
+
+        // The original registration must still be the live one.
+        let current = registry
+            .get_participant(&id)
+            .expect("original still present");
+        assert_eq!(current.client_id(), original_client_id);
+        assert_eq!(current.participant_sid(), &sid);
     }
 
     /// Regression test for the same-identity reconnect race:
@@ -286,14 +393,18 @@ mod tests {
         let sid_2 = test_sid("viewer-1-attempt-2");
 
         // Step 1: attempt 1 joins.
-        assert!(registry.register_participant(
-            id.clone(),
-            sid_1.clone(),
-            version.clone(),
-            test_writer(),
-            &cancel,
-            [],
-        ));
+        assert!(
+            registry
+                .register_participant(
+                    id.clone(),
+                    sid_1.clone(),
+                    version.clone(),
+                    test_writer(),
+                    &cancel,
+                    [],
+                )
+                .is_none()
+        );
         let attempt_1 = registry.get_participant(&id).expect("attempt 1 present");
         assert_eq!(attempt_1.participant_sid(), &sid_1);
 
@@ -305,14 +416,18 @@ mod tests {
         let drained = registry.drain_pending_resets();
         assert_eq!(drained, vec![sid_1.clone()]);
         assert!(registry.remove_participant(&sid_1).is_some());
-        assert!(registry.register_participant(
-            id.clone(),
-            sid_2.clone(),
-            version,
-            test_writer(),
-            &cancel,
-            [],
-        ));
+        assert!(
+            registry
+                .register_participant(
+                    id.clone(),
+                    sid_2.clone(),
+                    version,
+                    test_writer(),
+                    &cancel,
+                    [],
+                )
+                .is_none()
+        );
 
         let attempt_2 = registry.get_participant(&id).expect("attempt 2 present");
         assert_ne!(attempt_2.participant_sid(), &sid_1);
@@ -322,13 +437,86 @@ mod tests {
         let removed = registry.remove_participant(&sid_1);
         assert!(removed.is_none());
         assert!(
-            registry.has_participant(&id),
+            registry.get_participant(&id).is_some(),
             "attempt 2 must still be registered after stale disconnect was ignored",
         );
 
         // Sanity: matching SID does remove.
         let removed = registry.remove_participant(&sid_2);
         assert!(removed.is_some());
-        assert!(!registry.has_participant(&id));
+        assert!(registry.get_participant(&id).is_none());
+    }
+
+    /// Regression test for the symmetric variant of the same-identity reconnect
+    /// race (companion to
+    /// [`stale_disconnect_must_not_remove_reconnected_participant`]):
+    ///
+    /// 1. Attempt 1 (`viewer-1`, SID `S1`) is in the registry. Its flush-task
+    ///    is healthy — no reset is in flight.
+    /// 2. The viewer reconnects under a new SID `S2`. LiveKit emits
+    ///    `ParticipantActive(viewer-1, S2)` BEFORE
+    ///    `ParticipantDisconnected(viewer-1, S1)` — possible under impairment
+    ///    when the server's `disconnect_existing` admits the new join before
+    ///    the old teardown propagates to other participants.
+    /// 3. The session calls `register_participant(viewer-1, S2, ..)`. The
+    ///    registry must REPLACE the prior `S1` registration with the new `S2`
+    ///    one, not silently no-op.
+    /// 4. The late `ParticipantDisconnected(viewer-1, S1)` arrives. SID-keyed
+    ///    `remove_participant` no-ops (the registered SID is now `S2`).
+    ///
+    /// Without the fix, step 3 silently fails (the registry's slot is already
+    /// occupied) and step 4 removes attempt 1 — leaving NOTHING registered for
+    /// `viewer-1` while attempt 2 is alive in the LiveKit room. The viewer is
+    /// stranded and the gateway never sends it data.
+    #[tokio::test]
+    async fn same_identity_reconnect_must_replace_prior_registration() {
+        let registry = make_registry();
+        let cancel = CancellationToken::new();
+        let id = ParticipantIdentity("viewer-1".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let sid_1 = test_sid("viewer-1-attempt-1");
+        let sid_2 = test_sid("viewer-1-attempt-2");
+
+        // Step 1: attempt 1 joins normally.
+        let prior = registry.register_participant(
+            id.clone(),
+            sid_1.clone(),
+            version.clone(),
+            test_writer(),
+            &cancel,
+            [],
+        );
+        assert!(prior.is_none(), "no prior registration expected");
+        let attempt_1 = registry.get_participant(&id).expect("attempt 1 present");
+        let client_id_1 = attempt_1.client_id();
+        drop(attempt_1);
+
+        // Step 2: reconnect under a new SID. ParticipantActive(S2) arrives
+        // before ParticipantDisconnected(S1). The session calls
+        // `register_participant` for the new instance; the registry must
+        // atomically replace the prior registration and return it.
+        let prior = registry
+            .register_participant(
+                id.clone(),
+                sid_2.clone(),
+                version,
+                test_writer(),
+                &cancel,
+                [],
+            )
+            .expect("prior registration must be returned for cleanup");
+        assert_eq!(prior.participant_sid(), &sid_1);
+        assert_eq!(prior.client_id(), client_id_1);
+
+        // Step 3: late stale Disconnected(S1) arrives. SID-keyed remove must
+        // no-op because the registered SID is now S2.
+        assert!(registry.remove_participant(&sid_1).is_none());
+
+        // Step 4: attempt 2 must still be registered.
+        let current = registry
+            .get_participant(&id)
+            .expect("attempt 2 must remain registered after a late stale Disconnected for the prior SID");
+        assert_eq!(current.participant_sid(), &sid_2);
+        assert_ne!(current.client_id(), client_id_1);
     }
 }

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -67,6 +67,10 @@ impl ParticipantRegistry {
     /// flush-task write failure — matches this exact instance rather than
     /// some other connection that happens to share the identity.
     ///
+    /// `joined_at` is the LiveKit server-assigned join timestamp (ms since
+    /// epoch) for this connection instance — it disambiguates two
+    /// same-identity registrations independently of arrival order.
+    ///
     /// `session_cancel` is the session's cancellation token; the spawned
     /// flush-task takes a child of it so the task exits on session close.
     ///
@@ -77,26 +81,36 @@ impl ParticipantRegistry {
     ///
     /// - If no participant is registered for `id`, the new one is inserted
     ///   and `None` is returned.
-    /// - If a participant is registered with a **different** `participant_sid`,
-    ///   it is removed (its flush-task is cancelled by `Participants`'
-    ///   removal path) and the new one is inserted in its place; the prior
-    ///   `Arc<Participant>` is returned so the caller can run any
-    ///   session-level cleanup (subscription sweep, listener callbacks).
-    ///   This handles the case where LiveKit emits the reconnect's
-    ///   `ParticipantActive` *before* the prior instance's
+    /// - If a participant is registered with a **different** `participant_sid`
+    ///   and the incoming `joined_at` is **at least** the stored one's, the
+    ///   prior registration is removed (its flush-task is cancelled by
+    ///   `Participants`' removal path), the new one is inserted in its
+    ///   place, and the prior `Arc<Participant>` is returned so the caller
+    ///   can run any session-level cleanup (subscription sweep, listener
+    ///   callbacks). This handles the case where LiveKit emits the
+    ///   reconnect's `ParticipantActive` *before* the prior instance's
     ///   `ParticipantDisconnected`; without atomic replacement the new
     ///   instance would be silently dropped and the late `Disconnected`
     ///   would then evict the only registration, stranding the live viewer.
+    /// - If a participant is registered with a **different** `participant_sid`
+    ///   but the incoming `joined_at` is **older** than the stored one's,
+    ///   the incoming registration is treated as stale: the existing
+    ///   registration is left untouched, the freshly-spawned participant
+    ///   is cancelled and dropped, and `None` is returned. This protects
+    ///   against an out-of-order `ParticipantActive` for a superseded
+    ///   instance overwriting a fresher registration.
     /// - If a participant is registered with the **same** `participant_sid`,
     ///   the existing registration is left untouched, the freshly-spawned
     ///   participant is cancelled and dropped, and `None` is returned. This
     ///   path is defensive: in practice LiveKit never reuses a SID across
     ///   instances, so re-registering an identical `(identity, sid)` pair
     ///   indicates a redundant call rather than a true reconnect.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn register_participant<I>(
         &self,
         id: ParticipantIdentity,
         participant_sid: ParticipantSid,
+        joined_at: i64,
         protocol_version: Version,
         writer: ParticipantWriter,
         session_cancel: &CancellationToken,
@@ -108,6 +122,7 @@ impl ParticipantRegistry {
         let (participant, flush_handle) = Participant::spawn(
             id,
             participant_sid,
+            joined_at,
             protocol_version,
             writer,
             self.message_backlog_size,
@@ -125,23 +140,39 @@ impl ParticipantRegistry {
         // Same-identity reconnect (different SID): atomically remove the prior
         // registration so this `register_participant` call cannot lose a
         // race with a late `ParticipantDisconnected` for the prior instance.
-        let prior =
-            if let Some(existing) = participants.get_by_identity(participant.participant_id()) {
-                if existing.participant_sid() == participant.participant_sid() {
-                    // Defensive no-op: same instance is already registered. Drop
-                    // the freshly-spawned participant (and its writer); cancel
-                    // its flush-task so it exits promptly.
-                    participant.cancel();
-                    return None;
-                }
-                let prior_sid = existing.participant_sid().clone();
-                let prior = participants
-                    .remove_by_sid(&prior_sid)
-                    .expect("get_by_identity returned Some; remove must succeed");
-                Some(prior)
-            } else {
-                None
-            };
+        // A stale incoming registration (older `joined_at`) is rejected so a
+        // reordered `ParticipantActive` for a superseded instance cannot
+        // stomp the live one.
+        let prior = if let Some(existing) =
+            participants.get_by_identity(participant.participant_id())
+        {
+            if existing.participant_sid() == participant.participant_sid() {
+                // Defensive no-op: same instance is already registered. Drop
+                // the freshly-spawned participant (and its writer); cancel
+                // its flush-task so it exits promptly.
+                participant.cancel();
+                return None;
+            }
+            if existing.joined_at() > participant.joined_at() {
+                tracing::info!(
+                    identity = %participant.participant_id(),
+                    existing_sid = %existing.participant_sid(),
+                    existing_joined_at = existing.joined_at(),
+                    incoming_sid = %participant.participant_sid(),
+                    incoming_joined_at = participant.joined_at(),
+                    "ignoring stale same-identity registration (incoming joined_at precedes registered instance)",
+                );
+                participant.cancel();
+                return None;
+            }
+            let prior_sid = existing.participant_sid().clone();
+            let prior = participants
+                .remove_by_sid(&prior_sid)
+                .expect("get_by_identity returned Some; remove must succeed");
+            Some(prior)
+        } else {
+            None
+        };
 
         let inserted = participants.insert(participant, flush_handle);
         debug_assert!(
@@ -260,6 +291,7 @@ mod tests {
         let prior = registry.register_participant(
             id.clone(),
             sid.clone(),
+            1_000,
             version,
             test_writer(),
             &cancel,
@@ -289,6 +321,7 @@ mod tests {
                 .register_participant(
                     id.clone(),
                     sid_1.clone(),
+                    1_000,
                     version.clone(),
                     test_writer(),
                     &cancel,
@@ -304,6 +337,7 @@ mod tests {
             .register_participant(
                 id.clone(),
                 sid_2.clone(),
+                2_000,
                 version,
                 test_writer(),
                 &cancel,
@@ -334,6 +368,7 @@ mod tests {
                 .register_participant(
                     id.clone(),
                     sid.clone(),
+                    1_000,
                     version.clone(),
                     test_writer(),
                     &cancel,
@@ -348,6 +383,7 @@ mod tests {
         let prior = registry.register_participant(
             id.clone(),
             sid.clone(),
+            1_000,
             version,
             test_writer(),
             &cancel,
@@ -398,6 +434,7 @@ mod tests {
                 .register_participant(
                     id.clone(),
                     sid_1.clone(),
+                    1_000,
                     version.clone(),
                     test_writer(),
                     &cancel,
@@ -421,6 +458,7 @@ mod tests {
                 .register_participant(
                     id.clone(),
                     sid_2.clone(),
+                    2_000,
                     version,
                     test_writer(),
                     &cancel,
@@ -481,6 +519,7 @@ mod tests {
         let prior = registry.register_participant(
             id.clone(),
             sid_1.clone(),
+            1_000,
             version.clone(),
             test_writer(),
             &cancel,
@@ -499,6 +538,7 @@ mod tests {
             .register_participant(
                 id.clone(),
                 sid_2.clone(),
+                2_000,
                 version,
                 test_writer(),
                 &cancel,
@@ -518,5 +558,132 @@ mod tests {
         );
         assert_eq!(current.participant_sid(), &sid_2);
         assert_ne!(current.client_id(), client_id_1);
+    }
+
+    /// `register_participant` must reject a same-identity registration whose
+    /// `joined_at` is older than the currently stored one. Without this
+    /// check, two `ParticipantActive` events processed out of order — the
+    /// older instance landing after the newer one — would stomp the live
+    /// registration with a superseded one.
+    #[tokio::test]
+    async fn register_is_noop_when_incoming_joined_at_precedes_existing() {
+        let registry = make_registry();
+        let cancel = CancellationToken::new();
+        let id = ParticipantIdentity("viewer-1".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let sid_old = test_sid("viewer-1-attempt-1");
+        let sid_new = test_sid("viewer-1-attempt-2");
+
+        // The newer instance lands first.
+        assert!(
+            registry
+                .register_participant(
+                    id.clone(),
+                    sid_new.clone(),
+                    2_000,
+                    version.clone(),
+                    test_writer(),
+                    &cancel,
+                    [],
+                )
+                .is_none()
+        );
+        let current_client_id = registry
+            .get_participant(&id)
+            .expect("newer instance present")
+            .client_id();
+
+        // A delayed `ParticipantActive` for the older instance arrives. It
+        // must not displace the newer registration.
+        let prior = registry.register_participant(
+            id.clone(),
+            sid_old.clone(),
+            1_000,
+            version,
+            test_writer(),
+            &cancel,
+            [],
+        );
+        assert!(
+            prior.is_none(),
+            "stale same-identity registration must be a no-op",
+        );
+
+        let current = registry
+            .get_participant(&id)
+            .expect("newer instance still registered");
+        assert_eq!(current.participant_sid(), &sid_new);
+        assert_eq!(
+            current.client_id(),
+            current_client_id,
+            "stale registration must not have replaced the newer instance",
+        );
+    }
+
+    /// Companion to the test above: a registration whose `joined_at` is
+    /// newer than the currently stored one must replace it as before. This
+    /// pins down that the monotonicity check uses `>` (strictly older) and
+    /// not `>=`, so equal timestamps still fall through to "later wins"
+    /// rather than blocking a legitimate reconnect.
+    #[tokio::test]
+    async fn register_replaces_when_incoming_joined_at_is_equal_or_newer() {
+        let registry = make_registry();
+        let cancel = CancellationToken::new();
+        let id = ParticipantIdentity("viewer-1".to_string());
+        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
+        let sid_1 = test_sid("viewer-1-attempt-1");
+        let sid_2 = test_sid("viewer-1-attempt-2");
+        let sid_3 = test_sid("viewer-1-attempt-3");
+
+        let _ = registry.register_participant(
+            id.clone(),
+            sid_1.clone(),
+            1_000,
+            version.clone(),
+            test_writer(),
+            &cancel,
+            [],
+        );
+
+        // Equal `joined_at`, different SID: replace (later wins).
+        let prior = registry.register_participant(
+            id.clone(),
+            sid_2.clone(),
+            1_000,
+            version.clone(),
+            test_writer(),
+            &cancel,
+            [],
+        );
+        assert!(
+            prior.is_some(),
+            "equal-joined_at, different-SID must replace"
+        );
+        assert_eq!(
+            registry
+                .get_participant(&id)
+                .expect("replacement present")
+                .participant_sid(),
+            &sid_2,
+        );
+
+        // Strictly newer `joined_at`: replace.
+        let prior = registry.register_participant(
+            id.clone(),
+            sid_3.clone(),
+            2_000,
+            version,
+            test_writer(),
+            &cancel,
+            [],
+        );
+        assert!(prior.is_some(), "newer-joined_at must replace");
+        assert_eq!(
+            registry
+                .get_participant(&id)
+                .expect("replacement present")
+                .participant_sid(),
+            &sid_3,
+        );
     }
 }

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -234,8 +234,8 @@ impl ParticipantRegistry {
     }
 
     /// Drains the pending-reset set and returns its contents.
-    pub(crate) fn drain_pending_resets(&self) -> Vec<ParticipantSid> {
-        self.pending_resets.lock().drain().collect()
+    pub(crate) fn drain_pending_resets(&self) -> HashSet<ParticipantSid> {
+        std::mem::take(&mut *self.pending_resets.lock())
     }
 
     /// Test-only hook to simulate a flush-task failure by directly inserting
@@ -451,7 +451,7 @@ mod tests {
         // Step 3: drain + reset. Reset = remove (with the stored SID) +
         // re-insert under the new SID.
         let drained = registry.drain_pending_resets();
-        assert_eq!(drained, vec![sid_1.clone()]);
+        assert_eq!(drained, HashSet::from([sid_1.clone()]));
         assert!(registry.remove_participant(&sid_1).is_some());
         assert!(
             registry

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -83,11 +83,6 @@ impl Participants {
         self.by_sid.get(sid)
     }
 
-    /// Returns `true` if a participant with this identity is registered.
-    pub fn contains_identity(&self, identity: &ParticipantIdentity) -> bool {
-        self.by_identity.contains_key(identity)
-    }
-
     /// Iterates over all registered participants.
     pub fn iter(&self) -> impl Iterator<Item = &Arc<Participant>> {
         self.by_identity.values()

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -977,16 +977,32 @@ impl RemoteAccessSession {
     ///
     /// When a participant is added, a ServerInfo message and channel Advertisement messages are
     /// immediately queued for transmission.
+    ///
+    /// If a participant for `participant_id` is already registered with the
+    /// **same** `livekit_sid`, this is a no-op (the same connection instance
+    /// is being re-announced — nothing to do). If a participant is registered
+    /// with a **different** `livekit_sid`, this is treated as a same-identity
+    /// reconnect: the new control stream is opened, the prior registration is
+    /// atomically replaced, and the prior participant's cleanup runs (so its
+    /// subscriptions are torn down and listener `on_unsubscribe` /
+    /// `on_client_unadvertise` callbacks fire). This handles the case where
+    /// LiveKit emits the reconnect's `ParticipantActive` *before* the prior
+    /// instance's `ParticipantDisconnected`.
     pub(crate) async fn add_participant(
-        &self,
+        self: &Arc<Self>,
         participant_id: ParticipantIdentity,
         participant_sid: ParticipantSid,
         protocol_version: Version,
     ) -> Result<(), Box<RemoteAccessError>> {
-        // Gate on the registry *before* opening the stream: `stream_bytes` is
-        // an RPC that should not be wasted on an already-registered identity.
-        if self.participant_registry.has_participant(&participant_id) {
-            return Ok(());
+        // Gate on the registry *before* opening the stream: `stream_bytes`
+        // is an RPC that should not be wasted on an already-registered
+        // (identity, sid) pair. A different-SID hit means the registered
+        // instance is stale and we must fall through to open a stream for
+        // the new instance.
+        if let Some(existing) = self.participant_registry.get_participant(&participant_id) {
+            if existing.participant_sid() == &participant_sid {
+                return Ok(());
+            }
         }
 
         let stream = self
@@ -1015,20 +1031,28 @@ impl RemoteAccessSession {
             "registering participant {participant_id:?} with {} initial messages",
             initial_messages.len()
         );
-        let inserted = self.participant_registry.register_participant(
+        // Hold `subscription_lock` across the registry call + any cleanup
+        // for a replaced prior, so a same-identity reconnect ordering is
+        // serialized with concurrent subscribe / unsubscribe / remove paths.
+        let _guard = self.subscription_lock.lock();
+        let replaced = self.participant_registry.register_participant(
             participant_id.clone(),
-            participant_sid,
+            participant_sid.clone(),
             protocol_version,
             ParticipantWriter::Livekit(stream),
             &self.cancellation_token,
             initial_messages,
         );
-        debug_assert!(
-            inserted,
-            "register_participant returned false for {participant_id:?}; \
-             concurrent add_participant for the same identity violates the \
-             caller-serialization contract",
-        );
+        if let Some(prior) = replaced {
+            info!(
+                remote_access_session_id = self.remote_access_session_id(),
+                participant_identity = %participant_id,
+                prior_sid = %prior.participant_sid(),
+                new_sid = %participant_sid,
+                "replaced same-identity participant on out-of-order ParticipantActive (new connection instance superseded the prior one)",
+            );
+            self.run_participant_removal_cleanup(&prior);
+        }
         Ok(())
     }
 
@@ -1050,6 +1074,17 @@ impl RemoteAccessSession {
     ) -> Option<Arc<Participant>> {
         let _guard = self.subscription_lock.lock();
         let participant = self.participant_registry.remove_participant(target_sid)?;
+        self.run_participant_removal_cleanup(&participant);
+        Some(participant)
+    }
+
+    /// Runs the post-removal cleanup for `participant`: subscription sweep,
+    /// context unsubscribe, video-track teardown, connection-graph update,
+    /// and listener callbacks.
+    ///
+    /// Caller must hold `subscription_lock` and have already removed
+    /// `participant` from the registry.
+    fn run_participant_removal_cleanup(self: &Arc<Self>, participant: &Arc<Participant>) {
         let client_id = participant.client_id();
         let participant_id = participant.participant_id();
         let removed = self
@@ -1092,8 +1127,6 @@ impl RemoteAccessSession {
                 listener.on_client_unadvertise(&client, descriptor);
             }
         }
-
-        Some(participant)
     }
 
     /// Listen for room events and dispatch them.

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -975,32 +975,56 @@ impl RemoteAccessSession {
     /// `ParticipantDisconnected` event (or a flush-task failure) can be matched
     /// against this instance rather than the identity alone.
     ///
+    /// `joined_at` is the LiveKit-assigned join timestamp (ms since epoch)
+    /// for this connection instance; it lets the registry reject a
+    /// same-identity registration whose `joined_at` is older than the
+    /// currently stored one (out-of-order `ParticipantActive` for a
+    /// superseded instance).
+    ///
     /// When a participant is added, a ServerInfo message and channel Advertisement messages are
     /// immediately queued for transmission.
     ///
     /// If a participant for `participant_id` is already registered with the
     /// **same** `livekit_sid`, this is a no-op (the same connection instance
-    /// is being re-announced — nothing to do). If a participant is registered
-    /// with a **different** `livekit_sid`, this is treated as a same-identity
-    /// reconnect: the new control stream is opened, the prior registration is
-    /// atomically replaced, and the prior participant's cleanup runs (so its
-    /// subscriptions are torn down and listener `on_unsubscribe` /
+    /// is being re-announced — nothing to do). If the registered instance
+    /// has a different SID but a `joined_at` that is **later** than
+    /// `joined_at`, the incoming registration is also a no-op: it's a
+    /// reordered `ParticipantActive` for an instance the server has
+    /// already superseded. Otherwise this is treated as a same-identity
+    /// reconnect: the new control stream is opened, the prior registration
+    /// is atomically replaced, and the prior participant's cleanup runs
+    /// (so its subscriptions are torn down and listener `on_unsubscribe` /
     /// `on_client_unadvertise` callbacks fire). This handles the case where
-    /// LiveKit emits the reconnect's `ParticipantActive` *before* the prior
-    /// instance's `ParticipantDisconnected`.
+    /// LiveKit emits the reconnect's `ParticipantActive` *before* the
+    /// prior instance's `ParticipantDisconnected`.
     pub(crate) async fn add_participant(
         self: &Arc<Self>,
         participant_id: ParticipantIdentity,
         participant_sid: ParticipantSid,
+        joined_at: i64,
         protocol_version: Version,
     ) -> Result<(), Box<RemoteAccessError>> {
         // Gate on the registry *before* opening the stream: `stream_bytes`
         // is an RPC that should not be wasted on an already-registered
-        // (identity, sid) pair. A different-SID hit means the registered
-        // instance is stale and we must fall through to open a stream for
-        // the new instance.
+        // (identity, sid) pair, and equally not wasted on a stale incoming
+        // instance the registry would reject. A different-SID hit with a
+        // newer-or-equal `joined_at` means the registered instance is
+        // older and we must fall through to open a stream for the new
+        // instance.
         if let Some(existing) = self.participant_registry.get_participant(&participant_id) {
             if existing.participant_sid() == &participant_sid {
+                return Ok(());
+            }
+            if existing.joined_at() > joined_at {
+                info!(
+                    remote_access_session_id = self.remote_access_session_id(),
+                    participant_identity = %participant_id,
+                    existing_sid = %existing.participant_sid(),
+                    existing_joined_at = existing.joined_at(),
+                    incoming_sid = %participant_sid,
+                    incoming_joined_at = joined_at,
+                    "skipping add_participant for stale instance (incoming joined_at precedes registered)",
+                );
                 return Ok(());
             }
         }
@@ -1038,6 +1062,7 @@ impl RemoteAccessSession {
         let replaced = self.participant_registry.register_participant(
             participant_id.clone(),
             participant_sid.clone(),
+            joined_at,
             protocol_version,
             ParticipantWriter::Livekit(stream),
             &self.cancellation_token,
@@ -1199,15 +1224,17 @@ impl RemoteAccessSession {
                     return true;
                 };
                 let sid = participant.sid();
+                let joined_at = participant.joined_at();
                 info!(
                     remote_access_session_id,
                     participant_identity = %participant_identity,
                     sid = %sid,
+                    joined_at,
                     version = %version,
                     "participant active in room"
                 );
                 if let Err(e) = self
-                    .add_participant(participant_identity, sid, version)
+                    .add_participant(participant_identity, sid, joined_at, version)
                     .await
                 {
                     error!(remote_access_session_id, error = %e, "failed to add participant: {e}");
@@ -1435,17 +1462,18 @@ impl RemoteAccessSession {
         // `ParticipantDisconnected` event is already queued and a future reconnect will
         // go through the normal `ParticipantConnected` → `add_participant` path.
         //
-        // If a new instance has already reconnected under the same identity,
-        // its SID and attributes are what we re-register with — so that (a) a
-        // later stale `ParticipantDisconnected` for the *old* instance's SID
-        // won't match and tear down this re-registration, and (b) a
-        // protocol-version change between instances is honoured rather than
-        // assumed-unchanged.
-        let Some((sid, attributes)) = self
+        // its SID, attributes, and `joined_at` are what we re-register with
+        // — so that (a) a later stale `ParticipantDisconnected` for the
+        // *old* instance's SID won't match and tear down this
+        // re-registration, (b) a protocol-version change between instances
+        // is honoured rather than assumed-unchanged, and (c) the registry's
+        // `joined_at` monotonicity check sees a value tied to this specific
+        // instance.
+        let Some((sid, attributes, joined_at)) = self
             .room
             .remote_participants()
             .get(&participant_id)
-            .map(|p| (p.sid(), p.attributes()))
+            .map(|p| (p.sid(), p.attributes(), p.joined_at()))
         else {
             info!(
                 remote_access_session_id,
@@ -1473,10 +1501,14 @@ impl RemoteAccessSession {
             remote_access_session_id,
             participant_identity = %participant_id,
             sid = %sid,
+            joined_at,
             version = %version,
             "resetting participant after control-plane failure",
         );
-        if let Err(e) = self.add_participant(participant_id, sid, version).await {
+        if let Err(e) = self
+            .add_participant(participant_id, sid, joined_at, version)
+            .await
+        {
             error!(
                 remote_access_session_id,
                 error = %e,
@@ -2381,6 +2413,7 @@ mod tests {
         let (participant, handle) = Participant::spawn(
             ParticipantIdentity("test".to_string()),
             test_sid("flush-test"),
+            0,
             protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone(),
             ParticipantWriter::Test(writer.clone()),
             DEFAULT_MESSAGE_BACKLOG_SIZE,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -985,7 +985,7 @@ impl RemoteAccessSession {
     /// immediately queued for transmission.
     ///
     /// If a participant for `participant_id` is already registered with the
-    /// **same** `livekit_sid`, this is a no-op (the same connection instance
+    /// **same** `participant_sid`, this is a no-op (the same connection instance
     /// is being re-announced — nothing to do). If the registered instance
     /// has a different SID but a `joined_at` that is **later** than
     /// `joined_at`, the incoming registration is also a no-op: it's a
@@ -1462,6 +1462,7 @@ impl RemoteAccessSession {
         // `ParticipantDisconnected` event is already queued and a future reconnect will
         // go through the normal `ParticipantConnected` → `add_participant` path.
         //
+        // If a new instance has already reconnected under the same identity,
         // its SID, attributes, and `joined_at` are what we re-register with
         // — so that (a) a later stale `ParticipantDisconnected` for the
         // *old* instance's SID won't match and tear down this


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Chris fixed a race in [clalancette/fix-failing-netem-test](https://github.com/foxglove/foxglove-sdk/pull/1194)

Which handles the case where Disconnected(S1) arrives after the replacement is already installed by the reset path. There's a similar race when ParticipantActive(S2) arrives before Disconnected(S1), so no reset has yet been triggered.

1) Attempt 1 registered (SID S1).
2) LiveKit emits ParticipantActive(S2) (or ParticipantConnected then Active) for attempt 2 before the disconnect event for attempt 1.
3) add_participant runs, sees self.registry.has_participant(&id) == true (attempt 1 is still there) → returns Ok(()) early.
4) LiveKit emits ParticipantDisconnected(S1) for attempt 1.
5) remove_participant(id, S1) → SID matches stored → attempt 1 is correctly removed.

Net result: nobody is registered for id, but attempt 2 is alive in the LiveKit room. We never come back to register it.

I added a test same_identity_reconnect_must_replace_prior_registration() which reproduces the issue, and then fixed it.

I'm not 100% sure this can happen in real life, it's possible livekit would always send disconnected first. But I have my doubts they do that or that it's even possible to always do that.
