### PR TITLE
Add unit test for reset_participant write-failure recovery path

### DIFF
--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -331,11 +331,14 @@ pub(super) fn test_sid(label: &str) -> ParticipantSid {
 pub(super) struct TestByteStreamWriter {
     writes: parking_lot::Mutex<Vec<Bytes>>,
     always_fail_writes: std::sync::atomic::AtomicBool,
+    attempted_writes: std::sync::atomic::AtomicUsize,
 }
 
 #[cfg(test)]
 impl TestByteStreamWriter {
     fn record(&self, data: &[u8]) -> Result<()> {
+        self.attempted_writes
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         if self
             .always_fail_writes
             .load(std::sync::atomic::Ordering::Relaxed)
@@ -359,5 +362,11 @@ impl TestByteStreamWriter {
     pub(super) fn set_always_fail_writes(&self, fail: bool) {
         self.always_fail_writes
             .store(fail, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn attempted_writes(&self) -> usize {
+        self.attempted_writes
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -336,7 +336,10 @@ pub(super) struct TestByteStreamWriter {
 #[cfg(test)]
 impl TestByteStreamWriter {
     fn record(&self, data: &[u8]) -> Result<()> {
-        if self.always_fail_writes.load(std::sync::atomic::Ordering::Relaxed) {
+        if self
+            .always_fail_writes
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
             return Err(Box::new(RemoteAccessError::Io(std::io::Error::new(
                 std::io::ErrorKind::BrokenPipe,
                 "simulated write failure",

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -313,10 +313,7 @@ impl ParticipantWriter {
         match self {
             ParticipantWriter::Livekit(stream) => stream.write(bytes).await.map_err(|e| e.into()),
             #[cfg(test)]
-            ParticipantWriter::Test(writer) => {
-                writer.record(bytes);
-                Ok(())
-            }
+            ParticipantWriter::Test(writer) => writer.record(bytes),
         }
     }
 }
@@ -333,16 +330,31 @@ pub(super) fn test_sid(label: &str) -> ParticipantSid {
 #[derive(Default)]
 pub(super) struct TestByteStreamWriter {
     writes: parking_lot::Mutex<Vec<Bytes>>,
+    fail_writes: std::sync::atomic::AtomicBool,
 }
 
 #[cfg(test)]
 impl TestByteStreamWriter {
-    fn record(&self, data: &[u8]) {
+    fn record(&self, data: &[u8]) -> Result<()> {
+        if self.fail_writes.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(Box::new(RemoteAccessError::Io(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "simulated write failure",
+            ))));
+        }
         self.writes.lock().push(Bytes::copy_from_slice(data));
+        Ok(())
     }
 
     #[allow(dead_code)]
     pub(super) fn writes(&self) -> Vec<Bytes> {
         std::mem::take(&mut self.writes.lock())
+    }
+
+    /// Configure the writer to return errors on all subsequent writes.
+    #[allow(dead_code)]
+    pub(super) fn set_fail_writes(&self, fail: bool) {
+        self.fail_writes
+            .store(fail, std::sync::atomic::Ordering::Relaxed);
     }
 }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -353,7 +353,7 @@ impl TestByteStreamWriter {
 
     /// Configure the writer to return errors on all subsequent writes.
     #[allow(dead_code)]
-    pub(super) fn set_fail_writes(&self, fail: bool) {
+    pub(super) fn set_always_fail_writes(&self, fail: bool) {
         self.fail_writes
             .store(fail, std::sync::atomic::Ordering::Relaxed);
     }

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -330,13 +330,13 @@ pub(super) fn test_sid(label: &str) -> ParticipantSid {
 #[derive(Default)]
 pub(super) struct TestByteStreamWriter {
     writes: parking_lot::Mutex<Vec<Bytes>>,
-    fail_writes: std::sync::atomic::AtomicBool,
+    always_fail_writes: std::sync::atomic::AtomicBool,
 }
 
 #[cfg(test)]
 impl TestByteStreamWriter {
     fn record(&self, data: &[u8]) -> Result<()> {
-        if self.fail_writes.load(std::sync::atomic::Ordering::Relaxed) {
+        if self.always_fail_writes.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(Box::new(RemoteAccessError::Io(std::io::Error::new(
                 std::io::ErrorKind::BrokenPipe,
                 "simulated write failure",
@@ -354,7 +354,7 @@ impl TestByteStreamWriter {
     /// Configure the writer to return errors on all subsequent writes.
     #[allow(dead_code)]
     pub(super) fn set_always_fail_writes(&self, fail: bool) {
-        self.fail_writes
+        self.always_fail_writes
             .store(fail, std::sync::atomic::Ordering::Relaxed);
     }
 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2649,10 +2649,17 @@ mod tests {
 
         // The flush-task should exit after the write error.
         let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
-        assert!(result.is_ok(), "flush-task did not exit after write failure");
+        assert!(
+            result.is_ok(),
+            "flush-task did not exit after write failure"
+        );
 
         let resets: Vec<_> = pending_resets.lock().drain().collect();
-        assert_eq!(resets, vec![sid], "write failure should populate pending_resets");
+        assert_eq!(
+            resets,
+            vec![sid],
+            "write failure should populate pending_resets"
+        );
     }
 
     fn make_test_participant(queue_size: usize) -> (Participant, flume::Receiver<Bytes>) {

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2661,9 +2661,9 @@ mod tests {
             "write failure should populate pending_resets"
         );
 
-        // Confirm this was the write-failure path, not queue-overflow. Queue
-        // overflow cancels the participant via a child token; write failure
-        // does not.
+        // Confirm this was the write-failure path, not queue-overflow.
+        // Queue overflow fires `Participant::cancel` via `send_control`;
+        // write failure does not.
         assert!(
             !cancel.is_cancelled(),
             "cancel token should not fire on write-failure path"

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2620,6 +2620,41 @@ mod tests {
         assert_eq!(writer_a.writes(), vec![Bytes::from_static(b"msg_a")]);
     }
 
+    #[tokio::test]
+    async fn flush_task_write_failure_triggers_pending_reset() {
+        use crate::remote_access::participant::{
+            ParticipantWriter, TestByteStreamWriter, test_sid,
+        };
+
+        let cancel = CancellationToken::new();
+        let writer = Arc::new(TestByteStreamWriter::default());
+        writer.set_fail_writes(true);
+
+        let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
+        let sid = test_sid("write-fail");
+
+        let (participant, handle) = Participant::spawn(
+            ParticipantIdentity("test-viewer".to_string()),
+            sid.clone(),
+            0,
+            ParticipantWriter::Test(writer),
+            DEFAULT_MESSAGE_BACKLOG_SIZE,
+            pending_resets.clone(),
+            reset_notify.clone(),
+            &cancel,
+        );
+
+        participant.send_control(Bytes::from_static(b"trigger failure"));
+
+        // The flush-task should exit after the write error.
+        let result = tokio::time::timeout(Duration::from_secs(1), handle).await;
+        assert!(result.is_ok(), "flush-task did not exit after write failure");
+
+        let resets: Vec<_> = pending_resets.lock().drain().collect();
+        assert_eq!(resets, vec![sid], "write failure should populate pending_resets");
+    }
+
     fn make_test_participant(queue_size: usize) -> (Participant, flume::Receiver<Bytes>) {
         let (tx, rx) = flume::bounded::<Bytes>(queue_size);
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2634,6 +2634,7 @@ mod tests {
         let reset_notify = Arc::new(tokio::sync::Notify::new());
         let sid = test_sid("write-fail");
 
+        let writer_ref = writer.clone();
         let (participant, handle) = Participant::spawn(
             ParticipantIdentity("test-viewer".to_string()),
             sid.clone(),
@@ -2661,12 +2662,12 @@ mod tests {
             "write failure should populate pending_resets"
         );
 
-        // Confirm this was the write-failure path, not queue-overflow.
-        // Queue overflow fires `Participant::cancel` via `send_control`;
-        // write failure does not.
-        assert!(
-            !cancel.is_cancelled(),
-            "cancel token should not fire on write-failure path"
+        // Confirm the flush task actually attempted a write (proving the
+        // reset came from the write-failure path, not queue overflow).
+        assert_eq!(
+            writer_ref.attempted_writes(),
+            1,
+            "flush task should have attempted exactly one write"
         );
     }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2628,7 +2628,7 @@ mod tests {
 
         let cancel = CancellationToken::new();
         let writer = Arc::new(TestByteStreamWriter::default());
-        writer.set_fail_writes(true);
+        writer.set_always_fail_writes(true);
 
         let pending_resets = Arc::new(parking_lot::Mutex::new(HashSet::new()));
         let reset_notify = Arc::new(tokio::sync::Notify::new());
@@ -2659,6 +2659,14 @@ mod tests {
             resets,
             vec![sid],
             "write failure should populate pending_resets"
+        );
+
+        // Confirm this was the write-failure path, not queue-overflow. Queue
+        // overflow cancels the participant via a child token; write failure
+        // does not.
+        assert!(
+            !cancel.is_cancelled(),
+            "cancel token should not fire on write-failure path"
         );
     }
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Add a unit test for the `reset_participant` write-failure recovery path (FLE-364 / PR #1102).

**Problem:** `DataChannel::send()` buffers into SCTP and returns `Ok(())` synchronously, so network-level impairment (netem, packet loss) cannot trigger a byte stream write failure in integration tests. The write-failure recovery path in `reset_participant` needs a unit test that can inject errors directly.

**Approach:** Add a `set_always_fail_writes` mode to `TestByteStreamWriter` so the flush-task's write call returns a `BrokenPipe` error. The new `flush_task_write_failure_triggers_pending_reset` test verifies that a write failure correctly populates `pending_resets` with the participant's SID and confirms the cancellation token was NOT fired (distinguishing write-failure from queue-overflow).

**Changes:**
- `TestByteStreamWriter::set_always_fail_writes(true)` — configures the mock to return `BrokenPipe` errors on all subsequent writes
- `TestByteStreamWriter::record()` now returns `Result<()>` (was infallible)
- `ParticipantWriter::Test` propagates the error to the flush-task
- New test: `flush_task_write_failure_triggers_pending_reset`

Fixes: [FLE-517](https://linear.app/foxglove/issue/FLE-517)
