### PR TITLE
remote access: sysinfo: implement two different measures for CPU measurements

### DIFF
--- a/rust/foxglove/src/system_info.rs
+++ b/rust/foxglove/src/system_info.rs
@@ -48,11 +48,19 @@ const SYSINFO_JSON_SCHEMA: &str = r#"{
     },
     "process_cpu_percent": {
       "type": "number",
-      "description": "CPU usage for the SDK process, as a percent. Values are normalized per logical CPU: 100.0 means a single CPU is fully utilized, so the maximum value is 100.0 * num_cpus."
+      "description": "CPU usage for the SDK process, as a percent of total system CPU capacity (0.0 to 100.0). 100.0 means the process is using all logical CPUs at full utilization."
+    },
+    "process_busy_cpu_cores": {
+      "type": "number",
+      "description": "CPU usage for the SDK process, expressed in core-equivalents (0.0 to num_cpus). 1.0 means a single logical CPU is fully utilized."
     },
     "total_cpu_percent": {
       "type": "number",
       "description": "Total CPU usage across all logical CPUs on the system, as a percent (0.0 to 100.0)."
+    },
+    "total_busy_cpu_cores": {
+      "type": "number",
+      "description": "Total CPU usage across the system, expressed in core-equivalents (0.0 to num_cpus). 1.0 means one logical CPU's worth of work is being done."
     },
     "num_cpus": {
       "type": "integer",
@@ -95,13 +103,23 @@ pub(crate) struct SystemInfo {
     pub process_memory: f64,
     /// Virtual memory used by the SDK process, in bytes.
     pub process_virtual_memory: f64,
-    /// CPU usage for the SDK process, as a percent.
+    /// CPU usage for the SDK process, as a percent of total system CPU capacity
+    /// (0.0 to 100.0).
     ///
-    /// Values are normalized per logical CPU: 100.0 means a single CPU is fully
-    /// utilized, so the maximum value is `100.0 * num_cpus`.
+    /// 100.0 means the process is using all logical CPUs at full utilization.
     pub process_cpu_percent: f64,
+    /// CPU usage for the SDK process, expressed in core-equivalents
+    /// (0.0 to `num_cpus`).
+    ///
+    /// 1.0 means a single logical CPU is fully utilized.
+    pub process_busy_cpu_cores: f64,
     /// Total CPU usage across all logical CPUs on the system, as a percent (0.0 to 100.0).
     pub total_cpu_percent: f64,
+    /// Total CPU usage across the system, expressed in core-equivalents
+    /// (0.0 to `num_cpus`).
+    ///
+    /// 1.0 means one logical CPU's worth of work is being done.
+    pub total_busy_cpu_cores: f64,
     /// Number of logical CPUs on the system.
     pub num_cpus: u32,
     /// Total physical memory on the system, in bytes.
@@ -312,16 +330,32 @@ async fn run_publisher(channel: Channel<SystemInfo>, refresh_interval: Duration)
         system.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), false, process_refresh);
         system.refresh_cpu_specifics(cpu_refresh);
 
-        let (process_memory, process_virtual_memory, process_cpu_percent) = system
+        let (process_memory, process_virtual_memory, process_cpu_per_core_percent) = system
             .process(pid)
             .map(|p| (p.memory(), p.virtual_memory(), p.cpu_usage()))
             .unwrap_or_default();
 
