### PR TITLE
ci: Add msg-schema-stability check to flag breaking ROS .msg edits

### DIFF
--- a/.github/workflows/schema-stability.yml
+++ b/.github/workflows/schema-stability.yml
@@ -1,0 +1,61 @@
+name: Schema stability
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  msg-schema-check:
+    name: msg-schema-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for modified or deleted ROS .msg files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HAS_OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'breaking:msg-schema') }}
+        run: |
+          set -euo pipefail
+
+          # --diff-filter=MDR: Modified, Deleted, or Renamed. Pure additions of
+          # new .msg files don't break existing downstream consumers, but renames
+          # do (a consumer importing Foo.msg breaks when it becomes Bar.msg).
+          # --name-status prints M/D/R prefixes so the summary distinguishes
+          # them, and renames show both old and new paths on one line.
+          changed=$(git diff --name-status --diff-filter=MDR \
+            "$BASE_SHA"..."$HEAD_SHA" \
+            -- 'schemas/ros1/*.msg' 'schemas/ros2/*.msg')
+
+          if [ -z "$changed" ]; then
+            echo "No modified or deleted ROS .msg files."
+            exit 0
+          fi
+
+          {
+            echo "## Modified or deleted ROS .msg files"
+            echo
+            echo '```'
+            echo "$changed"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$HAS_OVERRIDE" = "true" ]; then
+            {
+              echo
+              echo "Override label \`breaking:msg-schema\` is present — allowing intentional schema break."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "Override label is present; allowing this PR."
+            exit 0
+          fi
+
+          {
+            echo
+            echo "This PR modifies or deletes ROS .msg files, which can break downstream consumers."
+            echo "If this is intentional and approved by reviewers, add the \`breaking:msg-schema\` label to override."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Modified or deleted ROS .msg files require the 'breaking:msg-schema' label."
+          exit 1

--- a/.github/workflows/schema-stability.yml
+++ b/.github/workflows/schema-stability.yml
@@ -5,7 +5,25 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.paths.outputs.msg == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: paths
+        with:
+          filters: |
+            msg:
+              - 'schemas/ros1/**'
+              - 'schemas/ros2/**'
+              - '.github/workflows/schema-stability.yml'
+
   msg-schema-check:
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     name: msg-schema-check
     runs-on: ubuntu-latest
     steps:
@@ -59,3 +77,16 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::error::Modified or deleted ROS .msg files require the 'breaking:msg-schema' label."
           exit 1
+
+  # Gate job for branch protection. Always posts a status so that the required
+  # check passes even when msg-schema-check is skipped. Configure your required
+  # status check to reference this job ("Schema stability / msg-schema-status")
+  # instead of msg-schema-check.
+  msg-schema-status:
+    name: msg-schema-status
+    needs: [changes, msg-schema-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/schema-stability.yml
+++ b/.github/workflows/schema-stability.yml
@@ -5,25 +5,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      should_run: ${{ steps.paths.outputs.msg == 'true' }}
-    steps:
-      - uses: dorny/paths-filter@v4
-        id: paths
-        with:
-          filters: |
-            msg:
-              - 'schemas/ros1/**'
-              - 'schemas/ros2/**'
-              - '.github/workflows/schema-stability.yml'
-
   msg-schema-check:
-    needs: changes
-    if: needs.changes.outputs.should_run == 'true'
     name: msg-schema-check
     runs-on: ubuntu-latest
     steps:
@@ -77,16 +59,3 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::error::Modified or deleted ROS .msg files require the 'breaking:msg-schema' label."
           exit 1
-
-  # Gate job for branch protection. Always posts a status so that the required
-  # check passes even when msg-schema-check is skipped. Configure your required
-  # status check to reference this job ("Schema stability / msg-schema-status")
-  # instead of msg-schema-check.
-  msg-schema-status:
-    name: msg-schema-status
-    needs: [changes, msg-schema-check]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: exit 1


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

We recently had a problem where we somewhat unintentionally broke the message schema (see #965).  This is problematic particular for stable ROS distributions, which usually expect messages to be stable throughout their lifetime (this isn't a hard requirement, but it is nicer to your users).

To make sure we really, really mean to do this, this PR adds a new workflow.  It detects modifications or deletions to schemas/ros1/*.msg and schemas/ros2/*.msg in PRs. Pure additions don't trigger the check. The 'breaking:msg-schema' label overrides the gate when the change is intentional and approved.

If we approve of this direction, then there are some things we need to do:
1.  We'll need to agree on the name of the override label.  I currently have it as `breaking:msg-schema`, but I really don't care what it is called.
2.  We'll need to create a new label with that name so we can use it as an override.
3.  We need to decide whether we only want this to trigger on the ROS message schemas, or all of them (like protobuf).  I chose ROS only here because it is basically a canary for everything else.  But if someone thinks we should trigger on all schema changes, that is easy to add.
4. We'll need to add this workflow to the "required-checks" for the repository.

Opinions welcome!

Fixes FLE-491