### PR TITLE
Bump livekit from 0.7.37 to 0.7.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -277,7 +277,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -1647,7 +1647,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.14",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tracing",
@@ -2022,7 +2022,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2115,17 +2115,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -2142,7 +2131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -2153,7 +2142,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -2181,7 +2170,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -2199,14 +2188,14 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.31",
- "rustls-native-certs 0.8.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -2221,7 +2210,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "hyper",
  "ipnet",
@@ -2674,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0c053af35021bc5d2f286b8e6a4f552bc75fdc14e40ebe2d0ef42ffa70a6b4"
+checksum = "16ab8e9dfb98df4871aa7ad857038e3f583be4c8542e924d1042fd7c70099b66"
 dependencies = [
  "cxx",
  "glib",
@@ -2721,9 +2710,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "livekit"
-version = "0.7.37"
+version = "0.7.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c38bd12b8cef6b8589d124e20460fd7ccc4cfb08d817de7d9d4b615d8c48e3f"
+checksum = "6d55b5d635bca311a21e8061df4410e556ddfe453a0f9124fca57b89a7875471"
 dependencies = [
  "base64 0.22.1",
  "bmrng",
@@ -2749,14 +2738,15 @@ dependencies = [
 
 [[package]]
 name = "livekit-api"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900451a686a1ce8488c420e81a2135831383b03aade6bc3075cf80463d3dd6a4"
+checksum = "884000d8e75c43f599acbfaf735d7c6d1a332741ae7ade1cc215c852277ede99"
 dependencies = [
  "base64 0.21.7",
+ "bytes",
  "device-info",
  "futures-util",
- "http 1.3.1",
+ "http",
  "jsonwebtoken",
  "livekit-protocol",
  "livekit-runtime",
@@ -2767,15 +2757,15 @@ dependencies = [
  "prost 0.12.6",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "rustls-native-certs 0.6.3",
+ "rustls-native-certs",
  "scopeguard",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.14",
  "tokio",
- "tokio-rustls 0.24.1",
- "tokio-tungstenite 0.20.1",
+ "tokio-rustls",
+ "tokio-tungstenite 0.29.0",
  "url",
 ]
 
@@ -3932,7 +3922,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.31",
+ "rustls",
  "socket2",
  "thiserror 2.0.14",
  "tokio",
@@ -3953,7 +3943,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.31",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.14",
@@ -4180,7 +4170,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4191,15 +4181,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.31",
- "rustls-native-certs 0.8.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -4222,7 +4212,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4234,7 +4224,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.31",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4242,7 +4232,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4349,18 +4339,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
@@ -4370,21 +4348,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -4396,16 +4362,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.6.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
+ "security-framework",
 ]
 
 [[package]]
@@ -4429,11 +4386,11 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.31",
- "rustls-native-certs 0.8.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
- "security-framework 3.6.0",
+ "rustls-webpki",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4444,16 +4401,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4557,16 +4504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,19 +4521,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -5236,21 +5160,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.31",
+ "rustls",
  "tokio",
 ]
 
@@ -5268,33 +5182,34 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
- "tungstenite 0.20.1",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.31",
- "rustls-native-certs 0.8.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -5428,7 +5343,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "iri-string",
  "pin-project-lite",
@@ -5540,41 +5455,40 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand 0.8.6",
- "rustls 0.21.12",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http",
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.31",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.14",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.14",
+ "url",
 ]
 
 [[package]]
@@ -5871,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda197783d7898f62bc52ea551c113d615c266b866b686f4a627277b0f0928b0"
+checksum = "9d15d80a6bb4b1a35240738c68f08d98e1c3c36faf77d62a7de9a4c027272c03"
 dependencies = [
  "cc",
  "cxx",
@@ -5886,9 +5800,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys-build"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9a618b192cc7c7824b0f3bb931876fa7df8ba518ea163bd9f6e6e2d4b485e8"
+checksum = "1eb24fb5fbef34fddb908af3b72335fa934067c233a24ed1f3b572e30ad0ef7e"
 dependencies = [
  "anyhow",
  "fs2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest 0.13.2",
+ "rustls",
  "schemars 1.0.4",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ab8e9dfb98df4871aa7ad857038e3f583be4c8542e924d1042fd7c70099b66"
+checksum = "2cae05e24c35aa8ce098ffaad811014ca4d418cd749458be44622f8efafe81b9"
 dependencies = [
  "cxx",
  "glib",
@@ -2710,9 +2710,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "livekit"
-version = "0.7.38"
+version = "0.7.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d55b5d635bca311a21e8061df4410e556ddfe453a0f9124fca57b89a7875471"
+checksum = "fe31ec1bd67b43d2afe694d1ba85ccbb0ac46e342d1671ccbeefb739a796a456"
 dependencies = [
  "base64 0.22.1",
  "bmrng",
@@ -2738,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "livekit-api"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884000d8e75c43f599acbfaf735d7c6d1a332741ae7ade1cc215c852277ede99"
+checksum = "9f924cfa8f1ce1b3db80744f9676e0f88ff6239ffc125c5011fff33d05cc8b70"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "livekit-datatrack"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dba71a581354a0dcb89e4a396ae08b386b4103e743b22d145711878105aa8d"
+checksum = "aa2912f350a2355b40253d205b4d53756e93213fc069093a934df98426f92d90"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2791,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "livekit-protocol"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf1cc4ab39d7857fb31be648f43aa7068acb54a6960270dccd300dd5c8d0a98"
+checksum = "d034f6a859427bbb5ac990d802fc4ce80e708c0311cad331c95d014f33a5247d"
 dependencies = [
  "futures-util",
  "livekit-runtime",
@@ -5785,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d15d80a6bb4b1a35240738c68f08d98e1c3c36faf77d62a7de9a4c027272c03"
+checksum = "d49e5eb4976021ce2b0047637aefcc56f3d56f1137e8eafae79a661fc50db7c6"
 dependencies = [
  "cc",
  "cxx",

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -29,6 +29,7 @@ remote-access = [
   "dep:livekit",
   "dep:libwebrtc",
   "dep:reqwest",
+  "dep:rustls",
   "dep:semver",
 ]
 lz4 = ["mcap/lz4"]
@@ -74,6 +75,7 @@ foxglove_derive = { version = "0.23.2", path = "../foxglove_derive", optional = 
 futures = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3.31", features = ["sink", "std"], optional = true }
 livekit = { version = "0.7.37", optional = true, features = ["rustls-tls-native-roots"] }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["aws-lc-rs"] }
 libwebrtc = { version = "0.3.24", optional = true }
 mcap.workspace = true
 parking_lot = "0.12.4"

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -37,6 +37,7 @@ tls = [
   "websocket",
   "tokio-tungstenite/rustls-tls-native-roots",
   "dep:aws-lc-rs",
+  "dep:rustls",
   "dep:tokio-rustls",
 ]
 stream = ["dep:futures", "dep:tokio"]

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -75,7 +75,7 @@ foxglove_derive = { version = "0.23.2", path = "../foxglove_derive", optional = 
 futures = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3.31", features = ["sink", "std"], optional = true }
 livekit = { version = "0.7.37", optional = true, features = ["rustls-tls-native-roots"] }
-rustls = { version = "0.23", optional = true, default-features = false, features = ["aws-lc-rs"] }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
 libwebrtc = { version = "0.3.24", optional = true }
 mcap.workspace = true
 parking_lot = "0.12.4"

--- a/rust/foxglove/src/crypto.rs
+++ b/rust/foxglove/src/crypto.rs
@@ -6,5 +6,8 @@
 /// one automatically. See FLE-231 for introducing explicit crate features to
 /// select the crypto provider.
 pub(crate) fn install_default_crypto_provider() {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    if provider.install_default().is_err() {
+        tracing::debug!("rustls crypto provider already installed; using the existing provider");
+    }
 }

--- a/rust/foxglove/src/crypto.rs
+++ b/rust/foxglove/src/crypto.rs
@@ -1,0 +1,10 @@
+//! rustls crypto provider selection.
+
+/// Installs aws-lc-rs as the process-wide default rustls crypto provider.
+///
+/// We have both ring and aws-lc-rs in the dependency tree, so rustls cannot pick
+/// one automatically. See FLE-231 for introducing explicit crate features to
+/// select the crypto provider.
+pub(crate) fn install_default_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -441,6 +441,9 @@ mod runtime;
 )]
 pub use runtime::shutdown_runtime;
 
+#[cfg(any(feature = "tls", feature = "remote-access"))]
+mod crypto;
+
 #[cfg(feature = "remote-access")]
 mod api_client;
 #[cfg(feature = "remote-access")]

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -412,9 +412,7 @@ impl Gateway {
     /// Returns an error if no device token is provided and the `FOXGLOVE_DEVICE_TOKEN`
     /// environment variable is not set.
     pub fn start(mut self) -> Result<GatewayHandle, FoxgloveError> {
-        // Install aws-lc-rs as the default crypto provider, because we have both ring and aws-lc-rs in the dependency tree.
-        // See FLE-231 for introducing explicit crate features to select the crypto provider.
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        crate::crypto::install_default_crypto_provider();
 
         let device_token = self
             .device_token

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -412,6 +412,10 @@ impl Gateway {
     /// Returns an error if no device token is provided and the `FOXGLOVE_DEVICE_TOKEN`
     /// environment variable is not set.
     pub fn start(mut self) -> Result<GatewayHandle, FoxgloveError> {
+        // Install aws-lc-rs as the default crypto provider, because we have both ring and aws-lc-rs in the dependency tree.
+        // See FLE-231 for introducing explicit crate features to select the crypto provider.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let device_token = self
             .device_token
             .or_else(|| std::env::var(FOXGLOVE_DEVICE_TOKEN_ENV).ok())

--- a/rust/foxglove/src/websocket/streams/rust_tls.rs
+++ b/rust/foxglove/src/websocket/streams/rust_tls.rs
@@ -24,8 +24,8 @@ pub struct StreamConfiguration {
 }
 
 fn build_tls_acceptor(tls_identity: &TlsIdentity) -> Result<TlsAcceptor, FoxgloveError> {
-    // Install aws-lc-rs as the default crypto provider, because we have both ring and aws-lc-rs in the dependency tree
-    // TODO: can we choose one or the other via a crate feature (or flag on tls_identity?)
+    // Install aws-lc-rs as the default crypto provider, because we have both ring and aws-lc-rs in the dependency tree.
+    // See FLE-231 for introducing explicit crate features to select the crypto provider.
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let cert = CertificateDer::from_pem_slice(&tls_identity.cert)

--- a/rust/foxglove/src/websocket/streams/rust_tls.rs
+++ b/rust/foxglove/src/websocket/streams/rust_tls.rs
@@ -24,9 +24,7 @@ pub struct StreamConfiguration {
 }
 
 fn build_tls_acceptor(tls_identity: &TlsIdentity) -> Result<TlsAcceptor, FoxgloveError> {
-    // Install aws-lc-rs as the default crypto provider, because we have both ring and aws-lc-rs in the dependency tree.
-    // See FLE-231 for introducing explicit crate features to select the crypto provider.
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    crate::crypto::install_default_crypto_provider();
 
     let cert = CertificateDer::from_pem_slice(&tls_identity.cert)
         .map_err(|e| FoxgloveError::ConfigurationError(format!("TLS configuration: {e}")))?;


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
The main motivation for this bump is the livekit-api update, which drops
the transitive rustls-webpki 0.101.x dependency, addressing
GHSA-82j2-j2ch-gfr8.

It turns out that, in order to consume this newer version, we also have to
set a default crypto provider for rustls. In this change, I'm simply hard-
coding aws-lc-rs, as we've done for the websocket TLS implementation.
In a follow-up PR, we'll add crate features that a user can use to choose
between aws-lc-rs and ring.

### Links
Fixes: FLE-510
Fixes: FLE-516