### PR TITLE
python: Don't package for atypical/legacy arches

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -259,7 +259,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter ${{ matrix.platform.extra-args }}
+          args: --release --out dist -i python3.10 ${{ matrix.platform.extra-args }}
           sccache: "false"
           manylinux: ${{ matrix.platform.manylinux }}
           before-script-linux: ${{ matrix.platform.before-script }}
@@ -299,7 +299,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist -i python3.10
           sccache: "false"
           manylinux: musllinux_1_2
           docker-options: "--env MATURIN_NO_MISSING_BUILD_BACKEND_WARNING=1"
@@ -332,12 +332,7 @@ jobs:
         if: ${{ matrix.platform.target == 'x86' }}
         with:
           architecture: x86
-          python-version: |
-            3.14
-            3.13
-            3.12
-            3.11
-            3.10
+          python-version: "3.10"
 
       - name: Install NASM
         if: ${{ matrix.platform.target == 'x86_64' }}
@@ -354,7 +349,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter ${{ matrix.platform.extra-args }}
+          args: --release --out dist -i python3.10 ${{ matrix.platform.extra-args }}
           sccache: "false"
           docker-options: "--env MATURIN_NO_MISSING_BUILD_BACKEND_WARNING=1"
         env:
@@ -392,7 +387,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter ${{ matrix.platform.extra-args }}
+          args: --release --out dist -i python3.10 ${{ matrix.platform.extra-args }}
           sccache: "false"
           docker-options: "--env MATURIN_NO_MISSING_BUILD_BACKEND_WARNING=1"
       - name: Upload wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -210,10 +210,6 @@ jobs:
             target: x86_64
             manylinux: auto
             artifact-suffix: ""
-          - runner: ubuntu-22.04
-            target: x86
-            manylinux: auto
-            artifact-suffix: ""
           - runner: ubuntu-22.04-arm
             target: aarch64
             manylinux: "2_28"
@@ -235,14 +231,6 @@ jobs:
             artifact-suffix: ""
           - runner: ubuntu-22.04
             target: armv7
-            manylinux: auto
-            artifact-suffix: ""
-          - runner: ubuntu-22.04
-            target: s390x
-            manylinux: auto
-            artifact-suffix: ""
-          - runner: ubuntu-22.04
-            target: ppc64le
             manylinux: auto
             artifact-suffix: ""
     steps:
@@ -279,8 +267,6 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          - runner: ubuntu-22.04
-            target: x86
           - runner: ubuntu-22.04
             target: aarch64
           - runner: ubuntu-22.04

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.22.1"
 bytes.workspace = true
 log.workspace = true
 prost-types = "0.13"
-pyo3 = "0.25.1"
+pyo3 = { version = "0.25.1", features = ["abi3-py310"] }
 pyo3-log = "0.12.3"
 thiserror.workspace = true
 tracing.workspace = true

--- a/python/foxglove-sdk/README.md
+++ b/python/foxglove-sdk/README.md
@@ -25,8 +25,8 @@ Remote access is available on the following platforms:
 |----------------|-------------|---------------|
 | Linux (glibc)  | x86_64      | Yes (manylinux_2_28, glibc >= 2.28) |
 | Linux (glibc)  | aarch64     | Yes (manylinux_2_28, glibc >= 2.28) |
-| Linux (glibc)  | x86, armv7, s390x, ppc64le | No |
-| Linux (musl)   | all         | No            |
+| Linux (glibc)  | armv7       | No            |
+| Linux (musl)   | x86_64, aarch64, armv7 | No |
 | macOS          | aarch64     | Yes           |
 | macOS          | x86_64      | Yes           |
 | Windows        | x86_64      | Yes           |


### PR DESCRIPTION
### Changelog
- Python wheels are no longer built for ppc64le/s390x/x86

### Docs
None

### Description
We've run out of space in our pypi project. Our releases are currently
~650MiB, and we should reduce that.

This change updates CI to stop packaging for architectures that our
users are unlikely to use:

- ppc64le: Use for HPC
- s390x: IBM mainframes
- x86: 32-bit is so last century

Taken in addition to [the previous change](https://github.com/foxglove/foxglove-sdk/pull/1229) to target abi3, this change
reduces our release size by another ~80 MiB, bringing us down to about
~100 MiB per release.

### Links
Fixes: FLE-525