### PR TITLE
remote access: don't publish data tracks for video channels

### DIFF
--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -287,7 +287,7 @@ impl Sink for RemoteAccessSession {
                         qos.reliability = Reliability::Lossy;
                     }
                     state.insert_qos_profile(ch.id(), qos);
-                    if qos.reliability != Reliability::Reliable {
+                    if qos.reliability != Reliability::Reliable && video_schema.is_none() {
                         ids.push(ch.id());
                     }
                 }

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -650,6 +650,35 @@ impl ViewerConnection {
         }
     }
 
+    /// Asserts that no data track named `data-ch-{channel_id}` has been published.
+    ///
+    /// Drains any in-flight `DataTrackPublished` events for a short window into
+    /// [`pending_data_tracks`](Self::pending_data_tracks), then asserts that none of
+    /// the buffered tracks match the expected name. Use this after eagerly-published
+    /// data tracks for other channels have already been received, so that any
+    /// simultaneously-published track for `channel_id` would also have arrived.
+    pub async fn assert_no_data_track_for_channel(&mut self, channel_id: u64) {
+        let expected_name = format!("data-ch-{channel_id}");
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(300);
+        loop {
+            match tokio::time::timeout_at(deadline, self.events.recv()).await {
+                Err(_) | Ok(None) => break,
+                Ok(Some(RoomEvent::DataTrackPublished(track))) => {
+                    self.pending_data_tracks.push(track);
+                }
+                Ok(Some(_)) => continue,
+            }
+        }
+        assert!(
+            !self
+                .pending_data_tracks
+                .iter()
+                .any(|t| t.info().name() == expected_name),
+            "unexpected data track published for channel {channel_id}: \
+             video-capable channels must not get a data track"
+        );
+    }
+
     /// Reads and returns the next ConnectionGraphUpdate message.
     pub async fn expect_connection_graph_update(
         &mut self,

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -473,6 +473,10 @@ async fn livekit_video_channel_messages_bypass_data_plane() -> Result<()> {
     // Wait for the JSON channel's data track to be ready.
     viewer.ensure_device_data_track(json_id).await?;
 
+    // The video channel must never get an eagerly-published data track; its
+    // frames are routed through WebRTC video tracks, not the data plane.
+    viewer.assert_no_data_track_for_channel(video_id).await;
+
     // Log to the video channel first, then the JSON channel.
     // If the video message leaked to the data plane, it would arrive before
     // the JSON message (FIFO ordering).


### PR DESCRIPTION
Fixes: [FLE-503](https://linear.app/foxglove/issue/FLE-503)