### PR TITLE
ci: Bump version before building release artifacts

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -11,10 +11,10 @@ on:
       sdk-version:
         required: true
         type: string
-    outputs:
-      artifact_pattern:
-        description: "pattern to match all uploaded artifact names"
-        value: ${{ jobs.build.outputs.artifact_pattern }}
+      ref:
+        description: "Git ref to check out. Defaults to the workflow's ref."
+        required: false
+        type: string
 
 jobs:
   changes:
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: |
           sudo apt-get update
@@ -146,6 +148,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: ${{ matrix.target }}
@@ -251,6 +255,8 @@ jobs:
       CXX: clang++
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
@@ -274,6 +280,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref }}
           lfs: true
 
       - name: Install common dependencies

--- a/.github/workflows/cpp_data_loader.yml
+++ b/.github/workflows/cpp_data_loader.yml
@@ -10,10 +10,10 @@ on:
       sdk-version:
         required: true
         type: string
-    outputs:
-      artifact_pattern:
-        description: "pattern to match all uploaded artifact names"
-        value: ${{ jobs.build.outputs.artifact_pattern }}
+      ref:
+        description: "Git ref to check out. Defaults to the workflow's ref."
+        required: false
+        type: string
 
 jobs:
   build:
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: wasm32-unknown-unknown

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -57,6 +57,7 @@ jobs:
           git push -f origin "${{ env.SDK_BRANCH }}"
     outputs:
       prev-version: ${{ steps.bump-version.outputs.prev-version }}
+      sdk-branch: ${{ env.SDK_BRANCH }}
 
   c-cpp:
     needs: bump
@@ -65,14 +66,14 @@ jobs:
       pull-requests: read
     with:
       sdk-version: ${{ github.event.inputs.version }}
-      ref: ${{ env.SDK_BRANCH }}
+      ref: ${{ needs.bump.outputs.sdk-branch }}
 
   cpp-data-loader:
     needs: bump
     uses: ./.github/workflows/cpp_data_loader.yml
     with:
       sdk-version: ${{ github.event.inputs.version }}
-      ref: ${{ env.SDK_BRANCH }}
+      ref: ${{ needs.bump.outputs.sdk-branch }}
 
   draft:
     runs-on: ubuntu-latest
@@ -100,7 +101,7 @@ jobs:
           gh release create "${{ env.SDK_TAG }}" \
             ./ci_artifacts/* \
             --title "${{ env.SDK_TAG }}" \
-            --target "${{ env.SDK_BRANCH }}" \
+            --target "${{ needs.bump.outputs.sdk-branch }}" \
             --generate-notes \
             --notes-start-tag "sdk/v${{ needs.bump.outputs.prev-version }}" \
             --draft

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -65,14 +65,14 @@ jobs:
       pull-requests: read
     with:
       sdk-version: ${{ github.event.inputs.version }}
-      ref: release/sdk/${{ github.event.inputs.version }}
+      ref: ${{ env.SDK_BRANCH }}
 
   cpp-data-loader:
     needs: bump
     uses: ./.github/workflows/cpp_data_loader.yml
     with:
       sdk-version: ${{ github.event.inputs.version }}
-      ref: release/sdk/${{ github.event.inputs.version }}
+      ref: ${{ env.SDK_BRANCH }}
 
   draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -17,22 +17,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  c-cpp:
-    uses: ./.github/workflows/c_cpp.yml
-    permissions:
-      pull-requests: read
-    with:
-      sdk-version: ${{ github.event.inputs.version }}
-  cpp-data-loader:
-    uses: ./.github/workflows/cpp_data_loader.yml
-    with:
-      sdk-version: ${{ github.event.inputs.version }}
-
-  draft:
+  # Bump versions and push the release branch first, so subsequent build jobs
+  # can compile against the new version.
+  bump:
     runs-on: ubuntu-latest
-    needs:
-      - c-cpp
-      - cpp-data-loader
     permissions:
       contents: write
     steps:
@@ -67,7 +55,34 @@ jobs:
           git add .
           git commit -m "Release '${{ env.SDK_TAG }}'"
           git push -f origin "${{ env.SDK_BRANCH }}"
+    outputs:
+      prev-version: ${{ steps.bump-version.outputs.prev-version }}
 
+  c-cpp:
+    needs: bump
+    uses: ./.github/workflows/c_cpp.yml
+    permissions:
+      pull-requests: read
+    with:
+      sdk-version: ${{ github.event.inputs.version }}
+      ref: release/sdk/${{ github.event.inputs.version }}
+
+  cpp-data-loader:
+    needs: bump
+    uses: ./.github/workflows/cpp_data_loader.yml
+    with:
+      sdk-version: ${{ github.event.inputs.version }}
+      ref: release/sdk/${{ github.event.inputs.version }}
+
+  draft:
+    runs-on: ubuntu-latest
+    needs:
+      - bump
+      - c-cpp
+      - cpp-data-loader
+    permissions:
+      contents: write
+    steps:
       - name: Download C/C++ artifacts
         uses: actions/download-artifact@v8
         with:
@@ -87,5 +102,5 @@ jobs:
             --title "${{ env.SDK_TAG }}" \
             --target "${{ env.SDK_BRANCH }}" \
             --generate-notes \
-            --notes-start-tag "sdk/v${{ steps.bump-version.outputs.prev-version }}" \
+            --notes-start-tag "sdk/v${{ needs.bump.outputs.prev-version }}" \
             --draft


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
We've been tagging our C++ release artifacts with the previous version
number. This change fixes that, by bumping the version number before
building the artifacts.

This change also removes the `artifact_pattern` output from the cpp and
cpp_data_loader workflows, which appears to be vestigial.

### Links
Fixes: FLE-487