### PR TITLE
Add a flush method to MCAP writer

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -5146,6 +5146,18 @@ foxglove_error foxglove_mcap_close(struct foxglove_mcap_writer *writer);
 
 #if !defined(__wasm__)
 /**
+ * Finishes the current chunk (if any) and flushes the underlying writer.
+ *
+ * Returns 0 on success, or returns a FoxgloveError code on error.
+ *
+ * # Safety
+ * `writer` must be a valid pointer to a `FoxgloveMcapWriter` created via `foxglove_mcap_open`.
+ */
+foxglove_error foxglove_mcap_flush(struct foxglove_mcap_writer *writer);
+#endif
+
+#if !defined(__wasm__)
+/**
  * Write metadata to an MCAP file.
  *
  * Metadata consists of key-value string pairs associated with a name.

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -5148,6 +5148,9 @@ foxglove_error foxglove_mcap_close(struct foxglove_mcap_writer *writer);
 /**
  * Finishes the current chunk (if any) and flushes the underlying writer.
  *
+ * Note that compression ratios tend to improve over the lifetime of a chunk, so flushing
+ * frequently with chunked output may reduce overall compression.
+ *
  * Returns 0 on success, or returns a FoxgloveError code on error.
  *
  * # Safety

--- a/c/src/channel.rs
+++ b/c/src/channel.rs
@@ -448,6 +448,9 @@ pub unsafe extern "C" fn foxglove_mcap_close(
 
 /// Finishes the current chunk (if any) and flushes the underlying writer.
 ///
+/// Note that compression ratios tend to improve over the lifetime of a chunk, so flushing
+/// frequently with chunked output may reduce overall compression.
+///
 /// Returns 0 on success, or returns a FoxgloveError code on error.
 ///
 /// # Safety

--- a/c/src/channel.rs
+++ b/c/src/channel.rs
@@ -286,6 +286,13 @@ impl McapWriterVariant {
             McapWriterVariant::Custom(writer) => writer.attach(attachment),
         }
     }
+
+    fn flush(&self) -> Result<(), foxglove::FoxgloveError> {
+        match self {
+            McapWriterVariant::File(writer) => writer.flush(),
+            McapWriterVariant::Custom(writer) => writer.flush(),
+        }
+    }
 }
 
 /// An MCAP attachment to store in an MCAP file.
@@ -437,6 +444,32 @@ pub unsafe extern "C" fn foxglove_mcap_close(
 
     // We don't care about the return value
     unsafe { result_to_c(result, std::ptr::null_mut()) }
+}
+
+/// Finishes the current chunk (if any) and flushes the underlying writer.
+///
+/// Returns 0 on success, or returns a FoxgloveError code on error.
+///
+/// # Safety
+/// `writer` must be a valid pointer to a `FoxgloveMcapWriter` created via `foxglove_mcap_open`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn foxglove_mcap_flush(
+    writer: Option<&mut FoxgloveMcapWriter>,
+) -> FoxgloveError {
+    let Some(writer) = writer else {
+        tracing::error!("foxglove_mcap_flush called with null writer");
+        return FoxgloveError::ValueError;
+    };
+    let Some(writer_handle) = writer.0.as_ref() else {
+        return FoxgloveError::SinkClosed;
+    };
+    match writer_handle.flush() {
+        Ok(()) => FoxgloveError::Ok,
+        Err(e) => {
+            tracing::error!("foxglove_mcap_flush failed: {e}");
+            e.into()
+        }
+    }
 }
 
 /// Write metadata to an MCAP file.

--- a/cpp/foxglove/include/foxglove/mcap.hpp
+++ b/cpp/foxglove/include/foxglove/mcap.hpp
@@ -177,6 +177,9 @@ public:
 
   /// @brief Finishes the current chunk (if any) and flushes the underlying writer.
   ///
+  /// Note that compression ratios tend to improve over the lifetime of a chunk, so flushing
+  /// frequently with chunked output may reduce overall compression.
+  ///
   /// @return FoxgloveError::Ok on success, or an error code on failure
   FoxgloveError flush();
 

--- a/cpp/foxglove/include/foxglove/mcap.hpp
+++ b/cpp/foxglove/include/foxglove/mcap.hpp
@@ -175,6 +175,11 @@ public:
   /// @brief Stops logging events and flushes buffered data.
   FoxgloveError close();
 
+  /// @brief Finishes the current chunk (if any) and flushes the underlying writer.
+  ///
+  /// @return FoxgloveError::Ok on success, or an error code on failure
+  FoxgloveError flush();
+
   /// @brief Default move constructor.
   McapWriter(McapWriter&&) = default;
   /// @brief Default move assignment.

--- a/cpp/foxglove/src/mcap.cpp
+++ b/cpp/foxglove/src/mcap.cpp
@@ -115,6 +115,11 @@ FoxgloveError McapWriter::close() {
   return FoxgloveError(error);
 }
 
+FoxgloveError McapWriter::flush() {
+  foxglove_error error = foxglove_mcap_flush(impl_.get());
+  return FoxgloveError(error);
+}
+
 FoxgloveError McapWriter::attach(const Attachment& attachment) {
   foxglove_mcap_attachment c_attachment;
   c_attachment.log_time = attachment.log_time;

--- a/cpp/foxglove/tests/test_mcap.cpp
+++ b/cpp/foxglove/tests/test_mcap.cpp
@@ -146,6 +146,32 @@ TEST_CASE_METHOD(McapTestFile, "different contexts") {
   REQUIRE_THAT(content, !ContainsSubstring("Hello, world!"));
 }
 
+TEST_CASE_METHOD(McapTestFile, "flush writes data without closing") {
+  auto context = foxglove::Context::create();
+
+  foxglove::McapWriterOptions options;
+  options.context = context;
+  options.path = path();
+  auto writer = foxglove::McapWriter::create(options);
+  REQUIRE(writer.has_value());
+
+  foxglove::Schema schema;
+  schema.name = "ExampleSchema";
+  auto channel_result = foxglove::RawChannel::create("example_flush", "json", schema, context);
+  auto& channel = requireValue(channel_result);
+  std::string data = "Hello, flush!";
+  channel.log(reinterpret_cast<const std::byte*>(data.data()), data.size());
+
+  // The buffered data should be persisted on flush, well before close.
+  auto size_before = std::filesystem::file_size(path());
+  auto error = writer->flush();
+  REQUIRE(error == foxglove::FoxgloveError::Ok);
+  auto size_after = std::filesystem::file_size(path());
+  REQUIRE(size_after > size_before);
+
+  writer->close();
+}
+
 TEST_CASE_METHOD(McapTestFile, "specify profile") {
   auto context = foxglove::Context::create();
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
@@ -98,6 +98,12 @@ class MCAPWriter:
         """
         ...
 
+    def flush(self) -> None:
+        """
+        Finishes the current chunk (if any) and flushes the underlying writer.
+        """
+        ...
+
     def write_metadata(self, name: str, metadata: dict[str, str]) -> None:
         """
         Write metadata to the MCAP file.

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
@@ -101,6 +101,9 @@ class MCAPWriter:
     def flush(self) -> None:
         """
         Finishes the current chunk (if any) and flushes the underlying writer.
+
+        Note that compression ratios tend to improve over the lifetime of a chunk, so
+        flushing frequently with chunked output may reduce overall compression.
         """
         ...
 

--- a/python/foxglove-sdk/python/foxglove/tests/test_mcap.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_mcap.py
@@ -369,6 +369,28 @@ def test_attach_after_close(tmp_mcap: Path) -> None:
         )
 
 
+def test_flush_writes_data_without_closing(tmp_mcap: Path) -> None:
+    """flush() should persist buffered data while keeping the writer open."""
+    writer = open_mcap(tmp_mcap)
+    for ii in range(20):
+        chan.log({"foo": ii})
+    size_before = tmp_mcap.stat().st_size
+    writer.flush()
+    size_after = tmp_mcap.stat().st_size
+    assert size_after > size_before
+    # Writer is still open: closing should still work and grow the file further.
+    writer.close()
+    assert tmp_mcap.stat().st_size > size_after
+
+
+def test_flush_after_close(tmp_mcap: Path) -> None:
+    """flush() after close should raise."""
+    writer = open_mcap(tmp_mcap)
+    writer.close()
+    with pytest.raises(Exception):  # FoxgloveError for SinkClosed
+        writer.flush()
+
+
 # =============================================================================
 # Tests for file-like object support
 # =============================================================================

--- a/python/foxglove-sdk/src/mcap.rs
+++ b/python/foxglove-sdk/src/mcap.rs
@@ -265,6 +265,16 @@ impl PyMcapWriter {
         Ok(())
     }
 
+    /// Finishes the current chunk (if any) and flushes the underlying writer.
+    fn flush(&self) -> PyResult<()> {
+        if let Some(writer) = &self.0 {
+            writer.flush().map_err(PyFoxgloveError::from)?;
+        } else {
+            return Err(PyFoxgloveError::from(foxglove::FoxgloveError::SinkClosed).into());
+        }
+        Ok(())
+    }
+
     /// Write metadata to the MCAP file.
     ///
     /// Metadata consists of key-value string pairs associated with a name.

--- a/python/foxglove-sdk/src/mcap.rs
+++ b/python/foxglove-sdk/src/mcap.rs
@@ -266,6 +266,9 @@ impl PyMcapWriter {
     }
 
     /// Finishes the current chunk (if any) and flushes the underlying writer.
+    ///
+    /// Note that compression ratios tend to improve over the lifetime of a chunk, so flushing
+    /// frequently with chunked output may reduce overall compression.
     fn flush(&self) -> PyResult<()> {
         if let Some(writer) = &self.0 {
             writer.flush().map_err(PyFoxgloveError::from)?;

--- a/rust/foxglove/src/mcap_writer.rs
+++ b/rust/foxglove/src/mcap_writer.rs
@@ -161,6 +161,14 @@ impl<W: Write + Seek + Send + 'static> McapWriterHandle<W> {
         self.sink.finish()
     }
 
+    /// Finishes the current chunk (if any) and flushes the underlying writer.
+    ///
+    /// Note that compression ratios tend to improve over the lifetime of a chunk, so flushing
+    /// frequently with chunked output may reduce overall compression.
+    pub fn flush(&self) -> Result<(), FoxgloveError> {
+        self.sink.flush()
+    }
+
     /// Writes MCAP metadata to the file.
     ///
     /// If the metadata map is empty, this method returns early without writing anything.

--- a/rust/foxglove/src/mcap_writer/mcap_sink.rs
+++ b/rust/foxglove/src/mcap_writer/mcap_sink.rs
@@ -129,6 +129,18 @@ impl<W: Write + Seek> McapSink<W> {
         Ok(Some(writer.writer.into_inner()))
     }
 
+    /// Finishes the current chunk (if any) and flushes the underlying writer.
+    ///
+    /// # Returns
+    /// * `Ok(())` if the writer was flushed successfully
+    /// * `Err(FoxgloveError::SinkClosed)` if the writer has been closed
+    /// * `Err(FoxgloveError)` if there was an error writing to the file
+    pub fn flush(&self) -> Result<(), FoxgloveError> {
+        let mut guard = self.inner.lock();
+        let writer = guard.as_mut().ok_or(FoxgloveError::SinkClosed)?;
+        writer.writer.flush().map_err(FoxgloveError::from)
+    }
+
     /// Writes MCAP metadata to the file.
     ///
     /// If the metadata map is empty, this method returns early without writing anything.
@@ -701,6 +713,54 @@ mod tests {
             .find(|(name, _)| name == "image.png")
             .expect("image.png not found");
         assert_eq!(image.1, &[0x89, 0x50, 0x4E, 0x47]);
+    }
+
+    #[test]
+    fn test_flush_writes_data_to_underlying_writer() {
+        let temp_file = NamedTempFile::new().expect("create tempfile");
+        let temp_path = temp_file.path().to_owned();
+
+        let ctx = Context::new();
+        let ch = new_test_channel(&ctx, "foo".to_string(), "foo_schema".to_string());
+        let writer = McapSink::new(&temp_file, WriteOptions::default(), None)
+            .expect("failed to create writer");
+
+        writer
+            .log(&ch, b"msg1", &Metadata { log_time: 1 })
+            .expect("failed to log");
+
+        // Before flushing, the file should not yet contain the chunk record.
+        let size_before = std::fs::metadata(&temp_path).unwrap().len();
+        writer.flush().expect("failed to flush");
+        let size_after = std::fs::metadata(&temp_path).unwrap().len();
+        assert!(
+            size_after > size_before,
+            "expected file size to grow after flush ({size_before} -> {size_after})"
+        );
+
+        // Subsequent log+finish should still produce a readable MCAP.
+        writer
+            .log(&ch, b"msg2", &Metadata { log_time: 2 })
+            .expect("failed to log");
+        writer.finish().expect("failed to finish");
+
+        let mut messages = Vec::new();
+        foreach_mcap_message(&temp_path, |msg| messages.push(msg.data.to_vec()))
+            .expect("failed to read messages");
+        assert_eq!(messages, vec![b"msg1".to_vec(), b"msg2".to_vec()]);
+    }
+
+    #[test]
+    fn test_flush_after_close() {
+        let temp_file = NamedTempFile::new().expect("create tempfile");
+
+        let writer = McapSink::new(&temp_file, WriteOptions::default(), None)
+            .expect("failed to create writer");
+
+        writer.finish().expect("failed to finish recording");
+
+        let result = writer.flush();
+        assert!(matches!(result, Err(FoxgloveError::SinkClosed)));
     }
 
     #[test]


### PR DESCRIPTION
### Changelog
- Added a flush method to MCAP writer

### Docs
None

### Description
This change adds a flush method to the MCAP writer, which can be used to
finish the current chunk and flush it to disk. The lack of this method was
simply oversight; it should've been there from the beginning.

### Testing
Added unit tests.

### Links
Fixes: FLE-514