### PR TITLE
python: Update remote access example to depend on v0.23.0

### DIFF
--- a/python/foxglove-sdk-examples/remote-access/main.py
+++ b/python/foxglove-sdk-examples/remote-access/main.py
@@ -28,7 +28,7 @@ class Listener(RemoteAccessListener):
     def on_connection_status_changed(
         self, status: RemoteAccessConnectionStatus
     ) -> None:
-        logging.info(f"Connection status: {status.name}")
+        logging.info(f"Connection status: {status}")
 
     def on_message_data(
         self,

--- a/python/foxglove-sdk-examples/remote-access/pyproject.toml
+++ b/python/foxglove-sdk-examples/remote-access/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Foxglove", email = "support@foxglove.dev" }]
 requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
-    "foxglove-sdk>=0.21.0",
+    "foxglove-sdk>=0.23.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Update the python remote access example to use the latest SDK release.

Also fix an AttributeError in the example.

### Testing
`uv run main.py`

### Links
Fixes: FLE-470