### PR TITLE
foxglove_bridge: Disable remote access for glibc<2.35

### DIFF
--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -247,10 +247,9 @@ install(TARGETS foxglove_bridge_component
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
-# Install the SDK shared libraries alongside the bridge component library so
-# the runtime linker can find them via RPATH ($ORIGIN). When remote access is
-# disabled, foxglove-shared is statically linked into foxglove_cpp_shared and
-# does not need to be installed.
+# Install the SDK shared library alongside the bridge component library so the
+# runtime linker can find it via RPATH ($ORIGIN). Not needed when remote access
+# is disabled, since the SDK is statically linked into foxglove_cpp_shared.
 install(FILES $<TARGET_FILE:foxglove_cpp_shared> DESTINATION lib)
 if (FOXGLOVE_BRIDGE_REMOTE_ACCESS)
   install(FILES $<TARGET_FILE:foxglove-shared> DESTINATION lib)

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -19,7 +19,26 @@ if (POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
 
-option(FOXGLOVE_BRIDGE_REMOTE_ACCESS "Build with remote access gateway support" ON)
+# Remote access requires glibc >= 2.35 on Linux.
+set(_remote_access_default ON)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  execute_process(
+    COMMAND getconf GNU_LIBC_VERSION
+    OUTPUT_VARIABLE _glibc_version_output
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE _glibc_result
+  )
+  if(_glibc_result EQUAL 0 AND _glibc_version_output MATCHES "glibc ([0-9]+)\\.([0-9]+)")
+    set(_glibc_major ${CMAKE_MATCH_1})
+    set(_glibc_minor ${CMAKE_MATCH_2})
+    if(_glibc_major LESS 2 OR (_glibc_major EQUAL 2 AND _glibc_minor LESS 35))
+      message(STATUS "Detected glibc ${_glibc_major}.${_glibc_minor} (< 2.35); defaulting FOXGLOVE_BRIDGE_REMOTE_ACCESS to OFF")
+      set(_remote_access_default OFF)
+    endif()
+  endif()
+endif()
+option(FOXGLOVE_BRIDGE_REMOTE_ACCESS "Build with remote access gateway support" ${_remote_access_default})
 
 macro(enable_strict_compiler_warnings target)
   if (MSVC)
@@ -76,6 +95,10 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(foxglove_sdk)
 file(GLOB_RECURSE FOXGLOVE_SDK_SOURCES CONFIGURE_DEPENDS "${foxglove_sdk_SOURCE_DIR}/src/*.cpp")
+# Exclude remote access sources when remote access is disabled.
+if (NOT FOXGLOVE_BRIDGE_REMOTE_ACCESS)
+  list(FILTER FOXGLOVE_SDK_SOURCES EXCLUDE REGEX ".*remote_access\\.cpp$")
+endif()
 
 add_library(foxglove_cpp_shared SHARED)
 target_include_directories(foxglove_cpp_shared SYSTEM
@@ -84,11 +107,18 @@ target_include_directories(foxglove_cpp_shared SYSTEM
     $<INSTALL_INTERFACE:include>
 )
 target_sources(foxglove_cpp_shared PRIVATE ${FOXGLOVE_SDK_SOURCES})
-# Import the prebuilt C shared library from the fetched SDK
-add_library(foxglove-shared SHARED IMPORTED)
-set_target_properties(foxglove-shared PROPERTIES
-  IMPORTED_LOCATION ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.so
-)
+# Import the prebuilt C library from the fetched SDK.
+if (FOXGLOVE_BRIDGE_REMOTE_ACCESS)
+  add_library(foxglove-shared SHARED IMPORTED)
+  set_target_properties(foxglove-shared PROPERTIES
+    IMPORTED_LOCATION ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.so
+  )
+else()
+  add_library(foxglove-shared STATIC IMPORTED)
+  set_target_properties(foxglove-shared PROPERTIES
+    IMPORTED_LOCATION ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.a
+  )
+endif()
 target_link_libraries(foxglove_cpp_shared PRIVATE foxglove-shared)
 set_target_properties(foxglove_cpp_shared PROPERTIES
   INSTALL_RPATH "$ORIGIN"
@@ -218,9 +248,13 @@ install(TARGETS foxglove_bridge_component
   RUNTIME DESTINATION bin
 )
 # Install the SDK shared libraries alongside the bridge component library so
-# the runtime linker can find them via RPATH ($ORIGIN).
+# the runtime linker can find them via RPATH ($ORIGIN). When remote access is
+# disabled, foxglove-shared is statically linked into foxglove_cpp_shared and
+# does not need to be installed.
 install(FILES $<TARGET_FILE:foxglove_cpp_shared> DESTINATION lib)
-install(FILES $<TARGET_FILE:foxglove-shared> DESTINATION lib)
+if (FOXGLOVE_BRIDGE_REMOTE_ACCESS)
+  install(FILES $<TARGET_FILE:foxglove-shared> DESTINATION lib)
+endif()
 install(TARGETS foxglove_bridge
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -19,9 +19,13 @@ if (POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
 
-# Remote access requires glibc >= 2.35 on Linux.
-set(_remote_access_default ON)
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+# Remote access requires glibc >= 2.35 on Linux. Detect the build host's glibc
+# (when not cross-compiling) so we can lower the default to OFF on older
+# systems and warn if the user pins it ON.
+set(_glibc_detected FALSE)
+set(_glibc_too_old FALSE)
+set(_glibc_version "")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT CMAKE_CROSSCOMPILING)
   execute_process(
     COMMAND getconf GNU_LIBC_VERSION
     OUTPUT_VARIABLE _glibc_version_output
@@ -32,13 +36,28 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   if(_glibc_result EQUAL 0 AND _glibc_version_output MATCHES "glibc ([0-9]+)\\.([0-9]+)")
     set(_glibc_major ${CMAKE_MATCH_1})
     set(_glibc_minor ${CMAKE_MATCH_2})
+    set(_glibc_detected TRUE)
+    set(_glibc_version "${_glibc_major}.${_glibc_minor}")
     if(_glibc_major LESS 2 OR (_glibc_major EQUAL 2 AND _glibc_minor LESS 35))
-      message(STATUS "Detected glibc ${_glibc_major}.${_glibc_minor} (< 2.35); defaulting FOXGLOVE_BRIDGE_REMOTE_ACCESS to OFF")
-      set(_remote_access_default OFF)
+      set(_glibc_too_old TRUE)
     endif()
   endif()
 endif()
+
+set(_remote_access_default ON)
+if(NOT DEFINED CACHE{FOXGLOVE_BRIDGE_REMOTE_ACCESS})
+  if(_glibc_too_old)
+    message(STATUS "Detected glibc ${_glibc_version} (< 2.35); defaulting FOXGLOVE_BRIDGE_REMOTE_ACCESS to OFF")
+    set(_remote_access_default OFF)
+  elseif(NOT _glibc_detected)
+    message(STATUS "Could not detect glibc version, defaulting FOXGLOVE_BRIDGE_REMOTE_ACCESS to ON")
+  endif()
+endif()
 option(FOXGLOVE_BRIDGE_REMOTE_ACCESS "Build with remote access gateway support" ${_remote_access_default})
+
+if(FOXGLOVE_BRIDGE_REMOTE_ACCESS AND _glibc_too_old)
+  message(WARNING "FOXGLOVE_BRIDGE_REMOTE_ACCESS=ON but build host has glibc ${_glibc_version} (< 2.35); the link step is likely to fail.")
+endif()
 
 macro(enable_strict_compiler_warnings target)
   if (MSVC)


### PR DESCRIPTION
### Changelog
- foxglove_bridge: Disable remote access for platforms with glibc<2.35

### Docs
None

### Description
Apparently the ROS build farm also builds the bridge for RHEL9, which
has glibc 2.34, and is not compatible with the remote-access-enabled
builds of the SDK.

This change updates the CMakeLists.txt for the bridge to introspect the
version of glibc and use that as the basis for choosing the default
value for the FOXGLOVE_BRIDGE_REMOTE_ACCESS option. When remote access
is disabled, we link the bridge against the staticlib.

### Links
Fixes: FLE-507

### Testing
- Built the bridge in a rockylinux:9 container against ROS jazzy,
  validated that the build shows the "Detected glibc 2.34..." message,
  and builds successfully against libfoxglove.a.
- Built the bridge in the foxglove-sdk-ros-humble container without
  specifying FOXGLOVE_BRIDGE_REMOTE_ACCESS, validated that the default
  value is ON, and that the bridge links against libfoxglove.so.