### PR TITLE
Tighten visibility in the remote_access module

### DIFF
--- a/rust/foxglove/src/remote_access/capability.rs
+++ b/rust/foxglove/src/remote_access/capability.rs
@@ -17,7 +17,7 @@ pub enum Capability {
 }
 
 impl Capability {
-    pub(crate) fn as_protocol_capabilities(&self) -> &'static [server_info::Capability] {
+    pub(super) fn as_protocol_capabilities(&self) -> &'static [server_info::Capability] {
         match self {
             Self::ClientPublish => &[server_info::Capability::ClientPublish],
             Self::Parameters => &[

--- a/rust/foxglove/src/remote_access/client.rs
+++ b/rust/foxglove/src/remote_access/client.rs
@@ -21,7 +21,7 @@ pub struct Client {
 
 impl Client {
     /// Instantiate a new client.
-    pub(crate) fn new(client_id: ClientId, participant_id: ParticipantIdentity) -> Self {
+    pub(super) fn new(client_id: ClientId, participant_id: ParticipantIdentity) -> Self {
         Self {
             client_id,
             participant_id,

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -84,20 +84,20 @@ impl ConnectionStatus {
 ///
 /// This should be constructed from the [`crate::remote_access::Gateway`] builder.
 pub(crate) struct ConnectionParams {
-    pub name: Option<String>,
-    pub device_token: String,
-    pub foxglove_api_url: Option<String>,
-    pub foxglove_api_timeout: Option<Duration>,
-    pub listener: Option<Arc<dyn super::Listener>>,
-    pub capabilities: Vec<Capability>,
-    pub supported_encodings: Option<IndexSet<String>>,
-    pub fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
-    pub runtime: Handle,
-    pub channel_filter: Option<Arc<dyn SinkChannelFilter>>,
-    pub qos_classifier: Option<Arc<dyn QosClassifier>>,
-    pub server_info: Option<HashMap<String, String>>,
-    pub message_backlog_size: Option<usize>,
-    pub context: Weak<Context>,
+    pub(crate) name: Option<String>,
+    pub(crate) device_token: String,
+    pub(crate) foxglove_api_url: Option<String>,
+    pub(crate) foxglove_api_timeout: Option<Duration>,
+    pub(crate) listener: Option<Arc<dyn super::Listener>>,
+    pub(crate) capabilities: Vec<Capability>,
+    pub(crate) supported_encodings: Option<IndexSet<String>>,
+    pub(crate) fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
+    pub(crate) runtime: Handle,
+    pub(crate) channel_filter: Option<Arc<dyn SinkChannelFilter>>,
+    pub(crate) qos_classifier: Option<Arc<dyn QosClassifier>>,
+    pub(crate) server_info: Option<HashMap<String, String>>,
+    pub(crate) message_backlog_size: Option<usize>,
+    pub(crate) context: Weak<Context>,
 }
 
 /// Pair of device metadata (fetched once via `fetch_device_info`) and the authenticated API

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -83,21 +83,21 @@ impl ConnectionStatus {
 /// Parameters for constructing a [`RemoteAccessConnection`].
 ///
 /// This should be constructed from the [`crate::remote_access::Gateway`] builder.
-pub(crate) struct ConnectionParams {
-    pub(crate) name: Option<String>,
-    pub(crate) device_token: String,
-    pub(crate) foxglove_api_url: Option<String>,
-    pub(crate) foxglove_api_timeout: Option<Duration>,
-    pub(crate) listener: Option<Arc<dyn super::Listener>>,
-    pub(crate) capabilities: Vec<Capability>,
-    pub(crate) supported_encodings: Option<IndexSet<String>>,
-    pub(crate) fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
-    pub(crate) runtime: Handle,
-    pub(crate) channel_filter: Option<Arc<dyn SinkChannelFilter>>,
-    pub(crate) qos_classifier: Option<Arc<dyn QosClassifier>>,
-    pub(crate) server_info: Option<HashMap<String, String>>,
-    pub(crate) message_backlog_size: Option<usize>,
-    pub(crate) context: Weak<Context>,
+pub(super) struct ConnectionParams {
+    pub(super) name: Option<String>,
+    pub(super) device_token: String,
+    pub(super) foxglove_api_url: Option<String>,
+    pub(super) foxglove_api_timeout: Option<Duration>,
+    pub(super) listener: Option<Arc<dyn super::Listener>>,
+    pub(super) capabilities: Vec<Capability>,
+    pub(super) supported_encodings: Option<IndexSet<String>>,
+    pub(super) fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
+    pub(super) runtime: Handle,
+    pub(super) channel_filter: Option<Arc<dyn SinkChannelFilter>>,
+    pub(super) qos_classifier: Option<Arc<dyn QosClassifier>>,
+    pub(super) server_info: Option<HashMap<String, String>>,
+    pub(super) message_backlog_size: Option<usize>,
+    pub(super) context: Weak<Context>,
 }
 
 /// Pair of device metadata (fetched once via `fetch_device_info`) and the authenticated API
@@ -118,7 +118,7 @@ struct WakeSignal {
 
 /// RemoteAccessConnection manages the connected [`RemoteAccessSession`] to the LiveKit server,
 /// and holds the parameters and other state that outlive a session.
-pub(crate) struct RemoteAccessConnection {
+pub(super) struct RemoteAccessConnection {
     name: Option<String>,
     device_token: String,
     foxglove_api_url: Option<String>,
@@ -653,7 +653,7 @@ impl RemoteAccessConnection {
     /// This method will fail if the services capability was not declared, if a service name is
     /// not unique, or if a service has no request encoding and the connection has no supported
     /// encodings.
-    pub(crate) fn add_services(
+    pub(super) fn add_services(
         &self,
         new_services: Vec<Service>,
     ) -> std::result::Result<(), FoxgloveError> {
@@ -710,7 +710,7 @@ impl RemoteAccessConnection {
     /// Removes services by name.
     ///
     /// Unrecognized service names are silently ignored.
-    pub(crate) fn remove_services(&self, names: impl IntoIterator<Item = impl AsRef<str>>) {
+    pub(super) fn remove_services(&self, names: impl IntoIterator<Item = impl AsRef<str>>) {
         let removed_ids: Vec<ServiceId> = {
             let mut services = self.services.write();
             names
@@ -727,7 +727,7 @@ impl RemoteAccessConnection {
         }
     }
 
-    pub(crate) fn shutdown(&self) {
+    pub(super) fn shutdown(&self) {
         self.cancellation_token.cancel();
     }
 }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -27,7 +27,7 @@ const DEFAULT_FETCH_ASSET_PER_PARTICIPANT: usize = 32;
 /// Each participant has an identity, a per-participant control plane queue, and
 /// rate-limiting semaphores. The actual byte-stream writer lives in a dedicated
 /// flush-task (spawned by `Participant::spawn`), not in this struct.
-pub(crate) struct Participant {
+pub(super) struct Participant {
     /// Locally-significant identifier for this particular instance of this participant.
     client_id: ClientId,
     /// LiveKit participant identity (stable across disconnect + reconnect).
@@ -204,7 +204,7 @@ impl Participant {
 
     /// Cancel this participant's flush-task. The task will exit at the next
     /// `select!` iteration.
-    pub(crate) fn cancel(&self) {
+    pub(super) fn cancel(&self) {
         self.cancel.cancel();
     }
 
@@ -217,7 +217,7 @@ impl Participant {
     /// per physical connection instance — used to disambiguate a stale
     /// `ParticipantDisconnected` from a legitimate disconnect when the same
     /// identity has reconnected.
-    pub(crate) fn participant_sid(&self) -> &ParticipantSid {
+    pub(super) fn participant_sid(&self) -> &ParticipantSid {
         &self.participant_sid
     }
 
@@ -225,14 +225,14 @@ impl Participant {
     /// connection instance. Used by the participant registry to reject a
     /// stale same-identity registration whose `joined_at` precedes the
     /// currently stored instance.
-    pub(crate) fn joined_at(&self) -> i64 {
+    pub(super) fn joined_at(&self) -> i64 {
         self.joined_at
     }
 
     /// Try to queue a control plane message. Returns `false` if the queue is
     /// full and the caller should trigger a participant reset.
     #[must_use]
-    pub(crate) fn try_queue_control(&self, data: Bytes) -> bool {
+    pub(super) fn try_queue_control(&self, data: Bytes) -> bool {
         match self.control_tx.try_send(data) {
             Ok(()) => true,
             Err(flume::TrySendError::Full(_)) => {
@@ -254,7 +254,7 @@ impl Participant {
     /// Queue a control plane message, requesting a participant reset if the
     /// queue is full. Also cancels the per-participant token so the flush-task
     /// stops immediately — no point draining messages for a client being disconnected.
-    pub(crate) fn send_control(&self, data: Bytes) {
+    pub(super) fn send_control(&self, data: Bytes) {
         if !self.try_queue_control(data) {
             self.cancel.cancel();
             self.pending_resets
@@ -265,14 +265,14 @@ impl Participant {
     }
 
     /// Send a fetch asset response to the participant via the control plane queue.
-    pub(crate) fn send_asset_response(&self, data: &[u8], request_id: u32) {
+    pub(super) fn send_asset_response(&self, data: &[u8], request_id: u32) {
         self.send_control(encode_binary_message(&FetchAssetResponse::asset_data(
             request_id, data,
         )));
     }
 
     /// Send a fetch asset error to the participant via the control plane queue.
-    pub(crate) fn send_asset_error(&self, error: &str, request_id: u32) {
+    pub(super) fn send_asset_error(&self, error: &str, request_id: u32) {
         self.send_control(encode_binary_message(&FetchAssetResponse::error_message(
             request_id, error,
         )));
@@ -299,7 +299,7 @@ impl std::fmt::Display for Participant {
 /// Owned by the per-participant flush-task, not by `Participant` itself.
 ///
 /// Mocked with a `TestByteStreamWriter` for tests.
-pub(crate) enum ParticipantWriter {
+pub(super) enum ParticipantWriter {
     Livekit(ByteStreamWriter),
     #[allow(dead_code)]
     #[cfg(test)]
@@ -322,14 +322,14 @@ impl ParticipantWriter {
 /// Constructs a `ParticipantSid` for tests. LiveKit requires the `PA_`
 /// prefix; anything stable+unique works for identifying distinct instances.
 #[cfg(test)]
-pub(crate) fn test_sid(label: &str) -> ParticipantSid {
+pub(super) fn test_sid(label: &str) -> ParticipantSid {
     ParticipantSid::try_from(format!("PA_{label}"))
         .expect("test_sid label should form a valid ParticipantSid")
 }
 
 #[cfg(test)]
 #[derive(Default)]
-pub(crate) struct TestByteStreamWriter {
+pub(super) struct TestByteStreamWriter {
     writes: parking_lot::Mutex<Vec<Bytes>>,
 }
 
@@ -340,7 +340,7 @@ impl TestByteStreamWriter {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn writes(&self) -> Vec<Bytes> {
+    pub(super) fn writes(&self) -> Vec<Bytes> {
         std::mem::take(&mut self.writes.lock())
     }
 }

--- a/rust/foxglove/src/remote_access/participant_registry.rs
+++ b/rust/foxglove/src/remote_access/participant_registry.rs
@@ -25,7 +25,7 @@ use crate::remote_access::participants::Participants;
 
 /// Owns the participant membership state machine: add / remove / lookup, plus
 /// the `pending_resets` channel that lets a flush-task request its own reset.
-pub(crate) struct ParticipantRegistry {
+pub(super) struct ParticipantRegistry {
     /// Map of connected participants and their flush-task join handles.
     participants: RwLock<Participants>,
     /// Set of `ParticipantSid`s pending a reset (disconnect + reconnect).
@@ -39,7 +39,7 @@ pub(crate) struct ParticipantRegistry {
 }
 
 impl ParticipantRegistry {
-    pub(crate) fn new(message_backlog_size: usize) -> Self {
+    pub(super) fn new(message_backlog_size: usize) -> Self {
         Self {
             participants: RwLock::new(Participants::new()),
             pending_resets: Arc::new(Mutex::new(HashSet::new())),
@@ -106,7 +106,7 @@ impl ParticipantRegistry {
     ///   instances, so re-registering an identical `(identity, sid)` pair
     ///   indicates a redundant call rather than a true reconnect.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn register_participant<I>(
+    pub(super) fn register_participant<I>(
         &self,
         id: ParticipantIdentity,
         participant_sid: ParticipantSid,
@@ -195,7 +195,7 @@ impl ParticipantRegistry {
     /// handle as part of the removal; the caller is responsible for any
     /// further cleanup (subscription sweep, listener callbacks) via
     /// [`SessionState::cleanup_for_removed_identity`].
-    pub(crate) fn remove_participant(
+    pub(super) fn remove_participant(
         &self,
         target_sid: &ParticipantSid,
     ) -> Option<Arc<Participant>> {
@@ -203,7 +203,7 @@ impl ParticipantRegistry {
     }
 
     /// Returns the participant for the given identity, if any.
-    pub(crate) fn get_participant(&self, id: &ParticipantIdentity) -> Option<Arc<Participant>> {
+    pub(super) fn get_participant(&self, id: &ParticipantIdentity) -> Option<Arc<Participant>> {
         self.participants.read().get_by_identity(id).cloned()
     }
 
@@ -211,7 +211,7 @@ impl ParticipantRegistry {
     /// read lock. Identities with no matching registration are silently
     /// skipped (a participant may have been removed between the identity
     /// snapshot and this call; the missed send is harmless).
-    pub(crate) fn resolve_identities<I>(&self, identities: I) -> Vec<Arc<Participant>>
+    pub(super) fn resolve_identities<I>(&self, identities: I) -> Vec<Arc<Participant>>
     where
         I: IntoIterator<Item = ParticipantIdentity>,
     {
@@ -223,18 +223,18 @@ impl ParticipantRegistry {
     }
 
     /// Returns the number of registered participants.
-    pub(crate) fn participant_count(&self) -> usize {
+    pub(super) fn participant_count(&self) -> usize {
         self.participants.read().len()
     }
 
     /// Clones every currently-registered participant into a `Vec`. Useful for
     /// iterating at broadcast points without holding the read lock.
-    pub(crate) fn collect_participants(&self) -> Vec<Arc<Participant>> {
+    pub(super) fn collect_participants(&self) -> Vec<Arc<Participant>> {
         self.participants.read().iter().cloned().collect()
     }
 
     /// Drains the pending-reset set and returns its contents.
-    pub(crate) fn drain_pending_resets(&self) -> HashSet<ParticipantSid> {
+    pub(super) fn drain_pending_resets(&self) -> HashSet<ParticipantSid> {
         std::mem::take(&mut *self.pending_resets.lock())
     }
 
@@ -243,13 +243,13 @@ impl ParticipantRegistry {
     /// is only written by flush-tasks on write failure and by
     /// `Participant::send_control` on queue overflow.
     #[cfg(test)]
-    pub(crate) fn pending_resets(&self) -> &Arc<Mutex<HashSet<ParticipantSid>>> {
+    pub(super) fn pending_resets(&self) -> &Arc<Mutex<HashSet<ParticipantSid>>> {
         &self.pending_resets
     }
 
     /// Shared reference to the reset notifier, for use by the session's event
     /// loop `select!`.
-    pub(crate) fn reset_notify(&self) -> &Arc<Notify> {
+    pub(super) fn reset_notify(&self) -> &Arc<Notify> {
         &self.reset_notify
     }
 
@@ -259,7 +259,7 @@ impl ParticipantRegistry {
     /// For use at session teardown only — the caller must ensure no further
     /// `register_participant` / `remove_participant` / `reset_participant`
     /// calls can race with this one.
-    pub(crate) async fn shutdown(&self) {
+    pub(super) async fn shutdown(&self) {
         let handles = self.participants.write().drain();
         let _ = futures_util::future::join_all(handles).await;
     }

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -79,7 +79,7 @@ impl Participants {
     /// Test-only accessor — production reads the index implicitly via
     /// [`remove_by_sid`].
     #[cfg(test)]
-    pub(crate) fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
+    fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
         self.by_sid.get(sid)
     }
 

--- a/rust/foxglove/src/remote_access/participants.rs
+++ b/rust/foxglove/src/remote_access/participants.rs
@@ -21,7 +21,7 @@ use crate::remote_access::participant::Participant;
 /// and `ParticipantSid`, with each participant's flush-task `JoinHandle`
 /// stored alongside.
 #[derive(Default)]
-pub(crate) struct Participants {
+pub(super) struct Participants {
     by_identity: HashMap<ParticipantIdentity, Arc<Participant>>,
     by_sid: HashMap<ParticipantSid, Arc<Participant>>,
     flush_handles: HashMap<ParticipantIdentity, JoinHandle<()>>,
@@ -61,7 +61,7 @@ impl Participants {
     /// already been removed, will not match here because each connection
     /// instance gets a unique `ParticipantSid` (a same-identity reconnect
     /// has a *different* SID).
-    pub(crate) fn remove_by_sid(&mut self, sid: &ParticipantSid) -> Option<Arc<Participant>> {
+    pub(super) fn remove_by_sid(&mut self, sid: &ParticipantSid) -> Option<Arc<Participant>> {
         let participant = self.by_sid.remove(sid)?;
         let identity = participant.participant_id();
         self.by_identity.remove(identity);
@@ -97,7 +97,7 @@ impl Participants {
     /// returns the detached `JoinHandle`s for the caller to await. After
     /// this returns the registry is empty. Parallels [`remove_by_sid`] in
     /// owning the cancel-then-detach lifecycle internally.
-    pub(crate) fn drain(&mut self) -> Vec<JoinHandle<()>> {
+    pub(super) fn drain(&mut self) -> Vec<JoinHandle<()>> {
         for p in self.by_identity.values() {
             p.cancel();
         }

--- a/rust/foxglove/src/remote_access/protocol_version.rs
+++ b/rust/foxglove/src/remote_access/protocol_version.rs
@@ -12,8 +12,7 @@ pub(crate) const PROTOCOL_VERSION_ATTRIBUTE: &str = "protocolVersion";
 pub(crate) const REMOTE_ACCESS_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
 
 /// The minimum remote access protocol version this SDK will accept from a connecting participant.
-pub(crate) const REMOTE_ACCESS_MIN_SUPPORTED_PROTOCOL_VERSION: semver::Version =
-    semver::Version::new(2, 2, 0);
+const REMOTE_ACCESS_MIN_SUPPORTED_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
 
 /// The protocol version assumed when a participant does not advertise one.
 pub(crate) const DEFAULT_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
@@ -24,7 +23,7 @@ pub(crate) const DEFAULT_PROTOCOL_VERSION: semver::Version = semver::Version::ne
 /// build, so we default to [`DEFAULT_PROTOCOL_VERSION`].
 ///
 /// Returns `None` if the attribute value is present but cannot be parsed as a semver triple.
-pub(crate) fn parse_participant_protocol_version(
+fn parse_participant_protocol_version(
     attributes: &HashMap<String, String>,
 ) -> Option<semver::Version> {
     let Some(version_str) = attributes.get(PROTOCOL_VERSION_ATTRIBUTE) else {

--- a/rust/foxglove/src/remote_access/protocol_version.rs
+++ b/rust/foxglove/src/remote_access/protocol_version.rs
@@ -6,16 +6,16 @@ use livekit::id::ParticipantIdentity;
 use tracing::error;
 
 /// The LiveKit participant attribute key used to advertise the remote access protocol version.
-pub(crate) const PROTOCOL_VERSION_ATTRIBUTE: &str = "protocolVersion";
+pub(super) const PROTOCOL_VERSION_ATTRIBUTE: &str = "protocolVersion";
 
 /// The remote access protocol version supported by this SDK build.
-pub(crate) const REMOTE_ACCESS_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
+pub(super) const REMOTE_ACCESS_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
 
 /// The minimum remote access protocol version this SDK will accept from a connecting participant.
 const REMOTE_ACCESS_MIN_SUPPORTED_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
 
 /// The protocol version assumed when a participant does not advertise one.
-pub(crate) const DEFAULT_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
+pub(super) const DEFAULT_PROTOCOL_VERSION: semver::Version = semver::Version::new(2, 2, 0);
 
 /// Parse the remote access protocol version from a LiveKit participant's attributes.
 ///
@@ -50,7 +50,7 @@ fn parse_participant_protocol_version(
 /// Returns the parsed version if compatible, or `None` if the participant should be rejected.
 /// Callers should use [`REMOTE_ACCESS_PROTOCOL_VERSION`] (not the minimum) when reporting an
 /// incompatibility to the user, since the minimum does not cover major-version mismatches.
-pub(crate) fn check_participant_protocol_version(
+pub(super) fn check_participant_protocol_version(
     participant_identity: &ParticipantIdentity,
     attributes: &HashMap<String, String>,
     remote_access_session_id: Option<&str>,

--- a/rust/foxglove/src/remote_access/qos.rs
+++ b/rust/foxglove/src/remote_access/qos.rs
@@ -23,7 +23,7 @@ pub enum Reliability {
 /// Construct with [`QosProfile::default()`] or [`QosProfile::builder()`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct QosProfile {
-    pub(crate) reliability: Reliability,
+    pub(super) reliability: Reliability,
 }
 
 impl QosProfile {
@@ -69,7 +69,7 @@ pub trait QosClassifier: Sync + Send {
     fn classify(&self, channel: &ChannelDescriptor) -> QosProfile;
 }
 
-pub(crate) struct QosClassifierFn<F>(pub(crate) F)
+pub(super) struct QosClassifierFn<F>(pub(super) F)
 where
     F: Fn(&ChannelDescriptor) -> QosProfile + Sync + Send;
 

--- a/rust/foxglove/src/remote_access/qos.rs
+++ b/rust/foxglove/src/remote_access/qos.rs
@@ -69,7 +69,7 @@ pub trait QosClassifier: Sync + Send {
     fn classify(&self, channel: &ChannelDescriptor) -> QosProfile;
 }
 
-pub(crate) struct QosClassifierFn<F>(pub F)
+pub(crate) struct QosClassifierFn<F>(pub(crate) F)
 where
     F: Fn(&ChannelDescriptor) -> QosProfile + Sync + Send;
 

--- a/rust/foxglove/src/remote_access/rtt_tracker.rs
+++ b/rust/foxglove/src/remote_access/rtt_tracker.rs
@@ -4,7 +4,7 @@ use tracing::debug;
 const EWMA_ALPHA: f64 = 0.3;
 
 /// Tracks round-trip time measurements with an EWMA, mirroring the app-side approach.
-pub(crate) struct RttTracker {
+pub(super) struct RttTracker {
     label: &'static str,
     first_sample_excluded: bool,
     /// Most recent raw RTT sample, retained for future stats/diagnostics reporting.

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -60,10 +60,10 @@ pub(crate) use video_track::{
 };
 
 #[derive(Debug)]
-pub(crate) struct SessionStats {
-    pub participants: usize,
-    pub subscriptions: usize,
-    pub video_tracks: usize,
+struct SessionStats {
+    participants: usize,
+    subscriptions: usize,
+    video_tracks: usize,
 }
 
 const CONTROL_CHANNEL_TOPIC: &str = "control";
@@ -413,7 +413,7 @@ impl RemoteAccessSession {
         &self.room
     }
 
-    pub(crate) fn stats(&self) -> SessionStats {
+    fn stats(&self) -> SessionStats {
         let state = self.state.read();
         SessionStats {
             participants: self.participant_registry.participant_count(),

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -347,22 +347,22 @@ impl Sink for RemoteAccessSession {
 }
 
 pub(crate) struct SessionParams {
-    pub room: Room,
-    pub context: Weak<Context>,
-    pub channel_filter: Option<Arc<dyn SinkChannelFilter>>,
-    pub qos_classifier: Option<Arc<dyn QosClassifier>>,
-    pub listener: Option<Arc<dyn Listener>>,
-    pub capabilities: Vec<Capability>,
-    pub supported_encodings: IndexSet<String>,
-    pub runtime: Handle,
-    pub cancellation_token: CancellationToken,
-    pub message_backlog_size: usize,
-    pub services: Arc<parking_lot::RwLock<ServiceMap>>,
-    pub connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
-    pub remote_access_session_id: Option<String>,
-    pub fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
-    pub server_info: ServerInfo,
-    pub device_wait_for_viewer: Option<Duration>,
+    pub(crate) room: Room,
+    pub(crate) context: Weak<Context>,
+    pub(crate) channel_filter: Option<Arc<dyn SinkChannelFilter>>,
+    pub(crate) qos_classifier: Option<Arc<dyn QosClassifier>>,
+    pub(crate) listener: Option<Arc<dyn Listener>>,
+    pub(crate) capabilities: Vec<Capability>,
+    pub(crate) supported_encodings: IndexSet<String>,
+    pub(crate) runtime: Handle,
+    pub(crate) cancellation_token: CancellationToken,
+    pub(crate) message_backlog_size: usize,
+    pub(crate) services: Arc<parking_lot::RwLock<ServiceMap>>,
+    pub(crate) connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
+    pub(crate) remote_access_session_id: Option<String>,
+    pub(crate) fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
+    pub(crate) server_info: ServerInfo,
+    pub(crate) device_wait_for_viewer: Option<Duration>,
 }
 
 impl RemoteAccessSession {

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -53,9 +53,9 @@ use crate::{
 };
 
 mod data_track;
-pub(crate) use data_track::DataTrack;
+pub(super) use data_track::DataTrack;
 mod video_track;
-pub(crate) use video_track::{
+pub(super) use video_track::{
     VideoInputSchema, VideoMetadata, VideoPublisher, get_video_input_schema,
 };
 
@@ -70,7 +70,7 @@ const CONTROL_CHANNEL_TOPIC: &str = "control";
 const MESSAGE_FRAME_SIZE: usize = 5; // 1 byte opcode + u32 LE length
 const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 
-pub(crate) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
+pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 
 /// The operation code for the message framing for protocol v2.
 /// Distinguishes between frames containing JSON messages vs binary messages.
@@ -135,7 +135,7 @@ fn build_advertise_services_msg(services: &[Arc<Service>]) -> Option<AdvertiseSe
 ///
 /// The Sink impl is at the RemoteAccessSession level (not per-participant)
 /// so that it can deliver messages via multi-cast to multiple participants.
-pub(crate) struct RemoteAccessSession {
+pub(super) struct RemoteAccessSession {
     sink_id: SinkId,
     room: Room,
     context: Weak<Context>,
@@ -346,27 +346,27 @@ impl Sink for RemoteAccessSession {
     }
 }
 
-pub(crate) struct SessionParams {
-    pub(crate) room: Room,
-    pub(crate) context: Weak<Context>,
-    pub(crate) channel_filter: Option<Arc<dyn SinkChannelFilter>>,
-    pub(crate) qos_classifier: Option<Arc<dyn QosClassifier>>,
-    pub(crate) listener: Option<Arc<dyn Listener>>,
-    pub(crate) capabilities: Vec<Capability>,
-    pub(crate) supported_encodings: IndexSet<String>,
-    pub(crate) runtime: Handle,
-    pub(crate) cancellation_token: CancellationToken,
-    pub(crate) message_backlog_size: usize,
-    pub(crate) services: Arc<parking_lot::RwLock<ServiceMap>>,
-    pub(crate) connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
-    pub(crate) remote_access_session_id: Option<String>,
-    pub(crate) fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
-    pub(crate) server_info: ServerInfo,
-    pub(crate) device_wait_for_viewer: Option<Duration>,
+pub(super) struct SessionParams {
+    pub(super) room: Room,
+    pub(super) context: Weak<Context>,
+    pub(super) channel_filter: Option<Arc<dyn SinkChannelFilter>>,
+    pub(super) qos_classifier: Option<Arc<dyn QosClassifier>>,
+    pub(super) listener: Option<Arc<dyn Listener>>,
+    pub(super) capabilities: Vec<Capability>,
+    pub(super) supported_encodings: IndexSet<String>,
+    pub(super) runtime: Handle,
+    pub(super) cancellation_token: CancellationToken,
+    pub(super) message_backlog_size: usize,
+    pub(super) services: Arc<parking_lot::RwLock<ServiceMap>>,
+    pub(super) connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
+    pub(super) remote_access_session_id: Option<String>,
+    pub(super) fetch_asset_handler: Option<Arc<dyn AssetHandler<Client>>>,
+    pub(super) server_info: ServerInfo,
+    pub(super) device_wait_for_viewer: Option<Duration>,
 }
 
 impl RemoteAccessSession {
-    pub(crate) fn new(params: SessionParams) -> Self {
+    pub(super) fn new(params: SessionParams) -> Self {
         let (video_metadata_tx, video_metadata_rx) = tokio::sync::watch::channel(());
         let participant_registry = ParticipantRegistry::new(params.message_backlog_size);
         Self {
@@ -401,15 +401,15 @@ impl RemoteAccessSession {
         self.capabilities.contains(&cap)
     }
 
-    pub(crate) fn remote_access_session_id(&self) -> Option<&str> {
+    pub(super) fn remote_access_session_id(&self) -> Option<&str> {
         self.remote_access_session_id.as_deref()
     }
 
-    pub(crate) fn sink_id(&self) -> SinkId {
+    pub(super) fn sink_id(&self) -> SinkId {
         self.sink_id
     }
 
-    pub(crate) fn room(&self) -> &Room {
+    pub(super) fn room(&self) -> &Room {
         &self.room
     }
 
@@ -447,7 +447,7 @@ impl RemoteAccessSession {
     /// Watches for video metadata changes and re-advertises affected channels.
     ///
     /// Runs until the cancellation token fires.
-    pub(crate) async fn run_video_metadata_watcher(session: Arc<Self>) {
+    pub(super) async fn run_video_metadata_watcher(session: Arc<Self>) {
         let mut video_metadata: HashMap<ChannelId, VideoMetadata> = HashMap::new();
         let mut video_metadata_rx = session.video_metadata_rx.clone();
         loop {
@@ -463,7 +463,7 @@ impl RemoteAccessSession {
 
     /// Cancel the session's `CancellationToken`, signaling all session-scoped
     /// tasks to stop.
-    pub(crate) fn cancel(&self) {
+    pub(super) fn cancel(&self) {
         self.cancellation_token.cancel();
     }
 
@@ -472,7 +472,7 @@ impl RemoteAccessSession {
     ///
     /// The caller must ensure that `handle_room_events` has stopped so no new
     /// `remove_participant` / `reset_participant` calls can race with us.
-    pub(crate) async fn close(&self) {
+    pub(super) async fn close(&self) {
         // Cancel flush-tasks and await them before tearing down the transport.
         // In-flight writes either complete or fail once `room.close()` runs.
         self.participant_registry.shutdown().await;
@@ -486,7 +486,7 @@ impl RemoteAccessSession {
     }
 
     /// Read framed messages from a client byte stream on the control channel.
-    pub(crate) async fn handle_byte_stream_from_client(
+    pub(super) async fn handle_byte_stream_from_client(
         self: &Arc<Self>,
         participant_identity: ParticipantIdentity,
         reader: ByteStreamReader,
@@ -890,7 +890,7 @@ impl RemoteAccessSession {
 
     /// Send an incompatible protocol version error to a participant that will not be added to the
     /// session. Opens a one-shot byte stream, writes the error status, and closes it.
-    pub(crate) async fn send_incompatible_version_error(
+    pub(super) async fn send_incompatible_version_error(
         &self,
         participant_id: &ParticipantIdentity,
         attributes: &std::collections::HashMap<String, String>,
@@ -1003,7 +1003,7 @@ impl RemoteAccessSession {
     /// `on_client_unadvertise` callbacks fire). This handles the case where
     /// LiveKit emits the reconnect's `ParticipantActive` *before* the
     /// prior instance's `ParticipantDisconnected`.
-    pub(crate) async fn add_participant(
+    pub(super) async fn add_participant(
         self: &Arc<Self>,
         participant_id: ParticipantIdentity,
         participant_sid: ParticipantSid,
@@ -1099,7 +1099,7 @@ impl RemoteAccessSession {
     /// instance has a *different* SID, so a stale removal misses here rather
     /// than tearing down the replacement. Callers handle the `None` case
     /// according to their context.
-    pub(crate) fn remove_participant(
+    pub(super) fn remove_participant(
         self: &Arc<Self>,
         target_sid: &ParticipantSid,
     ) -> Option<Arc<Participant>> {
@@ -1164,7 +1164,7 @@ impl RemoteAccessSession {
     ///
     /// Returns when the room is disconnected, the event stream ends, or the session has been
     /// idle (no active participants) for longer than `device_wait_for_viewer`.
-    pub(crate) async fn handle_room_events(
+    pub(super) async fn handle_room_events(
         self: &Arc<Self>,
         mut room_events: tokio::sync::mpsc::UnboundedReceiver<RoomEvent>,
     ) {
@@ -1558,7 +1558,7 @@ impl RemoteAccessSession {
     }
 
     /// Periodically logs session statistics for monitoring and debugging.
-    pub(crate) async fn log_periodic_stats(&self) {
+    pub(super) async fn log_periodic_stats(&self) {
         let remote_access_session_id = self.remote_access_session_id();
         let period = Duration::from_secs(30);
         let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
@@ -1639,7 +1639,7 @@ impl RemoteAccessSession {
     }
 
     /// Broadcasts service advertisements for the given service IDs to all connected participants.
-    pub(crate) fn advertise_new_services(&self, service_ids: &[ServiceId]) {
+    pub(super) fn advertise_new_services(&self, service_ids: &[ServiceId]) {
         let services: Vec<_> = {
             let services = self.services.read();
             service_ids
@@ -1653,7 +1653,7 @@ impl RemoteAccessSession {
     }
 
     /// Broadcasts service unadvertisements for the given service IDs to all connected participants.
-    pub(crate) fn unadvertise_services(&self, service_ids: &[ServiceId]) {
+    pub(super) fn unadvertise_services(&self, service_ids: &[ServiceId]) {
         let msg = UnadvertiseServices::new(service_ids.iter().copied().map(u32::from));
         self.broadcast_control(encode_json_message(&msg));
     }
@@ -1887,7 +1887,7 @@ impl RemoteAccessSession {
     }
 
     /// Publish parameter values to all participants subscribed to those parameters.
-    pub(crate) fn publish_parameter_values(&self, parameters: Vec<Parameter>) {
+    pub(super) fn publish_parameter_values(&self, parameters: Vec<Parameter>) {
         if !self.has_capability(Capability::Parameters) {
             error!("Server does not support parameters capability");
             return;
@@ -1928,12 +1928,12 @@ impl RemoteAccessSession {
     }
 
     /// Publish a status message to all connected participants.
-    pub(crate) fn publish_status(&self, status: Status) {
+    pub(super) fn publish_status(&self, status: Status) {
         self.broadcast_control(encode_json_message(&status));
     }
 
     /// Remove status messages by ID from all connected participants.
-    pub(crate) fn remove_status(&self, status_ids: Vec<String>) {
+    pub(super) fn remove_status(&self, status_ids: Vec<String>) {
         let message = RemoveStatus::new(status_ids);
         self.broadcast_control(encode_json_message(&message));
     }
@@ -1998,7 +1998,7 @@ impl RemoteAccessSession {
     }
 
     /// Replaces the connection graph and sends updates to subscribed participants.
-    pub(crate) fn replace_connection_graph(&self, replacement_graph: ConnectionGraph) {
+    pub(super) fn replace_connection_graph(&self, replacement_graph: ConnectionGraph) {
         let mut graph = self.connection_graph.lock();
         let update = graph.update(replacement_graph);
         let encoded = encode_json_message(&update);

--- a/rust/foxglove/src/remote_access/session/video_track.rs
+++ b/rust/foxglove/src/remote_access/session/video_track.rs
@@ -37,7 +37,7 @@ pub enum VideoInputSchema {
 /// Detect the video input schema from an (encoding, schema_name) pair.
 ///
 /// Returns `Some(InputSchema)` if the channel carries an image type we can transcode to video.
-pub fn detect_video_schema(encoding: &str, schema_name: &str) -> Option<VideoInputSchema> {
+fn detect_video_schema(encoding: &str, schema_name: &str) -> Option<VideoInputSchema> {
     match (encoding, schema_name) {
         ("protobuf", "foxglove.CompressedImage") => Some(VideoInputSchema::FoxgloveCompressedImage),
         ("protobuf", "foxglove.RawImage") => Some(VideoInputSchema::FoxgloveRawImage),

--- a/rust/foxglove/src/remote_access/session/video_track.rs
+++ b/rust/foxglove/src/remote_access/session/video_track.rs
@@ -66,9 +66,9 @@ pub fn get_video_input_schema(channel: &RawChannel) -> Option<VideoInputSchema> 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct VideoMetadata {
     /// The image encoding (pixel format or compression codec).
-    pub encoding: ImageEncoding,
+    pub(crate) encoding: ImageEncoding,
     /// The coordinate frame ID of the image source (e.g. `"camera_optical_frame"`).
-    pub frame_id: String,
+    pub(crate) frame_id: String,
 }
 
 /// Newtype wrapping [`I420Buffer`] that implements [`Yuv420Buffer`].

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -13,33 +13,33 @@ use crate::remote_access::session::{DataTrack, VideoInputSchema, VideoMetadata, 
 use crate::{ChannelDescriptor, ChannelId, RawChannel};
 
 /// Channels and parameters that lost their last subscriber when a participant was removed.
-pub(crate) struct RemovedSubscriptions {
+pub(super) struct RemovedSubscriptions {
     /// Channel IDs that lost their last subscriber (of any type).
-    pub(crate) last_unsubscribed: SmallVec<[ChannelId; 4]>,
+    pub(super) last_unsubscribed: SmallVec<[ChannelId; 4]>,
     /// Channel IDs that lost their last video subscriber.
-    pub(crate) last_video_unsubscribed: SmallVec<[ChannelId; 4]>,
+    pub(super) last_video_unsubscribed: SmallVec<[ChannelId; 4]>,
     /// Descriptors for all channels the participant was subscribed to at removal time.
-    pub(crate) subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
+    pub(super) subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
     /// Client channels that were advertised by the removed participant.
-    pub(crate) client_channels: Vec<ChannelDescriptor>,
+    pub(super) client_channels: Vec<ChannelDescriptor>,
     /// Parameter names that lost their last subscriber.
-    pub(crate) last_param_unsubscribed: Vec<String>,
+    pub(super) last_param_unsubscribed: Vec<String>,
 }
 
 /// Result of subscribing a participant to channels.
-pub(crate) struct SubscribeResult {
+pub(super) struct SubscribeResult {
     /// Channel IDs that gained their first subscriber.
-    pub(crate) first_subscribed: SmallVec<[ChannelId; 4]>,
+    pub(super) first_subscribed: SmallVec<[ChannelId; 4]>,
     /// Descriptors for all channels where this participant was actually added.
-    pub(crate) newly_subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
+    pub(super) newly_subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
 }
 
 /// Result of unsubscribing a participant from channels.
-pub(crate) struct UnsubscribeResult {
+pub(super) struct UnsubscribeResult {
     /// Channel IDs that lost their last subscriber.
-    pub(crate) last_unsubscribed: SmallVec<[ChannelId; 4]>,
+    pub(super) last_unsubscribed: SmallVec<[ChannelId; 4]>,
     /// Descriptors for all channels where this participant was actually removed.
-    pub(crate) actually_unsubscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
+    pub(super) actually_unsubscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
 }
 
 /// State machine for a remote access session.
@@ -53,7 +53,7 @@ pub(crate) struct UnsubscribeResult {
 ///
 /// A subscriber is a "data subscriber" if they appear in `subscriptions` but not in
 /// `video_subscribers`. See [`Self::has_data_subscribers`].
-pub(crate) struct SessionState {
+pub(super) struct SessionState {
     /// Channels that have been advertised to participants.
     channels: HashMap<ChannelId, Arc<RawChannel>>,
     /// QoS profile per channel.

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -348,7 +348,7 @@ impl SessionState {
 
     /// Removes video metadata for a video channel.
     #[cfg(test)]
-    pub fn remove_video_metadata(&mut self, channel_id: &ChannelId) {
+    fn remove_video_metadata(&mut self, channel_id: &ChannelId) {
         self.video_metadata.remove(channel_id);
     }
 

--- a/rust/foxglove/src/remote_access/session_state.rs
+++ b/rust/foxglove/src/remote_access/session_state.rs
@@ -15,31 +15,31 @@ use crate::{ChannelDescriptor, ChannelId, RawChannel};
 /// Channels and parameters that lost their last subscriber when a participant was removed.
 pub(crate) struct RemovedSubscriptions {
     /// Channel IDs that lost their last subscriber (of any type).
-    pub last_unsubscribed: SmallVec<[ChannelId; 4]>,
+    pub(crate) last_unsubscribed: SmallVec<[ChannelId; 4]>,
     /// Channel IDs that lost their last video subscriber.
-    pub last_video_unsubscribed: SmallVec<[ChannelId; 4]>,
+    pub(crate) last_video_unsubscribed: SmallVec<[ChannelId; 4]>,
     /// Descriptors for all channels the participant was subscribed to at removal time.
-    pub subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
+    pub(crate) subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
     /// Client channels that were advertised by the removed participant.
-    pub client_channels: Vec<ChannelDescriptor>,
+    pub(crate) client_channels: Vec<ChannelDescriptor>,
     /// Parameter names that lost their last subscriber.
-    pub last_param_unsubscribed: Vec<String>,
+    pub(crate) last_param_unsubscribed: Vec<String>,
 }
 
 /// Result of subscribing a participant to channels.
 pub(crate) struct SubscribeResult {
     /// Channel IDs that gained their first subscriber.
-    pub first_subscribed: SmallVec<[ChannelId; 4]>,
+    pub(crate) first_subscribed: SmallVec<[ChannelId; 4]>,
     /// Descriptors for all channels where this participant was actually added.
-    pub newly_subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
+    pub(crate) newly_subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
 }
 
 /// Result of unsubscribing a participant from channels.
 pub(crate) struct UnsubscribeResult {
     /// Channel IDs that lost their last subscriber.
-    pub last_unsubscribed: SmallVec<[ChannelId; 4]>,
+    pub(crate) last_unsubscribed: SmallVec<[ChannelId; 4]>,
     /// Descriptors for all channels where this participant was actually removed.
-    pub actually_unsubscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
+    pub(crate) actually_unsubscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
 }
 
 /// State machine for a remote access session.


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

This came out of review of #1194 .  While doing that I noticed that we had a bunch of unnecessary visibility in these modules.  In particular:

1.  There were a few structs and functions which were never used outside of their file, yet marked as `pub` or `pub(crate)`.  Remove the visibility symbols to make them private.
2. There were a few structs where the type was `pub(crate)`, but the field were marked `pub`.  That doesn't make too much sense; something outside of the crate wouldn't be able to get to the type, so it can't get to the fields.  Change those to `pub(crate)`.
3. There were a number of places marked `pub(crate)` that can be tightened up to `pub(super)`.  Do that as well.

The end result here is basically no change to the binary, but just cleaner scope.

Part of FLE-475