### PR TITLE
ci: Fix draft release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           gh release create "${{ env.SDK_TAG }}" \
             ./ci_artifacts/* \
+            --repo "${{ github.repository }}" \
             --title "${{ env.SDK_TAG }}" \
             --target "${{ needs.bump.outputs.sdk-branch }}" \
             --generate-notes \


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
In #1223, we split up the draft release workflow so that we bump the
version number before building the release artifacts. This broke the
workflow, because the call to `gh release create` is made without
checking out the repository and without specifying the repository
explicitly with the `--repo` argument.

This change fixes the invocation to specify the `--repo` argument.