### PR TITLE
remote_access: Close Sink::log same-identity reconnect race

### DIFF
--- a/rust/foxglove/src/remote_access/channel_registry.rs
+++ b/rust/foxglove/src/remote_access/channel_registry.rs
@@ -207,10 +207,7 @@ impl ChannelRegistry {
     }
 
     /// Returns all subscriber SIDs for the given channel.
-    pub fn channel_subscriber_sids(
-        &self,
-        channel_id: &ChannelId,
-    ) -> SmallVec<[ParticipantSid; 4]> {
+    pub fn channel_subscriber_sids(&self, channel_id: &ChannelId) -> SmallVec<[ParticipantSid; 4]> {
         self.subscriptions
             .get(channel_id)
             .map(|s| s.iter().cloned().collect())
@@ -238,10 +235,7 @@ impl ChannelRegistry {
     /// Returns SIDs of participants that have data subscriptions for a channel.
     ///
     /// A "data subscriber" is one in `subscriptions` but not `video_subscribers`.
-    pub fn data_subscriber_sids(
-        &self,
-        channel_id: &ChannelId,
-    ) -> SmallVec<[ParticipantSid; 4]> {
+    pub fn data_subscriber_sids(&self, channel_id: &ChannelId) -> SmallVec<[ParticipantSid; 4]> {
         let Some(subscribers) = self.subscriptions.get(channel_id) else {
             return SmallVec::new();
         };

--- a/rust/foxglove/src/remote_access/channel_registry.rs
+++ b/rust/foxglove/src/remote_access/channel_registry.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use livekit::id::{ParticipantIdentity, TrackSid};
+use livekit::id::{ParticipantIdentity, ParticipantSid, TrackSid};
 use smallvec::SmallVec;
 use tracing::{debug, info};
 
@@ -55,18 +55,24 @@ pub(super) struct UnsubscribeResult {
 ///
 /// A subscriber is a "data subscriber" if they appear in `subscriptions` but not in
 /// `video_subscribers`. See [`Self::has_data_subscribers`].
+///
+/// Subscription maps are keyed by [`ParticipantSid`] rather than
+/// [`ParticipantIdentity`] so a same-identity reconnect cannot inherit the
+/// prior connection's subscriptions: each connection instance gets a fresh
+/// SID, and a stale snapshotted SID resolves to `None` in the participant
+/// registry rather than the new instance.
 pub(super) struct ChannelRegistry {
     /// Channels that have been advertised to participants.
     channels: HashMap<ChannelId, Arc<RawChannel>>,
     /// QoS profile per channel.
     qos_profiles: HashMap<ChannelId, QosProfile>,
-    /// All subscriber identities per channel, regardless of subscription type.
-    subscriptions: HashMap<ChannelId, SmallVec<[ParticipantIdentity; 1]>>,
+    /// All subscriber SIDs per channel, regardless of subscription type.
+    subscriptions: HashMap<ChannelId, SmallVec<[ParticipantSid; 1]>>,
     /// Data tracks for advertised channels.
     /// Lifecycle follows channel advertise/unadvertise, not subscribe/unsubscribe.
     data_tracks: HashMap<ChannelId, DataTrack>,
-    /// Video subscriber identities per channel.
-    video_subscribers: HashMap<ChannelId, SmallVec<[ParticipantIdentity; 1]>>,
+    /// Video subscriber SIDs per channel.
+    video_subscribers: HashMap<ChannelId, SmallVec<[ParticipantSid; 1]>>,
     /// Detected video input schemas for channels.
     video_schemas: HashMap<ChannelId, VideoInputSchema>,
     /// Active video publishers, keyed by channel ID.
@@ -95,24 +101,26 @@ impl ChannelRegistry {
         }
     }
 
-    /// Sweeps `identity` out of every channel-subscription map and returns the
-    /// descriptors of channels that lost their last subscriber (and other
-    /// aftercare info) for the caller to fire listener callbacks on.
+    /// Sweeps `sid` out of every channel-subscription map and removes the
+    /// `identity`-keyed client-channel set, returning the descriptors of
+    /// channels that lost their last subscriber (and other aftercare info)
+    /// for the caller to fire listener callbacks on.
     ///
     /// Does not touch the participant registry — the caller is expected to
-    /// have already removed the participant entry there. No-op if `identity`
-    /// has no subscriptions or client channels.
+    /// have already removed the participant entry there. No-op if `sid` has
+    /// no subscriptions and `identity` has no client channels.
     #[must_use]
-    pub fn cleanup_for_removed_identity(
+    pub fn cleanup_for_removed_participant(
         &mut self,
+        sid: &ParticipantSid,
         identity: &ParticipantIdentity,
     ) -> RemovedSubscriptions {
-        info!("cleaning up state for removed identity {identity:?}");
+        info!("cleaning up state for removed participant sid={sid:?} identity={identity:?}");
 
         let mut last_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         let mut subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]> = SmallVec::new();
         for (&channel_id, subscribers) in &mut self.subscriptions {
-            if let Some(pos) = subscribers.iter().position(|id| id == identity) {
+            if let Some(pos) = subscribers.iter().position(|s| s == sid) {
                 subscribers.swap_remove(pos);
                 debug_assert!(
                     self.channels.contains_key(&channel_id),
@@ -129,7 +137,7 @@ impl ChannelRegistry {
 
         let mut last_video_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         self.video_subscribers.retain(|&channel_id, subscribers| {
-            subscribers.retain(|id| id != identity);
+            subscribers.retain(|s| s != sid);
             if subscribers.is_empty() {
                 last_video_unsubscribed.push(channel_id);
                 false
@@ -199,11 +207,11 @@ impl ChannelRegistry {
         self.channels.get(channel_id).map(|ch| ch.descriptor())
     }
 
-    /// Returns all subscriber identities for the given channel.
-    pub fn channel_subscriber_identities(
+    /// Returns all subscriber SIDs for the given channel.
+    pub fn channel_subscriber_sids(
         &self,
         channel_id: &ChannelId,
-    ) -> SmallVec<[ParticipantIdentity; 4]> {
+    ) -> SmallVec<[ParticipantSid; 4]> {
         self.subscriptions
             .get(channel_id)
             .map(|s| s.iter().cloned().collect())
@@ -228,20 +236,20 @@ impl ChannelRegistry {
             .unwrap_or_default()
     }
 
-    /// Returns identities of participants that have data subscriptions for a channel.
+    /// Returns SIDs of participants that have data subscriptions for a channel.
     ///
     /// A "data subscriber" is one in `subscriptions` but not `video_subscribers`.
-    pub fn data_subscriber_identities(
+    pub fn data_subscriber_sids(
         &self,
         channel_id: &ChannelId,
-    ) -> SmallVec<[ParticipantIdentity; 4]> {
+    ) -> SmallVec<[ParticipantSid; 4]> {
         let Some(subscribers) = self.subscriptions.get(channel_id) else {
             return SmallVec::new();
         };
         let video_subs = self.video_subscribers.get(channel_id);
         subscribers
             .iter()
-            .filter(|identity| !video_subs.is_some_and(|vs| vs.contains(identity)))
+            .filter(|sid| !video_subs.is_some_and(|vs| vs.contains(sid)))
             .cloned()
             .collect()
     }
@@ -365,7 +373,7 @@ impl ChannelRegistry {
         }
     }
 
-    /// Subscribes a participant to the given channels.
+    /// Subscribes a participant (identified by `sid`) to the given channels.
     ///
     /// Returns:
     /// - `first_subscribed`: channel IDs that gained their first subscriber (for context notifications).
@@ -374,20 +382,20 @@ impl ChannelRegistry {
     #[must_use]
     pub fn subscribe(
         &mut self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
         channel_ids: &[ChannelId],
     ) -> SubscribeResult {
         let mut first_subscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         let mut newly_subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]> = SmallVec::new();
         for &channel_id in channel_ids {
             let subscribers = self.subscriptions.entry(channel_id).or_default();
-            if subscribers.contains(identity) {
-                info!("{identity:?} is already subscribed to channel {channel_id:?}; ignoring");
+            if subscribers.contains(sid) {
+                info!("{sid:?} is already subscribed to channel {channel_id:?}; ignoring");
                 continue;
             }
             let is_first = subscribers.is_empty();
-            subscribers.push(identity.clone());
-            debug!("{identity:?} subscribed to channel {channel_id:?}");
+            subscribers.push(sid.clone());
+            debug!("{sid:?} subscribed to channel {channel_id:?}");
             debug_assert!(
                 self.channels.contains_key(&channel_id),
                 "Subscribing to channel {channel_id:?} which is not advertised"
@@ -405,7 +413,7 @@ impl ChannelRegistry {
         }
     }
 
-    /// Unsubscribes a participant from the given channels.
+    /// Unsubscribes a participant (identified by `sid`) from the given channels.
     ///
     /// Returns:
     /// - `last_unsubscribed`: channel IDs that lost their last subscriber (for context notifications).
@@ -414,7 +422,7 @@ impl ChannelRegistry {
     #[must_use]
     pub fn unsubscribe(
         &mut self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
         channel_ids: &[ChannelId],
     ) -> UnsubscribeResult {
         let mut last_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
@@ -422,15 +430,15 @@ impl ChannelRegistry {
             SmallVec::new();
         for &channel_id in channel_ids {
             let Some(subscribers) = self.subscriptions.get_mut(&channel_id) else {
-                info!("{identity:?} is not subscribed to channel {channel_id:?}; ignoring");
+                info!("{sid:?} is not subscribed to channel {channel_id:?}; ignoring");
                 continue;
             };
-            let Some(pos) = subscribers.iter().position(|id| id == identity) else {
-                info!("{identity:?} is not subscribed to channel {channel_id:?}; ignoring");
+            let Some(pos) = subscribers.iter().position(|s| s == sid) else {
+                info!("{sid:?} is not subscribed to channel {channel_id:?}; ignoring");
                 continue;
             };
             subscribers.swap_remove(pos);
-            debug!("{identity:?} unsubscribed from channel {channel_id:?}");
+            debug!("{sid:?} unsubscribed from channel {channel_id:?}");
             debug_assert!(
                 self.channels.contains_key(&channel_id),
                 "Unsubscribing from channel {channel_id:?} which is not advertised"
@@ -458,7 +466,7 @@ impl ChannelRegistry {
         self.video_track_sids.len()
     }
 
-    /// Adds a participant to video subscribers for the given channels.
+    /// Adds a participant (identified by `sid`) to video subscribers for the given channels.
     ///
     /// The caller is responsible for calling [`Self::subscribe`] separately, if necessary.
     ///
@@ -466,17 +474,17 @@ impl ChannelRegistry {
     #[must_use]
     pub fn subscribe_video(
         &mut self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
         channel_ids: &[ChannelId],
     ) -> SmallVec<[ChannelId; 4]> {
         let mut first_subscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         for &channel_id in channel_ids {
             let subscribers = self.video_subscribers.entry(channel_id).or_default();
-            if subscribers.contains(identity) {
+            if subscribers.contains(sid) {
                 continue;
             }
             let is_first = subscribers.is_empty();
-            subscribers.push(identity.clone());
+            subscribers.push(sid.clone());
             if is_first {
                 first_subscribed.push(channel_id);
             }
@@ -484,7 +492,7 @@ impl ChannelRegistry {
         first_subscribed
     }
 
-    /// Removes a participant from video subscribers for the given channels.
+    /// Removes a participant (identified by `sid`) from video subscribers for the given channels.
     ///
     /// The caller is responsible for calling [`Self::unsubscribe`] separately, if necessary.
     ///
@@ -492,7 +500,7 @@ impl ChannelRegistry {
     #[must_use]
     pub fn unsubscribe_video(
         &mut self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
         channel_ids: &[ChannelId],
     ) -> SmallVec<[ChannelId; 4]> {
         let mut last_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
@@ -500,7 +508,7 @@ impl ChannelRegistry {
             let Some(subscribers) = self.video_subscribers.get_mut(&channel_id) else {
                 continue;
             };
-            let Some(pos) = subscribers.iter().position(|id| id == identity) else {
+            let Some(pos) = subscribers.iter().position(|s| s == sid) else {
                 continue;
             };
             subscribers.swap_remove(pos);
@@ -558,6 +566,10 @@ mod tests {
         ParticipantIdentity(name.to_string())
     }
 
+    fn make_sid(label: &str) -> ParticipantSid {
+        crate::remote_access::participant::test_sid(label)
+    }
+
     fn make_channel(topic: &str) -> Arc<RawChannel> {
         use crate::{ChannelBuilder, Context, Schema};
         let ctx = Context::new();
@@ -584,11 +596,11 @@ mod tests {
     #[test]
     fn first_subscriber_is_reported() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
 
-        let result = state.subscribe(&id, &[ch.id()]);
+        let result = state.subscribe(&sid, &[ch.id()]);
         assert_eq!(result.first_subscribed.as_slice(), &[ch.id()]);
         assert_eq!(result.newly_subscribed_descriptors.len(), 1);
         assert_eq!(result.newly_subscribed_descriptors[0].id(), ch.id());
@@ -597,13 +609,13 @@ mod tests {
     #[test]
     fn second_subscriber_is_not_reported_as_first() {
         let mut state = ChannelRegistry::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
 
-        let _ = state.subscribe(&id_a, &[ch.id()]);
-        let result = state.subscribe(&id_b, &[ch.id()]);
+        let _ = state.subscribe(&sid_a, &[ch.id()]);
+        let result = state.subscribe(&sid_b, &[ch.id()]);
         assert!(result.first_subscribed.is_empty());
         assert_eq!(result.newly_subscribed_descriptors.len(), 1);
     }
@@ -611,12 +623,12 @@ mod tests {
     #[test]
     fn duplicate_subscribe_is_idempotent() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
 
-        let _ = state.subscribe(&id, &[ch.id()]);
-        let result = state.subscribe(&id, &[ch.id()]);
+        let _ = state.subscribe(&sid, &[ch.id()]);
+        let result = state.subscribe(&sid, &[ch.id()]);
         assert!(result.first_subscribed.is_empty());
         assert!(result.newly_subscribed_descriptors.is_empty());
         assert_eq!(state.subscriptions[&ch.id()].len(), 1);
@@ -625,13 +637,13 @@ mod tests {
     #[test]
     fn subscribe_multiple_channels_at_once() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
         state.insert_channel(&ch1);
         state.insert_channel(&ch2);
 
-        let result = state.subscribe(&id, &[ch1.id(), ch2.id()]);
+        let result = state.subscribe(&sid, &[ch1.id(), ch2.id()]);
         assert_eq!(result.first_subscribed.len(), 2);
         assert_eq!(result.newly_subscribed_descriptors.len(), 2);
     }
@@ -639,12 +651,12 @@ mod tests {
     #[test]
     fn last_unsubscriber_is_reported() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
 
-        let _ = state.subscribe(&id, &[ch.id()]);
-        let result = state.unsubscribe(&id, &[ch.id()]);
+        let _ = state.subscribe(&sid, &[ch.id()]);
+        let result = state.unsubscribe(&sid, &[ch.id()]);
         assert_eq!(result.last_unsubscribed.as_slice(), &[ch.id()]);
         assert_eq!(result.actually_unsubscribed_descriptors.len(), 1);
     }
@@ -652,15 +664,15 @@ mod tests {
     #[test]
     fn unsubscribe_with_remaining_subscribers_is_not_reported() {
         let mut state = ChannelRegistry::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
 
-        let _ = state.subscribe(&id_a, &[ch.id()]);
-        let _ = state.subscribe(&id_b, &[ch.id()]);
+        let _ = state.subscribe(&sid_a, &[ch.id()]);
+        let _ = state.subscribe(&sid_b, &[ch.id()]);
 
-        let result = state.unsubscribe(&id_a, &[ch.id()]);
+        let result = state.unsubscribe(&sid_a, &[ch.id()]);
         assert!(result.last_unsubscribed.is_empty());
         assert_eq!(state.subscriptions[&ch.id()].len(), 1);
     }
@@ -668,8 +680,8 @@ mod tests {
     #[test]
     fn unsubscribe_when_not_subscribed_is_noop() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
-        let result = state.unsubscribe(&id, &[ChannelId::new(1)]);
+        let sid = make_sid("alice");
+        let result = state.unsubscribe(&sid, &[ChannelId::new(1)]);
         assert!(result.last_unsubscribed.is_empty());
     }
 
@@ -678,50 +690,51 @@ mod tests {
     #[test]
     fn first_video_subscriber_is_reported() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
-        let first = state.subscribe_video(&id, &[ChannelId::new(1)]);
+        let sid = make_sid("alice");
+        let first = state.subscribe_video(&sid, &[ChannelId::new(1)]);
         assert_eq!(first.as_slice(), &[ChannelId::new(1)]);
     }
 
     #[test]
     fn last_video_unsubscriber_is_reported() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
-        let _ = state.subscribe_video(&id, &[ChannelId::new(1)]);
-        let last = state.unsubscribe_video(&id, &[ChannelId::new(1)]);
+        let sid = make_sid("alice");
+        let _ = state.subscribe_video(&sid, &[ChannelId::new(1)]);
+        let last = state.unsubscribe_video(&sid, &[ChannelId::new(1)]);
         assert_eq!(last.as_slice(), &[ChannelId::new(1)]);
     }
 
     #[test]
     fn video_only_subscriber_is_not_a_data_subscriber() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&id, &[ch.id()]);
-        let _ = state.subscribe_video(&id, &[ch.id()]);
+        let _ = state.subscribe(&sid, &[ch.id()]);
+        let _ = state.subscribe_video(&sid, &[ch.id()]);
         assert!(!state.has_data_subscribers(&ch.id()));
     }
 
     #[test]
     fn switching_from_video_to_data() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&id, &[ch.id()]);
-        let _ = state.subscribe_video(&id, &[ch.id()]);
+        let _ = state.subscribe(&sid, &[ch.id()]);
+        let _ = state.subscribe_video(&sid, &[ch.id()]);
         assert!(!state.has_data_subscribers(&ch.id()));
-        let _ = state.unsubscribe_video(&id, &[ch.id()]);
+        let _ = state.unsubscribe_video(&sid, &[ch.id()]);
         assert!(state.has_data_subscribers(&ch.id()));
     }
 
-    // ---- cleanup_for_removed_identity ----
+    // ---- cleanup_for_removed_participant ----
 
     #[test]
-    fn cleanup_missing_identity_is_noop() {
+    fn cleanup_missing_participant_is_noop() {
         let mut state = ChannelRegistry::new();
-        let cleanup = state.cleanup_for_removed_identity(&make_identity("nobody"));
+        let cleanup = state
+            .cleanup_for_removed_participant(&make_sid("nobody"), &make_identity("nobody"));
         assert!(cleanup.last_unsubscribed.is_empty());
         assert!(cleanup.last_video_unsubscribed.is_empty());
         assert!(cleanup.subscribed_descriptors.is_empty());
@@ -731,12 +744,13 @@ mod tests {
     #[test]
     fn cleanup_sweeps_subscriptions() {
         let mut state = ChannelRegistry::new();
+        let sid = make_sid("alice");
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&id, &[ch.id()]);
+        let _ = state.subscribe(&sid, &[ch.id()]);
 
-        let cleanup = state.cleanup_for_removed_identity(&id);
+        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
         assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch.id()]);
         assert!(!state.has_data_subscribers(&ch.id()));
     }
@@ -744,17 +758,18 @@ mod tests {
     #[test]
     fn cleanup_reports_only_last_unsubscribed_channels() {
         let mut state = ChannelRegistry::new();
+        let sid_a = make_sid("alice");
         let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_b = make_sid("bob");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
         state.insert_channel(&ch1);
         state.insert_channel(&ch2);
 
-        let _ = state.subscribe(&id_a, &[ch1.id(), ch2.id()]);
-        let _ = state.subscribe(&id_b, &[ch1.id()]);
+        let _ = state.subscribe(&sid_a, &[ch1.id(), ch2.id()]);
+        let _ = state.subscribe(&sid_b, &[ch1.id()]);
 
-        let cleanup = state.cleanup_for_removed_identity(&id_a);
+        let cleanup = state.cleanup_for_removed_participant(&sid_a, &id_a);
         // ch1 still has bob, so only ch2 should be reported.
         assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch2.id()]);
         assert_eq!(state.subscriptions[&ch1.id()].len(), 1);
@@ -763,13 +778,14 @@ mod tests {
     #[test]
     fn cleanup_sweeps_video_subscriptions() {
         let mut state = ChannelRegistry::new();
+        let sid = make_sid("alice");
         let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&id, &[ch.id()]);
-        let _ = state.subscribe_video(&id, &[ch.id()]);
+        let _ = state.subscribe(&sid, &[ch.id()]);
+        let _ = state.subscribe_video(&sid, &[ch.id()]);
 
-        let cleanup = state.cleanup_for_removed_identity(&id);
+        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
         assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch.id()]);
         assert_eq!(cleanup.last_video_unsubscribed.as_slice(), &[ch.id()]);
     }
@@ -777,25 +793,27 @@ mod tests {
     #[test]
     fn cleanup_returns_subscribed_descriptors() {
         let mut state = ChannelRegistry::new();
+        let sid = make_sid("alice");
         let id = make_identity("alice");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
         state.insert_channel(&ch1);
         state.insert_channel(&ch2);
-        let _ = state.subscribe(&id, &[ch1.id(), ch2.id()]);
+        let _ = state.subscribe(&sid, &[ch1.id(), ch2.id()]);
 
-        let cleanup = state.cleanup_for_removed_identity(&id);
+        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
         assert_eq!(cleanup.subscribed_descriptors.len(), 2);
     }
 
     #[test]
     fn cleanup_sweeps_client_channels() {
         let mut state = ChannelRegistry::new();
+        let sid = make_sid("alice");
         let id = make_identity("alice");
         state.insert_client_channel(&id, make_client_channel(1, "/cmd_vel"));
         state.insert_client_channel(&id, make_client_channel(2, "/joy"));
 
-        let cleanup = state.cleanup_for_removed_identity(&id);
+        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
         assert_eq!(cleanup.client_channels.len(), 2);
         assert!(
             state
@@ -808,16 +826,17 @@ mod tests {
     #[test]
     fn cleanup_for_mixed_video_preferences() {
         let mut state = ChannelRegistry::new();
+        let sid_a = make_sid("alice");
         let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_b = make_sid("bob");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&id_a, &[ch.id()]);
-        let _ = state.subscribe(&id_b, &[ch.id()]);
-        let _ = state.subscribe_video(&id_a, &[ch.id()]);
+        let _ = state.subscribe(&sid_a, &[ch.id()]);
+        let _ = state.subscribe(&sid_b, &[ch.id()]);
+        let _ = state.subscribe_video(&sid_a, &[ch.id()]);
 
         // Remove alice: channel keeps bob, loses its last video subscriber.
-        let cleanup = state.cleanup_for_removed_identity(&id_a);
+        let cleanup = state.cleanup_for_removed_participant(&sid_a, &id_a);
         assert!(cleanup.last_unsubscribed.is_empty());
         assert_eq!(cleanup.last_video_unsubscribed.as_slice(), &[ch.id()]);
         assert!(state.has_data_subscribers(&ch.id()));
@@ -826,42 +845,42 @@ mod tests {
     // ---- channel + client-channel lookups ----
 
     #[test]
-    fn channel_subscriber_identities_empty_for_unknown_channel() {
+    fn channel_subscriber_sids_empty_for_unknown_channel() {
         let state = ChannelRegistry::new();
         assert!(
             state
-                .channel_subscriber_identities(&ChannelId::new(999))
+                .channel_subscriber_sids(&ChannelId::new(999))
                 .is_empty()
         );
     }
 
     #[test]
-    fn channel_subscriber_identities_returns_subscribers() {
+    fn channel_subscriber_sids_returns_subscribers() {
         let mut state = ChannelRegistry::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&id_a, &[ch.id()]);
-        let _ = state.subscribe(&id_b, &[ch.id()]);
+        let _ = state.subscribe(&sid_a, &[ch.id()]);
+        let _ = state.subscribe(&sid_b, &[ch.id()]);
 
-        let result = state.channel_subscriber_identities(&ch.id());
+        let result = state.channel_subscriber_sids(&ch.id());
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&id_a));
-        assert!(result.contains(&id_b));
+        assert!(result.contains(&sid_a));
+        assert!(result.contains(&sid_b));
     }
 
     #[test]
-    fn channel_subscriber_identities_empty_after_remove_channel() {
+    fn channel_subscriber_sids_empty_after_remove_channel() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
-        let _ = state.subscribe(&id, &[ch.id()]);
-        assert_eq!(state.channel_subscriber_identities(&ch.id()).len(), 1);
+        let _ = state.subscribe(&sid, &[ch.id()]);
+        assert_eq!(state.channel_subscriber_sids(&ch.id()).len(), 1);
 
         state.remove_channel(ch.id());
-        assert!(state.channel_subscriber_identities(&ch.id()).is_empty());
+        assert!(state.channel_subscriber_sids(&ch.id()).is_empty());
     }
 
     #[test]
@@ -955,33 +974,29 @@ mod tests {
         assert_eq!(state.qos_profile(&ch.id()).reliability, Reliability::Lossy);
     }
 
-    // ---- data_subscriber_identities ----
+    // ---- data_subscriber_sids ----
 
     #[test]
-    fn data_subscriber_identities_empty_when_no_subscribers() {
+    fn data_subscriber_sids_empty_when_no_subscribers() {
         let state = ChannelRegistry::new();
-        assert!(
-            state
-                .data_subscriber_identities(&ChannelId::new(1))
-                .is_empty()
-        );
+        assert!(state.data_subscriber_sids(&ChannelId::new(1)).is_empty());
     }
 
     #[test]
-    fn data_subscriber_identities_returns_data_only_subscribers() {
+    fn data_subscriber_sids_returns_data_only_subscribers() {
         let mut state = ChannelRegistry::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
         let ch = make_channel("/data");
         state.insert_channel(&ch);
         // Both subscribe (data). Bob also subscribes to video.
-        let _ = state.subscribe(&id_a, &[ch.id()]);
-        let _ = state.subscribe(&id_b, &[ch.id()]);
-        let _ = state.subscribe_video(&id_b, &[ch.id()]);
+        let _ = state.subscribe(&sid_a, &[ch.id()]);
+        let _ = state.subscribe(&sid_b, &[ch.id()]);
+        let _ = state.subscribe_video(&sid_b, &[ch.id()]);
 
-        let subs = state.data_subscriber_identities(&ch.id());
+        let subs = state.data_subscriber_sids(&ch.id());
         assert_eq!(subs.len(), 1);
-        assert_eq!(&subs[0], &id_a);
+        assert_eq!(&subs[0], &sid_a);
     }
 
     // ---- advertise-metadata rendering ----

--- a/rust/foxglove/src/remote_access/channel_registry.rs
+++ b/rust/foxglove/src/remote_access/channel_registry.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use livekit::id::{ParticipantIdentity, ParticipantSid, TrackSid};
+use livekit::id::{ParticipantSid, TrackSid};
 use smallvec::SmallVec;
 use tracing::{debug, info};
 
@@ -56,11 +56,11 @@ pub(super) struct UnsubscribeResult {
 /// A subscriber is a "data subscriber" if they appear in `subscriptions` but not in
 /// `video_subscribers`. See [`Self::has_data_subscribers`].
 ///
-/// Subscription maps are keyed by [`ParticipantSid`] rather than
-/// [`ParticipantIdentity`] so a same-identity reconnect cannot inherit the
-/// prior connection's subscriptions: each connection instance gets a fresh
-/// SID, and a stale snapshotted SID resolves to `None` in the participant
-/// registry rather than the new instance.
+/// All per-participant maps (`subscriptions`, `video_subscribers`,
+/// `client_channels`) are keyed by [`ParticipantSid`] rather than identity, so
+/// a same-identity reconnect cannot inherit the prior connection's state: each
+/// connection instance gets a fresh SID, and a stale snapshotted SID resolves
+/// to `None` in the participant registry rather than the new instance.
 pub(super) struct ChannelRegistry {
     /// Channels that have been advertised to participants.
     channels: HashMap<ChannelId, Arc<RawChannel>>,
@@ -81,8 +81,8 @@ pub(super) struct ChannelRegistry {
     video_track_sids: HashMap<ChannelId, TrackSid>,
     /// Video metadata last advertised for each video channel.
     video_metadata: HashMap<ChannelId, VideoMetadata>,
-    /// Client-advertised channels, keyed by participant identity then client-assigned channel ID.
-    client_channels: HashMap<ParticipantIdentity, HashMap<ChannelId, ChannelDescriptor>>,
+    /// Client-advertised channels, keyed by participant SID then client-assigned channel ID.
+    client_channels: HashMap<ParticipantSid, HashMap<ChannelId, ChannelDescriptor>>,
 }
 
 impl ChannelRegistry {
@@ -102,20 +102,19 @@ impl ChannelRegistry {
     }
 
     /// Sweeps `sid` out of every channel-subscription map and removes the
-    /// `identity`-keyed client-channel set, returning the descriptors of
-    /// channels that lost their last subscriber (and other aftercare info)
-    /// for the caller to fire listener callbacks on.
+    /// participant's client-channel set, returning the descriptors of channels
+    /// that lost their last subscriber (and other aftercare info) for the
+    /// caller to fire listener callbacks on.
     ///
     /// Does not touch the participant registry — the caller is expected to
     /// have already removed the participant entry there. No-op if `sid` has
-    /// no subscriptions and `identity` has no client channels.
+    /// no subscriptions or client channels.
     #[must_use]
     pub fn cleanup_for_removed_participant(
         &mut self,
         sid: &ParticipantSid,
-        identity: &ParticipantIdentity,
     ) -> RemovedSubscriptions {
-        info!("cleaning up state for removed participant sid={sid:?} identity={identity:?}");
+        info!("cleaning up state for removed participant sid={sid:?}");
 
         let mut last_unsubscribed: SmallVec<[ChannelId; 4]> = SmallVec::new();
         let mut subscribed_descriptors: SmallVec<[ChannelDescriptor; 4]> = SmallVec::new();
@@ -148,7 +147,7 @@ impl ChannelRegistry {
 
         let client_channels = self
             .client_channels
-            .remove(identity)
+            .remove(sid)
             .map(|map| map.into_values().collect())
             .unwrap_or_default();
 
@@ -166,10 +165,10 @@ impl ChannelRegistry {
     /// had a channel with the same ID advertised.
     pub fn insert_client_channel(
         &mut self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
         channel: ChannelDescriptor,
     ) -> bool {
-        let map = self.client_channels.entry(identity.clone()).or_default();
+        let map = self.client_channels.entry(sid.clone()).or_default();
         match map.entry(channel.id()) {
             Entry::Occupied(_) => false,
             Entry::Vacant(v) => {
@@ -182,22 +181,22 @@ impl ChannelRegistry {
     /// Returns a client-advertised channel for a participant, if present.
     pub fn get_client_channel(
         &self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
         channel_id: ChannelId,
     ) -> Option<&ChannelDescriptor> {
-        self.client_channels.get(identity)?.get(&channel_id)
+        self.client_channels.get(sid)?.get(&channel_id)
     }
 
     /// Removes and returns a client-advertised channel for a participant.
     pub fn remove_client_channel(
         &mut self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
         channel_id: ChannelId,
     ) -> Option<ChannelDescriptor> {
-        let map = self.client_channels.get_mut(identity)?;
+        let map = self.client_channels.get_mut(sid)?;
         let descriptor = map.remove(&channel_id)?;
         if map.is_empty() {
-            self.client_channels.remove(identity);
+            self.client_channels.remove(sid);
         }
         Some(descriptor)
     }
@@ -562,10 +561,6 @@ mod tests {
     use super::*;
     use crate::img2yuv::{ImageEncoding, RawImageEncoding};
 
-    fn make_identity(name: &str) -> ParticipantIdentity {
-        ParticipantIdentity(name.to_string())
-    }
-
     fn make_sid(label: &str) -> ParticipantSid {
         crate::remote_access::participant::test_sid(label)
     }
@@ -733,8 +728,7 @@ mod tests {
     #[test]
     fn cleanup_missing_participant_is_noop() {
         let mut state = ChannelRegistry::new();
-        let cleanup = state
-            .cleanup_for_removed_participant(&make_sid("nobody"), &make_identity("nobody"));
+        let cleanup = state.cleanup_for_removed_participant(&make_sid("nobody"));
         assert!(cleanup.last_unsubscribed.is_empty());
         assert!(cleanup.last_video_unsubscribed.is_empty());
         assert!(cleanup.subscribed_descriptors.is_empty());
@@ -745,12 +739,11 @@ mod tests {
     fn cleanup_sweeps_subscriptions() {
         let mut state = ChannelRegistry::new();
         let sid = make_sid("alice");
-        let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
         let _ = state.subscribe(&sid, &[ch.id()]);
 
-        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
+        let cleanup = state.cleanup_for_removed_participant(&sid);
         assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch.id()]);
         assert!(!state.has_data_subscribers(&ch.id()));
     }
@@ -759,7 +752,6 @@ mod tests {
     fn cleanup_reports_only_last_unsubscribed_channels() {
         let mut state = ChannelRegistry::new();
         let sid_a = make_sid("alice");
-        let id_a = make_identity("alice");
         let sid_b = make_sid("bob");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
@@ -769,7 +761,7 @@ mod tests {
         let _ = state.subscribe(&sid_a, &[ch1.id(), ch2.id()]);
         let _ = state.subscribe(&sid_b, &[ch1.id()]);
 
-        let cleanup = state.cleanup_for_removed_participant(&sid_a, &id_a);
+        let cleanup = state.cleanup_for_removed_participant(&sid_a);
         // ch1 still has bob, so only ch2 should be reported.
         assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch2.id()]);
         assert_eq!(state.subscriptions[&ch1.id()].len(), 1);
@@ -779,13 +771,12 @@ mod tests {
     fn cleanup_sweeps_video_subscriptions() {
         let mut state = ChannelRegistry::new();
         let sid = make_sid("alice");
-        let id = make_identity("alice");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
         let _ = state.subscribe(&sid, &[ch.id()]);
         let _ = state.subscribe_video(&sid, &[ch.id()]);
 
-        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
+        let cleanup = state.cleanup_for_removed_participant(&sid);
         assert_eq!(cleanup.last_unsubscribed.as_slice(), &[ch.id()]);
         assert_eq!(cleanup.last_video_unsubscribed.as_slice(), &[ch.id()]);
     }
@@ -794,14 +785,13 @@ mod tests {
     fn cleanup_returns_subscribed_descriptors() {
         let mut state = ChannelRegistry::new();
         let sid = make_sid("alice");
-        let id = make_identity("alice");
         let ch1 = make_channel("/topic1");
         let ch2 = make_channel("/topic2");
         state.insert_channel(&ch1);
         state.insert_channel(&ch2);
         let _ = state.subscribe(&sid, &[ch1.id(), ch2.id()]);
 
-        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
+        let cleanup = state.cleanup_for_removed_participant(&sid);
         assert_eq!(cleanup.subscribed_descriptors.len(), 2);
     }
 
@@ -809,15 +799,14 @@ mod tests {
     fn cleanup_sweeps_client_channels() {
         let mut state = ChannelRegistry::new();
         let sid = make_sid("alice");
-        let id = make_identity("alice");
-        state.insert_client_channel(&id, make_client_channel(1, "/cmd_vel"));
-        state.insert_client_channel(&id, make_client_channel(2, "/joy"));
+        state.insert_client_channel(&sid, make_client_channel(1, "/cmd_vel"));
+        state.insert_client_channel(&sid, make_client_channel(2, "/joy"));
 
-        let cleanup = state.cleanup_for_removed_participant(&sid, &id);
+        let cleanup = state.cleanup_for_removed_participant(&sid);
         assert_eq!(cleanup.client_channels.len(), 2);
         assert!(
             state
-                .remove_client_channel(&id, ChannelId::new(1))
+                .remove_client_channel(&sid, ChannelId::new(1))
                 .is_none(),
             "map entry must be gone",
         );
@@ -827,7 +816,6 @@ mod tests {
     fn cleanup_for_mixed_video_preferences() {
         let mut state = ChannelRegistry::new();
         let sid_a = make_sid("alice");
-        let id_a = make_identity("alice");
         let sid_b = make_sid("bob");
         let ch = make_channel("/topic1");
         state.insert_channel(&ch);
@@ -836,7 +824,7 @@ mod tests {
         let _ = state.subscribe_video(&sid_a, &[ch.id()]);
 
         // Remove alice: channel keeps bob, loses its last video subscriber.
-        let cleanup = state.cleanup_for_removed_participant(&sid_a, &id_a);
+        let cleanup = state.cleanup_for_removed_participant(&sid_a);
         assert!(cleanup.last_unsubscribed.is_empty());
         assert_eq!(cleanup.last_video_unsubscribed.as_slice(), &[ch.id()]);
         assert!(state.has_data_subscribers(&ch.id()));
@@ -886,18 +874,18 @@ mod tests {
     #[test]
     fn insert_client_channel_is_noop_for_duplicate() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
         let ch = make_client_channel(1, "/cmd");
-        assert!(state.insert_client_channel(&id, ch.clone()));
-        assert!(!state.insert_client_channel(&id, ch));
+        assert!(state.insert_client_channel(&sid, ch.clone()));
+        assert!(!state.insert_client_channel(&sid, ch));
     }
 
     #[test]
     fn remove_client_channel_returns_descriptor() {
         let mut state = ChannelRegistry::new();
-        let id = make_identity("alice");
-        state.insert_client_channel(&id, make_client_channel(1, "/cmd"));
-        let removed = state.remove_client_channel(&id, ChannelId::new(1));
+        let sid = make_sid("alice");
+        state.insert_client_channel(&sid, make_client_channel(1, "/cmd"));
+        let removed = state.remove_client_channel(&sid, ChannelId::new(1));
         assert_eq!(removed.unwrap().topic(), "/cmd");
     }
 
@@ -906,7 +894,7 @@ mod tests {
         let state = ChannelRegistry::new();
         assert!(
             state
-                .get_client_channel(&make_identity("nobody"), ChannelId::new(1))
+                .get_client_channel(&make_sid("nobody"), ChannelId::new(1))
                 .is_none()
         );
     }

--- a/rust/foxglove/src/remote_access/parameter_subscriptions.rs
+++ b/rust/foxglove/src/remote_access/parameter_subscriptions.rs
@@ -3,14 +3,18 @@
 //! Tracks which participants are subscribed to which parameter names. Lifecycle
 //! is independent of channel subscriptions, so this lives in its own struct
 //! alongside [`crate::remote_access::channel_registry::ChannelRegistry`].
+//!
+//! Subscriptions are keyed by [`ParticipantSid`] rather than identity so a
+//! same-identity reconnect cannot inherit the prior connection's parameter
+//! subscriptions: each connection instance gets a fresh SID.
 
 use std::collections::{HashMap, HashSet};
 
-use livekit::id::ParticipantIdentity;
+use livekit::id::ParticipantSid;
 
-/// Tracks parameter-name → set of subscribed participant identities.
+/// Tracks parameter-name → set of subscribed participant SIDs.
 pub(super) struct ParameterSubscriptions {
-    subscribers_by_name: HashMap<String, HashSet<ParticipantIdentity>>,
+    subscribers_by_name: HashMap<String, HashSet<ParticipantSid>>,
 }
 
 impl ParameterSubscriptions {
@@ -23,15 +27,11 @@ impl ParameterSubscriptions {
     /// Add parameter subscriptions for a participant.
     ///
     /// Returns parameter names that are newly subscribed (i.e. had no prior subscribers).
-    pub(super) fn subscribe(
-        &mut self,
-        identity: &ParticipantIdentity,
-        names: Vec<String>,
-    ) -> Vec<String> {
+    pub(super) fn subscribe(&mut self, sid: &ParticipantSid, names: Vec<String>) -> Vec<String> {
         let mut new_names = Vec::new();
         for name in names {
             let subscribers = self.subscribers_by_name.entry(name.clone()).or_default();
-            if subscribers.insert(identity.clone()) && subscribers.len() == 1 {
+            if subscribers.insert(sid.clone()) && subscribers.len() == 1 {
                 new_names.push(name);
             }
         }
@@ -41,15 +41,11 @@ impl ParameterSubscriptions {
     /// Remove parameter subscriptions for a participant.
     ///
     /// Returns parameter names that lost their last subscriber.
-    pub(super) fn unsubscribe(
-        &mut self,
-        identity: &ParticipantIdentity,
-        names: Vec<String>,
-    ) -> Vec<String> {
+    pub(super) fn unsubscribe(&mut self, sid: &ParticipantSid, names: Vec<String>) -> Vec<String> {
         let mut old_names = Vec::new();
         for name in names {
             if let Some(subscribers) = self.subscribers_by_name.get_mut(&name) {
-                subscribers.remove(identity);
+                subscribers.remove(sid);
                 if subscribers.is_empty() {
                     self.subscribers_by_name.remove(&name);
                     old_names.push(name);
@@ -59,22 +55,22 @@ impl ParameterSubscriptions {
         old_names
     }
 
-    /// Returns the set of participant identities subscribed to a parameter.
-    pub(super) fn subscribers(&self, name: &str) -> Option<&HashSet<ParticipantIdentity>> {
+    /// Returns the set of participant SIDs subscribed to a parameter.
+    pub(super) fn subscribers(&self, name: &str) -> Option<&HashSet<ParticipantSid>> {
         self.subscribers_by_name.get(name)
     }
 
-    /// Sweep `identity` out of every parameter-subscription set.
+    /// Sweep `sid` out of every parameter-subscription set.
     ///
-    /// Returns parameter names that lost their last subscriber. No-op if `identity` was not
+    /// Returns parameter names that lost their last subscriber. No-op if `sid` was not
     /// subscribed to any parameter.
-    pub(super) fn cleanup_for_removed_identity(
+    pub(super) fn cleanup_for_removed_participant(
         &mut self,
-        identity: &ParticipantIdentity,
+        sid: &ParticipantSid,
     ) -> Vec<String> {
         let mut last_unsubscribed = Vec::new();
         self.subscribers_by_name.retain(|name, subscribers| {
-            subscribers.remove(identity);
+            subscribers.remove(sid);
             if subscribers.is_empty() {
                 last_unsubscribed.push(name.clone());
                 false
@@ -90,27 +86,27 @@ impl ParameterSubscriptions {
 mod tests {
     use super::*;
 
-    fn make_identity(name: &str) -> ParticipantIdentity {
-        ParticipantIdentity(name.to_string())
+    fn make_sid(label: &str) -> ParticipantSid {
+        crate::remote_access::participant::test_sid(label)
     }
 
     #[test]
     fn first_subscriber_is_reported() {
         let mut subs = ParameterSubscriptions::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
 
-        let new_names = subs.subscribe(&id, vec!["p1".into()]);
+        let new_names = subs.subscribe(&sid, vec!["p1".into()]);
         assert_eq!(new_names, vec!["p1".to_string()]);
     }
 
     #[test]
     fn second_subscriber_is_not_reported_as_first() {
         let mut subs = ParameterSubscriptions::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
 
-        let _ = subs.subscribe(&id_a, vec!["p1".into()]);
-        let new_names = subs.subscribe(&id_b, vec!["p1".into()]);
+        let _ = subs.subscribe(&sid_a, vec!["p1".into()]);
+        let new_names = subs.subscribe(&sid_b, vec!["p1".into()]);
         assert!(new_names.is_empty());
         assert_eq!(subs.subscribers("p1").unwrap().len(), 2);
     }
@@ -118,10 +114,10 @@ mod tests {
     #[test]
     fn duplicate_subscribe_is_idempotent() {
         let mut subs = ParameterSubscriptions::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
 
-        let _ = subs.subscribe(&id, vec!["p1".into()]);
-        let new_names = subs.subscribe(&id, vec!["p1".into()]);
+        let _ = subs.subscribe(&sid, vec!["p1".into()]);
+        let new_names = subs.subscribe(&sid, vec!["p1".into()]);
         assert!(new_names.is_empty());
         assert_eq!(subs.subscribers("p1").unwrap().len(), 1);
     }
@@ -129,9 +125,9 @@ mod tests {
     #[test]
     fn subscribe_multiple_names_at_once() {
         let mut subs = ParameterSubscriptions::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
 
-        let new_names = subs.subscribe(&id, vec!["p1".into(), "p2".into()]);
+        let new_names = subs.subscribe(&sid, vec!["p1".into(), "p2".into()]);
         assert_eq!(new_names.len(), 2);
         assert!(new_names.contains(&"p1".to_string()));
         assert!(new_names.contains(&"p2".to_string()));
@@ -140,10 +136,10 @@ mod tests {
     #[test]
     fn last_unsubscriber_is_reported() {
         let mut subs = ParameterSubscriptions::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
 
-        let _ = subs.subscribe(&id, vec!["p1".into()]);
-        let old_names = subs.unsubscribe(&id, vec!["p1".into()]);
+        let _ = subs.subscribe(&sid, vec!["p1".into()]);
+        let old_names = subs.unsubscribe(&sid, vec!["p1".into()]);
         assert_eq!(old_names, vec!["p1".to_string()]);
         assert!(subs.subscribers("p1").is_none());
     }
@@ -151,12 +147,12 @@ mod tests {
     #[test]
     fn non_last_unsubscriber_is_not_reported() {
         let mut subs = ParameterSubscriptions::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
 
-        let _ = subs.subscribe(&id_a, vec!["p1".into()]);
-        let _ = subs.subscribe(&id_b, vec!["p1".into()]);
-        let old_names = subs.unsubscribe(&id_a, vec!["p1".into()]);
+        let _ = subs.subscribe(&sid_a, vec!["p1".into()]);
+        let _ = subs.subscribe(&sid_b, vec!["p1".into()]);
+        let old_names = subs.unsubscribe(&sid_a, vec!["p1".into()]);
         assert!(old_names.is_empty());
         assert_eq!(subs.subscribers("p1").unwrap().len(), 1);
     }
@@ -164,9 +160,9 @@ mod tests {
     #[test]
     fn unsubscribe_unknown_name_is_noop() {
         let mut subs = ParameterSubscriptions::new();
-        let id = make_identity("alice");
+        let sid = make_sid("alice");
 
-        let old_names = subs.unsubscribe(&id, vec!["missing".into()]);
+        let old_names = subs.unsubscribe(&sid, vec!["missing".into()]);
         assert!(old_names.is_empty());
     }
 
@@ -177,28 +173,28 @@ mod tests {
     }
 
     #[test]
-    fn cleanup_for_removed_identity_drops_orphaned_names() {
+    fn cleanup_for_removed_participant_drops_orphaned_names() {
         let mut subs = ParameterSubscriptions::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
 
-        let _ = subs.subscribe(&id_a, vec!["p1".into(), "p2".into()]);
-        let _ = subs.subscribe(&id_b, vec!["p2".into()]);
+        let _ = subs.subscribe(&sid_a, vec!["p1".into(), "p2".into()]);
+        let _ = subs.subscribe(&sid_b, vec!["p2".into()]);
 
-        let last = subs.cleanup_for_removed_identity(&id_a);
+        let last = subs.cleanup_for_removed_participant(&sid_a);
         assert_eq!(last, vec!["p1".to_string()]);
         assert!(subs.subscribers("p1").is_none());
         assert_eq!(subs.subscribers("p2").unwrap().len(), 1);
     }
 
     #[test]
-    fn cleanup_for_unknown_identity_is_noop() {
+    fn cleanup_for_unknown_participant_is_noop() {
         let mut subs = ParameterSubscriptions::new();
-        let id_a = make_identity("alice");
-        let id_b = make_identity("bob");
+        let sid_a = make_sid("alice");
+        let sid_b = make_sid("bob");
 
-        let _ = subs.subscribe(&id_a, vec!["p1".into()]);
-        let last = subs.cleanup_for_removed_identity(&id_b);
+        let _ = subs.subscribe(&sid_a, vec!["p1".into()]);
+        let last = subs.cleanup_for_removed_participant(&sid_b);
         assert!(last.is_empty());
         assert_eq!(subs.subscribers("p1").unwrap().len(), 1);
     }

--- a/rust/foxglove/src/remote_access/parameter_subscriptions.rs
+++ b/rust/foxglove/src/remote_access/parameter_subscriptions.rs
@@ -64,10 +64,7 @@ impl ParameterSubscriptions {
     ///
     /// Returns parameter names that lost their last subscriber. No-op if `sid` was not
     /// subscribed to any parameter.
-    pub(super) fn cleanup_for_removed_participant(
-        &mut self,
-        sid: &ParticipantSid,
-    ) -> Vec<String> {
+    pub(super) fn cleanup_for_removed_participant(&mut self, sid: &ParticipantSid) -> Vec<String> {
         let mut last_unsubscribed = Vec::new();
         self.subscribers_by_name.retain(|name, subscribers| {
             subscribers.remove(sid);

--- a/rust/foxglove/src/remote_access/participant/collection.rs
+++ b/rust/foxglove/src/remote_access/participant/collection.rs
@@ -76,10 +76,7 @@ impl Participants {
     }
 
     /// Returns the participant for the given `ParticipantSid`, if present.
-    /// Test-only accessor — production reads the index implicitly via
-    /// [`remove_by_sid`].
-    #[cfg(test)]
-    fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
+    pub fn get_by_sid(&self, sid: &ParticipantSid) -> Option<&Arc<Participant>> {
         self.by_sid.get(sid)
     }
 

--- a/rust/foxglove/src/remote_access/participant/registry.rs
+++ b/rust/foxglove/src/remote_access/participant/registry.rs
@@ -205,8 +205,7 @@ impl ParticipantRegistry {
     }
 
     /// Returns `true` if a participant with the given `ParticipantSid` is
-    /// currently registered. See `RemoteAccessSession::participant_already_swept`
-    /// for the use case this exists to support.
+    /// currently registered.
     pub(crate) fn is_sid_registered(&self, sid: &ParticipantSid) -> bool {
         self.participants.read().get_by_sid(sid).is_some()
     }

--- a/rust/foxglove/src/remote_access/participant/registry.rs
+++ b/rust/foxglove/src/remote_access/participant/registry.rs
@@ -204,6 +204,17 @@ impl ParticipantRegistry {
         self.participants.read().get_by_identity(id).cloned()
     }
 
+    /// Returns `true` if a participant with the given `ParticipantSid` is
+    /// currently registered. Insert paths under `subscription_lock` use this
+    /// to skip mutations on behalf of a participant whose registration was
+    /// already swept by a reordered same-identity reconnect; without this
+    /// check, SID-keyed entries can be reinserted into channel / parameter
+    /// state after their cleanup ran, and nothing will sweep them again
+    /// until session shutdown.
+    pub(crate) fn is_sid_registered(&self, sid: &ParticipantSid) -> bool {
+        self.participants.read().get_by_sid(sid).is_some()
+    }
+
     /// Resolves a batch of `ParticipantSid`s to `Arc<Participant>`s under a
     /// single read lock. SIDs with no matching registration are silently
     /// skipped — and a SID never resolves to a different connection instance

--- a/rust/foxglove/src/remote_access/participant/registry.rs
+++ b/rust/foxglove/src/remote_access/participant/registry.rs
@@ -191,7 +191,7 @@ impl ParticipantRegistry {
     /// `Participants::remove_by_sid` cancels the flush-task and detaches its
     /// handle as part of the removal; the caller is responsible for any
     /// further cleanup (subscription sweep, listener callbacks) via
-    /// [`SessionState::cleanup_for_removed_identity`].
+    /// [`SessionState::cleanup_for_removed_participant`].
     pub(crate) fn remove_participant(
         &self,
         target_sid: &ParticipantSid,
@@ -204,18 +204,20 @@ impl ParticipantRegistry {
         self.participants.read().get_by_identity(id).cloned()
     }
 
-    /// Resolves a batch of identities to `Arc<Participant>`s under a single
-    /// read lock. Identities with no matching registration are silently
-    /// skipped (a participant may have been removed between the identity
-    /// snapshot and this call; the missed send is harmless).
-    pub(crate) fn resolve_identities<I>(&self, identities: I) -> Vec<Arc<Participant>>
+    /// Resolves a batch of `ParticipantSid`s to `Arc<Participant>`s under a
+    /// single read lock. SIDs with no matching registration are silently
+    /// skipped — and a SID never resolves to a different connection instance
+    /// than the one it was minted for, because LiveKit assigns a fresh SID
+    /// per connection. A same-identity reconnect therefore has a *different*
+    /// SID, so a stale SID resolves to `None` here rather than misdelivering
+    /// to the replacement.
+    pub(crate) fn resolve_sids<I>(&self, sids: I) -> Vec<Arc<Participant>>
     where
-        I: IntoIterator<Item = ParticipantIdentity>,
+        I: IntoIterator<Item = ParticipantSid>,
     {
         let participants = self.participants.read();
-        identities
-            .into_iter()
-            .filter_map(|id| participants.get_by_identity(&id).cloned())
+        sids.into_iter()
+            .filter_map(|sid| participants.get_by_sid(&sid).cloned())
             .collect()
     }
 

--- a/rust/foxglove/src/remote_access/participant/registry.rs
+++ b/rust/foxglove/src/remote_access/participant/registry.rs
@@ -205,12 +205,8 @@ impl ParticipantRegistry {
     }
 
     /// Returns `true` if a participant with the given `ParticipantSid` is
-    /// currently registered. Insert paths under `subscription_lock` use this
-    /// to skip mutations on behalf of a participant whose registration was
-    /// already swept by a reordered same-identity reconnect; without this
-    /// check, SID-keyed entries can be reinserted into channel / parameter
-    /// state after their cleanup ran, and nothing will sweep them again
-    /// until session shutdown.
+    /// currently registered. See `RemoteAccessSession::participant_already_swept`
+    /// for the use case this exists to support.
     pub(crate) fn is_sid_registered(&self, sid: &ParticipantSid) -> bool {
         self.participants.read().get_by_sid(sid).is_some()
     }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -850,7 +850,7 @@ impl RemoteAccessSession {
             let inserted = self
                 .channel_registry
                 .write()
-                .insert_client_channel(participant.participant_id(), descriptor.clone());
+                .insert_client_channel(participant.participant_sid(), descriptor.clone());
 
             if !inserted {
                 self.send_warning(
@@ -885,7 +885,7 @@ impl RemoteAccessSession {
             let removed = self
                 .channel_registry
                 .write()
-                .remove_client_channel(participant.participant_id(), channel_id);
+                .remove_client_channel(participant.participant_sid(), channel_id);
 
             match removed {
                 None => debug!(
@@ -964,7 +964,7 @@ impl RemoteAccessSession {
         let descriptor = {
             let state = self.channel_registry.read();
             state
-                .get_client_channel(participant.participant_id(), channel_id)
+                .get_client_channel(participant.participant_sid(), channel_id)
                 .cloned()
         };
         let Some(descriptor) = descriptor else {
@@ -1132,7 +1132,7 @@ impl RemoteAccessSession {
         let removed = self
             .channel_registry
             .write()
-            .cleanup_for_removed_participant(participant_sid, participant_id);
+            .cleanup_for_removed_participant(participant_sid);
         let last_param_unsubscribed = self
             .parameter_subscriptions
             .write()

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -204,7 +204,7 @@ impl Sink for RemoteAccessSession {
         // release it before resolving against the participant registry. A
         // same-identity reconnect arrives with a *different* `ParticipantSid`,
         // so a stale snapshotted SID resolves to `None` in the participant
-        // registry rather than the new attempt
+        // registry rather than the new attempt.
         let reliable_sids = {
             let state = self.channel_registry.read();
 
@@ -680,6 +680,19 @@ impl RemoteAccessSession {
     ) {
         let _guard = self.subscription_lock.lock();
 
+        // Re-check the participant under the lock: a reordered same-identity
+        // reconnect could have replaced this SID and run its removal cleanup
+        // between `handle_client_control_message`'s identity lookup and our
+        // acquisition of `subscription_lock`. If so, skip — otherwise the
+        // sweep we missed will never run again for this SID and the
+        // subscriptions inserted below leak until session shutdown.
+        if !self
+            .participant_registry
+            .is_sid_registered(participant.participant_sid())
+        {
+            return;
+        }
+
         // Collect new & modified subscriptions.
         //
         // If the client's subscription request is unsatisfiable, reject it with an error status
@@ -794,6 +807,19 @@ impl RemoteAccessSession {
         // handle_client_message resolves the participant and the point where
         // insert_client_channel asserts its presence, causing a panic.
         let _guard = self.subscription_lock.lock();
+
+        // Re-check the participant under the lock: a reordered same-identity
+        // reconnect could have replaced this SID and run its removal cleanup
+        // between `handle_client_control_message`'s identity lookup and our
+        // acquisition of `subscription_lock`. If so, skip — otherwise the
+        // sweep we missed will never run again for this SID and the
+        // client-channel entry inserted below leaks until session shutdown.
+        if !self
+            .participant_registry
+            .is_sid_registered(participant.participant_sid())
+        {
+            return;
+        }
 
         if !self.has_capability(Capability::ClientPublish) {
             self.send_error(
@@ -1848,6 +1874,20 @@ impl RemoteAccessSession {
             return;
         }
         let _guard = self.subscription_lock.lock();
+
+        // Re-check the participant under the lock: a reordered same-identity
+        // reconnect could have replaced this SID and run its removal cleanup
+        // between `handle_client_control_message`'s identity lookup and our
+        // acquisition of `subscription_lock`. If so, skip — otherwise the
+        // sweep we missed will never run again for this SID and the
+        // parameter subscriptions inserted below leak until session shutdown.
+        if !self
+            .participant_registry
+            .is_sid_registered(participant.participant_sid())
+        {
+            return;
+        }
+
         let new_names = self
             .parameter_subscriptions
             .write()

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -674,9 +674,8 @@ impl RemoteAccessSession {
     /// Insert paths must call this under `subscription_lock`; otherwise
     /// state keyed by the swept SID can be reinserted post-cleanup and
     /// leak until session shutdown.
-    fn participant_already_swept(&self, participant: &Participant) -> bool {
-        !self
-            .participant_registry
+    fn is_participant_registered(&self, participant: &Participant) -> bool {
+        self.participant_registry
             .is_sid_registered(participant.participant_sid())
     }
 
@@ -690,7 +689,7 @@ impl RemoteAccessSession {
         msg: client::Subscribe,
     ) {
         let _guard = self.subscription_lock.lock();
-        if self.participant_already_swept(participant) {
+        if !self.is_participant_registered(participant) {
             return;
         }
 
@@ -808,7 +807,7 @@ impl RemoteAccessSession {
         // handle_client_message resolves the participant and the point where
         // insert_client_channel asserts its presence, causing a panic.
         let _guard = self.subscription_lock.lock();
-        if self.participant_already_swept(participant) {
+        if !self.is_participant_registered(participant) {
             return;
         }
 
@@ -978,12 +977,6 @@ impl RemoteAccessSession {
             return;
         }
 
-        // Avoid surfacing a misleading "Client has not advertised channel"
-        // error for a channel the prior attempt legitimately advertised.
-        if self.participant_already_swept(participant) {
-            return;
-        }
-
         let channel_id = ChannelId::new(msg.channel_id.into());
         let descriptor = {
             let state = self.channel_registry.read();
@@ -992,6 +985,10 @@ impl RemoteAccessSession {
                 .cloned()
         };
         let Some(descriptor) = descriptor else {
+            // If the participant was removed concurrently, don't send an error.
+            if !self.is_participant_registered(participant) {
+                return;
+            }
             self.send_error(
                 participant,
                 format!("Client has not advertised channel: {}", msg.channel_id),
@@ -1872,7 +1869,7 @@ impl RemoteAccessSession {
             return;
         }
         let _guard = self.subscription_lock.lock();
-        if self.participant_already_swept(participant) {
+        if !self.is_participant_registered(participant) {
             return;
         }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -669,11 +669,11 @@ impl RemoteAccessSession {
         true
     }
 
-    /// Returns `true` if `participant`'s SID has already been replaced in
-    /// the participant registry by a reordered same-identity reconnect.
-    /// Insert paths must call this under `subscription_lock`; otherwise
-    /// state keyed by the swept SID can be reinserted post-cleanup and
-    /// leak until session shutdown.
+    /// Returns true if this participant's SID is still in the registry. The SID may have been
+    /// removed if the participant has disconnected, or reconnected as a new session.
+    ///
+    /// Handlers that insert subscriptions and client advertisements (which are scoped to the
+    /// participant session) must perform this check after acquiring [`Self::subscription_lock`].
     fn is_participant_registered(&self, participant: &Participant) -> bool {
         self.participant_registry
             .is_sid_registered(participant.participant_sid())

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -200,21 +200,16 @@ impl Sink for RemoteAccessSession {
     ) -> std::result::Result<(), FoxgloveError> {
         let channel_id = channel.id();
 
-        // Collect subscriber identities under the session-state lock and
-        // release it before broadcasting. Two races are possible between the
-        // collect and the registry resolve, both benign:
-        //   1. The participant has been removed and not replaced — the resolve
-        //      misses and the message is dropped (their control queue has
-        //      already been drained anyway).
-        //   2. The participant has been removed and a same-identity reconnect
-        //      has registered in their place. The resolve returns the new
-        //      attempt, which receives a MessageData for a channel it never
-        //      subscribed to. The channel ID is session-scoped (already
-        //      advertised on this session), so the viewer drops the unknown
-        //      subscription and continues. Resolution is keyed on
-        //      ParticipantIdentity, so this can never deliver data across
-        //      identities — only the same logical user across a reconnect.
-        let reliable_subscribers = {
+        // Resolve identities to Arc<Participant> while still holding the
+        // channel_registry read lock. Doing so closes a same-identity reconnect
+        // race that would otherwise let a freshly-registered attempt 2 receive
+        // a MessageData on a channel it never subscribed to: cleanup of
+        // attempt 1 needs channel_registry.write(), which can't run while we
+        // hold the read, and subscription_lock serializes attempt 2's add
+        // behind that cleanup. The lock-ordering invariant introduced here is
+        // channel_registry → participant_registry; no other path takes them
+        // in the opposite nested order.
+        let reliable_recipients = {
             let state = self.channel_registry.read();
 
             // Video track publisher: stays inside the state lock since the
@@ -224,26 +219,25 @@ impl Sink for RemoteAccessSession {
             }
 
             if !state.has_data_subscribers(&channel_id) {
-                None
+                Vec::new()
             } else if state.qos_profile(&channel_id).reliability == Reliability::Reliable {
-                Some(state.data_subscriber_identities(&channel_id))
+                let identities = state.data_subscriber_identities(&channel_id);
+                self.participant_registry.resolve_identities(identities)
             } else {
                 // Lossy channels: send via the eagerly-published data track
                 // inline, while we still hold the state read lock.
                 if let Some(track) = state.get_subscribed_data_track(&channel_id) {
                     track.log(channel_id, msg, metadata);
                 }
-                None
+                Vec::new()
             }
         };
 
         // Reliable channels: send MessageData via the control bytestream.
-        // Batch-resolve identities so we take the registry lock once rather
-        // than per-subscriber.
-        if let Some(subscribers) = reliable_subscribers {
+        if !reliable_recipients.is_empty() {
             let message = MessageData::new(u64::from(channel_id), metadata.log_time, msg);
             let encoded = encode_binary_message(&message);
-            for participant in self.participant_registry.resolve_identities(subscribers) {
+            for participant in reliable_recipients {
                 participant.send_control(encoded.clone());
             }
         }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -669,6 +669,17 @@ impl RemoteAccessSession {
         true
     }
 
+    /// Returns `true` if `participant`'s SID has already been replaced in
+    /// the participant registry by a reordered same-identity reconnect.
+    /// Insert paths must call this under `subscription_lock`; otherwise
+    /// state keyed by the swept SID can be reinserted post-cleanup and
+    /// leak until session shutdown.
+    fn participant_already_swept(&self, participant: &Participant) -> bool {
+        !self
+            .participant_registry
+            .is_sid_registered(participant.participant_sid())
+    }
+
     /// Subscribes the participant to the requested channels and notifies the listener.
     ///
     /// Channels the participant is already subscribed to are silently skipped.
@@ -679,17 +690,7 @@ impl RemoteAccessSession {
         msg: client::Subscribe,
     ) {
         let _guard = self.subscription_lock.lock();
-
-        // Re-check the participant under the lock: a reordered same-identity
-        // reconnect could have replaced this SID and run its removal cleanup
-        // between `handle_client_control_message`'s identity lookup and our
-        // acquisition of `subscription_lock`. If so, skip — otherwise the
-        // sweep we missed will never run again for this SID and the
-        // subscriptions inserted below leak until session shutdown.
-        if !self
-            .participant_registry
-            .is_sid_registered(participant.participant_sid())
-        {
+        if self.participant_already_swept(participant) {
             return;
         }
 
@@ -807,17 +808,7 @@ impl RemoteAccessSession {
         // handle_client_message resolves the participant and the point where
         // insert_client_channel asserts its presence, causing a panic.
         let _guard = self.subscription_lock.lock();
-
-        // Re-check the participant under the lock: a reordered same-identity
-        // reconnect could have replaced this SID and run its removal cleanup
-        // between `handle_client_control_message`'s identity lookup and our
-        // acquisition of `subscription_lock`. If so, skip — otherwise the
-        // sweep we missed will never run again for this SID and the
-        // client-channel entry inserted below leaks until session shutdown.
-        if !self
-            .participant_registry
-            .is_sid_registered(participant.participant_sid())
-        {
+        if self.participant_already_swept(participant) {
             return;
         }
 
@@ -986,6 +977,13 @@ impl RemoteAccessSession {
             );
             return;
         }
+
+        // Avoid surfacing a misleading "Client has not advertised channel"
+        // error for a channel the prior attempt legitimately advertised.
+        if self.participant_already_swept(participant) {
+            return;
+        }
+
         let channel_id = ChannelId::new(msg.channel_id.into());
         let descriptor = {
             let state = self.channel_registry.read();
@@ -1874,17 +1872,7 @@ impl RemoteAccessSession {
             return;
         }
         let _guard = self.subscription_lock.lock();
-
-        // Re-check the participant under the lock: a reordered same-identity
-        // reconnect could have replaced this SID and run its removal cleanup
-        // between `handle_client_control_message`'s identity lookup and our
-        // acquisition of `subscription_lock`. If so, skip — otherwise the
-        // sweep we missed will never run again for this SID and the
-        // parameter subscriptions inserted below leak until session shutdown.
-        if !self
-            .participant_registry
-            .is_sid_registered(participant.participant_sid())
-        {
+        if self.participant_already_swept(participant) {
             return;
         }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -200,16 +200,21 @@ impl Sink for RemoteAccessSession {
     ) -> std::result::Result<(), FoxgloveError> {
         let channel_id = channel.id();
 
-        // Resolve identities to Arc<Participant> while still holding the
-        // channel_registry read lock. Doing so closes a same-identity reconnect
-        // race that would otherwise let a freshly-registered attempt 2 receive
-        // a MessageData on a channel it never subscribed to: cleanup of
-        // attempt 1 needs channel_registry.write(), which can't run while we
-        // hold the read, and subscription_lock serializes attempt 2's add
-        // behind that cleanup. The lock-ordering invariant introduced here is
-        // channel_registry → participant_registry; no other path takes them
-        // in the opposite nested order.
-        let reliable_recipients = {
+        // Collect subscriber identities under the session-state lock and
+        // release it before broadcasting. Two races are possible between the
+        // collect and the registry resolve, both benign:
+        //   1. The participant has been removed and not replaced — the resolve
+        //      misses and the message is dropped (their control queue has
+        //      already been drained anyway).
+        //   2. The participant has been removed and a same-identity reconnect
+        //      has registered in their place. The resolve returns the new
+        //      attempt, which receives a MessageData for a channel it never
+        //      subscribed to. The channel ID is session-scoped (already
+        //      advertised on this session), so the viewer drops the unknown
+        //      subscription and continues. Resolution is keyed on
+        //      ParticipantIdentity, so this can never deliver data across
+        //      identities — only the same logical user across a reconnect.
+        let reliable_subscribers = {
             let state = self.channel_registry.read();
 
             // Video track publisher: stays inside the state lock since the
@@ -219,25 +224,26 @@ impl Sink for RemoteAccessSession {
             }
 
             if !state.has_data_subscribers(&channel_id) {
-                Vec::new()
+                None
             } else if state.qos_profile(&channel_id).reliability == Reliability::Reliable {
-                let identities = state.data_subscriber_identities(&channel_id);
-                self.participant_registry.resolve_identities(identities)
+                Some(state.data_subscriber_identities(&channel_id))
             } else {
                 // Lossy channels: send via the eagerly-published data track
                 // inline, while we still hold the state read lock.
                 if let Some(track) = state.get_subscribed_data_track(&channel_id) {
                     track.log(channel_id, msg, metadata);
                 }
-                Vec::new()
+                None
             }
         };
 
         // Reliable channels: send MessageData via the control bytestream.
-        if !reliable_recipients.is_empty() {
+        // Batch-resolve identities so we take the registry lock once rather
+        // than per-subscriber.
+        if let Some(subscribers) = reliable_subscribers {
             let message = MessageData::new(u64::from(channel_id), metadata.log_time, msg);
             let encoded = encode_binary_message(&message);
-            for participant in reliable_recipients {
+            for participant in self.participant_registry.resolve_identities(subscribers) {
                 participant.send_control(encoded.clone());
             }
         }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -200,21 +200,12 @@ impl Sink for RemoteAccessSession {
     ) -> std::result::Result<(), FoxgloveError> {
         let channel_id = channel.id();
 
-        // Collect subscriber identities under the session-state lock and
-        // release it before broadcasting. Two races are possible between the
-        // collect and the registry resolve, both benign:
-        //   1. The participant has been removed and not replaced — the resolve
-        //      misses and the message is dropped (their control queue has
-        //      already been drained anyway).
-        //   2. The participant has been removed and a same-identity reconnect
-        //      has registered in their place. The resolve returns the new
-        //      attempt, which receives a MessageData for a channel it never
-        //      subscribed to. The channel ID is session-scoped (already
-        //      advertised on this session), so the viewer drops the unknown
-        //      subscription and continues. Resolution is keyed on
-        //      ParticipantIdentity, so this can never deliver data across
-        //      identities — only the same logical user across a reconnect.
-        let reliable_subscribers = {
+        // Snapshot subscriber SIDs under the channel-registry read lock and
+        // release it before resolving against the participant registry. A
+        // same-identity reconnect arrives with a *different* `ParticipantSid`,
+        // so a stale snapshotted SID resolves to `None` in the participant
+        // registry rather than the new attempt
+        let reliable_sids = {
             let state = self.channel_registry.read();
 
             // Video track publisher: stays inside the state lock since the
@@ -224,26 +215,26 @@ impl Sink for RemoteAccessSession {
             }
 
             if !state.has_data_subscribers(&channel_id) {
-                None
+                SmallVec::new()
             } else if state.qos_profile(&channel_id).reliability == Reliability::Reliable {
-                Some(state.data_subscriber_identities(&channel_id))
+                state.data_subscriber_sids(&channel_id)
             } else {
                 // Lossy channels: send via the eagerly-published data track
                 // inline, while we still hold the state read lock.
                 if let Some(track) = state.get_subscribed_data_track(&channel_id) {
                     track.log(channel_id, msg, metadata);
                 }
-                None
+                SmallVec::new()
             }
         };
 
         // Reliable channels: send MessageData via the control bytestream.
-        // Batch-resolve identities so we take the registry lock once rather
-        // than per-subscriber.
-        if let Some(subscribers) = reliable_subscribers {
+        // Batch-resolve SIDs so we take the registry lock once rather than
+        // per-subscriber.
+        if !reliable_sids.is_empty() {
             let message = MessageData::new(u64::from(channel_id), metadata.log_time, msg);
             let encoded = encode_binary_message(&message);
-            for participant in self.participant_registry.resolve_identities(subscribers) {
+            for participant in self.participant_registry.resolve_sids(reliable_sids) {
                 participant.send_control(encoded.clone());
             }
         }
@@ -322,12 +313,12 @@ impl Sink for RemoteAccessSession {
         let _guard = self.subscription_lock.lock();
         let channel_id = channel.id();
 
-        // Collect subscriber identities before removal; we'll resolve them to
+        // Snapshot subscriber SIDs before removal; we'll resolve them to
         // `Client`s after via the registry.
-        let subscriber_identities = self
+        let subscriber_sids = self
             .channel_registry
             .read()
-            .channel_subscriber_identities(&channel_id);
+            .channel_subscriber_sids(&channel_id);
 
         if !self.channel_registry.write().remove_channel(channel_id) {
             return;
@@ -345,10 +336,7 @@ impl Sink for RemoteAccessSession {
         // Fire on_unsubscribe callbacks for subscribers of the removed channel.
         if let Some(listener) = &self.listener {
             let descriptor = channel.descriptor();
-            for participant in self
-                .participant_registry
-                .resolve_identities(subscriber_identities)
-            {
+            for participant in self.participant_registry.resolve_sids(subscriber_sids) {
                 let client = Client::new(
                     participant.client_id(),
                     participant.participant_id().clone(),
@@ -721,11 +709,11 @@ impl RemoteAccessSession {
         drop(state);
 
         let mut state = self.channel_registry.write();
-        let subscribe_result = state.subscribe(participant.participant_id(), &channel_ids);
+        let subscribe_result = state.subscribe(participant.participant_sid(), &channel_ids);
         let first_video_subscribed =
-            state.subscribe_video(participant.participant_id(), &video_channel_ids);
+            state.subscribe_video(participant.participant_sid(), &video_channel_ids);
         let last_video_unsubscribed =
-            state.unsubscribe_video(participant.participant_id(), &data_channel_ids);
+            state.unsubscribe_video(participant.participant_sid(), &data_channel_ids);
         drop(state);
 
         if !subscribe_result.first_subscribed.is_empty() {
@@ -767,9 +755,9 @@ impl RemoteAccessSession {
             .collect();
 
         let mut state = self.channel_registry.write();
-        let unsubscribe_result = state.unsubscribe(participant.participant_id(), &channel_ids);
+        let unsubscribe_result = state.unsubscribe(participant.participant_sid(), &channel_ids);
         let last_video_unsubscribed =
-            state.unsubscribe_video(participant.participant_id(), &channel_ids);
+            state.unsubscribe_video(participant.participant_sid(), &channel_ids);
         drop(state);
 
         if !unsubscribe_result.last_unsubscribed.is_empty() {
@@ -1140,10 +1128,11 @@ impl RemoteAccessSession {
     fn run_participant_removal_cleanup(self: &Arc<Self>, participant: &Arc<Participant>) {
         let client_id = participant.client_id();
         let participant_id = participant.participant_id();
+        let participant_sid = participant.participant_sid();
         let removed = self
             .channel_registry
             .write()
-            .cleanup_for_removed_identity(participant_id);
+            .cleanup_for_removed_participant(participant_sid, participant_id);
         let last_param_unsubscribed = self
             .parameter_subscriptions
             .write()

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1136,7 +1136,7 @@ impl RemoteAccessSession {
         let last_param_unsubscribed = self
             .parameter_subscriptions
             .write()
-            .cleanup_for_removed_identity(participant_id);
+            .cleanup_for_removed_participant(participant_sid);
 
         // Listener / context / video-track / connection-graph aftercare.
         if !removed.last_unsubscribed.is_empty() {
@@ -1851,7 +1851,7 @@ impl RemoteAccessSession {
         let new_names = self
             .parameter_subscriptions
             .write()
-            .subscribe(participant.participant_id(), names);
+            .subscribe(participant.participant_sid(), names);
         if !new_names.is_empty() {
             if let Some(listener) = &self.listener {
                 listener.on_parameters_subscribe(new_names);
@@ -1876,7 +1876,7 @@ impl RemoteAccessSession {
         let old_names = self
             .parameter_subscriptions
             .write()
-            .unsubscribe(participant.participant_id(), names);
+            .unsubscribe(participant.participant_sid(), names);
         if !old_names.is_empty() {
             if let Some(listener) = &self.listener {
                 listener.on_parameters_unsubscribe(old_names);
@@ -1917,7 +1917,7 @@ impl RemoteAccessSession {
                         .iter()
                         .filter(|p| {
                             subs.subscribers(&p.name)
-                                .is_some_and(|ids| ids.contains(participant.participant_id()))
+                                .is_some_and(|sids| sids.contains(participant.participant_sid()))
                         })
                         .cloned()
                         .collect();


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Sink::log previously read channel subscriber identities under the channel_registry lock, dropped it, and then resolved those identities to Arc<Participant>s under participant_registry. The gap between the two operations let a complete remove-then-add cycle for the same identity slip in: cleanup of attempt 1 cleared its channel subscriptions, attempt 2 registered with the same identity, and the late resolve handed the message to attempt 2 — which had never subscribed to the channel.

The race was benign in practice since the viewer drops MessageData on unsubscribed channels.  But we can fix it completely.  LiveKit assigns a fresh ParticipantSid per connection instance, so re-keying the maps by SID makes a stale snapshot resolve to None instead of crossing over to a different connection:

* ChannelRegistry::subscriptions / video_subscribers are SID-keyed; lookup helpers renamed *_identities → *_sids. Sink::log resolves under a single channel_registry.read() and a separate participant_registry lookup.
* ChannelRegistry::client_channels is SID-keyed. cleanup_for_removed_participant no longer needs an identity argument.
* ParameterSubscriptions is SID-keyed; cleanup_for_removed_identity → cleanup_for_removed_participant to match.

SID-keying introduces a new failure mode in the reverse direction: if a reordered ParticipantActive for a same-identity reconnect runs add_participant's cleanup of SID1 between an in-flight client message's get_participant(identity) and its acquisition of subscription_lock, an insert path could reinsert SID1 entries that nothing will ever sweep again (until session shutdown). Four handlers (handle_client_subscribe, handle_client_advertise, handle_subscribe_parameter_updates, handle_client_message_data) re-check via a small participant_already_swept helper and early-return when the SID has been replaced.

Part of FLE-475