+        // sysinfo reports per-process CPU usage normalized per logical CPU
+        // (100.0 == one CPU fully utilized, max == 100.0 * num_cpus), and global
+        // CPU usage as a 0-100 percent of total capacity. Convert both to a
+        // common pair of representations: a percent of total system capacity
+        // and an equivalent number of busy cores.
+        let process_busy_cpu_cores = f64::from(process_cpu_per_core_percent) / 100.0;
+        let process_cpu_percent = if num_cpus > 0 {
+            f64::from(process_cpu_per_core_percent) / f64::from(num_cpus)
+        } else {
+            0.0
+        };
+        let total_cpu_percent = f64::from(system.global_cpu_usage());
+        let total_busy_cpu_cores = total_cpu_percent * f64::from(num_cpus) / 100.0;
+
         let info = SystemInfo {
             process_memory: process_memory as f64,
             process_virtual_memory: process_virtual_memory as f64,
-            process_cpu_percent: process_cpu_percent as f64,
-            total_cpu_percent: system.global_cpu_usage() as f64,
+            process_cpu_percent,
+            process_busy_cpu_cores,
+            total_cpu_percent,
+            total_busy_cpu_cores,
             num_cpus,
             total_memory: system.total_memory() as f64,
             used_memory: system.used_memory() as f64,
@@ -361,7 +395,9 @@ mod tests {
             process_memory: 0.0,
             process_virtual_memory: 0.0,
             process_cpu_percent: 0.0,
+            process_busy_cpu_cores: 0.0,
             total_cpu_percent: 0.0,
+            total_busy_cpu_cores: 0.0,
             num_cpus: 0,
             total_memory: 0.0,
             used_memory: 0.0,
@@ -400,7 +436,9 @@ mod tests {
             process_memory: 1.0,
             process_virtual_memory: 2.0,
             process_cpu_percent: 3.0,
+            process_busy_cpu_cores: 3.5,
             total_cpu_percent: 4.0,
+            total_busy_cpu_cores: 4.5,
             num_cpus: 5,
             total_memory: 6.0,
             used_memory: 7.0,

--- a/rust/foxglove/src/system_info.rs
+++ b/rust/foxglove/src/system_info.rs
@@ -50,7 +50,7 @@ const SYSINFO_JSON_SCHEMA: &str = r#"{
       "type": "number",
       "description": "CPU usage for the SDK process, as a percent of total system CPU capacity (0.0 to 100.0). 100.0 means the process is using all logical CPUs at full utilization."
     },
-    "process_busy_cpu_cores": {
+    "process_cpu_cores": {
       "type": "number",
       "description": "CPU usage for the SDK process, expressed in core-equivalents (0.0 to num_cpus). 1.0 means a single logical CPU is fully utilized."
     },
@@ -58,7 +58,7 @@ const SYSINFO_JSON_SCHEMA: &str = r#"{
       "type": "number",
       "description": "Total CPU usage across all logical CPUs on the system, as a percent (0.0 to 100.0)."
     },
-    "total_busy_cpu_cores": {
+    "total_cpu_cores": {
       "type": "number",
       "description": "Total CPU usage across the system, expressed in core-equivalents (0.0 to num_cpus). 1.0 means one logical CPU's worth of work is being done."
     },
@@ -112,14 +112,14 @@ pub(crate) struct SystemInfo {
     /// (0.0 to `num_cpus`).
     ///
     /// 1.0 means a single logical CPU is fully utilized.
-    pub process_busy_cpu_cores: f64,
+    pub process_cpu_cores: f64,
     /// Total CPU usage across all logical CPUs on the system, as a percent (0.0 to 100.0).
     pub total_cpu_percent: f64,
     /// Total CPU usage across the system, expressed in core-equivalents
     /// (0.0 to `num_cpus`).
     ///
     /// 1.0 means one logical CPU's worth of work is being done.
-    pub total_busy_cpu_cores: f64,
+    pub total_cpu_cores: f64,
     /// Number of logical CPUs on the system.
     pub num_cpus: u32,
     /// Total physical memory on the system, in bytes.
@@ -340,22 +340,22 @@ async fn run_publisher(channel: Channel<SystemInfo>, refresh_interval: Duration)
         // CPU usage as a 0-100 percent of total capacity. Convert both to a
         // common pair of representations: a percent of total system capacity
         // and an equivalent number of busy cores.
-        let process_busy_cpu_cores = f64::from(process_cpu_per_core_percent) / 100.0;
+        let process_cpu_cores = f64::from(process_cpu_per_core_percent) / 100.0;
         let process_cpu_percent = if num_cpus > 0 {
             f64::from(process_cpu_per_core_percent) / f64::from(num_cpus)
         } else {
             0.0
         };
         let total_cpu_percent = f64::from(system.global_cpu_usage());
-        let total_busy_cpu_cores = total_cpu_percent * f64::from(num_cpus) / 100.0;
+        let total_cpu_cores = total_cpu_percent * f64::from(num_cpus) / 100.0;
 
         let info = SystemInfo {
             process_memory: process_memory as f64,
             process_virtual_memory: process_virtual_memory as f64,
             process_cpu_percent,
-            process_busy_cpu_cores,
+            process_cpu_cores,
             total_cpu_percent,
-            total_busy_cpu_cores,
+            total_cpu_cores,
             num_cpus,
             total_memory: system.total_memory() as f64,
             used_memory: system.used_memory() as f64,
@@ -395,9 +395,9 @@ mod tests {
             process_memory: 0.0,
             process_virtual_memory: 0.0,
             process_cpu_percent: 0.0,
-            process_busy_cpu_cores: 0.0,
+            process_cpu_cores: 0.0,
             total_cpu_percent: 0.0,
-            total_busy_cpu_cores: 0.0,
+            total_cpu_cores: 0.0,
             num_cpus: 0,
             total_memory: 0.0,
             used_memory: 0.0,
@@ -436,9 +436,9 @@ mod tests {
             process_memory: 1.0,
             process_virtual_memory: 2.0,
             process_cpu_percent: 3.0,
-            process_busy_cpu_cores: 3.5,
+            process_cpu_cores: 3.5,
             total_cpu_percent: 4.0,
-            total_busy_cpu_cores: 4.5,
+            total_cpu_cores: 4.5,
             num_cpus: 5,
             total_memory: 6.0,
             used_memory: 7.0,


### PR DESCRIPTION
### Changelog

Foxglove SDK: add two measures of CPU usage for process and system in sysinfo publisher. cpu_percent from 0-100% of total CPU available, and cpu_cores as a value from 0..num_cores (percent of one core).

### Docs

None

### Description

Previously process_cpu_percent was as a percent of 1 core while total_cpu_percent was 0-100% of total cpu cores. Both measures are useful, so we now report both for both process and system cpu. Users can choose which to plot.

- [x] Tested locally by plotting all 4 metrics and comparing to the measures reported by top.
