### PR TITLE
require video frames to be at least 16x16 (H.264 minimum)

### DIFF
--- a/rust/foxglove/src/remote_access/session/video_track.rs
+++ b/rust/foxglove/src/remote_access/session/video_track.rs
@@ -243,19 +243,7 @@ fn transcode_and_publish(
         .probe_dimensions()
         .map_err(VideoEncodeError::YuvConversion)?;
 
-    // Ensure even dimensions for YUV 4:2:0
-    let width = width & !1;
-    let height = height & !1;
-    if width == 0 || height == 0 {
-        return Err(VideoEncodeError::YuvConversion(
-            crate::img2yuv::Error::ZeroSized,
-        ));
-    }
-
-    // Reject frames smaller than one H.264/VP8/VP9 macroblock. See `MIN_VIDEO_DIMENSION`.
-    if width < MIN_VIDEO_DIMENSION || height < MIN_VIDEO_DIMENSION {
-        return Err(VideoEncodeError::TooSmall { width, height });
-    }
+    let (width, height) = validate_frame_dimensions(width, height)?;
 
     // Transcode to YUV 4:2:0.
     let mut buffer = I420Yuv420(I420Buffer::new(width, height));
@@ -279,6 +267,25 @@ fn transcode_and_publish(
     };
     video_source.capture_frame(&frame);
     Ok(metadata)
+}
+
+/// Validates and normalizes frame dimensions for video encoding.
+///
+/// Aligns dimensions to even values (required for YUV 4:2:0) and rejects frames that are
+/// too small for the encoder's macroblock size. Returns the even-aligned (width, height) on
+/// success.
+fn validate_frame_dimensions(width: u32, height: u32) -> Result<(u32, u32), VideoEncodeError> {
+    let even_width = width & !1;
+    let even_height = height & !1;
+    if even_width == 0 || even_height == 0 {
+        return Err(VideoEncodeError::YuvConversion(
+            crate::img2yuv::Error::ZeroSized,
+        ));
+    }
+    if even_width < MIN_VIDEO_DIMENSION || even_height < MIN_VIDEO_DIMENSION {
+        return Err(VideoEncodeError::TooSmall { width, height });
+    }
+    Ok((even_width, even_height))
 }
 
 /// Decode raw message bytes into an [`ImageMessage`] based on the input schema.
