### PR TITLE
python: Add name and value getters to pyclass enums

### DIFF
--- a/python/foxglove-sdk/python/foxglove/tests/test_messages.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_messages.py
@@ -67,3 +67,11 @@ def test_messages_can_construct_types() -> None:
     encoded = msg.encode()
     assert isinstance(encoded, bytes)
     assert len(encoded) == 34
+
+
+def test_enum_name_and_value() -> None:
+    """Codegen'd enums expose `.name` and `.value` like stdlib Enum."""
+    from foxglove.messages import LogLevel
+
+    assert LogLevel.Info.name == "Info"
+    assert LogLevel.Info.value == 2

--- a/python/foxglove-sdk/python/foxglove/tests/test_remote_access.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_remote_access.py
@@ -32,6 +32,8 @@ def test_capability_enum() -> None:
     assert Capability.ClientPublish is not None
     assert Capability.Services is not None
     assert Capability.ClientPublish != Capability.Services
+    assert Capability.Services.name == "Services"
+    assert Capability.Services.value == 2
 
 
 def test_connection_status_enum() -> None:

--- a/python/foxglove-sdk/python/foxglove/tests/test_server.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_server.py
@@ -63,6 +63,12 @@ def test_server_interface() -> None:
     server.stop()
 
 
+def test_status_level_enum() -> None:
+    """Hand-written `#[pyclass]` enums expose `.name` and `.value`."""
+    assert StatusLevel.Info.name == "Info"
+    assert StatusLevel.Info.value == 0
+
+
 def test_server_listener_provides_default_implementation() -> None:
     class DefaultServerListener(ServerListener):
         pass

--- a/python/foxglove-sdk/src/generated/messages.rs
+++ b/python/foxglove-sdk/src/generated/messages.rs
@@ -19,6 +19,27 @@ pub(crate) enum LinePrimitiveLineType {
     LineList = 2,
 }
 
+#[pymethods]
+impl LinePrimitiveLineType {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::LineStrip => "LineStrip",
+            Self::LineLoop => "LineLoop",
+            Self::LineList => "LineList",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::LineStrip => 0,
+            Self::LineLoop => 1,
+            Self::LineList => 2,
+        }
+    }
+}
+
 /// Log level
 #[pyclass(eq, eq_int, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
@@ -31,12 +52,58 @@ pub(crate) enum LogLevel {
     Fatal = 5,
 }
 
+#[pymethods]
+impl LogLevel {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::Debug => "Debug",
+            Self::Info => "Info",
+            Self::Warning => "Warning",
+            Self::Error => "Error",
+            Self::Fatal => "Fatal",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Unknown => 0,
+            Self::Debug => 1,
+            Self::Info => 2,
+            Self::Warning => 3,
+            Self::Error => 4,
+            Self::Fatal => 5,
+        }
+    }
+}
+
 /// An enumeration indicating which entities should match a SceneEntityDeletion command
 #[pyclass(eq, eq_int, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
 pub(crate) enum SceneEntityDeletionType {
     MatchingId = 0,
     All = 1,
+}
+
+#[pymethods]
+impl SceneEntityDeletionType {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::MatchingId => "MatchingId",
+            Self::All => "All",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::MatchingId => 0,
+            Self::All => 1,
+        }
+    }
 }
 
 /// Numeric type
@@ -54,6 +121,39 @@ pub(crate) enum PackedElementFieldNumericType {
     Float64 = 8,
 }
 
+#[pymethods]
+impl PackedElementFieldNumericType {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::Uint8 => "Uint8",
+            Self::Int8 => "Int8",
+            Self::Uint16 => "Uint16",
+            Self::Int16 => "Int16",
+            Self::Uint32 => "Uint32",
+            Self::Int32 => "Int32",
+            Self::Float32 => "Float32",
+            Self::Float64 => "Float64",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Unknown => 0,
+            Self::Uint8 => 1,
+            Self::Int8 => 2,
+            Self::Uint16 => 3,
+            Self::Int16 => 4,
+            Self::Uint32 => 5,
+            Self::Int32 => 6,
+            Self::Float32 => 7,
+            Self::Float64 => 8,
+        }
+    }
+}
+
 /// Type of points annotation
 #[pyclass(eq, eq_int, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
@@ -65,6 +165,31 @@ pub(crate) enum PointsAnnotationType {
     LineList = 4,
 }
 
+#[pymethods]
+impl PointsAnnotationType {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::Points => "Points",
+            Self::LineLoop => "LineLoop",
+            Self::LineStrip => "LineStrip",
+            Self::LineList => "LineList",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Unknown => 0,
+            Self::Points => 1,
+            Self::LineLoop => 2,
+            Self::LineStrip => 3,
+            Self::LineList => 4,
+        }
+    }
+}
+
 /// Type of position covariance
 #[pyclass(eq, eq_int, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
