### PR TITLE
remote_access: Remove dead VideoPublisher::video_source getter

### DIFF
--- a/rust/foxglove/src/remote_access/session/video_track.rs
+++ b/rust/foxglove/src/remote_access/session/video_track.rs
@@ -166,12 +166,6 @@ impl VideoPublisher {
         }
     }
 
-    /// Returns a reference to the underlying video source.
-    #[allow(dead_code)]
-    pub fn video_source(&self) -> &NativeVideoSource {
-        &self.video_source
-    }
-
     /// Returns the latest video metadata observed by this publisher, if any.
     pub fn metadata(&self) -> arc_swap::Guard<Option<Arc<VideoMetadata>>> {
         self.metadata.load()


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The getter was introduced with `#[allow(dead_code)]` in the original video-track commit and has never had a caller.

Part of FLE-475