### PR TITLE
ci(c-cpp): disable cache-bin in build matrix to avoid iOS-sim flakes

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -159,6 +159,9 @@ jobs:
           # Set a cache key to distinguish the remote-access-enabled linux
           # builds from the non-remote-access-enabled linux builds.
           cache-key: ${{ matrix.remote_access && 'ra-v2' || '' }}
+          # Don't cache ~/.cargo/bin — caching rustup proxies has poisoned
+          # the iOS-sim runner with a rustup-init binary masquerading as cargo.
+          cache-bin: false
 
       # aws-lc-sys requires iOS 13+ to build. The conditional treats an unset
       # `crypto_provider` as the aws-lc-rs default, and skips this step for any


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The matrix build job intermittently fails on aarch64-apple-ios-sim with "unexpected argument 'rustc' found / Usage: rustup-init[EXE]" because Swatinem/rust-cache's cache-bin: true setting caches ~/.cargo/bin and restores it over the rustup proxies set up by setup-rust-toolchain. A poisoned cache entry leaves cargo pointing at rustup-init, so the next `cargo rustc ...` invocation fails immediately. Re-runs usually succeed because they happen to miss the bad cache or overwrite it on save.

Setting cache-bin: false skips the .cargo/bin directory entirely. The SDK build doesn't rely on any user-installed cargo subcommands, so there's no caching benefit lost.

I'm not at all sure of Claude's reasoning here, or whether the fix will lose us performance.  Worth a try, I guess?