@@ -73,6 +198,29 @@ pub(crate) enum LocationFixPositionCovarianceType {
     Approximated = 1,
     DiagonalKnown = 2,
     Known = 3,
+}
+
+#[pymethods]
+impl LocationFixPositionCovarianceType {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::Approximated => "Approximated",
+            Self::DiagonalKnown => "DiagonalKnown",
+            Self::Known => "Known",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Unknown => 0,
+            Self::Approximated => 1,
+            Self::DiagonalKnown => 2,
+            Self::Known => 3,
+        }
+    }
 }
 
 /// A primitive representing an arrow

--- a/python/foxglove-sdk/src/mcap.rs
+++ b/python/foxglove-sdk/src/mcap.rs
@@ -86,6 +86,25 @@ pub enum PyMcapCompression {
     Lz4 = 1,
 }
 
+#[pymethods]
+impl PyMcapCompression {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Zstd => "Zstd",
+            Self::Lz4 => "Lz4",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Zstd => 0,
+            Self::Lz4 => 1,
+        }
+    }
+}
+
 impl From<PyMcapCompression> for McapCompression {
     fn from(value: PyMcapCompression) -> Self {
         match value {

--- a/python/foxglove-sdk/src/remote_access.rs
+++ b/python/foxglove-sdk/src/remote_access.rs
@@ -56,6 +56,29 @@ pub enum PyConnectionStatus {
     Shutdown = 3,
 }
 
+#[pymethods]
+impl PyConnectionStatus {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Connecting => "Connecting",
+            Self::Connected => "Connected",
+            Self::ShuttingDown => "ShuttingDown",
+            Self::Shutdown => "Shutdown",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Connecting => 0,
+            Self::Connected => 1,
+            Self::ShuttingDown => 2,
+            Self::Shutdown => 3,
+        }
+    }
+}
+
 impl From<ConnectionStatus> for PyConnectionStatus {
     fn from(value: ConnectionStatus) -> Self {
         match value {
@@ -77,6 +100,27 @@ pub enum PyRemoteAccessCapability {
     Parameters,
     /// Allow clients to call services.
     Services,
+}
+
+#[pymethods]
+impl PyRemoteAccessCapability {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::ClientPublish => "ClientPublish",
+            Self::Parameters => "Parameters",
+            Self::Services => "Services",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::ClientPublish => 0,
+            Self::Parameters => 1,
+            Self::Services => 2,
+        }
+    }
 }
 
 impl From<PyRemoteAccessCapability> for Capability {
@@ -352,6 +396,25 @@ pub enum PyReliability {
     Lossy,
     /// Data is sent over the reliable control channel (ordered, guaranteed delivery).
     Reliable,
+}
+
+#[pymethods]
+impl PyReliability {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Lossy => "Lossy",
+            Self::Reliable => "Reliable",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Lossy => 0,
+            Self::Reliable => 1,
+        }
+    }
 }
 
 impl From<PyReliability> for Reliability {

--- a/python/foxglove-sdk/src/remote_common.rs
+++ b/python/foxglove-sdk/src/remote_common.rs
@@ -214,6 +214,27 @@ pub enum PyParameterType {
     Float64Array,
 }
 
+#[pymethods]
+impl PyParameterType {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::ByteArray => "ByteArray",
+            Self::Float64 => "Float64",
+            Self::Float64Array => "Float64Array",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::ByteArray => 0,
+            Self::Float64 => 1,
+            Self::Float64Array => 2,
+        }
+    }
+}
+
 impl From<PyParameterType> for foxglove::websocket::ParameterType {
     fn from(value: PyParameterType) -> Self {
         match value {
@@ -574,6 +595,27 @@ pub enum PyStatusLevel {
     Info,
     Warning,
     Error,
+}
+
+#[pymethods]
+impl PyStatusLevel {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Info => "Info",
+            Self::Warning => "Warning",
+            Self::Error => "Error",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Info => 0,
+            Self::Warning => 1,
+            Self::Error => 2,
+        }
+    }
 }
 
 impl From<PyStatusLevel> for StatusLevel {

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -66,6 +66,29 @@ pub enum PyPlaybackStatus {
     Ended = 3,
 }
 
+#[pymethods]
+impl PyPlaybackStatus {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Playing => "Playing",
+            Self::Paused => "Paused",
+            Self::Buffering => "Buffering",
+            Self::Ended => "Ended",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Playing => 0,
+            Self::Paused => 1,
+            Self::Buffering => 2,
+            Self::Ended => 3,
+        }
+    }
+}
+
 impl From<PyPlaybackStatus> for PlaybackStatus {
     fn from(value: PyPlaybackStatus) -> PlaybackStatus {
         match value {
@@ -133,6 +156,25 @@ impl From<PyPlaybackState> for PlaybackState {
 pub enum PyPlaybackCommand {
     Play = 0,
     Pause = 1,
+}
+
+#[pymethods]
+impl PyPlaybackCommand {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Play => "Play",
+            Self::Pause => "Pause",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Play => 0,
+            Self::Pause => 1,
+        }
+    }
 }
 
 impl From<PlaybackCommand> for PyPlaybackCommand {
@@ -734,6 +776,33 @@ pub enum PyCapability {
     /// controls in the Foxglove app. This requires the server to specify the `data_start_time`
     /// and `data_end_time` fields in its `ServerInfo` message.
     PlaybackControl,
+}
+
+#[pymethods]
+impl PyCapability {
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Self::ClientPublish => "ClientPublish",
+            Self::ConnectionGraph => "ConnectionGraph",
+            Self::Parameters => "Parameters",
+            Self::Time => "Time",
+            Self::Services => "Services",
+            Self::PlaybackControl => "PlaybackControl",
+        }
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::ClientPublish => 0,
+            Self::ConnectionGraph => 1,
+            Self::Parameters => 2,
+            Self::Time => 3,
+            Self::Services => 4,
+            Self::PlaybackControl => 5,
+        }
+    }
 }
 
 impl From<PyCapability> for foxglove::websocket::Capability {

--- a/typescript/schemas/src/internal/generatePyclass.test.ts
+++ b/typescript/schemas/src/internal/generatePyclass.test.ts
@@ -30,6 +30,25 @@ describe("generatePyclass", () => {
          B = 1,
      }
 
+     #[pymethods]
+     impl ExampleMessageExampleEnum {
+         #[getter]
+         fn name(&self) -> &'static str {
+             match self {
+                 Self::A => "A",
+                 Self::B => "B",
+             }
+         }
+
+         #[getter]
+         fn value(&self) -> i32 {
+             match self {
+                 Self::A => 0,
+                 Self::B => 1,
+             }
+         }
+     }
+
      "
     `);
   });

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -382,16 +382,42 @@ function generateMessageClass(schema: FoxgloveMessageSchema): string {
 }
 
 function generateEnumClass(schema: FoxgloveEnumSchema): string {
+  const name = enumName(schema);
+  const variants = schema.values.map((value) => ({
+    rustName: constantToTitleCase(value.name),
+    value: value.value,
+  }));
+
   const enumLines = [
     rustDoc(schema.description),
     `#[pyclass(eq, eq_int, module = "foxglove.messages")]`,
     `#[derive(PartialEq, Clone)]`,
-    `pub(crate) enum ${enumName(schema)} {`,
-    ...schema.values.map((value) => `    ${constantToTitleCase(value.name)} = ${value.value},`),
-    "}\n\n",
+    `pub(crate) enum ${name} {`,
+    ...variants.map((v) => `    ${v.rustName} = ${v.value},`),
+    "}\n",
   ];
 
