### PR TITLE
cpp: Fix std::max type-deduction error in system_info.cpp

### DIFF
--- a/cpp/foxglove/src/system_info.cpp
+++ b/cpp/foxglove/src/system_info.cpp
@@ -21,7 +21,7 @@ FoxgloveResult<SystemInfoPublisher> SystemInfoPublisher::create(
   std::optional<uint64_t> refresh_interval_ms;
   if (options.refresh_interval) {
     refresh_interval_ms =
-      static_cast<uint64_t>(std::max(options.refresh_interval->count(), int64_t(0)));
+      static_cast<uint64_t>(std::max<int64_t>(options.refresh_interval->count(), 0));
     c_options.refresh_interval_ms = &*refresh_interval_ms;
   }
 


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

On toolchains where chrono::milliseconds::rep and int64_t are distinct 64-bit integer typedefs (e.g. libc++ on Linux x86_64, where rep is long long and int64_t is long), std::max's template argument deduction fails. Pin the template parameter to int64_t so both arguments are implicitly converted at the call site.

I noticed this while trying to compile our examples from the documentation at https://docs.foxglove.dev/docs/sdk/example .  This fixes it for me on clang.