### PR TITLE
remote_access: Remove unused per-participant protocol_version field

### DIFF
--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -549,7 +549,7 @@ impl RemoteAccessConnection {
             let sid = participant.sid();
             let joined_at = participant.joined_at();
             if let Err(e) = session
-                .add_participant(identity.clone(), sid, joined_at, version)
+                .add_participant(identity.clone(), sid, joined_at)
                 .await
             {
                 error!(

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -8,7 +8,6 @@ use livekit::{
     ByteStreamWriter, StreamWriter,
     id::{ParticipantIdentity, ParticipantSid},
 };
-use semver::Version;
 use tokio_util::sync::CancellationToken;
 
 use crate::protocol::v2::server::FetchAssetResponse;
@@ -46,15 +45,6 @@ pub(crate) struct Participant {
     /// race: a registration whose `joined_at` is older than the currently
     /// stored instance is dropped instead of replacing it.
     joined_at: i64,
-    /// The remote access protocol version advertised by this participant.
-    /// Stored for future use when branching protocol behavior based on the
-    /// participant's version. Captured at registration and refreshed on
-    /// reset: `reset_participant` re-validates the freshly-queried
-    /// attributes and the new participant is registered with that fresh
-    /// version, so the stored value reflects the current connection
-    /// instance's advertised version even across same-identity reconnects.
-    #[expect(dead_code)]
-    protocol_version: Version,
     /// Per-participant control plane queue. The receiving end is owned by the
     /// flush-task.
     control_tx: flume::Sender<Bytes>,
@@ -94,7 +84,6 @@ impl Participant {
         identity: ParticipantIdentity,
         participant_sid: ParticipantSid,
         joined_at: i64,
-        protocol_version: Version,
         writer: ParticipantWriter,
         queue_size: usize,
         pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
@@ -144,7 +133,6 @@ impl Participant {
             participant_id: identity,
             participant_sid,
             joined_at,
-            protocol_version,
             control_tx,
             pending_resets,
             reset_notify,
@@ -166,7 +154,6 @@ impl Participant {
     pub fn new(
         identity: ParticipantIdentity,
         participant_sid: ParticipantSid,
-        protocol_version: Version,
         control_tx: flume::Sender<Bytes>,
         pending_resets: Arc<parking_lot::Mutex<HashSet<ParticipantSid>>>,
         reset_notify: Arc<tokio::sync::Notify>,
@@ -177,7 +164,6 @@ impl Participant {
             participant_id: identity,
             participant_sid,
             joined_at: 0,
-            protocol_version,
             control_tx,
             pending_resets,
             reset_notify,

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use bytes::Bytes;
 use livekit::id::{ParticipantIdentity, ParticipantSid};
 use parking_lot::{Mutex, RwLock};
-use semver::Version;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
@@ -111,7 +110,6 @@ impl ParticipantRegistry {
         id: ParticipantIdentity,
         participant_sid: ParticipantSid,
         joined_at: i64,
-        protocol_version: Version,
         writer: ParticipantWriter,
         session_cancel: &CancellationToken,
         initial_messages: I,
@@ -123,7 +121,6 @@ impl ParticipantRegistry {
             id,
             participant_sid,
             joined_at,
-            protocol_version,
             writer,
             self.message_backlog_size,
             self.pending_resets.clone(),
@@ -270,7 +267,6 @@ mod tests {
     use super::*;
 
     use crate::remote_access::participant::{ParticipantWriter, TestByteStreamWriter, test_sid};
-    use crate::remote_access::protocol_version;
 
     fn make_registry() -> ParticipantRegistry {
         ParticipantRegistry::new(16)
@@ -285,14 +281,12 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
 
         let sid = test_sid("alice-1");
         let prior = registry.register_participant(
             id.clone(),
             sid.clone(),
             1_000,
-            version,
             test_writer(),
             &cancel,
             [],
@@ -312,21 +306,12 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid_1 = test_sid("alice-1");
         let sid_2 = test_sid("alice-2");
 
         assert!(
             registry
-                .register_participant(
-                    id.clone(),
-                    sid_1.clone(),
-                    1_000,
-                    version.clone(),
-                    test_writer(),
-                    &cancel,
-                    [],
-                )
+                .register_participant(id.clone(), sid_1.clone(), 1_000, test_writer(), &cancel, [],)
                 .is_none()
         );
         let original = registry.get_participant(&id).expect("first present");
@@ -334,15 +319,7 @@ mod tests {
         drop(original);
 
         let prior = registry
-            .register_participant(
-                id.clone(),
-                sid_2.clone(),
-                2_000,
-                version,
-                test_writer(),
-                &cancel,
-                [],
-            )
+            .register_participant(id.clone(), sid_2.clone(), 2_000, test_writer(), &cancel, [])
             .expect("prior registration must be returned for cleanup");
         assert_eq!(prior.client_id(), original_client_id);
         assert_eq!(prior.participant_sid(), &sid_1);
@@ -360,20 +337,11 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("alice".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid = test_sid("alice-1");
 
         assert!(
             registry
-                .register_participant(
-                    id.clone(),
-                    sid.clone(),
-                    1_000,
-                    version.clone(),
-                    test_writer(),
-                    &cancel,
-                    [],
-                )
+                .register_participant(id.clone(), sid.clone(), 1_000, test_writer(), &cancel, [],)
                 .is_none()
         );
         let original = registry.get_participant(&id).expect("first present");
@@ -384,7 +352,6 @@ mod tests {
             id.clone(),
             sid.clone(),
             1_000,
-            version,
             test_writer(),
             &cancel,
             [],
@@ -424,22 +391,13 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("viewer-1".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid_1 = test_sid("viewer-1-attempt-1");
         let sid_2 = test_sid("viewer-1-attempt-2");
 
         // Step 1: attempt 1 joins.
         assert!(
             registry
-                .register_participant(
-                    id.clone(),
-                    sid_1.clone(),
-                    1_000,
-                    version.clone(),
-                    test_writer(),
-                    &cancel,
-                    [],
-                )
+                .register_participant(id.clone(), sid_1.clone(), 1_000, test_writer(), &cancel, [],)
                 .is_none()
         );
         let attempt_1 = registry.get_participant(&id).expect("attempt 1 present");
@@ -455,15 +413,7 @@ mod tests {
         assert!(registry.remove_participant(&sid_1).is_some());
         assert!(
             registry
-                .register_participant(
-                    id.clone(),
-                    sid_2.clone(),
-                    2_000,
-                    version,
-                    test_writer(),
-                    &cancel,
-                    [],
-                )
+                .register_participant(id.clone(), sid_2.clone(), 2_000, test_writer(), &cancel, [],)
                 .is_none()
         );
 
@@ -511,7 +461,6 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("viewer-1".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid_1 = test_sid("viewer-1-attempt-1");
         let sid_2 = test_sid("viewer-1-attempt-2");
 
@@ -520,7 +469,6 @@ mod tests {
             id.clone(),
             sid_1.clone(),
             1_000,
-            version.clone(),
             test_writer(),
             &cancel,
             [],
@@ -535,15 +483,7 @@ mod tests {
         // `register_participant` for the new instance; the registry must
         // atomically replace the prior registration and return it.
         let prior = registry
-            .register_participant(
-                id.clone(),
-                sid_2.clone(),
-                2_000,
-                version,
-                test_writer(),
-                &cancel,
-                [],
-            )
+            .register_participant(id.clone(), sid_2.clone(), 2_000, test_writer(), &cancel, [])
             .expect("prior registration must be returned for cleanup");
         assert_eq!(prior.participant_sid(), &sid_1);
         assert_eq!(prior.client_id(), client_id_1);
@@ -570,7 +510,6 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("viewer-1".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid_old = test_sid("viewer-1-attempt-1");
         let sid_new = test_sid("viewer-1-attempt-2");
 
@@ -581,7 +520,6 @@ mod tests {
                     id.clone(),
                     sid_new.clone(),
                     2_000,
-                    version.clone(),
                     test_writer(),
                     &cancel,
                     [],
@@ -599,7 +537,6 @@ mod tests {
             id.clone(),
             sid_old.clone(),
             1_000,
-            version,
             test_writer(),
             &cancel,
             [],
@@ -630,7 +567,6 @@ mod tests {
         let registry = make_registry();
         let cancel = CancellationToken::new();
         let id = ParticipantIdentity("viewer-1".to_string());
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let sid_1 = test_sid("viewer-1-attempt-1");
         let sid_2 = test_sid("viewer-1-attempt-2");
         let sid_3 = test_sid("viewer-1-attempt-3");
@@ -639,7 +575,6 @@ mod tests {
             id.clone(),
             sid_1.clone(),
             1_000,
-            version.clone(),
             test_writer(),
             &cancel,
             [],
@@ -650,7 +585,6 @@ mod tests {
             id.clone(),
             sid_2.clone(),
             1_000,
-            version.clone(),
             test_writer(),
             &cancel,
             [],
@@ -672,7 +606,6 @@ mod tests {
             id.clone(),
             sid_3.clone(),
             2_000,
-            version,
             test_writer(),
             &cancel,
             [],

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -119,8 +119,6 @@ mod tests {
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
         let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
-        let version =
-            crate::remote_access::protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, _rx) = flume::bounded(16);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -128,7 +126,6 @@ mod tests {
         Arc::new(Participant::new(
             identity,
             sid,
-            version,
             tx,
             pending_resets,
             reset_notify,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -13,7 +13,6 @@ use livekit::{
 };
 use livekit::{StreamWriter, prelude::*};
 use parking_lot::RwLock;
-use semver::Version;
 use smallvec::SmallVec;
 use tokio::io::AsyncReadExt;
 use tokio::runtime::Handle;
@@ -1008,7 +1007,6 @@ impl RemoteAccessSession {
         participant_id: ParticipantIdentity,
         participant_sid: ParticipantSid,
         joined_at: i64,
-        protocol_version: Version,
     ) -> Result<(), Box<RemoteAccessError>> {
         // Gate on the registry *before* opening the stream: `stream_bytes`
         // is an RPC that should not be wasted on an already-registered
@@ -1069,7 +1067,6 @@ impl RemoteAccessSession {
             participant_id.clone(),
             participant_sid.clone(),
             joined_at,
-            protocol_version,
             ParticipantWriter::Livekit(stream),
             &self.cancellation_token,
             initial_messages,
@@ -1273,7 +1270,7 @@ impl RemoteAccessSession {
                     "participant active in room"
                 );
                 if let Err(e) = self
-                    .add_participant(participant_identity, sid, joined_at, version)
+                    .add_participant(participant_identity, sid, joined_at)
                     .await
                 {
                     error!(remote_access_session_id, error = %e, "failed to add participant: {e}");
@@ -1545,10 +1542,7 @@ impl RemoteAccessSession {
             version = %version,
             "resetting participant after control-plane failure",
         );
-        if let Err(e) = self
-            .add_participant(participant_id, sid, joined_at, version)
-            .await
-        {
+        if let Err(e) = self.add_participant(participant_id, sid, joined_at).await {
             error!(
                 remote_access_session_id,
                 error = %e,
@@ -2224,7 +2218,6 @@ mod tests {
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let identity = ParticipantIdentity(name.to_string());
         let sid = crate::remote_access::participant::test_sid(&format!("{name}-{n}"));
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded(16);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -2232,7 +2225,6 @@ mod tests {
         let participant = Arc::new(Participant::new(
             identity,
             sid,
-            version,
             tx,
             pending_resets,
             reset_notify,
@@ -2454,7 +2446,6 @@ mod tests {
             ParticipantIdentity("test".to_string()),
             test_sid("flush-test"),
             0,
-            protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone(),
             ParticipantWriter::Test(writer.clone()),
             DEFAULT_MESSAGE_BACKLOG_SIZE,
             pending_resets,
@@ -2535,7 +2526,6 @@ mod tests {
     }
 
     fn make_test_participant(queue_size: usize) -> (Participant, flume::Receiver<Bytes>) {
-        let version = protocol_version::REMOTE_ACCESS_PROTOCOL_VERSION.clone();
         let (tx, rx) = flume::bounded::<Bytes>(queue_size);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -2543,7 +2533,6 @@ mod tests {
         let participant = Participant::new(
             ParticipantIdentity("alice".to_string()),
             crate::remote_access::participant::test_sid("alice"),
-            version,
             tx,
             pending_resets,
             reset_notify,


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The `Participant` struct stored each viewer's advertised protocol version "for future use" but no code ever read it back, so it was flagged `#[expect(dead_code)]`. The compatibility check at registration is unchanged; only the speculative storage and the parameter chain that fed it (`Participant::spawn` / `::new`, `ParticipantRegistry::register_participant`,
`RemoteAccessSession::add_participant`) are removed.

This came out of review of #1194 .  If we ever need it back, it is easy to do.

This is part of FLE-475