-  return enumLines.join("\n");
+  // Stubs declare these as `Enum` subclasses, so make `name` and `value` work at runtime.
+  const pymethodsLines = [
+    `#[pymethods]`,
+    `impl ${name} {`,
+    `    #[getter]`,
+    `    fn name(&self) -> &'static str {`,
+    `        match self {`,
+    ...variants.map((v) => `            Self::${v.rustName} => "${v.rustName}",`),
+    `        }`,
+    `    }`,
+    ``,
+    `    #[getter]`,
+    `    fn value(&self) -> i32 {`,
+    `        match self {`,
+    ...variants.map((v) => `            Self::${v.rustName} => ${v.value},`),
+    `        }`,
+    `    }`,
+    `}\n\n`,
+  ];
+
+  return enumLines.join("\n") + "\n" + pymethodsLines.join("\n");
 }
 
 /**


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The .pyi stubs declare these classes as enum.Enum subclasses, so type checkers expect .name and .value to exist. At runtime they're PyO3 classes that don't inherit from Enum, so accessing those attributes raised AttributeError. Add #[pymethods] getters to all hand-written and codegen'd simple enums so the runtime matches the stubs for the two attributes users actually reach for.

I considered doing the more "principled" fix here, which would be to change these classes to inherit from `IntEnum` on the Python side (not the PyO3 side).  This would make these full Enum classes (so things like iteration would work), but slightly changes the API.  If someone thinks we should do that, I can change to that instead.

Fixes FLE-486