### PR TITLE
remote_access: Split parameter subscriptions out of SessionState; rename to ChannelRegistry

### DIFF
--- a/rust/foxglove/src/remote_access.rs
+++ b/rust/foxglove/src/remote_access.rs
@@ -1,10 +1,12 @@
 //! Remote access implementation.
 
 mod capability;
+mod channel_registry;
 mod client;
 mod connection;
 mod gateway;
 mod listener;
+mod parameter_subscriptions;
 mod participant;
 mod participant_registry;
 mod participants;
@@ -13,7 +15,6 @@ mod qos;
 mod rtt_tracker;
 pub mod service;
 mod session;
-mod session_state;
 mod sse;
 mod watch;
 mod watch_loop;

--- a/rust/foxglove/src/remote_access/channel_registry.rs
+++ b/rust/foxglove/src/remote_access/channel_registry.rs
@@ -1,5 +1,5 @@
+use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use livekit::id::{ParticipantIdentity, TrackSid};
@@ -12,7 +12,7 @@ use crate::remote_access::qos::{QosProfile, Reliability};
 use crate::remote_access::session::{DataTrack, VideoInputSchema, VideoMetadata, VideoPublisher};
 use crate::{ChannelDescriptor, ChannelId, RawChannel};
 
-/// Channels and parameters that lost their last subscriber when a participant was removed.
+/// Channels that lost their last subscriber when a participant was removed.
 pub(super) struct RemovedSubscriptions {
     /// Channel IDs that lost their last subscriber (of any type).
     pub(super) last_unsubscribed: SmallVec<[ChannelId; 4]>,
@@ -22,8 +22,6 @@ pub(super) struct RemovedSubscriptions {
     pub(super) subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
     /// Client channels that were advertised by the removed participant.
     pub(super) client_channels: Vec<ChannelDescriptor>,
-    /// Parameter names that lost their last subscriber.
-    pub(super) last_param_unsubscribed: Vec<String>,
 }
 
 /// Result of subscribing a participant to channels.
@@ -42,9 +40,13 @@ pub(super) struct UnsubscribeResult {
     pub(super) actually_unsubscribed_descriptors: SmallVec<[ChannelDescriptor; 4]>,
 }
 
-/// State machine for a remote access session.
+/// Channel registry and per-channel derived state for a remote access session.
 ///
-/// Tracks participants, advertised channels, and per-channel subscriptions.
+/// Holds advertised channels, their QoS, subscriptions (data + video), publisher and track
+/// state, and the inverse-indexed channels participants have advertised to us. Participant
+/// membership lives on [`super::participant_registry::ParticipantRegistry`]; parameter
+/// subscriptions live on [`super::parameter_subscriptions::ParameterSubscriptions`].
+///
 /// Contains no locking; callers are responsible for synchronization.
 ///
 /// Subscriptions are tracked in two maps:
@@ -53,7 +55,7 @@ pub(super) struct UnsubscribeResult {
 ///
 /// A subscriber is a "data subscriber" if they appear in `subscriptions` but not in
 /// `video_subscribers`. See [`Self::has_data_subscribers`].
-pub(super) struct SessionState {
+pub(super) struct ChannelRegistry {
     /// Channels that have been advertised to participants.
     channels: HashMap<ChannelId, Arc<RawChannel>>,
     /// QoS profile per channel.
@@ -75,11 +77,9 @@ pub(super) struct SessionState {
     video_metadata: HashMap<ChannelId, VideoMetadata>,
     /// Client-advertised channels, keyed by participant identity then client-assigned channel ID.
     client_channels: HashMap<ParticipantIdentity, HashMap<ChannelId, ChannelDescriptor>>,
-    /// Parameters subscribed to by participants, keyed by parameter name.
-    subscribed_parameters: HashMap<String, HashSet<ParticipantIdentity>>,
 }
 
-impl SessionState {
+impl ChannelRegistry {
     pub fn new() -> Self {
         Self {
             channels: HashMap::new(),
@@ -92,11 +92,10 @@ impl SessionState {
             video_track_sids: HashMap::new(),
             video_metadata: HashMap::new(),
             client_channels: HashMap::new(),
-            subscribed_parameters: HashMap::new(),
         }
     }
 
-    /// Sweeps `identity` out of every subscription map and returns the
+    /// Sweeps `identity` out of every channel-subscription map and returns the
     /// descriptors of channels that lost their last subscriber (and other
     /// aftercare info) for the caller to fire listener callbacks on.
     ///
@@ -145,23 +144,11 @@ impl SessionState {
             .map(|map| map.into_values().collect())
             .unwrap_or_default();
 
-        let mut last_param_unsubscribed = Vec::new();
-        self.subscribed_parameters.retain(|name, subscribers| {
-            subscribers.remove(identity);
-            if subscribers.is_empty() {
-                last_param_unsubscribed.push(name.clone());
-                false
-            } else {
-                true
-            }
-        });
-
         RemovedSubscriptions {
             last_unsubscribed,
             last_video_unsubscribed,
             subscribed_descriptors,
             client_channels,
-            last_param_unsubscribed,
         }
     }
 
@@ -560,50 +547,6 @@ impl SessionState {
     pub fn remove_data_track(&mut self, channel_id: &ChannelId) -> Option<DataTrack> {
         self.data_tracks.remove(channel_id)
     }
-
-    /// Add parameter subscriptions for a participant.
-    ///
-    /// Returns parameter names that are newly subscribed (i.e. had no prior subscribers).
-    pub fn subscribe_parameters(
-        &mut self,
-        identity: &ParticipantIdentity,
-        names: Vec<String>,
-    ) -> Vec<String> {
-        let mut new_names = Vec::new();
-        for name in names {
-            let subscribers = self.subscribed_parameters.entry(name.clone()).or_default();
-            if subscribers.insert(identity.clone()) && subscribers.len() == 1 {
-                new_names.push(name);
-            }
-        }
-        new_names
-    }
-
-    /// Remove parameter subscriptions for a participant.
-    ///
-    /// Returns parameter names that lost their last subscriber.
-    pub fn unsubscribe_parameters(
-        &mut self,
-        identity: &ParticipantIdentity,
-        names: Vec<String>,
-    ) -> Vec<String> {
-        let mut old_names = Vec::new();
-        for name in names {
-            if let Some(subscribers) = self.subscribed_parameters.get_mut(&name) {
-                subscribers.remove(identity);
-                if subscribers.is_empty() {
-                    self.subscribed_parameters.remove(&name);
-                    old_names.push(name);
-                }
-            }
-        }
-        old_names
-    }
-
-    /// Returns the set of participant identities subscribed to a parameter.
-    pub fn parameter_subscribers(&self, name: &str) -> Option<&HashSet<ParticipantIdentity>> {
-        self.subscribed_parameters.get(name)
-    }
 }
 
 #[cfg(test)]
@@ -640,7 +583,7 @@ mod tests {
 
     #[test]
     fn first_subscriber_is_reported() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -653,7 +596,7 @@ mod tests {
 
     #[test]
     fn second_subscriber_is_not_reported_as_first() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id_a = make_identity("alice");
         let id_b = make_identity("bob");
         let ch = make_channel("/topic1");
@@ -667,7 +610,7 @@ mod tests {
 
     #[test]
     fn duplicate_subscribe_is_idempotent() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -681,7 +624,7 @@ mod tests {
 
     #[test]
     fn subscribe_multiple_channels_at_once() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
@@ -695,7 +638,7 @@ mod tests {
 
     #[test]
     fn last_unsubscriber_is_reported() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -708,7 +651,7 @@ mod tests {
 
     #[test]
     fn unsubscribe_with_remaining_subscribers_is_not_reported() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id_a = make_identity("alice");
         let id_b = make_identity("bob");
         let ch = make_channel("/topic1");
@@ -724,7 +667,7 @@ mod tests {
 
     #[test]
     fn unsubscribe_when_not_subscribed_is_noop() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let result = state.unsubscribe(&id, &[ChannelId::new(1)]);
         assert!(result.last_unsubscribed.is_empty());
@@ -734,7 +677,7 @@ mod tests {
 
     #[test]
     fn first_video_subscriber_is_reported() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let first = state.subscribe_video(&id, &[ChannelId::new(1)]);
         assert_eq!(first.as_slice(), &[ChannelId::new(1)]);
@@ -742,7 +685,7 @@ mod tests {
 
     #[test]
     fn last_video_unsubscriber_is_reported() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let _ = state.subscribe_video(&id, &[ChannelId::new(1)]);
         let last = state.unsubscribe_video(&id, &[ChannelId::new(1)]);
@@ -751,7 +694,7 @@ mod tests {
 
     #[test]
     fn video_only_subscriber_is_not_a_data_subscriber() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -762,7 +705,7 @@ mod tests {
 
     #[test]
     fn switching_from_video_to_data() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -777,18 +720,17 @@ mod tests {
 
     #[test]
     fn cleanup_missing_identity_is_noop() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let cleanup = state.cleanup_for_removed_identity(&make_identity("nobody"));
         assert!(cleanup.last_unsubscribed.is_empty());
         assert!(cleanup.last_video_unsubscribed.is_empty());
         assert!(cleanup.subscribed_descriptors.is_empty());
         assert!(cleanup.client_channels.is_empty());
-        assert!(cleanup.last_param_unsubscribed.is_empty());
     }
 
     #[test]
     fn cleanup_sweeps_subscriptions() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -801,7 +743,7 @@ mod tests {
 
     #[test]
     fn cleanup_reports_only_last_unsubscribed_channels() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id_a = make_identity("alice");
         let id_b = make_identity("bob");
         let ch1 = make_channel("/topic1");
@@ -820,7 +762,7 @@ mod tests {
 
     #[test]
     fn cleanup_sweeps_video_subscriptions() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -834,7 +776,7 @@ mod tests {
 
     #[test]
     fn cleanup_returns_subscribed_descriptors() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
@@ -848,7 +790,7 @@ mod tests {
 
     #[test]
     fn cleanup_sweeps_client_channels() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         state.insert_client_channel(&id, make_client_channel(1, "/cmd_vel"));
         state.insert_client_channel(&id, make_client_channel(2, "/joy"));
@@ -865,7 +807,7 @@ mod tests {
 
     #[test]
     fn cleanup_for_mixed_video_preferences() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id_a = make_identity("alice");
         let id_b = make_identity("bob");
         let ch = make_channel("/topic1");
@@ -885,7 +827,7 @@ mod tests {
 
     #[test]
     fn channel_subscriber_identities_empty_for_unknown_channel() {
-        let state = SessionState::new();
+        let state = ChannelRegistry::new();
         assert!(
             state
                 .channel_subscriber_identities(&ChannelId::new(999))
@@ -895,7 +837,7 @@ mod tests {
 
     #[test]
     fn channel_subscriber_identities_returns_subscribers() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id_a = make_identity("alice");
         let id_b = make_identity("bob");
         let ch = make_channel("/topic1");
@@ -911,7 +853,7 @@ mod tests {
 
     #[test]
     fn channel_subscriber_identities_empty_after_remove_channel() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -924,7 +866,7 @@ mod tests {
 
     #[test]
     fn insert_client_channel_is_noop_for_duplicate() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         let ch = make_client_channel(1, "/cmd");
         assert!(state.insert_client_channel(&id, ch.clone()));
@@ -933,7 +875,7 @@ mod tests {
 
     #[test]
     fn remove_client_channel_returns_descriptor() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id = make_identity("alice");
         state.insert_client_channel(&id, make_client_channel(1, "/cmd"));
         let removed = state.remove_client_channel(&id, ChannelId::new(1));
@@ -942,7 +884,7 @@ mod tests {
 
     #[test]
     fn get_client_channel_returns_none_for_unknown() {
-        let state = SessionState::new();
+        let state = ChannelRegistry::new();
         assert!(
             state
                 .get_client_channel(&make_identity("nobody"), ChannelId::new(1))
@@ -954,7 +896,7 @@ mod tests {
 
     #[test]
     fn insert_and_query_channel() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
         assert_eq!(state.channels.len(), 1);
@@ -962,7 +904,7 @@ mod tests {
 
     #[test]
     fn remove_channel_returns_true_when_present() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
         assert!(state.remove_channel(ch.id()));
@@ -970,13 +912,13 @@ mod tests {
 
     #[test]
     fn remove_channel_returns_false_when_absent() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         assert!(!state.remove_channel(ChannelId::new(999)));
     }
 
     #[test]
     fn qos_profile_defaults_to_lossy() {
-        let state = SessionState::new();
+        let state = ChannelRegistry::new();
         assert_eq!(
             state.qos_profile(&ChannelId::new(42)).reliability,
             Reliability::Lossy,
@@ -985,7 +927,7 @@ mod tests {
 
     #[test]
     fn insert_and_retrieve_qos_profile() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let ch = make_channel("/config");
         state.insert_channel(&ch);
         let qos = QosProfile::builder()
@@ -1000,7 +942,7 @@ mod tests {
 
     #[test]
     fn remove_channel_cleans_up_qos_profile() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let ch = make_channel("/config");
         state.insert_channel(&ch);
         state.insert_qos_profile(
@@ -1017,7 +959,7 @@ mod tests {
 
     #[test]
     fn data_subscriber_identities_empty_when_no_subscribers() {
-        let state = SessionState::new();
+        let state = ChannelRegistry::new();
         assert!(
             state
                 .data_subscriber_identities(&ChannelId::new(1))
@@ -1027,7 +969,7 @@ mod tests {
 
     #[test]
     fn data_subscriber_identities_returns_data_only_subscribers() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let id_a = make_identity("alice");
         let id_b = make_identity("bob");
         let ch = make_channel("/data");
@@ -1046,7 +988,7 @@ mod tests {
 
     #[test]
     fn add_metadata_to_advertisement_injects_video_metadata() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let ch = make_channel("/camera");
         state.insert_channel(&ch);
         state.insert_video_schema(ch.id(), VideoInputSchema::FoxgloveRawImage);
@@ -1079,7 +1021,7 @@ mod tests {
 
     #[test]
     fn add_metadata_to_advertisement_omits_empty_frame_id() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let ch = make_channel("/camera");
         state.insert_channel(&ch);
         state.insert_video_schema(ch.id(), VideoInputSchema::FoxgloveRawImage);
@@ -1102,7 +1044,7 @@ mod tests {
 
     #[test]
     fn remove_video_metadata_clears_from_advertisement() {
-        let mut state = SessionState::new();
+        let mut state = ChannelRegistry::new();
         let ch = make_channel("/camera");
         state.insert_channel(&ch);
         state.insert_video_schema(ch.id(), VideoInputSchema::FoxgloveRawImage);

--- a/rust/foxglove/src/remote_access/parameter_subscriptions.rs
+++ b/rust/foxglove/src/remote_access/parameter_subscriptions.rs
@@ -1,0 +1,86 @@
+//! Parameter-subscription bookkeeping for a remote access session.
+//!
+//! Tracks which participants are subscribed to which parameter names. Lifecycle
+//! is independent of channel subscriptions, so this lives in its own struct
+//! alongside [`crate::remote_access::channel_registry::ChannelRegistry`].
+
+use std::collections::{HashMap, HashSet};
+
+use livekit::id::ParticipantIdentity;
+
+/// Tracks parameter-name → set of subscribed participant identities.
+#[derive(Default)]
+pub(super) struct ParameterSubscriptions {
+    subscribers_by_name: HashMap<String, HashSet<ParticipantIdentity>>,
+}
+
+impl ParameterSubscriptions {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add parameter subscriptions for a participant.
+    ///
+    /// Returns parameter names that are newly subscribed (i.e. had no prior subscribers).
+    pub(super) fn subscribe(
+        &mut self,
+        identity: &ParticipantIdentity,
+        names: Vec<String>,
+    ) -> Vec<String> {
+        let mut new_names = Vec::new();
+        for name in names {
+            let subscribers = self.subscribers_by_name.entry(name.clone()).or_default();
+            if subscribers.insert(identity.clone()) && subscribers.len() == 1 {
+                new_names.push(name);
+            }
+        }
+        new_names
+    }
+
+    /// Remove parameter subscriptions for a participant.
+    ///
+    /// Returns parameter names that lost their last subscriber.
+    pub(super) fn unsubscribe(
+        &mut self,
+        identity: &ParticipantIdentity,
+        names: Vec<String>,
+    ) -> Vec<String> {
+        let mut old_names = Vec::new();
+        for name in names {
+            if let Some(subscribers) = self.subscribers_by_name.get_mut(&name) {
+                subscribers.remove(identity);
+                if subscribers.is_empty() {
+                    self.subscribers_by_name.remove(&name);
+                    old_names.push(name);
+                }
+            }
+        }
+        old_names
+    }
+
+    /// Returns the set of participant identities subscribed to a parameter.
+    pub(super) fn subscribers(&self, name: &str) -> Option<&HashSet<ParticipantIdentity>> {
+        self.subscribers_by_name.get(name)
+    }
+
+    /// Sweep `identity` out of every parameter-subscription set.
+    ///
+    /// Returns parameter names that lost their last subscriber. No-op if `identity` was not
+    /// subscribed to any parameter.
+    pub(super) fn cleanup_for_removed_identity(
+        &mut self,
+        identity: &ParticipantIdentity,
+    ) -> Vec<String> {
+        let mut last_unsubscribed = Vec::new();
+        self.subscribers_by_name.retain(|name, subscribers| {
+            subscribers.remove(identity);
+            if subscribers.is_empty() {
+                last_unsubscribed.push(name.clone());
+                false
+            } else {
+                true
+            }
+        });
+        last_unsubscribed
+    }
+}

--- a/rust/foxglove/src/remote_access/parameter_subscriptions.rs
+++ b/rust/foxglove/src/remote_access/parameter_subscriptions.rs
@@ -9,14 +9,15 @@ use std::collections::{HashMap, HashSet};
 use livekit::id::ParticipantIdentity;
 
 /// Tracks parameter-name → set of subscribed participant identities.
-#[derive(Default)]
 pub(super) struct ParameterSubscriptions {
     subscribers_by_name: HashMap<String, HashSet<ParticipantIdentity>>,
 }
 
 impl ParameterSubscriptions {
     pub(super) fn new() -> Self {
-        Self::default()
+        Self {
+            subscribers_by_name: HashMap::new(),
+        }
     }
 
     /// Add parameter subscriptions for a participant.
@@ -82,5 +83,123 @@ impl ParameterSubscriptions {
             }
         });
         last_unsubscribed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_identity(name: &str) -> ParticipantIdentity {
+        ParticipantIdentity(name.to_string())
+    }
+
+    #[test]
+    fn first_subscriber_is_reported() {
+        let mut subs = ParameterSubscriptions::new();
+        let id = make_identity("alice");
+
+        let new_names = subs.subscribe(&id, vec!["p1".into()]);
+        assert_eq!(new_names, vec!["p1".to_string()]);
+    }
+
+    #[test]
+    fn second_subscriber_is_not_reported_as_first() {
+        let mut subs = ParameterSubscriptions::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+
+        let _ = subs.subscribe(&id_a, vec!["p1".into()]);
+        let new_names = subs.subscribe(&id_b, vec!["p1".into()]);
+        assert!(new_names.is_empty());
+        assert_eq!(subs.subscribers("p1").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn duplicate_subscribe_is_idempotent() {
+        let mut subs = ParameterSubscriptions::new();
+        let id = make_identity("alice");
+
+        let _ = subs.subscribe(&id, vec!["p1".into()]);
+        let new_names = subs.subscribe(&id, vec!["p1".into()]);
+        assert!(new_names.is_empty());
+        assert_eq!(subs.subscribers("p1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn subscribe_multiple_names_at_once() {
+        let mut subs = ParameterSubscriptions::new();
+        let id = make_identity("alice");
+
+        let new_names = subs.subscribe(&id, vec!["p1".into(), "p2".into()]);
+        assert_eq!(new_names.len(), 2);
+        assert!(new_names.contains(&"p1".to_string()));
+        assert!(new_names.contains(&"p2".to_string()));
+    }
+
+    #[test]
+    fn last_unsubscriber_is_reported() {
+        let mut subs = ParameterSubscriptions::new();
+        let id = make_identity("alice");
+
+        let _ = subs.subscribe(&id, vec!["p1".into()]);
+        let old_names = subs.unsubscribe(&id, vec!["p1".into()]);
+        assert_eq!(old_names, vec!["p1".to_string()]);
+        assert!(subs.subscribers("p1").is_none());
+    }
+
+    #[test]
+    fn non_last_unsubscriber_is_not_reported() {
+        let mut subs = ParameterSubscriptions::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+
+        let _ = subs.subscribe(&id_a, vec!["p1".into()]);
+        let _ = subs.subscribe(&id_b, vec!["p1".into()]);
+        let old_names = subs.unsubscribe(&id_a, vec!["p1".into()]);
+        assert!(old_names.is_empty());
+        assert_eq!(subs.subscribers("p1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn unsubscribe_unknown_name_is_noop() {
+        let mut subs = ParameterSubscriptions::new();
+        let id = make_identity("alice");
+
+        let old_names = subs.unsubscribe(&id, vec!["missing".into()]);
+        assert!(old_names.is_empty());
+    }
+
+    #[test]
+    fn subscribers_returns_none_for_unknown() {
+        let subs = ParameterSubscriptions::new();
+        assert!(subs.subscribers("nope").is_none());
+    }
+
+    #[test]
+    fn cleanup_for_removed_identity_drops_orphaned_names() {
+        let mut subs = ParameterSubscriptions::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+
+        let _ = subs.subscribe(&id_a, vec!["p1".into(), "p2".into()]);
+        let _ = subs.subscribe(&id_b, vec!["p2".into()]);
+
+        let last = subs.cleanup_for_removed_identity(&id_a);
+        assert_eq!(last, vec!["p1".to_string()]);
+        assert!(subs.subscribers("p1").is_none());
+        assert_eq!(subs.subscribers("p2").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn cleanup_for_unknown_identity_is_noop() {
+        let mut subs = ParameterSubscriptions::new();
+        let id_a = make_identity("alice");
+        let id_b = make_identity("bob");
+
+        let _ = subs.subscribe(&id_a, vec!["p1".into()]);
+        let last = subs.cleanup_for_removed_identity(&id_b);
+        assert!(last.is_empty());
+        assert_eq!(subs.subscribers("p1").unwrap().len(), 1);
     }
 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -42,12 +42,13 @@ use crate::{
     remote_access::qos::{QosClassifier, Reliability},
     remote_access::{
         AssetHandler, Capability, Listener, RemoteAccessError,
+        channel_registry::ChannelRegistry,
         client::Client,
+        parameter_subscriptions::ParameterSubscriptions,
         participant::{Participant, ParticipantWriter},
         participant_registry::ParticipantRegistry,
         protocol_version,
         rtt_tracker::RttTracker,
-        session_state::SessionState,
     },
 };
 
@@ -139,10 +140,14 @@ pub(super) struct RemoteAccessSession {
     room: Room,
     context: Weak<Context>,
     remote_access_session_id: Option<String>,
-    /// Session-level state: channels, subscriptions, video publishers, client
-    /// channels, parameter subscriptions. Participant membership lives on
-    /// [`participant_registry`] instead.
-    state: RwLock<SessionState>,
+    /// Channel-keyed session state: channels, subscriptions, video publishers,
+    /// and inverse-indexed client-advertised channels. Participant membership
+    /// lives on [`participant_registry`]; parameter subscriptions live on
+    /// [`parameter_subscriptions`].
+    channel_registry: RwLock<ChannelRegistry>,
+    /// Parameter-name → subscriber bookkeeping. Independent lifecycle from
+    /// channel subscriptions, so it lives in its own struct.
+    parameter_subscriptions: RwLock<ParameterSubscriptions>,
     channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     qos_classifier: Option<Arc<dyn QosClassifier>>,
     listener: Option<Arc<dyn Listener>>,
@@ -202,7 +207,7 @@ impl Sink for RemoteAccessSession {
         //      ParticipantIdentity, so this can never deliver data across
         //      identities — only the same logical user across a reconnect.
         let reliable_subscribers = {
-            let state = self.state.read();
+            let state = self.channel_registry.read();
 
             // Video track publisher: stays inside the state lock since the
             // publisher handle is not cloneable out of the map.
@@ -263,7 +268,7 @@ impl Sink for RemoteAccessSession {
         let advertised_ids: std::collections::HashSet<u64> =
             advertise_msg.channels.iter().map(|ch| ch.id).collect();
         let advertised_channel_ids: SmallVec<[ChannelId; 4]> = {
-            let mut state = self.state.write();
+            let mut state = self.channel_registry.write();
             let mut ids = SmallVec::new();
             for &ch in &filtered {
                 if advertised_ids.contains(&u64::from(ch.id())) {
@@ -311,15 +316,20 @@ impl Sink for RemoteAccessSession {
 
         // Collect subscriber identities before removal; we'll resolve them to
         // `Client`s after via the registry.
-        let subscriber_identities = self.state.read().channel_subscriber_identities(&channel_id);
+        let subscriber_identities = self
+            .channel_registry
+            .read()
+            .channel_subscriber_identities(&channel_id);
 
-        if !self.state.write().remove_channel(channel_id) {
+        if !self.channel_registry.write().remove_channel(channel_id) {
             return;
         }
 
         self.teardown_video_track(channel_id);
         self.teardown_data_track(channel_id);
-        self.state.write().remove_video_schema(&channel_id);
+        self.channel_registry
+            .write()
+            .remove_video_schema(&channel_id);
 
         let unadvertise = Unadvertise::new([u64::from(channel_id)]);
         self.broadcast_control(encode_json_message(&unadvertise));
@@ -373,7 +383,8 @@ impl RemoteAccessSession {
             room: params.room,
             context: params.context,
             remote_access_session_id: params.remote_access_session_id,
-            state: RwLock::new(SessionState::new()),
+            channel_registry: RwLock::new(ChannelRegistry::new()),
+            parameter_subscriptions: RwLock::new(ParameterSubscriptions::new()),
             channel_filter: params.channel_filter,
             qos_classifier: params.qos_classifier,
             listener: params.listener,
@@ -413,7 +424,7 @@ impl RemoteAccessSession {
     }
 
     fn stats(&self) -> SessionStats {
-        let state = self.state.read();
+        let state = self.channel_registry.read();
         SessionStats {
             participants: self.participant_registry.participant_count(),
             subscriptions: state.subscription_count(),
@@ -675,7 +686,7 @@ impl RemoteAccessSession {
         let mut channel_ids = SmallVec::<[ChannelId; 4]>::new();
         let mut video_channel_ids = SmallVec::<[ChannelId; 4]>::new();
         let mut data_channel_ids = SmallVec::<[ChannelId; 4]>::new();
-        let state = self.state.read();
+        let state = self.channel_registry.read();
         for ch in &msg.channels {
             let channel_id = ChannelId::new(ch.id);
             if ch.request_video_track {
@@ -695,7 +706,7 @@ impl RemoteAccessSession {
         }
         drop(state);
 
-        let mut state = self.state.write();
+        let mut state = self.channel_registry.write();
         let subscribe_result = state.subscribe(participant.participant_id(), &channel_ids);
         let first_video_subscribed =
             state.subscribe_video(participant.participant_id(), &video_channel_ids);
@@ -741,7 +752,7 @@ impl RemoteAccessSession {
             .map(|&id| ChannelId::new(id))
             .collect();
 
-        let mut state = self.state.write();
+        let mut state = self.channel_registry.write();
         let unsubscribe_result = state.unsubscribe(participant.participant_id(), &channel_ids);
         let last_video_unsubscribed =
             state.unsubscribe_video(participant.participant_id(), &channel_ids);
@@ -835,7 +846,7 @@ impl RemoteAccessSession {
             );
 
             let inserted = self
-                .state
+                .channel_registry
                 .write()
                 .insert_client_channel(participant.participant_id(), descriptor.clone());
 
@@ -870,7 +881,7 @@ impl RemoteAccessSession {
         for channel_id_raw in msg.channel_ids {
             let channel_id = ChannelId::new(channel_id_raw.into());
             let removed = self
-                .state
+                .channel_registry
                 .write()
                 .remove_client_channel(participant.participant_id(), channel_id);
 
@@ -949,7 +960,7 @@ impl RemoteAccessSession {
         }
         let channel_id = ChannelId::new(msg.channel_id.into());
         let descriptor = {
-            let state = self.state.read();
+            let state = self.channel_registry.read();
             state
                 .get_client_channel(participant.participant_id(), channel_id)
                 .cloned()
@@ -1116,7 +1127,11 @@ impl RemoteAccessSession {
         let client_id = participant.client_id();
         let participant_id = participant.participant_id();
         let removed = self
-            .state
+            .channel_registry
+            .write()
+            .cleanup_for_removed_identity(participant_id);
+        let last_param_unsubscribed = self
+            .parameter_subscriptions
             .write()
             .cleanup_for_removed_identity(participant_id);
 
@@ -1129,9 +1144,9 @@ impl RemoteAccessSession {
 
         self.stop_video_tracks(&removed.last_video_unsubscribed);
 
-        if !removed.last_param_unsubscribed.is_empty() {
+        if !last_param_unsubscribed.is_empty() {
             if let Some(listener) = &self.listener {
-                listener.on_parameters_unsubscribe(removed.last_param_unsubscribed);
+                listener.on_parameters_unsubscribe(last_param_unsubscribed);
             }
         }
 
@@ -1612,7 +1627,7 @@ impl RemoteAccessSession {
     /// Returns the currently-cached channel advertisements encoded as a single
     /// framed control-plane message, or `None` if no channels are advertised.
     fn encode_channel_advertisements(&self) -> Option<Bytes> {
-        let state = self.state.read();
+        let state = self.channel_registry.read();
         let msg = state.with_channels(|channels| {
             let msg = advertise::advertise_channels(channels.values());
             if msg.channels.is_empty() {
@@ -1831,9 +1846,9 @@ impl RemoteAccessSession {
         }
         let _guard = self.subscription_lock.lock();
         let new_names = self
-            .state
+            .parameter_subscriptions
             .write()
-            .subscribe_parameters(participant.participant_id(), names);
+            .subscribe(participant.participant_id(), names);
         if !new_names.is_empty() {
             if let Some(listener) = &self.listener {
                 listener.on_parameters_subscribe(new_names);
@@ -1856,9 +1871,9 @@ impl RemoteAccessSession {
         }
         let _guard = self.subscription_lock.lock();
         let old_names = self
-            .state
+            .parameter_subscriptions
             .write()
-            .unsubscribe_parameters(participant.participant_id(), names);
+            .unsubscribe(participant.participant_id(), names);
         if !old_names.is_empty() {
             if let Some(listener) = &self.listener {
                 listener.on_parameters_unsubscribe(old_names);
@@ -1891,15 +1906,14 @@ impl RemoteAccessSession {
         // are released to minimize lock scope.
         let participants = self.participant_registry.collect_participants();
         let to_send: Vec<(Arc<Participant>, Bytes)> = {
-            let state = self.state.read();
+            let subs = self.parameter_subscriptions.read();
             participants
                 .into_iter()
                 .filter_map(|participant| {
                     let filtered: Vec<_> = parameters
                         .iter()
                         .filter(|p| {
-                            state
-                                .parameter_subscribers(&p.name)
+                            subs.subscribers(&p.name)
                                 .is_some_and(|ids| ids.contains(participant.participant_id()))
                         })
                         .cloned()
@@ -2011,7 +2025,7 @@ impl RemoteAccessSession {
     fn republish_video_metadata(&self, advertised: &mut HashMap<ChannelId, VideoMetadata>) {
         // Collect channels whose video metadata has changed.
         let changed: SmallVec<[ChannelId; 4]> = {
-            let state = self.state.read();
+            let state = self.channel_registry.read();
             state
                 .iter_video_publishers()
                 .filter_map(|(&channel_id, publisher)| {
@@ -2031,7 +2045,7 @@ impl RemoteAccessSession {
 
         // Update session state and build the re-advertise message.
         let advertise_msg = {
-            let mut state = self.state.write();
+            let mut state = self.channel_registry.write();
             // Only insert metadata for channels that still exist, guarding against
             // a channel being removed between the read and write locks.
             for &channel_id in &changed {
@@ -2064,7 +2078,7 @@ impl RemoteAccessSession {
     /// Caller must hold `subscription_lock`.
     fn start_video_tracks(self: &Arc<Self>, first_subscribed: &[ChannelId]) {
         let to_start: SmallVec<[(ChannelId, VideoInputSchema); 4]> = {
-            let state = self.state.read();
+            let state = self.channel_registry.read();
             first_subscribed
                 .iter()
                 .filter_map(|&channel_id| {
@@ -2083,7 +2097,7 @@ impl RemoteAccessSession {
             ));
             let expected_publisher = publisher.clone();
 
-            self.state
+            self.channel_registry
                 .write()
                 .insert_video_publisher(channel_id, publisher);
 
@@ -2115,7 +2129,7 @@ impl RemoteAccessSession {
                         // one we created. A teardown+resubscribe cycle could have
                         // replaced it with a different publisher.
                         let store = {
-                            let mut state = session.state.write();
+                            let mut state = session.channel_registry.write();
                             let is_ours = state
                                 .get_video_publisher(&channel_id)
                                 .is_some_and(|p| Arc::ptr_eq(&p, &expected_publisher));
@@ -2157,7 +2171,7 @@ impl RemoteAccessSession {
     /// Caller must hold `subscription_lock`.
     fn teardown_video_track(&self, channel_id: ChannelId) {
         let sid = {
-            let mut state = self.state.write();
+            let mut state = self.channel_registry.write();
             // Removing the publisher drops it, which closes the mpsc channel and
             // terminates the background processing task.
             state.remove_video_publisher(&channel_id);
@@ -2188,7 +2202,7 @@ impl RemoteAccessSession {
                 *channel_id,
                 self.cancellation_token.clone(),
             );
-            self.state
+            self.channel_registry
                 .write()
                 .insert_data_track(*channel_id, data_track);
         }
@@ -2196,7 +2210,7 @@ impl RemoteAccessSession {
 
     /// Tear down the data track for a channel.
     fn teardown_data_track(&self, channel_id: ChannelId) {
-        if let Some(mut data_track) = self.state.write().remove_data_track(&channel_id) {
+        if let Some(mut data_track) = self.channel_registry.write().remove_data_track(&channel_id) {
             self.runtime.spawn(async move { data_track.close().await });
         }
     }


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The SessionState struct mixed channel-keyed state (advertised channels, subscriptions, video tracks, QoS, client-advertised channels) with parameter-name-keyed subscription tracking. The two have independent lifecycles and the bundling made the struct hard to name.

Splits the parameter-subscription bookkeeping into a new ParameterSubscriptions struct (in parameter_subscriptions.rs) and renames the rest to ChannelRegistry (in channel_registry.rs). The struct's docstring is also corrected — it was previously labeled a "state machine" despite having no states or transitions.

RemoteAccessSession now holds two RwLocks (channel_registry and parameter_subscriptions) instead of one. No call site holds both at once, so there is no lock-ordering or deadlock concern.

@gasmith Take particular note, since you suggested this renaming.  I'm not 100% sure that this split is better than what we have today, so opinions definitely welcome (including: close this, we don't need it).

Part of FLE-475