@@ -384,5 +391,84 @@ mod tests {
     fn test_unknown_schema() {
         assert_eq!(detect_video_schema("json", "SomeCustomType"), None);
         assert_eq!(detect_video_schema("protobuf", "foxglove.Pose"), None);
+    }
+
+    #[test]
+    fn validate_frame_dimensions_rejects_too_small() {
+        // Both axes below minimum
+        let err = validate_frame_dimensions(15, 15).unwrap_err();
+        assert!(matches!(
+            err,
+            VideoEncodeError::TooSmall {
+                width: 15,
+                height: 15
+            }
+        ));
+
+        // Width below minimum, height at minimum
+        let err = validate_frame_dimensions(15, 16).unwrap_err();
+        assert!(matches!(
+            err,
+            VideoEncodeError::TooSmall {
+                width: 15,
+                height: 16
+            }
+        ));
+
+        // Height below minimum, width at minimum
+        let err = validate_frame_dimensions(16, 15).unwrap_err();
+        assert!(matches!(
+            err,
+            VideoEncodeError::TooSmall {
+                width: 16,
+                height: 15
+            }
+        ));
+
+        // Odd dimension that rounds down below minimum (17 & !1 == 16, but 15 & !1 == 14)
+        let err = validate_frame_dimensions(15, 17).unwrap_err();
+        assert!(matches!(
+            err,
+            VideoEncodeError::TooSmall {
+                width: 15,
+                height: 17
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_frame_dimensions_accepts_at_minimum() {
+        // Exactly at the minimum boundary
+        assert_eq!(validate_frame_dimensions(16, 16).unwrap(), (16, 16));
+
+        // Just above minimum (odd values get even-aligned down)
+        assert_eq!(validate_frame_dimensions(17, 17).unwrap(), (16, 16));
+
+        // Larger values
+        assert_eq!(validate_frame_dimensions(1920, 1080).unwrap(), (1920, 1080));
+    }
+
+    #[test]
+    fn validate_frame_dimensions_rejects_zero_after_alignment() {
+        // A 1×1 image rounds to 0×0
+        let err = validate_frame_dimensions(1, 1).unwrap_err();
+        assert!(matches!(
+            err,
+            VideoEncodeError::YuvConversion(crate::img2yuv::Error::ZeroSized)
+        ));
+
+        // Width 0
+        let err = validate_frame_dimensions(0, 16).unwrap_err();
+        assert!(matches!(
+            err,
+            VideoEncodeError::YuvConversion(crate::img2yuv::Error::ZeroSized)
+        ));
+
+        // Height 0
+        let err = validate_frame_dimensions(16, 0).unwrap_err();
+        assert!(matches!(
+            err,
+            VideoEncodeError::YuvConversion(crate::img2yuv::Error::ZeroSized)
+        ));
     }
 }

--- a/rust/foxglove/src/remote_access/session/video_track.rs
+++ b/rust/foxglove/src/remote_access/session/video_track.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use arc_swap::ArcSwapOption;
 use bytes::Bytes;
@@ -9,6 +10,20 @@ use tracing::{debug, error, warn};
 
 use crate::RawChannel;
 use crate::img2yuv::{ImageEncoding, ImageMessage, Yuv420Buffer};
+use crate::throttler::Throttler;
+
+/// Minimum width and height (in pixels) that we will hand to the libwebrtc video encoder.
+///
+/// H.264, VP8, and VP9 all encode in 16×16 macroblocks. Some encoder backends — notably
+/// `libwebrtc`'s VAAPI H.264 encoder on Linux — do not validate this and can write out of
+/// bounds when given sub-macroblock frames, which manifests as heap corruption later in
+/// the process. Other backends (e.g. OpenH264) reject the frame but continue running.
+/// Enforcing this minimum on our side guarantees safe behavior regardless of the codec
+/// backend selected by libwebrtc.
+const MIN_VIDEO_DIMENSION: u32 = 16;
+
+/// Interval between throttled warnings for repeatedly-too-small frames on a single track.
+const TOO_SMALL_WARN_INTERVAL: Duration = Duration::from_secs(30);
 
 /// The input schema type for a video-capable channel.
 ///
@@ -99,6 +114,10 @@ enum VideoEncodeError {
     Decode(String),
     #[error("failed to convert image to YUV420: {0}")]
     YuvConversion(#[from] crate::img2yuv::Error),
+    #[error(
+        "frame {width}x{height} is below the minimum encoder size {MIN_VIDEO_DIMENSION}x{MIN_VIDEO_DIMENSION}"
+    )]
+    TooSmall { width: u32, height: u32 },
 }
 
 /// Publishes video frames to a LiveKit video track.
@@ -135,6 +154,9 @@ impl VideoPublisher {
         let task_metadata = metadata.clone();
         tokio::spawn(async move {
             let mut last_metadata: Option<VideoMetadata> = None;
+            // Throttles `TooSmall` warnings so a stream of undersized frames doesn't
+            // flood the log; other encode errors stay at debug level and are unthrottled.
+            let mut too_small_throttler = Throttler::new(TOO_SMALL_WARN_INTERVAL);
             while let Ok((data, log_time_ns)) = consumer_rx.recv_async().await {
                 let source = source.clone();
                 let result = tokio::task::spawn_blocking(move || {
@@ -147,6 +169,13 @@ impl VideoPublisher {
                             last_metadata = Some(new_metadata.clone());
                             task_metadata.store(Some(Arc::new(new_metadata)));
                             video_metadata_tx.send_modify(|_| {});
+                        }
+                    }
+                    Ok(Err(VideoEncodeError::TooSmall { width, height })) => {
+                        if too_small_throttler.try_acquire() {
+                            warn!(
+                                "video frame {width}x{height} is below the minimum encoder size {MIN_VIDEO_DIMENSION}x{MIN_VIDEO_DIMENSION}; dropping frame"
+                            );
                         }
                     }
                     Ok(Err(e)) => {
@@ -221,6 +250,11 @@ fn transcode_and_publish(
         return Err(VideoEncodeError::YuvConversion(
             crate::img2yuv::Error::ZeroSized,
         ));
+    }
+
+    // Reject frames smaller than one H.264/VP8/VP9 macroblock. See `MIN_VIDEO_DIMENSION`.
+    if width < MIN_VIDEO_DIMENSION || height < MIN_VIDEO_DIMENSION {
+        return Err(VideoEncodeError::TooSmall { width, height });
     }
 
     // Transcode to YUV 4:2:0.

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -804,10 +804,13 @@ async fn livekit_request_video_track_on_non_video_channel_sends_error() -> Resul
     Ok(())
 }
 
-/// Encode a 4x4 rgb8 `foxglove.RawImage` as protobuf bytes.
+/// Encode a 16x16 rgb8 `foxglove.RawImage` as protobuf bytes.
+///
+/// 16x16 is the minimum dimension accepted by the SDK's video encoder pipeline (one
+/// H.264/VP8/VP9 macroblock); smaller frames are dropped with a throttled warning.
 fn encode_raw_image(frame_id: &str) -> Vec<u8> {
-    let width: u32 = 4;
-    let height: u32 = 4;
+    let width: u32 = 16;
+    let height: u32 = 16;
     let step = width * 3; // rgb8: 3 bytes per pixel
     let data = vec![128u8; (step * height) as usize];
     let msg = RawImage {


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

H.264 uses macroblocks of 16x16 for inter-frame prediction. It doesn't support video smaller than one macroblock, and attempting to encode smaller video frames might cause problems with hardware accelerated libraries like LIBVA.

I thought this might be the cause of the crash in FLE-501, but it's not. Still it seems reasonable to enforce a minimum size and warn the user if they go below that.

Fixes: [FLE-508](https://linear.app/foxglove/issue/FLE-508)