### PR TITLE
Temporarily disable Rolling CI builds.

### DIFF
--- a/.github/workflows/draft-ros-release.yml
+++ b/.github/workflows/draft-ros-release.yml
@@ -54,7 +54,8 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
-        distro: [humble, jazzy, kilted, rolling]
+        # rolling temporarily disabled while upstream changes land; re-enable when stable
+        distro: [humble, jazzy, kilted]
         package: [bridge, msgs]
         include:
           - arch: x86_64

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -63,7 +63,7 @@ jobs:
           - humble
           - jazzy
           - kilted
-          - rolling
+          # rolling temporarily disabled while upstream changes land; re-enable when stable
     name: "ros (${{ matrix.ros_distribution }})"
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Upstream rolling is currently in the middle of a transition from Ubuntu 24.04 to 26.04.  While that happens, things will likely be chaotic.  Disable just that ROS CI job for now; we'll re-enable it once things settle down upstream.
