### PR TITLE
python: Package for abi3-py310

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -259,7 +259,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter ${{ matrix.platform.extra-args }}
+          args: --release --out dist -i python3.10 ${{ matrix.platform.extra-args }}
           sccache: "false"
           manylinux: ${{ matrix.platform.manylinux }}
           before-script-linux: ${{ matrix.platform.before-script }}
@@ -299,7 +299,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist -i python3.10
           sccache: "false"
           manylinux: musllinux_1_2
           docker-options: "--env MATURIN_NO_MISSING_BUILD_BACKEND_WARNING=1"
@@ -332,12 +332,7 @@ jobs:
         if: ${{ matrix.platform.target == 'x86' }}
         with:
           architecture: x86
-          python-version: |
-            3.14
-            3.13
-            3.12
-            3.11
-            3.10
+          python-version: "3.10"
 
       - name: Install NASM
         if: ${{ matrix.platform.target == 'x86_64' }}
@@ -354,7 +349,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter ${{ matrix.platform.extra-args }}
+          args: --release --out dist -i python3.10 ${{ matrix.platform.extra-args }}
           sccache: "false"
           docker-options: "--env MATURIN_NO_MISSING_BUILD_BACKEND_WARNING=1"
         env:
@@ -392,7 +387,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter ${{ matrix.platform.extra-args }}
+          args: --release --out dist -i python3.10 ${{ matrix.platform.extra-args }}
           sccache: "false"
           docker-options: "--env MATURIN_NO_MISSING_BUILD_BACKEND_WARNING=1"
       - name: Upload wheels

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.22.1"
 bytes.workspace = true
 log.workspace = true
 prost-types = "0.13"
-pyo3 = "0.25.1"
+pyo3 = { version = "0.25.1", features = ["abi3-py310"] }
 pyo3-log = "0.12.3"
 thiserror.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
### Changelog
- Python wheels are now packaged against abi3-py310

### Docs
None

### Description
We've run out of space in our pypi project. Our releases are currently
~650MiB, and we should reduce that.

This change updates CI to build a single abi3-py310 wheel per platform,
rather than building one for each specific version of python (cp310,
cp311, cp312, etc.). This change alone reduces our release size by
~500 MiB.

### Testing
Ran the remote-access SDK example using the abi3 wheel built in CI.

### Links
Fixes: FLE-524