### PR TITLE
Fix broken link and markdown formatting in C++ README

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -95,7 +95,7 @@ The gateway-related C declarations in `foxglove-c/foxglove-c.h` are guarded by `
 
 ### RGB Camera Visualization Example
 
-See detailed instructions on dependencies and visualizing data in the [example's readme](cpp/examples/rgb-camera-visualization/README.md).
+See detailed instructions on dependencies and visualizing data in the [example's readme](examples/rgb-camera-visualization/README.md).
 
 #### Building the Example
 

--- a/cpp/examples/rgb-camera-visualization/README.md
+++ b/cpp/examples/rgb-camera-visualization/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to stream RGB camera data to Foxglove using the C+
 
 This example uses OpenCV for camera capture. You'll need to install OpenCV development libraries:
 
-*Ubuntu/Debian:**
+**Ubuntu/Debian:**
 ```bash
 sudo apt update
 sudo apt install libopencv-dev

--- a/test_docs_links.py
+++ b/test_docs_links.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Test that all markdown links resolve correctly."""
+import re
+from pathlib import Path
+
+def test_cpp_readme_rgb_camera_link():
+    """Test that cpp/README.md correctly links to rgb-camera-visualization README."""
+    readme_path = Path("cpp/README.md")
+    content = readme_path.read_text()
+
+    # Find the link to rgb-camera-visualization
+    match = re.search(r'\[example\'s readme\]\(([^)]+)\)', content)
+    assert match, "Could not find 'example's readme' link"
+
+    link_target = match.group(1)
+
+    # The link should be relative to cpp/README.md
+    # So it should be "examples/rgb-camera-visualization/README.md"
+    expected = "examples/rgb-camera-visualization/README.md"
+    assert link_target == expected, f"Link should be '{expected}' but is '{link_target}'"
+
+    # Verify the target exists
+    target_path = readme_path.parent / link_target
+    assert target_path.exists(), f"Link target does not exist: {target_path}"
+
+def test_rgb_camera_readme_markdown():
+    """Test that rgb-camera-visualization README has proper markdown formatting."""
+    readme_path = Path("cpp/examples/rgb-camera-visualization/README.md")
+    lines = readme_path.read_text().splitlines()
+
+    # Check line 9 - should be "**Ubuntu/Debian:**"
+    assert lines[8] == "**Ubuntu/Debian:**", f"Line 9 formatting incorrect: {lines[8]}"
+
+if __name__ == "__main__":
+    test_cpp_readme_rgb_camera_link()
+    test_rgb_camera_readme_markdown()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

- Fixed the relative link to the rgb-camera-visualization example in `cpp/README.md`. The link used `cpp/examples/...` but since it is already inside the `cpp/` directory, the correct path is `examples/...`.
- Fixed a markdown formatting typo in the example's README where `*Ubuntu/Debian:**` was missing the opening double asterisk, rendering as literal asterisks instead of bold text.

## Test plan

- [ ] `python3 test_docs_links.py` passes (verifies link target exists and formatting is correct)
- [ ] Rendered markdown displays the link and bold text correctly on GitHub