### PR TITLE
Accept zero length messages

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -5367,9 +5367,12 @@ void foxglove_channel_metadata_iter_free(struct foxglove_channel_metadata_iterat
 /**
  * Log a message on a channel.
  *
+ * Zero-length messages are supported: pass `data_len == 0` with either a null `data` pointer
+ * or any non-null pointer. The contents of `data` are not read when `data_len == 0`.
+ *
  * # Safety
- * `data` must be non-null, and the range `[data, data + data_len)` must contain initialized data
- * contained within a single allocated object.
+ * If `data_len > 0`, `data` must be non-null and the range `[data, data + data_len)` must
+ * contain initialized data contained within a single allocated object.
  *
  * `log_time` Some(nanoseconds since epoch timestamp) or None to use the current time.
  */

--- a/c/src/channel.rs
+++ b/c/src/channel.rs
@@ -963,6 +963,7 @@ pub unsafe extern "C" fn foxglove_channel_log(
         tracing::error!("foxglove_channel_log called with null data but data_len > 0");
         return FoxgloveError::ValueError;
     } else {
+        // Safety: data is non-null and data_len > 0
         unsafe { std::slice::from_raw_parts(data, data_len) }
     };
     // avoid decrementing ref count

--- a/c/src/channel.rs
+++ b/c/src/channel.rs
@@ -932,9 +932,12 @@ pub unsafe extern "C" fn foxglove_channel_metadata_iter_free(
 
 /// Log a message on a channel.
 ///
+/// Zero-length messages are supported: pass `data_len == 0` with either a null `data` pointer
+/// or any non-null pointer. The contents of `data` are not read when `data_len == 0`.
+///
 /// # Safety
-/// `data` must be non-null, and the range `[data, data + data_len)` must contain initialized data
-/// contained within a single allocated object.
+/// If `data_len > 0`, `data` must be non-null and the range `[data, data + data_len)` must
+/// contain initialized data contained within a single allocated object.
 ///
 /// `log_time` Some(nanoseconds since epoch timestamp) or None to use the current time.
 #[unsafe(no_mangle)]
@@ -952,10 +955,16 @@ pub unsafe extern "C" fn foxglove_channel_log(
         tracing::error!("foxglove_channel_log called with null channel");
         return FoxgloveError::ValueError;
     };
-    if data.is_null() || data_len == 0 {
-        tracing::error!("foxglove_channel_log called with null or empty data");
+    let msg: &[u8] = if data_len == 0 {
+        // Allow a null data pointer for zero-length messages so callers don't have to
+        // construct a dummy non-null pointer just to log an empty payload.
+        &[]
+    } else if data.is_null() {
+        tracing::error!("foxglove_channel_log called with null data but data_len > 0");
         return FoxgloveError::ValueError;
-    }
+    } else {
+        unsafe { std::slice::from_raw_parts(data, data_len) }
+    };
     // avoid decrementing ref count
     let channel = ManuallyDrop::new(unsafe {
         Arc::from_raw(channel as *const _ as *const foxglove::RawChannel)
@@ -964,7 +973,7 @@ pub unsafe extern "C" fn foxglove_channel_log(
     let sink_id = std::num::NonZeroU64::new(sink_id).map(foxglove::SinkId::new);
 
     channel.log_with_meta_to_sink(
-        unsafe { std::slice::from_raw_parts(data, data_len) },
+        msg,
         foxglove::PartialMetadata {
             log_time: log_time.copied(),
         },

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -132,7 +132,11 @@ public:
   /// @note Logging is thread-safe. The data will be logged atomically
   /// before or after data logged from other threads.
   ///
-  /// @param data The message data.
+  /// Zero-length messages are supported: pass `data_len == 0` with either a null `data`
+  /// pointer or any non-null pointer. The contents of `data` are not read when
+  /// `data_len == 0`.
+  ///
+  /// @param data The message data. May be null when `data_len == 0`.
   /// @param data_len The length of the message data, in bytes.
   /// @param log_time The timestamp of the message, as nanoseconds since epoch. If omitted, the
   /// current time is used.

--- a/cpp/foxglove/tests/test_channel.cpp
+++ b/cpp/foxglove/tests/test_channel.cpp
@@ -7,6 +7,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include <array>
+#include <cstddef>
 #include <string>
 
 #include "common/file_cleanup.hpp"
@@ -134,4 +136,15 @@ TEST_CASE("channel with no metadata returns an empty value from metadata()") {
 
   auto chan_metadata = requireValue(channel).metadata();
   REQUIRE(requireValue(chan_metadata).empty());
+}
+
+TEST_CASE("channel.log() accepts a zero-length message") {
+  auto context = foxglove::Context::create();
+  auto channel_result = foxglove::RawChannel::create("/empty-msg", "json", std::nullopt, context);
+  auto& channel = requireValue(channel_result);
+
+  REQUIRE(channel.log(nullptr, 0) == foxglove::FoxgloveError::Ok);
+
+  const std::array<std::byte, 1> dummy{std::byte{0}};
+  REQUIRE(channel.log(dummy.data(), 0) == foxglove::FoxgloveError::Ok);
 }

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -241,3 +241,11 @@ def test_log_message_to_specific_sink(new_topic: str) -> None:
     ctx = Context()
     ch = Channel(new_topic, context=ctx)
     ch.log("test", sink_id=1)
+
+
+def test_log_zero_length_message(new_topic: str) -> None:
+    """Zero-length messages must be accepted by channel.log()."""
+    schema = Schema(name="raw", encoding="raw", data=b"")
+    channel = Channel(new_topic, message_encoding="raw", schema=schema)
+    channel.log(b"")
+    channel.log("")

--- a/python/foxglove-sdk/python/foxglove/tests/test_mcap.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_mcap.py
@@ -57,6 +57,32 @@ def test_explicit_close(tmp_mcap: Path) -> None:
     assert tmp_mcap.stat().st_size > size_before_close
 
 
+def test_log_zero_length_messages_round_trip(tmp_mcap: Path) -> None:
+    """Zero-length messages should be logged successfully and read back from MCAP."""
+    import mcap.reader
+    from foxglove import Schema
+
+    raw_chan = Channel(
+        "raw-empty",
+        message_encoding="raw",
+        schema=Schema(name="raw", encoding="raw", data=b""),
+    )
+    with open_mcap(tmp_mcap):
+        raw_chan.log(b"")
+        raw_chan.log(b"non-empty")
+        raw_chan.log(b"")
+
+    with open(tmp_mcap, "rb") as f:
+        reader = mcap.reader.make_reader(f)
+        payloads = [
+            message.data
+            for _, channel, message in reader.iter_messages()
+            if channel.topic == "raw-empty"
+        ]
+
+    assert payloads == [b"", b"non-empty", b""]
+
+
 def test_context_manager(tmp_mcap: Path) -> None:
     with open_mcap(tmp_mcap):
         for ii in range(20):

--- a/rust/foxglove/src/channel.rs
+++ b/rust/foxglove/src/channel.rs
@@ -281,6 +281,26 @@ mod test {
 
     #[traced_test]
     #[test]
+    fn test_log_empty_message_reaches_sink() {
+        let ctx = Context::new();
+        let recording_sink = Arc::new(RecordingSink::new());
+        assert!(ctx.add_sink(recording_sink.clone()));
+
+        let channel = new_test_channel(&ctx).unwrap();
+        channel.log(b"");
+        assert!(!logs_contain(ERROR_LOGGING_MESSAGE));
+
+        let messages = recording_sink.take_messages();
+        assert_eq!(messages.len(), 1, "empty message should still be delivered");
+        assert_eq!(messages[0].channel_id, channel.id());
+        assert!(
+            messages[0].msg.is_empty(),
+            "sink should receive the zero-length payload",
+        );
+    }
+
+    #[traced_test]
+    #[test]
     fn test_channel_close() {
         let ctx = Context::new();
         let ch = new_test_channel(&ctx).unwrap();

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -561,6 +561,48 @@ async fn test_log_only_to_subscribers() {
     let _ = server.stop();
 }
 
+#[traced_test]
+#[tokio::test]
+async fn test_server_transmits_empty_message() {
+    let ctx = Context::new();
+    let server = create_server(&ctx, ServerOptions::default());
+    let ch = new_channel("/empty", &ctx);
+
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut client = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect");
+    expect_recv!(client, ServerMessage::ServerInfo);
+    expect_recv!(client, ServerMessage::Advertise);
+
+    let subscription_id = 7;
+    client
+        .send(&Subscribe::new([Subscription::new(
+            subscription_id,
+            ch.id().into(),
+        )]))
+        .await
+        .expect("Failed to subscribe");
+
+    assert_eventually(|| ch.num_sinks() == 1).await;
+
+    let metadata = PartialMetadata {
+        log_time: Some(987654),
+    };
+    ch.log_with_meta(b"", metadata);
+
+    let msg = expect_recv!(client, ServerMessage::MessageData);
+    assert_eq!(msg.subscription_id, subscription_id);
+    assert_eq!(msg.log_time, 987654);
+    assert!(msg.data.is_empty(), "expected empty MessageData payload");
+
+    let _ = server.stop();
+}
+
 #[tokio::test]
 async fn test_on_unsubscribe_called_after_disconnect() {
     let recording_listener = Arc::new(RecordingServerListener::new());
@@ -956,6 +998,12 @@ async fn test_client_advertising() {
         .await
         .expect("Failed to send binary message");
 
+    // Send a zero-length message payload on the same channel.
+    client
+        .send(&client::MessageData::new(channel_id, &[][..]))
+        .await
+        .expect("Failed to send empty MessageData");
+
     // Does not error on a binary message with no opcode
     client
         .send(Message::binary(vec![]))
@@ -975,17 +1023,23 @@ async fn test_client_advertising() {
         .expect("Failed to send unadvertise");
 
     assert_eventually(|| {
-        dbg!(recording_listener.message_data_len()) == 1
+        dbg!(recording_listener.message_data_len()) == 2
             && dbg!(recording_listener.client_advertise_len()) == 1
             && dbg!(recording_listener.client_unadvertise_len()) == 1
     })
     .await;
 
-    // Server should have received one message
-    let mut received = recording_listener.take_message_data();
-    let message_data = received.pop().expect("No message received");
-    assert_eq!(message_data.channel.id, ClientChannelId::new(1));
-    assert_eq!(message_data.data, data);
+    // Server should have received both messages (in order): the non-empty payload first,
+    // then the zero-length payload.
+    let received = recording_listener.take_message_data();
+    assert_eq!(received.len(), 2);
+    assert_eq!(received[0].channel.id, ClientChannelId::new(1));
+    assert_eq!(received[0].data, data);
+    assert_eq!(received[1].channel.id, ClientChannelId::new(1));
+    assert!(
+        received[1].data.is_empty(),
+        "expected zero-length client MessageData",
+    );
 
     // Server should have ignored the duplicate advertisement
     let advertisements = recording_listener.take_client_advertise();


### PR DESCRIPTION
### Changelog

Foxglove C++ SDK now allows logging zero-length messages.

### Docs

None

### Description

Fixes a bug where the C++ SDK would return an error if you attempted to a log a zero length message.

Rust, Python, the WebSocketServer and Remote Access Gateway plus the Foxglove app already accepts this without error.
