### PR TITLE
Series of small cmake cleanups

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -235,7 +235,6 @@ endif()
 
 # Generated code (excluded from clang-tidy)
 set(foxglove_generated_srcs
-    "foxglove/include/foxglove/messages.hpp"
     "foxglove/src/messages.cpp"
 )
 add_library(foxglove_generated_obj OBJECT "${foxglove_generated_srcs}")
@@ -252,33 +251,9 @@ target_link_options(foxglove_generated_obj PRIVATE ${SANITIZER_LINK_OPTIONS})
 
 # Hand-written C++ code. Enumerated explicitly rather than globbed so that
 # adding or renaming a source forces a corresponding update here.
-# messages.{hpp,cpp} live in foxglove_generated_obj; remote_access.{hpp,cpp}
-# live in foxglove_ra_cpp_obj.
+# messages.cpp lives in foxglove_generated_obj; remote_access.cpp lives in
+# foxglove_ra_cpp_obj.
 set(foxglove_cpp_srcs
-    foxglove/include/foxglove/arena.hpp
-    foxglove/include/foxglove/channel.hpp
-    foxglove/include/foxglove/connection_graph.hpp
-    foxglove/include/foxglove/context.hpp
-    foxglove/include/foxglove/error.hpp
-    foxglove/include/foxglove/expected.hpp
-    foxglove/include/foxglove/fetch_asset.hpp
-    foxglove/include/foxglove/foxglove.hpp
-    foxglove/include/foxglove/mcap.hpp
-    foxglove/include/foxglove/parameter.hpp
-    foxglove/include/foxglove/playback_control_request.hpp
-    foxglove/include/foxglove/playback_state.hpp
-    foxglove/include/foxglove/remote_data_loader_backend.hpp
-    foxglove/include/foxglove/schema.hpp
-    foxglove/include/foxglove/schemas.hpp
-    foxglove/include/foxglove/server.hpp
-    foxglove/include/foxglove/server/connection_graph.hpp
-    foxglove/include/foxglove/server/fetch_asset.hpp
-    foxglove/include/foxglove/server/parameter.hpp
-    foxglove/include/foxglove/server/service.hpp
-    foxglove/include/foxglove/service.hpp
-    foxglove/include/foxglove/system_info.hpp
-    foxglove/include/foxglove/websocket.hpp
-    foxglove/src/mcap_internal.hpp
     foxglove/src/channel.cpp
     foxglove/src/connection_graph.cpp
     foxglove/src/context.cpp
@@ -347,7 +322,6 @@ endforeach()
 
 if(FOXGLOVE_REMOTE_ACCESS)
   add_library(foxglove_ra_cpp_obj OBJECT
-    "foxglove/include/foxglove/remote_access.hpp"
     "foxglove/src/remote_access.cpp"
   )
   set_property(TARGET foxglove_ra_cpp_obj PROPERTY POSITION_INDEPENDENT_CODE True)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -234,10 +234,7 @@ endif()
 ### C++
 
 # Generated code (excluded from clang-tidy)
-set(foxglove_generated_srcs
-    "foxglove/src/messages.cpp"
-)
-add_library(foxglove_generated_obj OBJECT "${foxglove_generated_srcs}")
+add_library(foxglove_generated_obj OBJECT "foxglove/src/messages.cpp")
 set_property(TARGET foxglove_generated_obj PROPERTY POSITION_INDEPENDENT_CODE True)
 set_property(TARGET foxglove_generated_obj PROPERTY CXX_STANDARD 17)
 set_property(TARGET foxglove_generated_obj PROPERTY CXX_STANDARD_REQUIRED True)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -250,17 +250,46 @@ target_include_directories(foxglove_generated_obj PRIVATE
 target_compile_options(foxglove_generated_obj PRIVATE ${SANITIZER_COMPILE_OPTIONS} ${STRICT_COMPILE_OPTIONS})
 target_link_options(foxglove_generated_obj PRIVATE ${SANITIZER_LINK_OPTIONS})
 
-# Hand-written C++ code
-file(GLOB_RECURSE foxglove_cpp_srcs CONFIGURE_DEPENDS
-    "foxglove/include/*.hpp"
-    "foxglove/src/*.hpp"
-    "foxglove/src/*.cpp"
-)
-list(REMOVE_ITEM foxglove_cpp_srcs
-    "${CMAKE_CURRENT_SOURCE_DIR}/foxglove/include/foxglove/messages.hpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/foxglove/src/messages.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/foxglove/include/foxglove/remote_access.hpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/foxglove/src/remote_access.cpp"
+# Hand-written C++ code. Enumerated explicitly rather than globbed so that
+# adding or renaming a source forces a corresponding update here.
+# messages.{hpp,cpp} live in foxglove_generated_obj; remote_access.{hpp,cpp}
+# live in foxglove_ra_cpp_obj.
+set(foxglove_cpp_srcs
+    foxglove/include/foxglove/arena.hpp
+    foxglove/include/foxglove/channel.hpp
+    foxglove/include/foxglove/connection_graph.hpp
+    foxglove/include/foxglove/context.hpp
+    foxglove/include/foxglove/error.hpp
+    foxglove/include/foxglove/expected.hpp
+    foxglove/include/foxglove/fetch_asset.hpp
+    foxglove/include/foxglove/foxglove.hpp
+    foxglove/include/foxglove/mcap.hpp
+    foxglove/include/foxglove/parameter.hpp
+    foxglove/include/foxglove/playback_control_request.hpp
+    foxglove/include/foxglove/playback_state.hpp
+    foxglove/include/foxglove/remote_data_loader_backend.hpp
+    foxglove/include/foxglove/schema.hpp
+    foxglove/include/foxglove/schemas.hpp
+    foxglove/include/foxglove/server.hpp
+    foxglove/include/foxglove/server/connection_graph.hpp
+    foxglove/include/foxglove/server/fetch_asset.hpp
+    foxglove/include/foxglove/server/parameter.hpp
+    foxglove/include/foxglove/server/service.hpp
+    foxglove/include/foxglove/service.hpp
+    foxglove/include/foxglove/system_info.hpp
+    foxglove/include/foxglove/websocket.hpp
+    foxglove/src/mcap_internal.hpp
+    foxglove/src/channel.cpp
+    foxglove/src/connection_graph.cpp
+    foxglove/src/context.cpp
+    foxglove/src/error.cpp
+    foxglove/src/fetch_asset.cpp
+    foxglove/src/foxglove.cpp
+    foxglove/src/mcap.cpp
+    foxglove/src/parameter.cpp
+    foxglove/src/service.cpp
+    foxglove/src/system_info.cpp
+    foxglove/src/websocket.cpp
 )
 
 add_library(foxglove_cpp_obj OBJECT "${foxglove_cpp_srcs}")

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -113,10 +113,25 @@ FetchContent_Declare(
   URL_HASH SHA256=${FOXGLOVE_SDK_SHA}
 )
 FetchContent_MakeAvailable(foxglove_sdk)
-file(GLOB_RECURSE FOXGLOVE_SDK_SOURCES CONFIGURE_DEPENDS "${foxglove_sdk_SOURCE_DIR}/src/*.cpp")
-# Exclude remote access sources when remote access is disabled.
-if (NOT FOXGLOVE_BRIDGE_REMOTE_ACCESS)
-  list(FILTER FOXGLOVE_SDK_SOURCES EXCLUDE REGEX ".*remote_access\\.cpp$")
+# Enumerated explicitly rather than globbed so that adding or renaming an SDK
+# source forces a corresponding update here. Keep in sync with cpp/foxglove/src/*.cpp.
+set(FOXGLOVE_SDK_SOURCES
+  ${foxglove_sdk_SOURCE_DIR}/src/channel.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/connection_graph.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/context.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/error.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/fetch_asset.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/foxglove.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/mcap.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/messages.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/parameter.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/service.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/system_info.cpp
+  ${foxglove_sdk_SOURCE_DIR}/src/websocket.cpp
+)
+# Include remote access sources when remote access is enabled.
+if (FOXGLOVE_BRIDGE_REMOTE_ACCESS)
+  list(APPEND FOXGLOVE_SDK_SOURCES ${foxglove_sdk_SOURCE_DIR}/src/remote_access.cpp)
 endif()
 
 add_library(foxglove_cpp_shared SHARED)

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.12)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
@@ -116,23 +116,24 @@ FetchContent_MakeAvailable(foxglove_sdk)
 # Enumerated explicitly rather than globbed so that adding or renaming an SDK
 # source forces a corresponding update here. Keep in sync with cpp/foxglove/src/*.cpp.
 set(FOXGLOVE_SDK_SOURCES
-  ${foxglove_sdk_SOURCE_DIR}/src/channel.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/connection_graph.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/context.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/error.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/fetch_asset.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/foxglove.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/mcap.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/messages.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/parameter.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/service.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/system_info.cpp
-  ${foxglove_sdk_SOURCE_DIR}/src/websocket.cpp
+  src/channel.cpp
+  src/connection_graph.cpp
+  src/context.cpp
+  src/error.cpp
+  src/fetch_asset.cpp
+  src/foxglove.cpp
+  src/mcap.cpp
+  src/messages.cpp
+  src/parameter.cpp
+  src/service.cpp
+  src/system_info.cpp
+  src/websocket.cpp
 )
 # Include remote access sources when remote access is enabled.
 if (FOXGLOVE_BRIDGE_REMOTE_ACCESS)
-  list(APPEND FOXGLOVE_SDK_SOURCES ${foxglove_sdk_SOURCE_DIR}/src/remote_access.cpp)
+  list(APPEND FOXGLOVE_SDK_SOURCES src/remote_access.cpp)
 endif()
+list(TRANSFORM FOXGLOVE_SDK_SOURCES PREPEND "${foxglove_sdk_SOURCE_DIR}/")
 
 add_library(foxglove_cpp_shared SHARED)
 target_include_directories(foxglove_cpp_shared SYSTEM


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

This is a rollup of a bunch of small CMake cleanup things I noticed as I was looking through the code.  None of these are required, but they do make our use of CMake a bit more idiomatic.  If we don't want the tradeoffs these expose, then closing this is also perfectly fine.

1.  Replace the source glob in ros/src/foxglove_bridge/CMakeLists.txt with an explicit list.  The glob is nice because it is somewhat lower maintenance, but it comes with a cost; adding or removing files will *not* automatically re-run CMake for you.  That means that when you add a new file, you have to clean out the build directory and re-run from scratch.  It is a tradeoff, but it is more idiomatic to list things out.
2. Same thing for cpp/CMakeLists.txt, with the same tradeoff.
3. Drop headers from cpp/CMakeLists.txt targets.  Headers are not directly involved in building an object file, so they shouldn't be listed for them.  Changes to headers will still be picked up through the `-MD` rules generated by the compiler.  The tradeoff here is that these won't show up as part of the target in an IDE, but I think that is less relevant nowadays.
4. Get rid of an unnecessary variable now that it only has one item.
5. Factor the SDK source prefix out of the bridge.  This is just a little cleaner.