### PR TITLE
rust: Introduce ParameterHandler for asynchronous parameter operations

### DIFF
--- a/rust/examples/remote_access_fetch_asset/src/main.rs
+++ b/rust/examples/remote_access_fetch_asset/src/main.rs
@@ -19,7 +19,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-
 use foxglove::LazyChannel;
 use foxglove::messages::{
     Color, ModelPrimitive, Pose, Quaternion, SceneEntity, SceneUpdate, Vector3,

--- a/rust/examples/remote_access_fetch_asset/src/main.rs
+++ b/rust/examples/remote_access_fetch_asset/src/main.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+
 use foxglove::LazyChannel;
 use foxglove::messages::{
     Color, ModelPrimitive, Pose, Quaternion, SceneEntity, SceneUpdate, Vector3,

--- a/rust/foxglove/src/remote_access.rs
+++ b/rust/foxglove/src/remote_access.rs
@@ -33,8 +33,11 @@ pub use crate::protocol::v2::parameter::{Parameter, ParameterType, ParameterValu
 // Re-export status types so callers can publish and remove status messages.
 pub use crate::protocol::v2::server::status::{Level as StatusLevel, Status};
 
-// Re-export fetch-asset types.
+// Re-export fetch-asset and parameter handler types.
 pub use crate::remote_common::fetch_asset::{AssetHandler, AssetResponder};
+pub use crate::remote_common::parameters::{
+    GetParametersResponder, ParameterHandler, SetParametersResponder,
+};
 
 use reqwest::StatusCode;
 use thiserror::Error;

--- a/rust/foxglove/src/remote_access/client.rs
+++ b/rust/foxglove/src/remote_access/client.rs
@@ -5,7 +5,7 @@ use livekit::id::ParticipantIdentity;
 use crate::protocol::common::parameter::Parameter;
 use crate::protocol::common::server::status::Status;
 use crate::remote_access::participant::Participant;
-use crate::remote_access::session::{RemoteAccessSession, encode_json_message};
+use crate::remote_access::session::encode_json_message;
 use crate::remote_common::ClientId;
 use crate::remote_common::fetch_asset::SendAssetResponse;
 use crate::remote_common::parameters::SendParameterResponse;
@@ -19,8 +19,6 @@ pub struct Client {
     participant_id: ParticipantIdentity,
     /// Weak reference to the participant, used for sending asset/parameter responses.
     participant: Option<Weak<Participant>>,
-    /// Weak reference to the owning session, used to broadcast parameter values to all subscribers.
-    session: Option<Weak<RemoteAccessSession>>,
 }
 
 impl Client {
@@ -30,7 +28,6 @@ impl Client {
             client_id,
             participant_id,
             participant: None,
-            session: None,
         }
     }
 
@@ -39,13 +36,11 @@ impl Client {
         client_id: ClientId,
         participant_id: ParticipantIdentity,
         participant: &Arc<Participant>,
-        session: Weak<RemoteAccessSession>,
     ) -> Self {
         Self {
             client_id,
             participant_id,
             participant: Some(Arc::downgrade(participant)),
-            session: Some(session),
         }
     }
 
@@ -122,17 +117,5 @@ impl SendParameterResponse for Client {
             msg = msg.with_id(id);
         }
         participant.send_control(encode_json_message(&msg));
-    }
-
-    fn broadcast_parameter_values(&self, parameters: Vec<Parameter>) {
-        let Some(session) = self.session.as_ref().and_then(|w| w.upgrade()) else {
-            tracing::debug!(
-                client_id = ?self.client_id,
-                participant_id = ?self.participant_id,
-                "session unavailable, dropping parameter broadcast"
-            );
-            return;
-        };
-        session.publish_parameter_values(parameters);
     }
 }

--- a/rust/foxglove/src/remote_access/client.rs
+++ b/rust/foxglove/src/remote_access/client.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Weak};
 use livekit::id::ParticipantIdentity;
 
 use crate::protocol::common::parameter::Parameter;
+use crate::protocol::common::server::ParameterValues;
 use crate::protocol::common::server::status::Status;
 use crate::remote_access::participant::Participant;
 use crate::remote_access::session::encode_json_message;
@@ -111,7 +112,6 @@ impl SendParameterResponse for Client {
             );
             return;
         };
-        use crate::protocol::common::server::ParameterValues;
         let mut msg = ParameterValues::new(parameters.into_iter().filter(|p| p.value.is_some()));
         if let Some(id) = request_id {
             msg = msg.with_id(id);

--- a/rust/foxglove/src/remote_access/client.rs
+++ b/rust/foxglove/src/remote_access/client.rs
@@ -2,11 +2,13 @@ use std::sync::{Arc, Weak};
 
 use livekit::id::ParticipantIdentity;
 
+use crate::protocol::common::parameter::Parameter;
 use crate::protocol::common::server::status::Status;
 use crate::remote_access::participant::Participant;
-use crate::remote_access::session::encode_json_message;
+use crate::remote_access::session::{RemoteAccessSession, encode_json_message};
 use crate::remote_common::ClientId;
 use crate::remote_common::fetch_asset::SendAssetResponse;
+use crate::remote_common::parameters::SendParameterResponse;
 
 /// Represents a connected remote access client.
 #[derive(Debug, Clone)]
@@ -15,10 +17,10 @@ pub struct Client {
     client_id: ClientId,
     /// LiveKit participant ID.
     participant_id: ParticipantIdentity,
-    /// Weak reference to the participant, used for sending asset responses.
-    /// Only set when created via `with_sender`. Using Weak allows the participant
-    /// to be cleaned up even if a slow handler is still holding a Client reference.
+    /// Weak reference to the participant, used for sending asset/parameter responses.
     participant: Option<Weak<Participant>>,
+    /// Weak reference to the owning session, used to broadcast parameter values to all subscribers.
+    session: Option<Weak<RemoteAccessSession>>,
 }
 
 impl Client {
@@ -28,19 +30,22 @@ impl Client {
             client_id,
             participant_id,
             participant: None,
+            session: None,
         }
     }
 
-    /// Instantiate a new client with the ability to send asset responses.
+    /// Instantiate a new client capable of sending asset/parameter responses.
     pub(super) fn with_sender(
         client_id: ClientId,
         participant_id: ParticipantIdentity,
         participant: &Arc<Participant>,
+        session: Weak<RemoteAccessSession>,
     ) -> Self {
         Self {
             client_id,
             participant_id,
             participant: Some(Arc::downgrade(participant)),
+            session: Some(session),
         }
     }
 
@@ -98,5 +103,36 @@ impl SendAssetResponse for Client {
             Ok(data) => participant.send_asset_response(data, request_id),
             Err(err) => participant.send_asset_error(err, request_id),
         }
+    }
+}
+
+impl SendParameterResponse for Client {
+    fn send_parameter_values(&self, parameters: Vec<Parameter>, request_id: Option<String>) {
+        let Some(participant) = self.participant.as_ref().and_then(|w| w.upgrade()) else {
+            tracing::debug!(
+                client_id = ?self.client_id,
+                participant_id = ?self.participant_id,
+                "participant disconnected, dropping parameter values response"
+            );
+            return;
+        };
+        use crate::protocol::common::server::ParameterValues;
+        let mut msg = ParameterValues::new(parameters.into_iter().filter(|p| p.value.is_some()));
+        if let Some(id) = request_id {
+            msg = msg.with_id(id);
+        }
+        participant.send_control(encode_json_message(&msg));
+    }
+
+    fn broadcast_parameter_values(&self, parameters: Vec<Parameter>) {
+        let Some(session) = self.session.as_ref().and_then(|w| w.upgrade()) else {
+            tracing::debug!(
+                client_id = ?self.client_id,
+                participant_id = ?self.participant_id,
+                "session unavailable, dropping parameter broadcast"
+            );
+            return;
+        };
+        session.publish_parameter_values(parameters);
     }
 }

--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     remote_common::{
         connection_graph::ConnectionGraph,
+        parameters::ParameterHandler,
         service::{Service, ServiceId, ServiceMap},
     },
 };
@@ -92,6 +93,7 @@ pub(super) struct ConnectionParams {
     pub(super) capabilities: Vec<Capability>,
     pub(super) supported_encodings: Option<IndexSet<String>>,
     pub(super) fetch_asset_handler: Option<Arc<dyn AssetHandler>>,
+    pub(super) parameter_handler: Option<Arc<dyn ParameterHandler>>,
     pub(super) runtime: Handle,
     pub(super) channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     pub(super) qos_classifier: Option<Arc<dyn QosClassifier>>,
@@ -127,6 +129,7 @@ pub(super) struct RemoteAccessConnection {
     capabilities: Vec<Capability>,
     supported_encodings: Option<IndexSet<String>>,
     fetch_asset_handler: Option<Arc<dyn AssetHandler>>,
+    parameter_handler: Option<Arc<dyn ParameterHandler>>,
     runtime: Handle,
     channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     qos_classifier: Option<Arc<dyn QosClassifier>>,
@@ -156,6 +159,7 @@ impl RemoteAccessConnection {
             capabilities: params.capabilities,
             supported_encodings: params.supported_encodings,
             fetch_asset_handler: params.fetch_asset_handler,
+            parameter_handler: params.parameter_handler,
             runtime: params.runtime,
             channel_filter: params.channel_filter,
             qos_classifier: params.qos_classifier,
@@ -318,13 +322,11 @@ impl RemoteAccessConnection {
             connection_graph: self.connection_graph.clone(),
             remote_access_session_id: remote_access_session_id.map(str::to_string),
             fetch_asset_handler: self.fetch_asset_handler.clone(),
+            parameter_handler: self.parameter_handler.clone(),
             server_info,
             device_wait_for_viewer: Some(device_wait_for_viewer),
         };
-        Ok((
-            Arc::new(RemoteAccessSession::new(session_params)),
-            room_events,
-        ))
+        Ok((RemoteAccessSession::new(session_params), room_events))
     }
 
     /// Run the server loop until cancelled in a new tokio task.

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -19,6 +19,7 @@ use super::qos::{QosClassifier, QosClassifierFn, QosProfile};
 
 use super::connection::{ConnectionParams, ConnectionStatus, RemoteAccessConnection};
 use super::{Capability, Listener};
+use crate::remote_common::parameters::ParameterHandler;
 
 /// A handle to the remote access gateway connection.
 ///
@@ -122,6 +123,7 @@ impl GatewayHandle {
             capabilities: Vec::new(),
             supported_encodings: None,
             fetch_asset_handler: None,
+            parameter_handler: None,
             runtime: runtime.clone(),
             channel_filter: None,
             qos_classifier: None,
@@ -168,6 +170,7 @@ pub struct Gateway {
     supported_encodings: Option<IndexSet<String>>,
     services: HashMap<String, Service>,
     fetch_asset_handler: Option<Arc<dyn AssetHandler>>,
+    parameter_handler: Option<Arc<dyn ParameterHandler>>,
     runtime: Option<Handle>,
     channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     qos_classifier: Option<Arc<dyn QosClassifier>>,
@@ -188,6 +191,7 @@ impl Default for Gateway {
             supported_encodings: None,
             services: HashMap::new(),
             fetch_asset_handler: None,
+            parameter_handler: None,
             runtime: None,
             channel_filter: None,
             qos_classifier: None,
@@ -213,6 +217,7 @@ impl std::fmt::Debug for Gateway {
                 "has_fetch_asset_handler",
                 &self.fetch_asset_handler.is_some(),
             )
+            .field("has_parameter_handler", &self.parameter_handler.is_some())
             .field("has_runtime", &self.runtime.is_some())
             .field("has_channel_filter", &self.channel_filter.is_some())
             .field("has_qos_classifier", &self.qos_classifier.is_some())
@@ -404,6 +409,13 @@ impl Gateway {
         self
     }
 
+    /// Configure the handler for client-initiated parameter operations. When set, takes
+    /// precedence over the deprecated parameter callbacks on [`Listener`].
+    pub fn parameter_handler(mut self, handler: Arc<dyn ParameterHandler>) -> Self {
+        self.parameter_handler = Some(handler);
+        self
+    }
+
     /// Starts the remote access gateway, which will establish a connection in the background.
     ///
     /// Returns a handle that can optionally be used to manage the gateway.
@@ -462,6 +474,11 @@ impl Gateway {
         if self.fetch_asset_handler.is_some() && !self.capabilities.contains(&Capability::Assets) {
             self.capabilities.push(Capability::Assets);
         }
+        // If the gateway was declared with a parameter handler, automatically add the "parameters" capability.
+        if self.parameter_handler.is_some() && !self.capabilities.contains(&Capability::Parameters)
+        {
+            self.capabilities.push(Capability::Parameters);
+        }
         // Conversely, the "assets" capability requires a fetch asset handler.
         if self.capabilities.contains(&Capability::Assets) && self.fetch_asset_handler.is_none() {
             return Err(FoxgloveError::ConfigurationError(
@@ -484,6 +501,7 @@ impl Gateway {
             capabilities: self.capabilities,
             supported_encodings: self.supported_encodings,
             fetch_asset_handler: self.fetch_asset_handler,
+            parameter_handler: self.parameter_handler,
             runtime: runtime.clone(),
             channel_filter: self.channel_filter,
             qos_classifier: self.qos_classifier,

--- a/rust/foxglove/src/remote_access/participant.rs
+++ b/rust/foxglove/src/remote_access/participant.rs
@@ -25,6 +25,7 @@ type Result<T> = std::result::Result<T, Box<RemoteAccessError>>;
 
 const DEFAULT_SERVICE_CALLS_PER_PARTICIPANT: usize = 32;
 const DEFAULT_FETCH_ASSET_PER_PARTICIPANT: usize = 32;
+const DEFAULT_PARAMETER_CALLS_PER_PARTICIPANT: usize = 32;
 
 /// A participant in the remote access session.
 ///
@@ -73,6 +74,9 @@ pub(super) struct Participant {
     service_call_sem: Semaphore,
     /// Limits concurrent fetch asset requests from this participant.
     fetch_asset_sem: Semaphore,
+    /// Limits concurrent parameter handler invocations (get + set combined) from this
+    /// participant. Subscribe / unsubscribe are bookkeeping-only and not gated.
+    parameter_sem: Semaphore,
 }
 
 impl Participant {
@@ -144,6 +148,7 @@ impl Participant {
             cancel,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
+            parameter_sem: Semaphore::new(DEFAULT_PARAMETER_CALLS_PER_PARTICIPANT),
         });
         (participant, flush_handle)
     }
@@ -175,6 +180,7 @@ impl Participant {
             cancel,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_PARTICIPANT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_PER_PARTICIPANT),
+            parameter_sem: Semaphore::new(DEFAULT_PARAMETER_CALLS_PER_PARTICIPANT),
         }
     }
 
@@ -191,6 +197,11 @@ impl Participant {
     /// Returns the fetch asset semaphore for this participant.
     pub fn fetch_asset_sem(&self) -> &Semaphore {
         &self.fetch_asset_sem
+    }
+
+    /// Returns the parameter handler semaphore for this participant.
+    pub fn parameter_sem(&self) -> &Semaphore {
+        &self.parameter_sem
     }
 
     /// Cancel this participant's flush-task. The task will exit at the next

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1176,10 +1176,7 @@ impl RemoteAccessSession {
         self.stop_video_tracks(&removed.last_video_unsubscribed);
 
         if !last_param_unsubscribed.is_empty() {
-            // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
-            if let Some(handler) = self.parameter_handler.as_ref() {
-                handler.unsubscribe(last_param_unsubscribed);
-            } else if let Some(listener) = &self.listener {
+            if let Some(listener) = &self.listener {
                 listener.on_parameters_unsubscribe(last_param_unsubscribed);
             }
         }
@@ -1923,10 +1920,7 @@ impl RemoteAccessSession {
             .write()
             .subscribe(participant.participant_sid(), names);
         if !new_names.is_empty() {
-            // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
-            if let Some(handler) = self.parameter_handler.as_ref() {
-                handler.subscribe(new_names);
-            } else if let Some(listener) = &self.listener {
+            if let Some(listener) = &self.listener {
                 listener.on_parameters_subscribe(new_names);
             }
         }
@@ -1951,10 +1945,7 @@ impl RemoteAccessSession {
             .write()
             .unsubscribe(participant.participant_sid(), names);
         if !old_names.is_empty() {
-            // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
-            if let Some(handler) = self.parameter_handler.as_ref() {
-                handler.unsubscribe(old_names);
-            } else if let Some(listener) = &self.listener {
+            if let Some(listener) = &self.listener {
                 listener.on_parameters_unsubscribe(old_names);
             }
         }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2737,7 +2737,7 @@ mod tests {
     }
 
     #[test]
-    fn set_parameters_responder_drop_sends_error_no_broadcast() {
+    fn set_parameters_responder_drop_sends_error() {
         let (participant, rx) = make_participant_with_rx("alice");
         let client = test_client(&participant);
         let guard = participant.parameter_sem().try_acquire().unwrap();
@@ -2748,8 +2748,6 @@ mod tests {
         let status: Status = recv_json(&rx);
         assert_eq!(status.level, StatusLevel::Error);
         assert!(status.message.contains("failed to send a response"));
-        // Nothing else queued (no broadcast attempt would land here anyway since the test
-        // client has no session ref, but this asserts the drop didn't enqueue extra).
         assert!(rx.try_recv().is_err());
     }
 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -26,6 +26,7 @@ use crate::remote_common::connection_graph::ConnectionGraph;
 use crate::remote_common::{
     AnyClient,
     fetch_asset::AssetResponder,
+    parameters::{GetParametersResponder, ParameterHandler, SetParametersResponder},
     service::{CallId, Service, ServiceId, ServiceMap},
 };
 use crate::time::millis_since_epoch;
@@ -146,6 +147,7 @@ fn build_advertise_services_msg(services: &[Arc<Service>]) -> Option<AdvertiseSe
 /// so that it can deliver messages via multi-cast to multiple participants.
 pub(super) struct RemoteAccessSession {
     sink_id: SinkId,
+    weak_self: Weak<Self>,
     room: Room,
     context: Weak<Context>,
     remote_access_session_id: Option<String>,
@@ -162,6 +164,7 @@ pub(super) struct RemoteAccessSession {
     listener: Option<Arc<dyn Listener>>,
     capabilities: Vec<Capability>,
     fetch_asset_handler: Option<Arc<dyn AssetHandler>>,
+    parameter_handler: Option<Arc<dyn ParameterHandler>>,
     runtime: Handle,
     cancellation_token: CancellationToken,
     services: Arc<parking_lot::RwLock<ServiceMap>>,
@@ -367,16 +370,18 @@ pub(super) struct SessionParams {
     pub(super) connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
     pub(super) remote_access_session_id: Option<String>,
     pub(super) fetch_asset_handler: Option<Arc<dyn AssetHandler>>,
+    pub(super) parameter_handler: Option<Arc<dyn ParameterHandler>>,
     pub(super) server_info: ServerInfo,
     pub(super) device_wait_for_viewer: Option<Duration>,
 }
 
 impl RemoteAccessSession {
-    pub(super) fn new(params: SessionParams) -> Self {
+    pub(super) fn new(params: SessionParams) -> Arc<Self> {
         let (video_metadata_tx, video_metadata_rx) = tokio::sync::watch::channel(());
         let participant_registry = ParticipantRegistry::new(params.message_backlog_size);
-        Self {
+        Arc::new_cyclic(|weak_self| Self {
             sink_id: SinkId::next(),
+            weak_self: weak_self.clone(),
             room: params.room,
             context: params.context,
             remote_access_session_id: params.remote_access_session_id,
@@ -387,6 +392,7 @@ impl RemoteAccessSession {
             listener: params.listener,
             capabilities: params.capabilities,
             fetch_asset_handler: params.fetch_asset_handler,
+            parameter_handler: params.parameter_handler,
             runtime: params.runtime,
             cancellation_token: params.cancellation_token,
             subscription_lock: parking_lot::Mutex::new(()),
@@ -400,7 +406,7 @@ impl RemoteAccessSession {
             server_info: params.server_info,
             participant_registry,
             device_wait_for_viewer: params.device_wait_for_viewer,
-        }
+        })
     }
 
     /// Returns true if the given capability is enabled for this session.
@@ -1170,7 +1176,10 @@ impl RemoteAccessSession {
         self.stop_video_tracks(&removed.last_video_unsubscribed);
 
         if !last_param_unsubscribed.is_empty() {
-            if let Some(listener) = &self.listener {
+            // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
+            if let Some(handler) = self.parameter_handler.as_ref() {
+                handler.unsubscribe(last_param_unsubscribed);
+            } else if let Some(listener) = &self.listener {
                 listener.on_parameters_unsubscribe(last_param_unsubscribed);
             }
         }
@@ -1792,6 +1801,7 @@ impl RemoteAccessSession {
             participant.client_id(),
             participant.participant_id().clone(),
             participant,
+            self.weak_self.clone(),
         ));
         let responder = AssetResponder::new(client, request_id, guard);
         handler.fetch(uri, responder);
@@ -1809,6 +1819,23 @@ impl RemoteAccessSession {
                 participant,
                 "Server does not support parameters capability".into(),
             );
+            return;
+        }
+
+        // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
+        if let Some(handler) = self.parameter_handler.as_ref() {
+            let Some(guard) = participant.parameter_sem().try_acquire() else {
+                self.send_error(participant, "Too many concurrent parameter requests".into());
+                return;
+            };
+            let client = AnyClient::from_remote_access(Client::with_sender(
+                participant.client_id(),
+                participant.participant_id().clone(),
+                participant,
+                self.weak_self.clone(),
+            ));
+            let responder = GetParametersResponder::new(client.clone(), request_id.clone(), guard);
+            handler.get(client, param_names, request_id, responder);
             return;
         }
 
@@ -1835,6 +1862,23 @@ impl RemoteAccessSession {
                 participant,
                 "Server does not support parameters capability".into(),
             );
+            return;
+        }
+
+        // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
+        if let Some(handler) = self.parameter_handler.as_ref() {
+            let Some(guard) = participant.parameter_sem().try_acquire() else {
+                self.send_error(participant, "Too many concurrent parameter requests".into());
+                return;
+            };
+            let client = AnyClient::from_remote_access(Client::with_sender(
+                participant.client_id(),
+                participant.participant_id().clone(),
+                participant,
+                self.weak_self.clone(),
+            ));
+            let responder = SetParametersResponder::new(client.clone(), request_id.clone(), guard);
+            handler.set(client, parameters, request_id, responder);
             return;
         }
 
@@ -1879,7 +1923,10 @@ impl RemoteAccessSession {
             .write()
             .subscribe(participant.participant_sid(), names);
         if !new_names.is_empty() {
-            if let Some(listener) = &self.listener {
+            // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
+            if let Some(handler) = self.parameter_handler.as_ref() {
+                handler.subscribe(new_names);
+            } else if let Some(listener) = &self.listener {
                 listener.on_parameters_subscribe(new_names);
             }
         }
@@ -1904,7 +1951,10 @@ impl RemoteAccessSession {
             .write()
             .unsubscribe(participant.participant_sid(), names);
         if !old_names.is_empty() {
-            if let Some(listener) = &self.listener {
+            // ParameterHandler takes precedence over the deprecated Listener parameter callbacks.
+            if let Some(handler) = self.parameter_handler.as_ref() {
+                handler.unsubscribe(old_names);
+            } else if let Some(listener) = &self.listener {
                 listener.on_parameters_unsubscribe(old_names);
             }
         }
@@ -2281,6 +2331,7 @@ mod tests {
             participant.client_id(),
             participant.participant_id().clone(),
             participant,
+            Weak::new(),
         ))
     }
 
@@ -2603,5 +2654,102 @@ mod tests {
         drop(rx);
         // Disconnected returns true (no reset needed).
         assert!(participant.try_queue_control(Bytes::from_static(b"msg")));
+    }
+
+    // ---- parameter handler responder tests ----
+
+    use crate::protocol::common::parameter::Parameter as CommonParameter;
+    use crate::protocol::common::server::ParameterValues;
+    use crate::protocol::common::server::status::{Level as StatusLevel, Status};
+    use crate::remote_common::parameters::{GetParametersResponder, SetParametersResponder};
+
+    /// Decode the next control message — which is framed as 1 byte opcode + 4 byte LE length +
+    /// JSON payload — as a `T`.
+    fn recv_json<T: serde::de::DeserializeOwned>(rx: &flume::Receiver<Bytes>) -> T {
+        let bytes = rx.try_recv().expect("expected control message");
+        assert!(
+            bytes.len() >= 5,
+            "control msg too short: {} bytes",
+            bytes.len()
+        );
+        assert_eq!(bytes[0], 1, "expected JSON opcode (1), got {}", bytes[0]);
+        let len = u32::from_le_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]) as usize;
+        let payload = &bytes[5..5 + len];
+        serde_json::from_slice(payload).expect("failed to decode control msg payload")
+    }
+
+    #[test]
+    fn get_parameters_responder_sends_values() {
+        let (participant, rx) = make_participant_with_rx("alice");
+        let client = test_client(&participant);
+        let guard = participant.parameter_sem().try_acquire().unwrap();
+        let responder = GetParametersResponder::new(client, Some("req-1".to_string()), guard);
+
+        responder.respond(vec![CommonParameter::float64("foo", 1.0)]);
+
+        let msg: ParameterValues = recv_json(&rx);
+        assert_eq!(msg.id.as_deref(), Some("req-1"));
+        assert_eq!(msg.parameters, vec![CommonParameter::float64("foo", 1.0)]);
+    }
+
+    #[test]
+    fn get_parameters_responder_drop_sends_error() {
+        let (participant, rx) = make_participant_with_rx("alice");
+        let client = test_client(&participant);
+        let guard = participant.parameter_sem().try_acquire().unwrap();
+        let responder = GetParametersResponder::new(client, Some("req-1".to_string()), guard);
+
+        drop(responder);
+
+        let status: Status = recv_json(&rx);
+        assert_eq!(status.level, StatusLevel::Error);
+        assert!(status.message.contains("failed to send a response"));
+    }
+
+    #[test]
+    fn set_parameters_responder_echoes_when_request_id_set() {
+        // The broadcast path requires a session, which we cannot construct in a unit test.
+        // The Client built by test_client() has no session ref, so broadcast is a no-op; we
+        // verify the echo path here.
+        let (participant, rx) = make_participant_with_rx("alice");
+        let client = test_client(&participant);
+        let guard = participant.parameter_sem().try_acquire().unwrap();
+        let responder = SetParametersResponder::new(client, Some("set-1".to_string()), guard);
+
+        responder.respond(vec![CommonParameter::float64("foo", 2.0)]);
+
+        let msg: ParameterValues = recv_json(&rx);
+        assert_eq!(msg.id.as_deref(), Some("set-1"));
+        assert_eq!(msg.parameters, vec![CommonParameter::float64("foo", 2.0)]);
+    }
+
+    #[test]
+    fn set_parameters_responder_no_echo_without_request_id() {
+        let (participant, rx) = make_participant_with_rx("alice");
+        let client = test_client(&participant);
+        let guard = participant.parameter_sem().try_acquire().unwrap();
+        let responder = SetParametersResponder::new(client, None, guard);
+
+        responder.respond(vec![CommonParameter::float64("foo", 2.0)]);
+
+        // No echo, and broadcast is a no-op since the test client has no session.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn set_parameters_responder_drop_sends_error_no_broadcast() {
+        let (participant, rx) = make_participant_with_rx("alice");
+        let client = test_client(&participant);
+        let guard = participant.parameter_sem().try_acquire().unwrap();
+        let responder = SetParametersResponder::new(client, Some("set-1".to_string()), guard);
+
+        drop(responder);
+
+        let status: Status = recv_json(&rx);
+        assert_eq!(status.level, StatusLevel::Error);
+        assert!(status.message.contains("failed to send a response"));
+        // Nothing else queued (no broadcast attempt would land here anyway since the test
+        // client has no session ref, but this asserts the drop didn't enqueue extra).
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -147,7 +147,6 @@ fn build_advertise_services_msg(services: &[Arc<Service>]) -> Option<AdvertiseSe
 /// so that it can deliver messages via multi-cast to multiple participants.
 pub(super) struct RemoteAccessSession {
     sink_id: SinkId,
-    weak_self: Weak<Self>,
     room: Room,
     context: Weak<Context>,
     remote_access_session_id: Option<String>,
@@ -379,9 +378,8 @@ impl RemoteAccessSession {
     pub(super) fn new(params: SessionParams) -> Arc<Self> {
         let (video_metadata_tx, video_metadata_rx) = tokio::sync::watch::channel(());
         let participant_registry = ParticipantRegistry::new(params.message_backlog_size);
-        Arc::new_cyclic(|weak_self| Self {
+        Arc::new(Self {
             sink_id: SinkId::next(),
-            weak_self: weak_self.clone(),
             room: params.room,
             context: params.context,
             remote_access_session_id: params.remote_access_session_id,
@@ -1798,7 +1796,6 @@ impl RemoteAccessSession {
             participant.client_id(),
             participant.participant_id().clone(),
             participant,
-            self.weak_self.clone(),
         ));
         let responder = AssetResponder::new(client, request_id, guard);
         handler.fetch(uri, responder);
@@ -1829,7 +1826,6 @@ impl RemoteAccessSession {
                 participant.client_id(),
                 participant.participant_id().clone(),
                 participant,
-                self.weak_self.clone(),
             ));
             let responder = GetParametersResponder::new(client.clone(), request_id.clone(), guard);
             handler.get(client, param_names, request_id, responder);
@@ -1872,7 +1868,6 @@ impl RemoteAccessSession {
                 participant.client_id(),
                 participant.participant_id().clone(),
                 participant,
-                self.weak_self.clone(),
             ));
             let responder = SetParametersResponder::new(client.clone(), request_id.clone(), guard);
             handler.set(client, parameters, request_id, responder);
@@ -2322,7 +2317,6 @@ mod tests {
             participant.client_id(),
             participant.participant_id().clone(),
             participant,
-            Weak::new(),
         ))
     }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2693,9 +2693,6 @@ mod tests {
 
     #[test]
     fn set_parameters_responder_echoes_when_request_id_set() {
-        // The broadcast path requires a session, which we cannot construct in a unit test.
-        // The Client built by test_client() has no session ref, so broadcast is a no-op; we
-        // verify the echo path here.
         let (participant, rx) = make_participant_with_rx("alice");
         let client = test_client(&participant);
         let guard = participant.parameter_sem().try_acquire().unwrap();
@@ -2717,7 +2714,7 @@ mod tests {
 
         responder.respond(vec![CommonParameter::float64("foo", 2.0)]);
 
-        // No echo, and broadcast is a no-op since the test client has no session.
+        // No echo without a request_id.
         assert!(rx.try_recv().is_err());
     }
 

--- a/rust/foxglove/src/remote_common.rs
+++ b/rust/foxglove/src/remote_common.rs
@@ -7,6 +7,8 @@ pub(crate) mod any_client;
 pub(crate) mod connection_graph;
 #[cfg(any(feature = "websocket", feature = "remote-access"))]
 pub(crate) mod fetch_asset;
+#[cfg(any(feature = "websocket", feature = "remote-access"))]
+pub(crate) mod parameters;
 pub(crate) mod semaphore;
 pub(crate) mod service;
 

--- a/rust/foxglove/src/remote_common/any_client.rs
+++ b/rust/foxglove/src/remote_common/any_client.rs
@@ -97,15 +97,6 @@ impl AnyClient {
         }
     }
 
-    pub(crate) fn broadcast_parameter_values(&self, parameters: Vec<Parameter>) {
-        match &self.0 {
-            #[cfg(feature = "websocket")]
-            AnyClientInner::WebSocket(c) => c.broadcast_parameter_values(parameters),
-            #[cfg(feature = "remote-access")]
-            AnyClientInner::RemoteAccess(c) => c.broadcast_parameter_values(parameters),
-        }
-    }
-
     pub(crate) fn send_asset_response(&self, result: Result<&[u8], &str>, request_id: u32) {
         match &self.0 {
             #[cfg(feature = "websocket")]

--- a/rust/foxglove/src/remote_common/any_client.rs
+++ b/rust/foxglove/src/remote_common/any_client.rs
@@ -1,8 +1,10 @@
 //! Transport-agnostic client handle for handler traits.
 
+use crate::protocol::common::parameter::Parameter;
 use crate::protocol::common::server::status::Status;
 use crate::remote_common::ClientId;
 use crate::remote_common::fetch_asset::SendAssetResponse;
+use crate::remote_common::parameters::SendParameterResponse;
 
 /// A client handle abstracted over the transport that delivered the request.
 #[derive(Debug, Clone)]
@@ -80,6 +82,28 @@ impl AnyClient {
     #[cfg(feature = "remote-access")]
     pub(crate) fn from_remote_access(client: crate::remote_access::Client) -> Self {
         Self(AnyClientInner::RemoteAccess(client))
+    }
+
+    pub(crate) fn send_parameter_values(
+        &self,
+        parameters: Vec<Parameter>,
+        request_id: Option<String>,
+    ) {
+        match &self.0 {
+            #[cfg(feature = "websocket")]
+            AnyClientInner::WebSocket(c) => c.send_parameter_values(parameters, request_id),
+            #[cfg(feature = "remote-access")]
+            AnyClientInner::RemoteAccess(c) => c.send_parameter_values(parameters, request_id),
+        }
+    }
+
+    pub(crate) fn broadcast_parameter_values(&self, parameters: Vec<Parameter>) {
+        match &self.0 {
+            #[cfg(feature = "websocket")]
+            AnyClientInner::WebSocket(c) => c.broadcast_parameter_values(parameters),
+            #[cfg(feature = "remote-access")]
+            AnyClientInner::RemoteAccess(c) => c.broadcast_parameter_values(parameters),
+        }
     }
 
     pub(crate) fn send_asset_response(&self, result: Result<&[u8], &str>, request_id: u32) {

--- a/rust/foxglove/src/remote_common/parameters.rs
+++ b/rust/foxglove/src/remote_common/parameters.rs
@@ -6,7 +6,7 @@ use crate::remote_common::semaphore::SemaphoreGuard;
 
 /// Internal trait implemented by each transport's `Client` type so that [`AnyClient`] can
 /// dispatch parameter responses without exposing the per-transport surface.
-pub(crate) trait SendParameterResponse: Clone + Send + 'static {
+pub(crate) trait SendParameterResponse {
     /// Send a `ParameterValues` message to the requesting client.
     fn send_parameter_values(&self, parameters: Vec<Parameter>, request_id: Option<String>);
 
@@ -54,18 +54,6 @@ pub trait ParameterHandler: Send + Sync + 'static {
         request_id: Option<String>,
         responder: SetParametersResponder,
     );
-
-    /// Invoked when a parameter name acquires its first subscriber.
-    ///
-    /// Default implementation is a no-op; override if you need to track which parameters have
-    /// active subscribers (e.g. to subscribe to upstream parameter-update events).
-    fn subscribe(&self, _names: Vec<String>) {}
-
-    /// Invoked when a parameter name loses its last subscriber (or its last subscriber
-    /// disconnects).
-    ///
-    /// Default implementation is a no-op; override symmetrically with [`Self::subscribe`].
-    fn unsubscribe(&self, _names: Vec<String>) {}
 }
 
 /// Responder for a client `getParameters` request.

--- a/rust/foxglove/src/remote_common/parameters.rs
+++ b/rust/foxglove/src/remote_common/parameters.rs
@@ -1,0 +1,189 @@
+//! Shared parameter handling primitives.
+
+use crate::protocol::common::parameter::Parameter;
+use crate::remote_common::AnyClient;
+use crate::remote_common::semaphore::SemaphoreGuard;
+
+/// Internal trait implemented by each transport's `Client` type so that [`AnyClient`] can
+/// dispatch parameter responses without exposing the per-transport surface.
+pub(crate) trait SendParameterResponse: Clone + Send + 'static {
+    /// Send a `ParameterValues` message to the requesting client.
+    fn send_parameter_values(&self, parameters: Vec<Parameter>, request_id: Option<String>);
+
+    /// Broadcast updated parameter values to all clients subscribed to those parameters on the
+    /// transport that owns this client.
+    fn broadcast_parameter_values(&self, parameters: Vec<Parameter>);
+}
+
+/// Handler for client-initiated parameter operations.
+///
+/// These methods are invoked from time-sensitive contexts and must not block. If blocking or
+/// long-running behavior is required, the implementation should use [`tokio::task::spawn`] (or
+/// [`tokio::task::spawn_blocking`]).
+///
+/// # Note on unset parameter values
+///
+/// Per the protocol spec, a [`Parameter`] with `value: None` represents an unset/deleted
+/// parameter and is not transmitted to clients. Such entries are filtered out of any response
+/// or broadcast emitted by the responders below.
+pub trait ParameterHandler: Send + Sync + 'static {
+    /// Handle a client request to get parameter values.
+    ///
+    /// `names` is the requested parameter names, or empty to request all parameters. Take
+    /// ownership of `responder` and eventually call [`GetParametersResponder::respond`].
+    /// Dropping the responder without responding sends a generic error status to the client.
+    fn get(
+        &self,
+        client: AnyClient,
+        names: Vec<String>,
+        request_id: Option<String>,
+        responder: GetParametersResponder,
+    );
+
+    /// Handle a client request to set parameter values.
+    ///
+    /// Take ownership of `responder` and eventually call [`SetParametersResponder::respond`]
+    /// with the parameters that were actually updated. Those values are echoed back to the
+    /// requesting client when `request_id` is present, and broadcast to all clients subscribed
+    /// to those parameter names. Dropping the responder without responding sends a generic
+    /// error status to the client and does *not* broadcast anything.
+    fn set(
+        &self,
+        client: AnyClient,
+        parameters: Vec<Parameter>,
+        request_id: Option<String>,
+        responder: SetParametersResponder,
+    );
+
+    /// Invoked when a parameter name acquires its first subscriber.
+    ///
+    /// Default implementation is a no-op; override if you need to track which parameters have
+    /// active subscribers (e.g. to subscribe to upstream parameter-update events).
+    fn subscribe(&self, _names: Vec<String>) {}
+
+    /// Invoked when a parameter name loses its last subscriber (or its last subscriber
+    /// disconnects).
+    ///
+    /// Default implementation is a no-op; override symmetrically with [`Self::subscribe`].
+    fn unsubscribe(&self, _names: Vec<String>) {}
+}
+
+/// Responder for a client `getParameters` request.
+///
+/// Take ownership and call [`Self::respond`] when the requested parameter values are available.
+/// Dropping the responder without responding sends a generic error status to the client.
+#[must_use]
+#[derive(Debug)]
+pub struct GetParametersResponder {
+    client: AnyClient,
+    inner: Option<ResponderInner>,
+}
+
+impl GetParametersResponder {
+    pub(crate) fn new(
+        client: AnyClient,
+        request_id: Option<String>,
+        guard: SemaphoreGuard,
+    ) -> Self {
+        Self {
+            client,
+            inner: Some(ResponderInner {
+                request_id,
+                _guard: guard,
+            }),
+        }
+    }
+
+    /// Returns a clone of the requesting client handle.
+    pub fn client(&self) -> AnyClient {
+        self.client.clone()
+    }
+
+    /// Send parameter values back to the requesting client.
+    ///
+    /// Entries with `value: None` are dropped before serialization (see the note on the
+    /// [`ParameterHandler`] trait).
+    pub fn respond(mut self, parameters: Vec<Parameter>) {
+        if let Some(inner) = self.inner.take() {
+            self.client
+                .send_parameter_values(parameters, inner.request_id);
+        }
+    }
+}
+
+impl Drop for GetParametersResponder {
+    fn drop(&mut self) {
+        if self.inner.take().is_some() {
+            self.client
+                .send_error("Internal server error: parameter handler failed to send a response");
+        }
+    }
+}
+
+/// Responder for a client `setParameters` request.
+///
+/// Take ownership and call [`Self::respond`] with the parameters that were actually applied. The
+/// responder echoes those values to the requesting client (when the request carried a
+/// `request_id`) and broadcasts them to all clients subscribed to those parameter names.
+///
+/// Dropping the responder without responding sends an error status to the requesting client and
+/// does not broadcast anything.
+#[must_use]
+#[derive(Debug)]
+pub struct SetParametersResponder {
+    client: AnyClient,
+    inner: Option<ResponderInner>,
+}
+
+impl SetParametersResponder {
+    pub(crate) fn new(
+        client: AnyClient,
+        request_id: Option<String>,
+        guard: SemaphoreGuard,
+    ) -> Self {
+        Self {
+            client,
+            inner: Some(ResponderInner {
+                request_id,
+                _guard: guard,
+            }),
+        }
+    }
+
+    /// Returns a clone of the requesting client handle.
+    pub fn client(&self) -> AnyClient {
+        self.client.clone()
+    }
+
+    /// Acknowledge the set request with the values that were actually applied. Echoes to the
+    /// requester when the request carried a `request_id`, and broadcasts to subscribers.
+    ///
+    /// Entries with `value: None` are dropped before serialization (see the note on the
+    /// [`ParameterHandler`] trait).
+    pub fn respond(mut self, parameters: Vec<Parameter>) {
+        if let Some(inner) = self.inner.take() {
+            if inner.request_id.is_some() {
+                self.client
+                    .send_parameter_values(parameters.clone(), inner.request_id);
+            }
+            self.client.broadcast_parameter_values(parameters);
+        }
+    }
+}
+
+impl Drop for SetParametersResponder {
+    fn drop(&mut self) {
+        if self.inner.take().is_some() {
+            self.client
+                .send_error("Internal server error: parameter handler failed to send a response");
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ResponderInner {
+    request_id: Option<String>,
+    /// Held to release a slot on the per-client parameter semaphore when the responder is
+    /// consumed or dropped.
+    _guard: SemaphoreGuard,
+}

--- a/rust/foxglove/src/remote_common/parameters.rs
+++ b/rust/foxglove/src/remote_common/parameters.rs
@@ -124,9 +124,14 @@ impl Drop for GetParametersResponder {
 /// generic error status to the requesting client.
 ///
 /// When the request carried a `request_id`, the values passed to [`Self::respond`] are echoed
-/// back to the requester; otherwise the responder does nothing on the wire. The responder does
-/// not notify other subscribers; see [`ParameterHandler::set`] for the rationale and how to
-/// broadcast updates.
+/// back to the requester; otherwise the responder does nothing on the wire.
+///
+/// # Differences from the legacy listener
+///
+/// The responder does not notify other parameter subscribers. This is a behavior change from
+/// the `ServerListener::on_set_parameters` / `Listener::on_set_parameters` path, which
+/// publishes the returned values to subscribers automatically. See [`ParameterHandler::set`]
+/// for the rationale and how to broadcast updates from a handler implementation.
 #[must_use]
 #[derive(Debug)]
 pub struct SetParametersResponder {

--- a/rust/foxglove/src/remote_common/parameters.rs
+++ b/rust/foxglove/src/remote_common/parameters.rs
@@ -9,10 +9,6 @@ use crate::remote_common::semaphore::SemaphoreGuard;
 pub(crate) trait SendParameterResponse {
     /// Send a `ParameterValues` message to the requesting client.
     fn send_parameter_values(&self, parameters: Vec<Parameter>, request_id: Option<String>);
-
-    /// Broadcast updated parameter values to all clients subscribed to those parameters on the
-    /// transport that owns this client.
-    fn broadcast_parameter_values(&self, parameters: Vec<Parameter>);
 }
 
 /// Handler for client-initiated parameter operations.
@@ -25,7 +21,7 @@ pub(crate) trait SendParameterResponse {
 ///
 /// Per the protocol spec, a [`Parameter`] with `value: None` represents an unset/deleted
 /// parameter and is not transmitted to clients. Such entries are filtered out of any response
-/// or broadcast emitted by the responders below.
+/// emitted by the responders below.
 pub trait ParameterHandler: Send + Sync + 'static {
     /// Handle a client request to get parameter values.
     ///
@@ -44,9 +40,15 @@ pub trait ParameterHandler: Send + Sync + 'static {
     ///
     /// Take ownership of `responder` and eventually call [`SetParametersResponder::respond`]
     /// with the parameters that were actually updated. Those values are echoed back to the
-    /// requesting client when `request_id` is present, and broadcast to all clients subscribed
-    /// to those parameter names. Dropping the responder without responding sends a generic
-    /// error status to the client and does *not* broadcast anything.
+    /// requesting client when `request_id` is present. Dropping the responder without responding
+    /// sends a generic error status to the client.
+    ///
+    /// The responder does not notify other parameter subscribers. A handler may be shared
+    /// across multiple sinks, so it is the implementer's responsibility to broadcast updates
+    /// to subscribers on each sink (for example, via
+    /// [`WebSocketServerHandle::publish_parameter_values`](crate::WebSocketServerHandle::publish_parameter_values)
+    /// or
+    /// [`GatewayHandle::publish_parameter_values`](crate::remote_access::GatewayHandle::publish_parameter_values)).
     fn set(
         &self,
         client: AnyClient,
@@ -111,11 +113,13 @@ impl Drop for GetParametersResponder {
 /// Responder for a client `setParameters` request.
 ///
 /// Take ownership and call [`Self::respond`] with the parameters that were actually applied. The
-/// responder echoes those values to the requesting client (when the request carried a
-/// `request_id`) and broadcasts them to all clients subscribed to those parameter names.
+/// responder echoes those values to the requesting client when the request carried a
+/// `request_id`, and does nothing otherwise.
 ///
-/// Dropping the responder without responding sends an error status to the requesting client and
-/// does not broadcast anything.
+/// The responder does not notify other subscribers; see [`ParameterHandler::set`] for the
+/// rationale and how to broadcast updates.
+///
+/// Dropping the responder without responding sends an error status to the requesting client.
 #[must_use]
 #[derive(Debug)]
 pub struct SetParametersResponder {
@@ -144,17 +148,16 @@ impl SetParametersResponder {
     }
 
     /// Acknowledge the set request with the values that were actually applied. Echoes to the
-    /// requester when the request carried a `request_id`, and broadcasts to subscribers.
+    /// requester when the request carried a `request_id`, otherwise does nothing.
     ///
     /// Entries with `value: None` are dropped before serialization (see the note on the
     /// [`ParameterHandler`] trait).
     pub fn respond(mut self, parameters: Vec<Parameter>) {
-        if let Some(inner) = self.inner.take() {
-            if inner.request_id.is_some() {
-                self.client
-                    .send_parameter_values(parameters.clone(), inner.request_id);
-            }
-            self.client.broadcast_parameter_values(parameters);
+        if let Some(inner) = self.inner.take()
+            && inner.request_id.is_some()
+        {
+            self.client
+                .send_parameter_values(parameters, inner.request_id);
         }
     }
 }

--- a/rust/foxglove/src/remote_common/parameters.rs
+++ b/rust/foxglove/src/remote_common/parameters.rs
@@ -160,11 +160,11 @@ impl SetParametersResponder {
     /// Entries with `value: None` are dropped before serialization (see the note on the
     /// [`ParameterHandler`] trait).
     pub fn respond(mut self, parameters: Vec<Parameter>) {
-        if let Some(inner) = self.inner.take()
-            && inner.request_id.is_some()
-        {
-            self.client
-                .send_parameter_values(parameters, inner.request_id);
+        if let Some(inner) = self.inner.take() {
+            if inner.request_id.is_some() {
+                self.client
+                    .send_parameter_values(parameters, inner.request_id);
+            }
         }
     }
 }

--- a/rust/foxglove/src/remote_common/parameters.rs
+++ b/rust/foxglove/src/remote_common/parameters.rs
@@ -25,9 +25,11 @@ pub(crate) trait SendParameterResponse {
 pub trait ParameterHandler: Send + Sync + 'static {
     /// Handle a client request to get parameter values.
     ///
-    /// `names` is the requested parameter names, or empty to request all parameters. Take
-    /// ownership of `responder` and eventually call [`GetParametersResponder::respond`].
-    /// Dropping the responder without responding sends a generic error status to the client.
+    /// `names` is the requested parameter names, or empty to request all parameters. The
+    /// implementation **must** take ownership of `responder` and eventually call
+    /// [`GetParametersResponder::respond`] (pass an empty vec if no values are available).
+    /// Dropping the responder without responding is reserved for unrecoverable internal errors
+    /// and sends a generic error status to the client.
     fn get(
         &self,
         client: AnyClient,
@@ -38,14 +40,17 @@ pub trait ParameterHandler: Send + Sync + 'static {
 
     /// Handle a client request to set parameter values.
     ///
-    /// Take ownership of `responder` and eventually call [`SetParametersResponder::respond`]
-    /// with the parameters that were actually updated. Those values are echoed back to the
-    /// requesting client when `request_id` is present. Dropping the responder without responding
-    /// sends a generic error status to the client.
+    /// The implementation **must** take ownership of `responder` and eventually call
+    /// [`SetParametersResponder::respond`] with the parameters that were actually applied, even
+    /// if the request could not be handled (pass an empty vec in that case). Dropping the
+    /// responder without responding is reserved for unrecoverable internal errors and sends a
+    /// generic error status to the client.
     ///
-    /// The responder does not notify other parameter subscribers. A handler may be shared
-    /// across multiple sinks, so it is the implementer's responsibility to broadcast updates
-    /// to subscribers on each sink (for example, via
+    /// When `request_id` is present, the parameters passed to
+    /// [`SetParametersResponder::respond`] are echoed back to the requesting client. The
+    /// responder does not notify other parameter subscribers: a handler may be shared across
+    /// multiple sinks, so it is the implementer's responsibility to broadcast updates to
+    /// subscribers on each sink (for example, via
     /// [`WebSocketServerHandle::publish_parameter_values`](crate::WebSocketServerHandle::publish_parameter_values)
     /// or
     /// [`GatewayHandle::publish_parameter_values`](crate::remote_access::GatewayHandle::publish_parameter_values)).
@@ -60,8 +65,9 @@ pub trait ParameterHandler: Send + Sync + 'static {
 
 /// Responder for a client `getParameters` request.
 ///
-/// Take ownership and call [`Self::respond`] when the requested parameter values are available.
-/// Dropping the responder without responding sends a generic error status to the client.
+/// The handler **must** call [`Self::respond`] with the requested parameter values (pass an
+/// empty vec if none are available). Dropping the responder without responding is reserved for
+/// unrecoverable internal errors and sends a generic error status to the requesting client.
 #[must_use]
 #[derive(Debug)]
 pub struct GetParametersResponder {
@@ -112,14 +118,15 @@ impl Drop for GetParametersResponder {
 
 /// Responder for a client `setParameters` request.
 ///
-/// Take ownership and call [`Self::respond`] with the parameters that were actually applied. The
-/// responder echoes those values to the requesting client when the request carried a
-/// `request_id`, and does nothing otherwise.
+/// The handler **must** call [`Self::respond`] with the parameters that were actually applied,
+/// even when the request could not be handled (pass an empty vec in that case). Dropping the
+/// responder without responding is reserved for unrecoverable internal errors and sends a
+/// generic error status to the requesting client.
 ///
-/// The responder does not notify other subscribers; see [`ParameterHandler::set`] for the
-/// rationale and how to broadcast updates.
-///
-/// Dropping the responder without responding sends an error status to the requesting client.
+/// When the request carried a `request_id`, the values passed to [`Self::respond`] are echoed
+/// back to the requester; otherwise the responder does nothing on the wire. The responder does
+/// not notify other subscribers; see [`ParameterHandler::set`] for the rationale and how to
+/// broadcast updates.
 #[must_use]
 #[derive(Debug)]
 pub struct SetParametersResponder {

--- a/rust/foxglove/src/testutil.rs
+++ b/rust/foxglove/src/testutil.rs
@@ -12,6 +12,9 @@ pub use global_context::GlobalContextTest;
 pub(crate) use mcap::read_summary;
 pub use sink::{ErrorSink, MockSink, RecordingSink};
 #[cfg(feature = "websocket")]
-pub(crate) use websocket::{RecordingServerListener, assert_eventually};
+pub(crate) use websocket::{
+    RecordingGetBehavior, RecordingParameterHandler, RecordingServerListener, RecordingSetBehavior,
+    assert_eventually,
+};
 #[cfg(feature = "websocket")]
 pub use websocket_client::{WebSocketClient, WebSocketClientError};

--- a/rust/foxglove/src/testutil/websocket.rs
+++ b/rust/foxglove/src/testutil/websocket.rs
@@ -282,8 +282,6 @@ impl Default for RecordingGetBehavior {
 pub(crate) struct RecordingParameterHandler {
     parameters_get: Mutex<Vec<GetParameters>>,
     parameters_set: Mutex<Vec<SetParameters>>,
-    parameters_subscribe: Mutex<Vec<Vec<String>>>,
-    parameters_unsubscribe: Mutex<Vec<Vec<String>>>,
     get_behavior: Mutex<RecordingGetBehavior>,
     set_behavior: Mutex<RecordingSetBehavior>,
 }
@@ -293,8 +291,6 @@ impl RecordingParameterHandler {
         Self {
             parameters_get: Mutex::default(),
             parameters_set: Mutex::default(),
-            parameters_subscribe: Mutex::default(),
-            parameters_unsubscribe: Mutex::default(),
             get_behavior: Mutex::new(RecordingGetBehavior::default()),
             set_behavior: Mutex::new(RecordingSetBehavior::default()),
         }
@@ -316,28 +312,12 @@ impl RecordingParameterHandler {
         self.parameters_set.lock().len()
     }
 
-    pub fn parameters_subscribe_len(&self) -> usize {
-        self.parameters_subscribe.lock().len()
-    }
-
-    pub fn parameters_unsubscribe_len(&self) -> usize {
-        self.parameters_unsubscribe.lock().len()
-    }
-
     pub fn take_parameters_get(&self) -> Vec<GetParameters> {
         std::mem::take(&mut self.parameters_get.lock())
     }
 
     pub fn take_parameters_set(&self) -> Vec<SetParameters> {
         std::mem::take(&mut self.parameters_set.lock())
-    }
-
-    pub fn take_parameters_subscribe(&self) -> Vec<Vec<String>> {
-        std::mem::take(&mut self.parameters_subscribe.lock())
-    }
-
-    pub fn take_parameters_unsubscribe(&self) -> Vec<Vec<String>> {
-        std::mem::take(&mut self.parameters_unsubscribe.lock())
     }
 }
 
@@ -379,14 +359,6 @@ impl ParameterHandler for RecordingParameterHandler {
             RecordingSetBehavior::With(values) => responder.respond(values),
             RecordingSetBehavior::DropResponder => drop(responder),
         }
-    }
-
-    fn subscribe(&self, names: Vec<String>) {
-        self.parameters_subscribe.lock().push(names);
-    }
-
-    fn unsubscribe(&self, names: Vec<String>) {
-        self.parameters_unsubscribe.lock().push(names);
     }
 }
 

--- a/rust/foxglove/src/testutil/websocket.rs
+++ b/rust/foxglove/src/testutil/websocket.rs
@@ -5,7 +5,8 @@ use parking_lot::Mutex;
 
 use crate::ChannelId;
 use crate::websocket::{
-    ChannelView, Client, ClientChannel, ClientChannelId, ClientId, Parameter, ServerListener,
+    AnyClient, ChannelView, Client, ClientChannel, ClientChannelId, ClientId,
+    GetParametersResponder, Parameter, ParameterHandler, ServerListener, SetParametersResponder,
 };
 
 #[allow(dead_code)]
@@ -246,6 +247,146 @@ impl ServerListener for RecordingServerListener {
 
     fn on_connection_graph_unsubscribe(&self) {
         self.inc_connection_graph_unsubscribe();
+    }
+}
+
+/// Behavior for the `RecordingParameterHandler` set callback: how should `set` respond?
+#[derive(Clone, Default)]
+#[allow(dead_code)] // tests pick subsets of these variants
+pub(crate) enum RecordingSetBehavior {
+    /// Respond with the parameters the handler was given.
+    #[default]
+    Echo,
+    /// Respond with the configured override.
+    With(Vec<Parameter>),
+    /// Drop the responder without responding (triggers the error fallback).
+    DropResponder,
+}
+
+/// Behavior for the `RecordingParameterHandler` get callback.
+#[derive(Clone)]
+pub(crate) enum RecordingGetBehavior {
+    /// Respond with the configured values.
+    Respond(Vec<Parameter>),
+    /// Drop the responder without responding.
+    DropResponder,
+}
+
+impl Default for RecordingGetBehavior {
+    fn default() -> Self {
+        Self::Respond(Vec::new())
+    }
+}
+
+/// Test double for [`ParameterHandler`] that records calls and lets each test tune the responses.
+pub(crate) struct RecordingParameterHandler {
+    parameters_get: Mutex<Vec<GetParameters>>,
+    parameters_set: Mutex<Vec<SetParameters>>,
+    parameters_subscribe: Mutex<Vec<Vec<String>>>,
+    parameters_unsubscribe: Mutex<Vec<Vec<String>>>,
+    get_behavior: Mutex<RecordingGetBehavior>,
+    set_behavior: Mutex<RecordingSetBehavior>,
+}
+
+impl RecordingParameterHandler {
+    pub fn new() -> Self {
+        Self {
+            parameters_get: Mutex::default(),
+            parameters_set: Mutex::default(),
+            parameters_subscribe: Mutex::default(),
+            parameters_unsubscribe: Mutex::default(),
+            get_behavior: Mutex::new(RecordingGetBehavior::default()),
+            set_behavior: Mutex::new(RecordingSetBehavior::default()),
+        }
+    }
+
+    pub fn set_get_behavior(&self, behavior: RecordingGetBehavior) {
+        *self.get_behavior.lock() = behavior;
+    }
+
+    pub fn set_set_behavior(&self, behavior: RecordingSetBehavior) {
+        *self.set_behavior.lock() = behavior;
+    }
+
+    pub fn parameters_get_len(&self) -> usize {
+        self.parameters_get.lock().len()
+    }
+
+    pub fn parameters_set_len(&self) -> usize {
+        self.parameters_set.lock().len()
+    }
+
+    pub fn parameters_subscribe_len(&self) -> usize {
+        self.parameters_subscribe.lock().len()
+    }
+
+    pub fn parameters_unsubscribe_len(&self) -> usize {
+        self.parameters_unsubscribe.lock().len()
+    }
+
+    pub fn take_parameters_get(&self) -> Vec<GetParameters> {
+        std::mem::take(&mut self.parameters_get.lock())
+    }
+
+    pub fn take_parameters_set(&self) -> Vec<SetParameters> {
+        std::mem::take(&mut self.parameters_set.lock())
+    }
+
+    pub fn take_parameters_subscribe(&self) -> Vec<Vec<String>> {
+        std::mem::take(&mut self.parameters_subscribe.lock())
+    }
+
+    pub fn take_parameters_unsubscribe(&self) -> Vec<Vec<String>> {
+        std::mem::take(&mut self.parameters_unsubscribe.lock())
+    }
+}
+
+impl ParameterHandler for RecordingParameterHandler {
+    fn get(
+        &self,
+        client: AnyClient,
+        names: Vec<String>,
+        request_id: Option<String>,
+        responder: GetParametersResponder,
+    ) {
+        self.parameters_get.lock().push(GetParameters {
+            client_id: client.id(),
+            param_names: names,
+            request_id,
+        });
+        let behavior = self.get_behavior.lock().clone();
+        match behavior {
+            RecordingGetBehavior::Respond(values) => responder.respond(values),
+            RecordingGetBehavior::DropResponder => drop(responder),
+        }
+    }
+
+    fn set(
+        &self,
+        client: AnyClient,
+        parameters: Vec<Parameter>,
+        request_id: Option<String>,
+        responder: SetParametersResponder,
+    ) {
+        self.parameters_set.lock().push(SetParameters {
+            client_id: client.id(),
+            parameters: parameters.clone(),
+            request_id,
+        });
+        let behavior = self.set_behavior.lock().clone();
+        match behavior {
+            RecordingSetBehavior::Echo => responder.respond(parameters),
+            RecordingSetBehavior::With(values) => responder.respond(values),
+            RecordingSetBehavior::DropResponder => drop(responder),
+        }
+    }
+
+    fn subscribe(&self, names: Vec<String>) {
+        self.parameters_subscribe.lock().push(names);
+    }
+
+    fn unsubscribe(&self, names: Vec<String>) {
+        self.parameters_unsubscribe.lock().push(names);
     }
 }
 

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -22,6 +22,9 @@ pub mod ws_protocol;
 pub use crate::remote_common::AnyClient;
 pub use crate::remote_common::fetch_asset::{AssetHandler, AssetResponder};
 pub(crate) use crate::remote_common::fetch_asset::{AsyncAssetHandlerFn, BlockingAssetHandlerFn};
+pub use crate::remote_common::parameters::{
+    GetParametersResponder, ParameterHandler, SetParametersResponder,
+};
 pub use capability::Capability;
 pub use channel_view::ChannelView;
 pub use client::{Client, ClientId};

--- a/rust/foxglove/src/websocket/client.rs
+++ b/rust/foxglove/src/websocket/client.rs
@@ -3,7 +3,6 @@ use std::sync::Weak;
 use super::Parameter;
 use super::Status;
 use super::connected_client::ConnectedClient;
-use super::server::Server;
 use crate::SinkId;
 pub use crate::remote_common::ClientId;
 use crate::remote_common::fetch_asset::SendAssetResponse;
@@ -15,7 +14,6 @@ pub struct Client {
     id: ClientId,
     sink_id: SinkId,
     client: Weak<ConnectedClient>,
-    server: Weak<Server>,
 }
 
 impl Client {
@@ -24,7 +22,6 @@ impl Client {
             id: client.id(),
             sink_id: client.sink_id(),
             client: client.weak().clone(),
-            server: client.server_weak().clone(),
         }
     }
 
@@ -61,12 +58,6 @@ impl SendParameterResponse for Client {
     fn send_parameter_values(&self, parameters: Vec<Parameter>, request_id: Option<String>) {
         if let Some(client) = self.client.upgrade() {
             client.update_parameters(parameters, request_id);
-        }
-    }
-
-    fn broadcast_parameter_values(&self, parameters: Vec<Parameter>) {
-        if let Some(server) = self.server.upgrade() {
-            server.publish_parameter_values(parameters);
         }
     }
 }

--- a/rust/foxglove/src/websocket/client.rs
+++ b/rust/foxglove/src/websocket/client.rs
@@ -1,10 +1,13 @@
 use std::sync::Weak;
 
+use super::Parameter;
 use super::Status;
 use super::connected_client::ConnectedClient;
+use super::server::Server;
 use crate::SinkId;
 pub use crate::remote_common::ClientId;
 use crate::remote_common::fetch_asset::SendAssetResponse;
+use crate::remote_common::parameters::SendParameterResponse;
 
 /// A connected client session with the WebSocket server.
 #[derive(Debug, Clone)]
@@ -12,6 +15,7 @@ pub struct Client {
     id: ClientId,
     sink_id: SinkId,
     client: Weak<ConnectedClient>,
+    server: Weak<Server>,
 }
 
 impl Client {
@@ -20,6 +24,7 @@ impl Client {
             id: client.id(),
             sink_id: client.sink_id(),
             client: client.weak().clone(),
+            server: client.server_weak().clone(),
         }
     }
 
@@ -48,6 +53,20 @@ impl SendAssetResponse for Client {
                 Ok(asset) => client.send_asset_response(asset, request_id),
                 Err(err) => client.send_asset_error(err, request_id),
             }
+        }
+    }
+}
+
+impl SendParameterResponse for Client {
+    fn send_parameter_values(&self, parameters: Vec<Parameter>, request_id: Option<String>) {
+        if let Some(client) = self.client.upgrade() {
+            client.update_parameters(parameters, request_id);
+        }
+    }
+
+    fn broadcast_parameter_values(&self, parameters: Vec<Parameter>) {
+        if let Some(server) = self.server.upgrade() {
+            server.publish_parameter_values(parameters);
         }
     }
 }

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -209,12 +209,6 @@ impl ConnectedClient {
         &self.weak_self
     }
 
-    /// Returns the weak reference to the owning server, used by `Client` to broadcast parameter
-    /// values directly to all subscribers.
-    pub(super) fn server_weak(&self) -> &Weak<Server> {
-        &self.server
-    }
-
     pub fn addr(&self) -> SocketAddr {
         self.addr
     }

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -28,7 +28,7 @@ use super::ws_protocol::server::MessageData;
 use super::ws_protocol::{self, ParseError};
 use super::{
     AnyClient, AssetResponder, Capability, Client, ClientChannel, ClientChannelId, ClientId,
-    Parameter, Status, StatusLevel, advertise,
+    GetParametersResponder, Parameter, SetParametersResponder, Status, StatusLevel, advertise,
 };
 use crate::remote_common::semaphore::Semaphore;
 
@@ -41,6 +41,7 @@ const MAX_SEND_RETRIES: usize = 10;
 const ADVERTISE_CHANNEL_BATCH_SIZE: usize = 100;
 const DEFAULT_SERVICE_CALLS_PER_CLIENT: usize = 32;
 const DEFAULT_FETCH_ASSET_CALLS_PER_CLIENT: usize = 32;
+const DEFAULT_PARAMETER_CALLS_PER_CLIENT: usize = 32;
 
 /// A reason for shutting down a client connection.
 #[derive(Debug, Clone, Copy)]
@@ -69,6 +70,9 @@ pub(super) struct ConnectedClient {
     control_plane_tx: flume::Sender<Message>,
     service_call_sem: Semaphore,
     fetch_asset_sem: Semaphore,
+    /// Caps the number of in-flight parameter handler invocations (get + set combined) per
+    /// client. Subscribe / unsubscribe are bookkeeping-only and not gated.
+    parameter_sem: Semaphore,
     /// Subscriptions from this client
     subscriptions: parking_lot::Mutex<BiHashMap<ChannelId, SubscriptionId>>,
     /// Channels advertised by this client
@@ -179,6 +183,7 @@ impl ConnectedClient {
             control_plane_tx,
             service_call_sem: Semaphore::new(DEFAULT_SERVICE_CALLS_PER_CLIENT),
             fetch_asset_sem: Semaphore::new(DEFAULT_FETCH_ASSET_CALLS_PER_CLIENT),
+            parameter_sem: Semaphore::new(DEFAULT_PARAMETER_CALLS_PER_CLIENT),
             subscriptions: parking_lot::Mutex::default(),
             advertised_channels: parking_lot::Mutex::default(),
             server: server.clone(),
@@ -202,6 +207,12 @@ impl ConnectedClient {
 
     pub fn weak(&self) -> &Weak<Self> {
         &self.weak_self
+    }
+
+    /// Returns the weak reference to the owning server, used by `Client` to broadcast parameter
+    /// values directly to all subscribers.
+    pub(super) fn server_weak(&self) -> &Weak<Server> {
+        &self.server
     }
 
     pub fn addr(&self) -> SocketAddr {
@@ -511,6 +522,18 @@ impl ConnectedClient {
             return;
         }
 
+        // ParameterHandler takes precedence over the deprecated ServerListener callbacks.
+        if let Some(handler) = server.parameter_handler() {
+            let Some(guard) = self.parameter_sem.try_acquire() else {
+                self.send_error("Too many concurrent parameter requests".to_string());
+                return;
+            };
+            let client = AnyClient::from_websocket(Client::new(self));
+            let responder = GetParametersResponder::new(client.clone(), request_id.clone(), guard);
+            handler.get(client, param_names, request_id, responder);
+            return;
+        }
+
         if let Some(handler) = server.listener() {
             let parameters =
                 handler.on_get_parameters(Client::new(self), param_names, request_id.as_deref());
@@ -526,6 +549,18 @@ impl ConnectedClient {
     ) {
         if !server.has_capability(Capability::Parameters) {
             self.send_error("Server does not support parameters capability".to_string());
+            return;
+        }
+
+        // ParameterHandler takes precedence over the deprecated ServerListener callbacks.
+        if let Some(handler) = server.parameter_handler() {
+            let Some(guard) = self.parameter_sem.try_acquire() else {
+                self.send_error("Too many concurrent parameter requests".to_string());
+                return;
+            };
+            let client = AnyClient::from_websocket(Client::new(self));
+            let responder = SetParametersResponder::new(client.clone(), request_id.clone(), guard);
+            handler.set(client, parameters, request_id, responder);
             return;
         }
 

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -447,11 +447,8 @@ impl Server {
             }
         }
 
-        // Notify handler. ParameterHandler takes precedence over the deprecated listener method.
         if !new_names.is_empty() {
-            if let Some(handler) = self.parameter_handler.as_ref() {
-                handler.subscribe(new_names);
-            } else if let Some(listener) = self.listener.as_ref() {
+            if let Some(listener) = self.listener.as_ref() {
                 listener.on_parameters_subscribe(new_names);
             }
         }
@@ -472,11 +469,8 @@ impl Server {
             }
         }
 
-        // Notify handler. ParameterHandler takes precedence over the deprecated listener method.
         if !old_names.is_empty() {
-            if let Some(handler) = self.parameter_handler.as_ref() {
-                handler.unsubscribe(old_names);
-            } else if let Some(listener) = self.listener.as_ref() {
+            if let Some(listener) = self.listener.as_ref() {
                 listener.on_parameters_unsubscribe(old_names);
             }
         }
@@ -497,11 +491,8 @@ impl Server {
             subs.remove(name);
         }
 
-        // Notify handler. ParameterHandler takes precedence over the deprecated listener method.
         if !old_names.is_empty() {
-            if let Some(handler) = self.parameter_handler.as_ref() {
-                handler.unsubscribe(old_names);
-            } else if let Some(listener) = self.listener.as_ref() {
+            if let Some(listener) = self.listener.as_ref() {
                 listener.on_parameters_unsubscribe(old_names);
             }
         }

--- a/rust/foxglove/src/websocket/server.rs
+++ b/rust/foxglove/src/websocket/server.rs
@@ -28,8 +28,8 @@ use super::ws_protocol::server::{
     AdvertiseServices, RemoveStatus, ServerInfo, UnadvertiseServices,
 };
 use super::{
-    AssetHandler, Capability, ClientId, ConnectionGraph, Parameter, ServerListener, Status,
-    advertise, handshake,
+    AssetHandler, Capability, ClientId, ConnectionGraph, Parameter, ParameterHandler,
+    ServerListener, Status, advertise, handshake,
 };
 
 // Queue up to 1024 messages per connected client before dropping messages
@@ -47,6 +47,7 @@ pub(crate) struct ServerOptions {
     pub supported_encodings: Option<IndexSet<String>>,
     pub runtime: Option<Handle>,
     pub fetch_asset_handler: Option<Arc<dyn AssetHandler>>,
+    pub parameter_handler: Option<Arc<dyn ParameterHandler>>,
     pub tls_identity: Option<TlsIdentity>,
     pub channel_filter: Option<Arc<dyn SinkChannelFilter>>,
     pub server_info: Option<HashMap<String, String>>,
@@ -185,6 +186,9 @@ pub(crate) struct Server {
     services: parking_lot::RwLock<ServiceMap>,
     /// Handler for fetch asset requests
     fetch_asset_handler: Option<Arc<dyn AssetHandler>>,
+    /// Handler for client parameter operations. When set, takes precedence over the deprecated
+    /// parameter callbacks on [`ServerListener`].
+    parameter_handler: Option<Arc<dyn ParameterHandler>>,
     /// Client tasks.
     tasks: parking_lot::Mutex<Option<JoinSet<()>>>,
     /// Configuration to support TLS streams when enabled.
@@ -242,6 +246,12 @@ impl Server {
             capabilities.insert(Capability::Assets);
         }
 
+        // If the server was declared with a parameter handler, automatically add the "parameters"
+        // capability.
+        if opts.parameter_handler.is_some() {
+            capabilities.insert(Capability::Parameters);
+        }
+
         Server {
             weak_self,
             context: Arc::downgrade(ctx),
@@ -265,6 +275,7 @@ impl Server {
             cancellation_token: CancellationToken::new(),
             services: parking_lot::RwLock::new(ServiceMap::from_iter(opts.services.into_values())),
             fetch_asset_handler: opts.fetch_asset_handler,
+            parameter_handler: opts.parameter_handler,
             tasks: parking_lot::Mutex::default(),
             stream_config,
             server_info: opts.server_info.unwrap_or_default(),
@@ -291,6 +302,11 @@ impl Server {
     /// Returns a reference to the fetch asset handler.
     pub(super) fn fetch_asset_handler(&self) -> Option<&dyn AssetHandler> {
         self.fetch_asset_handler.as_deref()
+    }
+
+    /// Returns a reference to the parameter handler, if registered.
+    pub(super) fn parameter_handler(&self) -> Option<&dyn ParameterHandler> {
+        self.parameter_handler.as_deref()
     }
 
     /// Returns a reference to the server listener.
@@ -431,9 +447,11 @@ impl Server {
             }
         }
 
-        // Notify listener.
+        // Notify handler. ParameterHandler takes precedence over the deprecated listener method.
         if !new_names.is_empty() {
-            if let Some(listener) = self.listener.as_ref() {
+            if let Some(handler) = self.parameter_handler.as_ref() {
+                handler.subscribe(new_names);
+            } else if let Some(listener) = self.listener.as_ref() {
                 listener.on_parameters_subscribe(new_names);
             }
         }
@@ -454,9 +472,11 @@ impl Server {
             }
         }
 
-        // Notify listener.
+        // Notify handler. ParameterHandler takes precedence over the deprecated listener method.
         if !old_names.is_empty() {
-            if let Some(listener) = self.listener.as_ref() {
+            if let Some(handler) = self.parameter_handler.as_ref() {
+                handler.unsubscribe(old_names);
+            } else if let Some(listener) = self.listener.as_ref() {
                 listener.on_parameters_unsubscribe(old_names);
             }
         }
@@ -477,9 +497,11 @@ impl Server {
             subs.remove(name);
         }
 
-        // Notify listener.
+        // Notify handler. ParameterHandler takes precedence over the deprecated listener method.
         if !old_names.is_empty() {
-            if let Some(listener) = self.listener.as_ref() {
+            if let Some(handler) = self.parameter_handler.as_ref() {
+                handler.unsubscribe(old_names);
+            } else if let Some(listener) = self.listener.as_ref() {
                 listener.on_parameters_unsubscribe(old_names);
             }
         }

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -2118,8 +2118,7 @@ async fn test_parameter_handler_get_drop_sends_error_status() {
 
 #[traced_test]
 #[tokio::test]
-async fn test_parameter_handler_set_echoes_and_broadcasts() {
-    let listener = Arc::new(RecordingServerListener::new());
+async fn test_parameter_handler_set_echoes() {
     let handler = Arc::new(RecordingParameterHandler::new());
 
     let ctx = Context::new();
@@ -2127,7 +2126,6 @@ async fn test_parameter_handler_set_echoes_and_broadcasts() {
         &ctx,
         ServerOptions {
             capabilities: Some(IndexSet::from([Capability::Parameters])),
-            listener: Some(listener.clone()),
             parameter_handler: Some(handler.clone()),
             ..Default::default()
         },
@@ -2137,43 +2135,21 @@ async fn test_parameter_handler_set_echoes_and_broadcasts() {
         .await
         .expect("Failed to start server");
 
-    // The setter; will subscribe to "foo" and then issue a set with request_id.
     let mut setter = WebSocketClient::connect(format!("{addr}"))
         .await
         .expect("Failed to connect setter");
-    // A second client subscribes to "foo" to receive the broadcast.
-    let mut subscriber = WebSocketClient::connect(format!("{addr}"))
-        .await
-        .expect("Failed to connect subscriber");
+    expect_recv!(setter, ServerMessage::ServerInfo);
 
-    subscriber
-        .send(&SubscribeParameterUpdates::new(["foo"]))
-        .await
-        .expect("Failed to send subscribe parameter updates");
-
-    assert_eventually(|| dbg!(listener.parameters_subscribe_len()) == 1).await;
-
-    let parameters = vec![
-        Parameter::float64("foo", 2.0),
-        Parameter::string("ignored", "by-subscriber"),
-    ];
+    let parameters = vec![Parameter::float64("foo", 2.0)];
     setter
         .send(&SetParameters::new(parameters.clone()).with_id("set-1"))
         .await
         .expect("Failed to send set parameters");
 
-    expect_recv!(setter, ServerMessage::ServerInfo);
-    expect_recv!(subscriber, ServerMessage::ServerInfo);
-
     // Setter receives an echoed ParameterValues with the request_id (RecordingSetBehavior::Echo).
     let echo = expect_recv!(setter, ServerMessage::ParameterValues);
     assert_eq!(echo.id, Some("set-1".into()));
     assert_eq!(echo.parameters, parameters);
-
-    // Subscriber receives a broadcast filtered to its subscription set ("foo").
-    let broadcast = expect_recv!(subscriber, ServerMessage::ParameterValues);
-    assert_eq!(broadcast.id, None);
-    assert_eq!(broadcast.parameters, parameters[..1].to_vec());
 
     let captured = handler.take_parameters_set().pop().unwrap();
     assert_eq!(captured.request_id, Some("set-1".to_string()));
@@ -2184,17 +2160,14 @@ async fn test_parameter_handler_set_echoes_and_broadcasts() {
 
 #[traced_test]
 #[tokio::test]
-async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
-    let listener = Arc::new(RecordingServerListener::new());
+async fn test_parameter_handler_set_no_echo_without_request_id() {
     let handler = Arc::new(RecordingParameterHandler::new());
-    handler.set_set_behavior(RecordingSetBehavior::DropResponder);
 
     let ctx = Context::new();
     let server = create_server(
         &ctx,
         ServerOptions {
             capabilities: Some(IndexSet::from([Capability::Parameters])),
-            listener: Some(listener.clone()),
             parameter_handler: Some(handler.clone()),
             ..Default::default()
         },
@@ -2207,26 +2180,50 @@ async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
     let mut setter = WebSocketClient::connect(format!("{addr}"))
         .await
         .expect("Failed to connect setter");
-    let mut subscriber = WebSocketClient::connect(format!("{addr}"))
-        .await
-        .expect("Failed to connect subscriber");
+    expect_recv!(setter, ServerMessage::ServerInfo);
 
-    subscriber
-        .send(&SubscribeParameterUpdates::new(["foo"]))
+    setter
+        .send(&SetParameters::new(vec![Parameter::float64("foo", 2.0)]))
         .await
-        .expect("Failed to send subscribe parameter updates");
+        .expect("Failed to send set parameters");
 
-    assert_eventually(|| dbg!(listener.parameters_subscribe_len()) == 1).await;
+    assert_eventually(|| dbg!(handler.parameters_set_len()) == 1).await;
+
+    // No echo expected because the request had no request_id.
+    server.stop().unwrap().wait().await;
+    expect_recv_close!(setter);
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_parameter_handler_set_drop_sends_error_status() {
+    let handler = Arc::new(RecordingParameterHandler::new());
+    handler.set_set_behavior(RecordingSetBehavior::DropResponder);
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::Parameters])),
+            parameter_handler: Some(handler.clone()),
+            ..Default::default()
+        },
+    );
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut setter = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect setter");
+    expect_recv!(setter, ServerMessage::ServerInfo);
 
     setter
         .send(&SetParameters::new(vec![Parameter::float64("foo", 2.0)]).with_id("set-1"))
         .await
         .expect("Failed to send set parameters");
 
-    expect_recv!(setter, ServerMessage::ServerInfo);
-    expect_recv!(subscriber, ServerMessage::ServerInfo);
-
-    // Setter sees an error advisory.
     let status = expect_recv!(setter, ServerMessage::Status);
     assert_eq!(
         status.level,
@@ -2234,9 +2231,7 @@ async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
     );
     assert!(status.message.contains("failed to send a response"));
 
-    // No ParameterValues should be broadcast to the subscriber.
-    server.stop().unwrap().wait().await;
-    expect_recv_close!(subscriber);
+    let _ = server.stop();
 }
 
 #[traced_test]

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -2119,6 +2119,7 @@ async fn test_parameter_handler_get_drop_sends_error_status() {
 #[traced_test]
 #[tokio::test]
 async fn test_parameter_handler_set_echoes_and_broadcasts() {
+    let listener = Arc::new(RecordingServerListener::new());
     let handler = Arc::new(RecordingParameterHandler::new());
 
     let ctx = Context::new();
@@ -2126,6 +2127,7 @@ async fn test_parameter_handler_set_echoes_and_broadcasts() {
         &ctx,
         ServerOptions {
             capabilities: Some(IndexSet::from([Capability::Parameters])),
+            listener: Some(listener.clone()),
             parameter_handler: Some(handler.clone()),
             ..Default::default()
         },
@@ -2149,7 +2151,7 @@ async fn test_parameter_handler_set_echoes_and_broadcasts() {
         .await
         .expect("Failed to send subscribe parameter updates");
 
-    assert_eventually(|| dbg!(handler.parameters_subscribe_len()) == 1).await;
+    assert_eventually(|| dbg!(listener.parameters_subscribe_len()) == 1).await;
 
     let parameters = vec![
         Parameter::float64("foo", 2.0),
@@ -2183,6 +2185,7 @@ async fn test_parameter_handler_set_echoes_and_broadcasts() {
 #[traced_test]
 #[tokio::test]
 async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
+    let listener = Arc::new(RecordingServerListener::new());
     let handler = Arc::new(RecordingParameterHandler::new());
     handler.set_set_behavior(RecordingSetBehavior::DropResponder);
 
@@ -2191,6 +2194,7 @@ async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
         &ctx,
         ServerOptions {
             capabilities: Some(IndexSet::from([Capability::Parameters])),
+            listener: Some(listener.clone()),
             parameter_handler: Some(handler.clone()),
             ..Default::default()
         },
@@ -2212,7 +2216,7 @@ async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
         .await
         .expect("Failed to send subscribe parameter updates");
 
-    assert_eventually(|| dbg!(handler.parameters_subscribe_len()) == 1).await;
+    assert_eventually(|| dbg!(listener.parameters_subscribe_len()) == 1).await;
 
     setter
         .send(&SetParameters::new(vec![Parameter::float64("foo", 2.0)]).with_id("set-1"))
@@ -2237,60 +2241,8 @@ async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
 
 #[traced_test]
 #[tokio::test]
-async fn test_parameter_handler_subscribe_unsubscribe() {
-    let handler = Arc::new(RecordingParameterHandler::new());
-
-    let ctx = Context::new();
-    let server = create_server(
-        &ctx,
-        ServerOptions {
-            capabilities: Some(IndexSet::from([Capability::Parameters])),
-            parameter_handler: Some(handler.clone()),
-            ..Default::default()
-        },
-    );
-    let addr = server
-        .start("127.0.0.1", 0)
-        .await
-        .expect("Failed to start server");
-
-    let mut client = WebSocketClient::connect(format!("{addr}"))
-        .await
-        .expect("Failed to connect");
-    expect_recv!(client, ServerMessage::ServerInfo);
-
-    client
-        .send(&SubscribeParameterUpdates::new(["foo", "bar"]))
-        .await
-        .expect("Failed to send subscribe parameter updates");
-
-    assert_eventually(|| dbg!(handler.parameters_subscribe_len()) == 1).await;
-
-    let subbed = handler.take_parameters_subscribe().pop().unwrap();
-    let mut subbed_sorted = subbed.clone();
-    subbed_sorted.sort();
-    assert_eq!(subbed_sorted, vec!["bar".to_string(), "foo".to_string()]);
-
-    client
-        .send(&UnsubscribeParameterUpdates::new(["foo", "bar"]))
-        .await
-        .expect("Failed to send unsubscribe parameter updates");
-
-    assert_eventually(|| dbg!(handler.parameters_unsubscribe_len()) == 1).await;
-
-    let unsubbed = handler.take_parameters_unsubscribe().pop().unwrap();
-    let mut unsubbed_sorted = unsubbed.clone();
-    unsubbed_sorted.sort();
-    assert_eq!(unsubbed_sorted, vec!["bar".to_string(), "foo".to_string()]);
-
-    let _ = server.stop();
-}
-
-#[traced_test]
-#[tokio::test]
 async fn test_parameter_handler_takes_precedence_over_listener() {
-    // Both registered. Handler should win for all four parameter callbacks; listener's
-    // parameter methods must not fire.
+    // Both registered. Handler should win for get/set; listener still receives sub/unsub.
     let listener = Arc::new(RecordingServerListener::new());
     let handler = Arc::new(RecordingParameterHandler::new());
     handler.set_get_behavior(RecordingGetBehavior::Respond(vec![Parameter::float64(
@@ -2337,16 +2289,14 @@ async fn test_parameter_handler_takes_precedence_over_listener() {
     assert_eventually(|| {
         dbg!(handler.parameters_get_len()) >= 1
             && dbg!(handler.parameters_set_len()) >= 1
-            && dbg!(handler.parameters_subscribe_len()) >= 1
-            && dbg!(handler.parameters_unsubscribe_len()) >= 1
+            && dbg!(listener.parameters_subscribe_len()) >= 1
+            && dbg!(listener.parameters_unsubscribe_len()) >= 1
     })
     .await;
 
-    // Listener parameter methods were never invoked.
+    // Listener get/set methods were never invoked.
     assert_eq!(listener.take_parameters_get().len(), 0);
     assert_eq!(listener.take_parameters_set().len(), 0);
-    assert_eq!(listener.take_parameters_subscribe().len(), 0);
-    assert_eq!(listener.take_parameters_unsubscribe().len(), 0);
 
     let _ = server.stop();
 }

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -32,7 +32,10 @@ use super::ws_protocol::server::{
     ServiceCallFailure, ServiceCallResponse, Status, advertise_services,
 };
 use crate::library_version::get_library_version;
-use crate::testutil::{RecordingServerListener, assert_eventually};
+use crate::testutil::{
+    RecordingGetBehavior, RecordingParameterHandler, RecordingServerListener, RecordingSetBehavior,
+    assert_eventually,
+};
 use crate::testutil::{WebSocketClient, WebSocketClientError};
 #[cfg(feature = "websocket-tls")]
 use crate::websocket::TlsIdentity;
@@ -2029,4 +2032,321 @@ async fn test_playback_control_without_time_range() {
     };
 
     create_server(&ctx, options);
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_parameter_handler_get_responds_with_values() {
+    let parameters = vec![Parameter::float64("foo", 1.0)];
+    let handler = Arc::new(RecordingParameterHandler::new());
+    handler.set_get_behavior(RecordingGetBehavior::Respond(parameters.clone()));
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::Parameters])),
+            parameter_handler: Some(handler.clone()),
+            ..Default::default()
+        },
+    );
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut client = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect");
+    expect_recv!(client, ServerMessage::ServerInfo);
+
+    client
+        .send(&GetParameters::new(["foo", "bar"]).with_id("req-1"))
+        .await
+        .expect("Failed to send get parameters");
+
+    let msg = expect_recv!(client, ServerMessage::ParameterValues);
+    assert_eq!(msg.id, Some("req-1".into()));
+    assert_eq!(msg.parameters, parameters);
+
+    let captured = handler.take_parameters_get().pop().unwrap();
+    assert_eq!(captured.param_names, vec!["foo", "bar"]);
+    assert_eq!(captured.request_id, Some("req-1".to_string()));
+
+    let _ = server.stop();
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_parameter_handler_get_drop_sends_error_status() {
+    let handler = Arc::new(RecordingParameterHandler::new());
+    handler.set_get_behavior(RecordingGetBehavior::DropResponder);
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::Parameters])),
+            parameter_handler: Some(handler.clone()),
+            ..Default::default()
+        },
+    );
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut client = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect");
+    expect_recv!(client, ServerMessage::ServerInfo);
+
+    client
+        .send(&GetParameters::new(["foo"]).with_id("req-1"))
+        .await
+        .expect("Failed to send get parameters");
+
+    let status = expect_recv!(client, ServerMessage::Status);
+    assert_eq!(
+        status.level,
+        super::ws_protocol::server::status::Level::Error
+    );
+    assert!(status.message.contains("failed to send a response"));
+
+    let _ = server.stop();
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_parameter_handler_set_echoes_and_broadcasts() {
+    let handler = Arc::new(RecordingParameterHandler::new());
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::Parameters])),
+            parameter_handler: Some(handler.clone()),
+            ..Default::default()
+        },
+    );
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    // The setter; will subscribe to "foo" and then issue a set with request_id.
+    let mut setter = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect setter");
+    // A second client subscribes to "foo" to receive the broadcast.
+    let mut subscriber = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect subscriber");
+
+    subscriber
+        .send(&SubscribeParameterUpdates::new(["foo"]))
+        .await
+        .expect("Failed to send subscribe parameter updates");
+
+    assert_eventually(|| dbg!(handler.parameters_subscribe_len()) == 1).await;
+
+    let parameters = vec![
+        Parameter::float64("foo", 2.0),
+        Parameter::string("ignored", "by-subscriber"),
+    ];
+    setter
+        .send(&SetParameters::new(parameters.clone()).with_id("set-1"))
+        .await
+        .expect("Failed to send set parameters");
+
+    expect_recv!(setter, ServerMessage::ServerInfo);
+    expect_recv!(subscriber, ServerMessage::ServerInfo);
+
+    // Setter receives an echoed ParameterValues with the request_id (RecordingSetBehavior::Echo).
+    let echo = expect_recv!(setter, ServerMessage::ParameterValues);
+    assert_eq!(echo.id, Some("set-1".into()));
+    assert_eq!(echo.parameters, parameters);
+
+    // Subscriber receives a broadcast filtered to its subscription set ("foo").
+    let broadcast = expect_recv!(subscriber, ServerMessage::ParameterValues);
+    assert_eq!(broadcast.id, None);
+    assert_eq!(broadcast.parameters, parameters[..1].to_vec());
+
+    let captured = handler.take_parameters_set().pop().unwrap();
+    assert_eq!(captured.request_id, Some("set-1".to_string()));
+    assert_eq!(captured.parameters, parameters);
+
+    let _ = server.stop();
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_parameter_handler_set_drop_sends_error_no_broadcast() {
+    let handler = Arc::new(RecordingParameterHandler::new());
+    handler.set_set_behavior(RecordingSetBehavior::DropResponder);
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::Parameters])),
+            parameter_handler: Some(handler.clone()),
+            ..Default::default()
+        },
+    );
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut setter = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect setter");
+    let mut subscriber = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect subscriber");
+
+    subscriber
+        .send(&SubscribeParameterUpdates::new(["foo"]))
+        .await
+        .expect("Failed to send subscribe parameter updates");
+
+    assert_eventually(|| dbg!(handler.parameters_subscribe_len()) == 1).await;
+
+    setter
+        .send(&SetParameters::new(vec![Parameter::float64("foo", 2.0)]).with_id("set-1"))
+        .await
+        .expect("Failed to send set parameters");
+
+    expect_recv!(setter, ServerMessage::ServerInfo);
+    expect_recv!(subscriber, ServerMessage::ServerInfo);
+
+    // Setter sees an error advisory.
+    let status = expect_recv!(setter, ServerMessage::Status);
+    assert_eq!(
+        status.level,
+        super::ws_protocol::server::status::Level::Error
+    );
+    assert!(status.message.contains("failed to send a response"));
+
+    // No ParameterValues should be broadcast to the subscriber.
+    server.stop().unwrap().wait().await;
+    expect_recv_close!(subscriber);
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_parameter_handler_subscribe_unsubscribe() {
+    let handler = Arc::new(RecordingParameterHandler::new());
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::Parameters])),
+            parameter_handler: Some(handler.clone()),
+            ..Default::default()
+        },
+    );
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut client = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect");
+    expect_recv!(client, ServerMessage::ServerInfo);
+
+    client
+        .send(&SubscribeParameterUpdates::new(["foo", "bar"]))
+        .await
+        .expect("Failed to send subscribe parameter updates");
+
+    assert_eventually(|| dbg!(handler.parameters_subscribe_len()) == 1).await;
+
+    let subbed = handler.take_parameters_subscribe().pop().unwrap();
+    let mut subbed_sorted = subbed.clone();
+    subbed_sorted.sort();
+    assert_eq!(subbed_sorted, vec!["bar".to_string(), "foo".to_string()]);
+
+    client
+        .send(&UnsubscribeParameterUpdates::new(["foo", "bar"]))
+        .await
+        .expect("Failed to send unsubscribe parameter updates");
+
+    assert_eventually(|| dbg!(handler.parameters_unsubscribe_len()) == 1).await;
+
+    let unsubbed = handler.take_parameters_unsubscribe().pop().unwrap();
+    let mut unsubbed_sorted = unsubbed.clone();
+    unsubbed_sorted.sort();
+    assert_eq!(unsubbed_sorted, vec!["bar".to_string(), "foo".to_string()]);
+
+    let _ = server.stop();
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_parameter_handler_takes_precedence_over_listener() {
+    // Both registered. Handler should win for all four parameter callbacks; listener's
+    // parameter methods must not fire.
+    let listener = Arc::new(RecordingServerListener::new());
+    let handler = Arc::new(RecordingParameterHandler::new());
+    handler.set_get_behavior(RecordingGetBehavior::Respond(vec![Parameter::float64(
+        "foo", 1.0,
+    )]));
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::Parameters])),
+            listener: Some(listener.clone()),
+            parameter_handler: Some(handler.clone()),
+            ..Default::default()
+        },
+    );
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut client = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect");
+    expect_recv!(client, ServerMessage::ServerInfo);
+
+    client
+        .send(&SubscribeParameterUpdates::new(["foo"]))
+        .await
+        .expect("Failed to send subscribe");
+    client
+        .send(&GetParameters::new(["foo"]).with_id("g1"))
+        .await
+        .expect("Failed to send get");
+    client
+        .send(&SetParameters::new(vec![Parameter::float64("foo", 3.0)]).with_id("s1"))
+        .await
+        .expect("Failed to send set");
+    client
+        .send(&UnsubscribeParameterUpdates::new(["foo"]))
+        .await
+        .expect("Failed to send unsubscribe");
+
+    assert_eventually(|| {
+        dbg!(handler.parameters_get_len()) >= 1
+            && dbg!(handler.parameters_set_len()) >= 1
+            && dbg!(handler.parameters_subscribe_len()) >= 1
+            && dbg!(handler.parameters_unsubscribe_len()) >= 1
+    })
+    .await;
+
+    // Listener parameter methods were never invoked.
+    assert_eq!(listener.take_parameters_get().len(), 0);
+    assert_eq!(listener.take_parameters_set().len(), 0);
+    assert_eq!(listener.take_parameters_subscribe().len(), 0);
+    assert_eq!(listener.take_parameters_unsubscribe().len(), 0);
+
+    let _ = server.stop();
 }

--- a/rust/foxglove/src/websocket_server.rs
+++ b/rust/foxglove/src/websocket_server.rs
@@ -13,7 +13,8 @@ use crate::websocket::TlsIdentity;
 use crate::websocket::service::Service;
 use crate::websocket::{
     AnyClient, AssetHandler, AsyncAssetHandlerFn, BlockingAssetHandlerFn, Capability,
-    ConnectionGraph, Parameter, Server, ServerOptions, ShutdownHandle, Status, create_server,
+    ConnectionGraph, Parameter, ParameterHandler, Server, ServerOptions, ShutdownHandle, Status,
+    create_server,
 };
 use crate::{AppUrl, ChannelDescriptor, Context, FoxgloveError, runtime::get_runtime_handle};
 
@@ -167,6 +168,16 @@ impl WebSocketServer {
         Err: Display,
     {
         self.options.fetch_asset_handler = Some(Arc::new(AsyncAssetHandlerFn(Arc::new(handler))));
+        self
+    }
+
+    /// Configure the handler for client-initiated parameter operations.
+    ///
+    /// When set, the handler takes precedence over the deprecated parameter callbacks on
+    /// [`ServerListener`](crate::websocket::ServerListener). Automatically adds
+    /// [`Capability::Parameters`] to the set of advertised capabilities.
+    pub fn parameter_handler(mut self, handler: Arc<dyn ParameterHandler>) -> Self {
+        self.options.parameter_handler = Some(handler);
         self
     }
 

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -789,6 +789,7 @@ type QosClassifierFn =
 pub struct TestGatewayOptions {
     pub filter: Option<ChannelFilterFn>,
     pub listener: Option<Arc<dyn foxglove::remote_access::Listener>>,
+    pub parameter_handler: Option<Arc<dyn foxglove::remote_access::ParameterHandler>>,
     pub capabilities: Vec<foxglove::remote_access::Capability>,
     pub services: Vec<Service>,
     pub qos_classifier: Option<QosClassifierFn>,
@@ -862,6 +863,9 @@ impl TestGateway {
         }
         if let Some(listener) = options.listener {
             gateway = gateway.listener(listener);
+        }
+        if let Some(handler) = options.parameter_handler {
+            gateway = gateway.parameter_handler(handler);
         }
         if !options.capabilities.is_empty() {
             gateway = gateway.capabilities(options.capabilities);

--- a/rust/remote_access_tests/tests/parameter_test.rs
+++ b/rust/remote_access_tests/tests/parameter_test.rs
@@ -8,20 +8,23 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use foxglove::protocol::v2::server::server_info;
-use foxglove::remote_access::{Capability, Listener, Parameter};
+use foxglove::remote_access::{
+    AnyClient, Capability, GetParametersResponder, Parameter, ParameterHandler,
+    SetParametersResponder,
+};
 use remote_access_tests::test_helpers::{TestGateway, TestGatewayOptions, ViewerConnection};
 use serial_test::serial;
 use tracing::info;
 use tracing_test::traced_test;
 
 // ---------------------------------------------------------------------------
-// Mock listener that records parameter callbacks
+// Mock parameter handler that records subscribe/unsubscribe calls
 // ---------------------------------------------------------------------------
 
-/// A mock [`Listener`] that handles parameter get/set requests and records
+/// A mock [`ParameterHandler`] that handles parameter get/set requests and records
 /// subscribe/unsubscribe callbacks.
-struct ParameterListener {
-    /// Parameters returned by `on_get_parameters`. Set by the test before sending requests.
+struct ParameterHandlerImpl {
+    /// Parameters returned by `get`. Set by the test before sending requests.
     stored_parameters: Mutex<Vec<Parameter>>,
     /// Records parameter names from subscribe callbacks.
     subscribed: Mutex<Vec<Vec<String>>>,
@@ -29,7 +32,7 @@ struct ParameterListener {
     unsubscribed: Mutex<Vec<Vec<String>>>,
 }
 
-impl ParameterListener {
+impl ParameterHandlerImpl {
     fn new(initial_parameters: Vec<Parameter>) -> Self {
         Self {
             stored_parameters: Mutex::new(initial_parameters),
@@ -47,31 +50,34 @@ impl ParameterListener {
     }
 }
 
-impl Listener for ParameterListener {
-    fn on_get_parameters(
+impl ParameterHandler for ParameterHandlerImpl {
+    fn get(
         &self,
-        _client: &foxglove::remote_access::Client,
-        param_names: Vec<String>,
-        _request_id: Option<&str>,
-    ) -> Vec<Parameter> {
+        _client: AnyClient,
+        names: Vec<String>,
+        _request_id: Option<String>,
+        responder: GetParametersResponder,
+    ) {
         let params = self.stored_parameters.lock().unwrap();
-        if param_names.is_empty() {
+        let values = if names.is_empty() {
             params.clone()
         } else {
             params
                 .iter()
-                .filter(|p| param_names.contains(&p.name))
+                .filter(|p| names.contains(&p.name))
                 .cloned()
                 .collect()
-        }
+        };
+        responder.respond(values);
     }
 
-    fn on_set_parameters(
+    fn set(
         &self,
-        _client: &foxglove::remote_access::Client,
+        _client: AnyClient,
         parameters: Vec<Parameter>,
-        _request_id: Option<&str>,
-    ) -> Vec<Parameter> {
+        _request_id: Option<String>,
+        responder: SetParametersResponder,
+    ) {
         let mut stored = self.stored_parameters.lock().unwrap();
         for param in &parameters {
             if let Some(existing) = stored.iter_mut().find(|p| p.name == param.name) {
@@ -80,15 +86,15 @@ impl Listener for ParameterListener {
                 stored.push(param.clone());
             }
         }
-        stored.clone()
+        responder.respond(stored.clone());
     }
 
-    fn on_parameters_subscribe(&self, param_names: Vec<String>) {
-        self.subscribed.lock().unwrap().push(param_names);
+    fn subscribe(&self, names: Vec<String>) {
+        self.subscribed.lock().unwrap().push(names);
     }
 
-    fn on_parameters_unsubscribe(&self, param_names: Vec<String>) {
-        self.unsubscribed.lock().unwrap().push(param_names);
+    fn unsubscribe(&self, names: Vec<String>) {
+        self.unsubscribed.lock().unwrap().push(names);
     }
 }
 
@@ -103,12 +109,12 @@ impl Listener for ParameterListener {
 #[serial(livekit)]
 async fn livekit_parameter_server_info_capabilities() -> Result<()> {
     let ctx = foxglove::Context::new();
-    let listener = Arc::new(ParameterListener::new(vec![]));
+    let handler = Arc::new(ParameterHandlerImpl::new(vec![]));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            listener: Some(listener),
+            parameter_handler: Some(handler),
             ..Default::default()
         },
     )
@@ -148,12 +154,12 @@ async fn livekit_parameter_get_parameters() -> Result<()> {
         Parameter::string("foo", "hello"),
         Parameter::float64("bar", 42.0),
     ];
-    let listener = Arc::new(ParameterListener::new(params));
+    let handler = Arc::new(ParameterHandlerImpl::new(params));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            listener: Some(listener),
+            parameter_handler: Some(handler),
             ..Default::default()
         },
     )
@@ -186,14 +192,14 @@ async fn livekit_parameter_get_parameters() -> Result<()> {
 #[serial(livekit)]
 async fn livekit_parameter_set_parameters() -> Result<()> {
     let ctx = foxglove::Context::new();
-    let listener = Arc::new(ParameterListener::new(vec![Parameter::string(
+    let handler = Arc::new(ParameterHandlerImpl::new(vec![Parameter::string(
         "color", "red",
     )]));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            listener: Some(listener),
+            parameter_handler: Some(handler),
             ..Default::default()
         },
     )
@@ -228,12 +234,12 @@ async fn livekit_parameter_set_parameters() -> Result<()> {
 #[serial(livekit)]
 async fn livekit_parameter_subscribe_and_publish() -> Result<()> {
     let ctx = foxglove::Context::new();
-    let listener = Arc::new(ParameterListener::new(vec![]));
+    let handler = Arc::new(ParameterHandlerImpl::new(vec![]));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            listener: Some(listener.clone()),
+            parameter_handler: Some(handler.clone()),
             ..Default::default()
         },
     )
@@ -250,11 +256,11 @@ async fn livekit_parameter_subscribe_and_publish() -> Result<()> {
     // Give the gateway time to process the subscription.
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Verify the listener was notified of the subscription.
-    let subscribed = listener.take_subscribed();
+    // Verify the handler was notified of the subscription.
+    let subscribed = handler.take_subscribed();
     assert!(
         !subscribed.is_empty(),
-        "listener should have received on_parameters_subscribe"
+        "handler should have received subscribe callback"
     );
 
     // Publish parameter values from the gateway handle.
@@ -280,7 +286,7 @@ async fn livekit_parameter_subscribe_and_publish() -> Result<()> {
 #[serial(livekit)]
 async fn livekit_parameter_set_notifies_subscriber_with_all_params() -> Result<()> {
     let ctx = foxglove::Context::new();
-    let listener = Arc::new(ParameterListener::new(vec![
+    let handler = Arc::new(ParameterHandlerImpl::new(vec![
         Parameter::string("color", "red"),
         Parameter::float64("size", 10.0),
     ]));
@@ -288,7 +294,7 @@ async fn livekit_parameter_set_notifies_subscriber_with_all_params() -> Result<(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            listener: Some(listener),
+            parameter_handler: Some(handler),
             ..Default::default()
         },
     )
@@ -340,12 +346,12 @@ async fn livekit_parameter_set_notifies_subscriber_with_all_params() -> Result<(
 #[serial(livekit)]
 async fn livekit_parameter_publish_filters_by_subscription() -> Result<()> {
     let ctx = foxglove::Context::new();
-    let listener = Arc::new(ParameterListener::new(vec![]));
+    let handler = Arc::new(ParameterHandlerImpl::new(vec![]));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            listener: Some(listener),
+            parameter_handler: Some(handler),
             ..Default::default()
         },
     )
@@ -382,12 +388,12 @@ async fn livekit_parameter_publish_filters_by_subscription() -> Result<()> {
 #[serial(livekit)]
 async fn livekit_parameter_unsubscribe_stops_delivery() -> Result<()> {
     let ctx = foxglove::Context::new();
-    let listener = Arc::new(ParameterListener::new(vec![]));
+    let handler = Arc::new(ParameterHandlerImpl::new(vec![]));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            listener: Some(listener.clone()),
+            parameter_handler: Some(handler.clone()),
             ..Default::default()
         },
     )
@@ -409,11 +415,11 @@ async fn livekit_parameter_unsubscribe_stops_delivery() -> Result<()> {
     viewer.send_unsubscribe_parameter_updates(&["temp"]).await?;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Verify the listener was notified of the unsubscription.
-    let unsubscribed = listener.take_unsubscribed();
+    // Verify the handler was notified of the unsubscription.
+    let unsubscribed = handler.take_unsubscribed();
     assert!(
         !unsubscribed.is_empty(),
-        "listener should have received on_parameters_unsubscribe"
+        "handler should have received unsubscribe callback"
     );
 
     // Publish again — viewer should NOT receive this.

--- a/rust/remote_access_tests/tests/parameter_test.rs
+++ b/rust/remote_access_tests/tests/parameter_test.rs
@@ -335,66 +335,6 @@ async fn livekit_parameter_subscribe_and_publish() -> Result<()> {
     Ok(())
 }
 
-/// Test that when viewer A sets a parameter while viewer B is subscribed, B
-/// receives ALL parameters (not just the one that was set) with no request ID.
-#[traced_test]
-#[ignore]
-#[tokio::test]
-#[serial(livekit)]
-async fn livekit_parameter_set_notifies_subscriber_with_all_params() -> Result<()> {
-    let ctx = foxglove::Context::new();
-    let handler = Arc::new(ParameterHandlerImpl::new(vec![
-        Parameter::string("color", "red"),
-        Parameter::float64("size", 10.0),
-    ]));
-    let gw = TestGateway::start_with_options(
-        &ctx,
-        TestGatewayOptions {
-            capabilities: vec![Capability::Parameters],
-            parameter_handler: Some(handler),
-            ..Default::default()
-        },
-    )
-    .await?;
-
-    // Viewer B subscribes to all parameters.
-    let mut viewer_b = ViewerConnection::connect(&gw.room_name, "viewer-b").await?;
-    let _server_info_b = viewer_b.expect_server_info().await?;
-    viewer_b
-        .send_subscribe_parameter_updates(&["color", "size"])
-        .await?;
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    // Viewer A sets a parameter (no subscription).
-    let mut viewer_a = ViewerConnection::connect(&gw.room_name, "viewer-a").await?;
-    let _server_info_a = viewer_a.expect_server_info().await?;
-    viewer_a
-        .send_set_parameters_with_id(vec![Parameter::string("color", "blue")], "set-a")
-        .await?;
-
-    // Viewer A gets the response with the request ID.
-    let response_a = viewer_a.expect_parameter_values().await?;
-    assert_eq!(response_a.id.as_deref(), Some("set-a"));
-
-    // Viewer B should receive a notification with ALL parameters and NO request ID.
-    let response_b = viewer_b.expect_parameter_values().await?;
-    info!("Viewer B received: {response_b:?}");
-    assert!(
-        response_b.id.is_none(),
-        "subscriber notification should have no request ID"
-    );
-    assert!(
-        response_b.parameters.len() >= 2,
-        "subscriber should receive all parameters, got {}",
-        response_b.parameters.len()
-    );
-
-    viewer_a.close().await?;
-    viewer_b.close().await?;
-    gw.stop().await?;
-    Ok(())
-}
-
 /// Test that `publish_parameter_values` filters by subscription: a viewer only
 /// receives parameters it subscribed to.
 #[traced_test]

--- a/rust/remote_access_tests/tests/parameter_test.rs
+++ b/rust/remote_access_tests/tests/parameter_test.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use foxglove::protocol::v2::server::server_info;
 use foxglove::remote_access::{
-    AnyClient, Capability, Client, GetParametersResponder, Listener, Parameter, ParameterHandler,
+    AnyClient, Capability, GetParametersResponder, Listener, Parameter, ParameterHandler,
     SetParametersResponder,
 };
 use remote_access_tests::test_helpers::{TestGateway, TestGatewayOptions, ViewerConnection};
@@ -18,13 +18,13 @@ use tracing::info;
 use tracing_test::traced_test;
 
 // ---------------------------------------------------------------------------
-// Mock parameter handler that records subscribe/unsubscribe calls
+// Mock listener that records parameter callbacks
 // ---------------------------------------------------------------------------
 
-/// A mock [`ParameterHandler`] that handles parameter get/set requests and records
+/// A mock [`Listener`] that handles parameter get/set requests and records
 /// subscribe/unsubscribe callbacks.
-struct ParameterHandlerImpl {
-    /// Parameters returned by `get`. Set by the test before sending requests.
+struct ParameterListener {
+    /// Parameters returned by `on_get_parameters`. Set by the test before sending requests.
     stored_parameters: Mutex<Vec<Parameter>>,
     /// Records parameter names from subscribe callbacks.
     subscribed: Mutex<Vec<Vec<String>>>,
@@ -32,7 +32,7 @@ struct ParameterHandlerImpl {
     unsubscribed: Mutex<Vec<Vec<String>>>,
 }
 
-impl ParameterHandlerImpl {
+impl ParameterListener {
     fn new(initial_parameters: Vec<Parameter>) -> Self {
         Self {
             stored_parameters: Mutex::new(initial_parameters),
@@ -47,6 +47,69 @@ impl ParameterHandlerImpl {
 
     fn take_unsubscribed(&self) -> Vec<Vec<String>> {
         std::mem::take(&mut *self.unsubscribed.lock().unwrap())
+    }
+}
+
+impl Listener for ParameterListener {
+    fn on_get_parameters(
+        &self,
+        _client: &foxglove::remote_access::Client,
+        param_names: Vec<String>,
+        _request_id: Option<&str>,
+    ) -> Vec<Parameter> {
+        let params = self.stored_parameters.lock().unwrap();
+        if param_names.is_empty() {
+            params.clone()
+        } else {
+            params
+                .iter()
+                .filter(|p| param_names.contains(&p.name))
+                .cloned()
+                .collect()
+        }
+    }
+
+    fn on_set_parameters(
+        &self,
+        _client: &foxglove::remote_access::Client,
+        parameters: Vec<Parameter>,
+        _request_id: Option<&str>,
+    ) -> Vec<Parameter> {
+        let mut stored = self.stored_parameters.lock().unwrap();
+        for param in &parameters {
+            if let Some(existing) = stored.iter_mut().find(|p| p.name == param.name) {
+                *existing = param.clone();
+            } else {
+                stored.push(param.clone());
+            }
+        }
+        stored.clone()
+    }
+
+    fn on_parameters_subscribe(&self, param_names: Vec<String>) {
+        self.subscribed.lock().unwrap().push(param_names);
+    }
+
+    fn on_parameters_unsubscribe(&self, param_names: Vec<String>) {
+        self.unsubscribed.lock().unwrap().push(param_names);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock parameter handler
+// ---------------------------------------------------------------------------
+
+/// A mock [`ParameterHandler`] that handles parameter get/set requests.
+struct ParameterHandlerImpl {
+    /// Parameters returned by `get`. Set by the test before sending requests.
+    stored_parameters: Mutex<Vec<Parameter>>,
+}
+
+impl ParameterHandlerImpl {
+    fn new(initial_parameters: Vec<Parameter>) -> Self {
+        Self {
+            stored_parameters: Mutex::new(initial_parameters),
+        }
     }
 }
 
@@ -87,14 +150,6 @@ impl ParameterHandler for ParameterHandlerImpl {
             }
         }
         responder.respond(stored.clone());
-    }
-
-    fn subscribe(&self, names: Vec<String>) {
-        self.subscribed.lock().unwrap().push(names);
-    }
-
-    fn unsubscribe(&self, names: Vec<String>) {
-        self.unsubscribed.lock().unwrap().push(names);
     }
 }
 
@@ -235,11 +290,13 @@ async fn livekit_parameter_set_parameters() -> Result<()> {
 async fn livekit_parameter_subscribe_and_publish() -> Result<()> {
     let ctx = foxglove::Context::new();
     let handler = Arc::new(ParameterHandlerImpl::new(vec![]));
+    let listener = Arc::new(ParameterListener::new(vec![]));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            parameter_handler: Some(handler.clone()),
+            parameter_handler: Some(handler),
+            listener: Some(listener.clone()),
             ..Default::default()
         },
     )
@@ -256,11 +313,11 @@ async fn livekit_parameter_subscribe_and_publish() -> Result<()> {
     // Give the gateway time to process the subscription.
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Verify the handler was notified of the subscription.
-    let subscribed = handler.take_subscribed();
+    // Verify the listener was notified of the subscription.
+    let subscribed = listener.take_subscribed();
     assert!(
         !subscribed.is_empty(),
-        "handler should have received subscribe callback"
+        "listener should have received on_parameters_subscribe"
     );
 
     // Publish parameter values from the gateway handle.
@@ -389,11 +446,13 @@ async fn livekit_parameter_publish_filters_by_subscription() -> Result<()> {
 async fn livekit_parameter_unsubscribe_stops_delivery() -> Result<()> {
     let ctx = foxglove::Context::new();
     let handler = Arc::new(ParameterHandlerImpl::new(vec![]));
+    let listener = Arc::new(ParameterListener::new(vec![]));
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {
             capabilities: vec![Capability::Parameters],
-            parameter_handler: Some(handler.clone()),
+            parameter_handler: Some(handler),
+            listener: Some(listener.clone()),
             ..Default::default()
         },
     )
@@ -415,11 +474,11 @@ async fn livekit_parameter_unsubscribe_stops_delivery() -> Result<()> {
     viewer.send_unsubscribe_parameter_updates(&["temp"]).await?;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Verify the handler was notified of the unsubscription.
-    let unsubscribed = handler.take_unsubscribed();
+    // Verify the listener was notified of the unsubscription.
+    let unsubscribed = listener.take_unsubscribed();
     assert!(
         !unsubscribed.is_empty(),
-        "handler should have received unsubscribe callback"
+        "listener should have received on_parameters_unsubscribe"
     );
 
     // Publish again — viewer should NOT receive this.
@@ -451,77 +510,6 @@ async fn livekit_parameter_unsubscribe_stops_delivery() -> Result<()> {
 // `ParameterHandler` tests above so each legacy branch keeps integration
 // coverage until the callbacks are removed. Delete this section when the
 // listener parameter callbacks are removed.
-
-/// Mock [`Listener`] that handles parameter get/set requests synchronously and
-/// records subscribe/unsubscribe callbacks.
-struct ParameterListener {
-    stored_parameters: Mutex<Vec<Parameter>>,
-    subscribed: Mutex<Vec<Vec<String>>>,
-    unsubscribed: Mutex<Vec<Vec<String>>>,
-}
-
-impl ParameterListener {
-    fn new(initial_parameters: Vec<Parameter>) -> Self {
-        Self {
-            stored_parameters: Mutex::new(initial_parameters),
-            subscribed: Mutex::new(Vec::new()),
-            unsubscribed: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn take_subscribed(&self) -> Vec<Vec<String>> {
-        std::mem::take(&mut *self.subscribed.lock().unwrap())
-    }
-
-    fn take_unsubscribed(&self) -> Vec<Vec<String>> {
-        std::mem::take(&mut *self.unsubscribed.lock().unwrap())
-    }
-}
-
-impl Listener for ParameterListener {
-    fn on_get_parameters(
-        &self,
-        _client: &Client,
-        param_names: Vec<String>,
-        _request_id: Option<&str>,
-    ) -> Vec<Parameter> {
-        let params = self.stored_parameters.lock().unwrap();
-        if param_names.is_empty() {
-            params.clone()
-        } else {
-            params
-                .iter()
-                .filter(|p| param_names.contains(&p.name))
-                .cloned()
-                .collect()
-        }
-    }
-
-    fn on_set_parameters(
-        &self,
-        _client: &Client,
-        parameters: Vec<Parameter>,
-        _request_id: Option<&str>,
-    ) -> Vec<Parameter> {
-        let mut stored = self.stored_parameters.lock().unwrap();
-        for param in &parameters {
-            if let Some(existing) = stored.iter_mut().find(|p| p.name == param.name) {
-                *existing = param.clone();
-            } else {
-                stored.push(param.clone());
-            }
-        }
-        stored.clone()
-    }
-
-    fn on_parameters_subscribe(&self, param_names: Vec<String>) {
-        self.subscribed.lock().unwrap().push(param_names);
-    }
-
-    fn on_parameters_unsubscribe(&self, param_names: Vec<String>) {
-        self.unsubscribed.lock().unwrap().push(param_names);
-    }
-}
 
 /// Listener variant of [`livekit_parameter_get_parameters`].
 #[traced_test]

--- a/rust/remote_access_tests/tests/parameter_test.rs
+++ b/rust/remote_access_tests/tests/parameter_test.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use foxglove::protocol::v2::server::server_info;
 use foxglove::remote_access::{
-    AnyClient, Capability, GetParametersResponder, Parameter, ParameterHandler,
+    AnyClient, Capability, Client, GetParametersResponder, Listener, Parameter, ParameterHandler,
     SetParametersResponder,
 };
 use remote_access_tests::test_helpers::{TestGateway, TestGatewayOptions, ViewerConnection};
@@ -427,6 +427,267 @@ async fn livekit_parameter_unsubscribe_stops_delivery() -> Result<()> {
         .publish_parameter_values(vec![Parameter::float64("temp", 30.0)]);
 
     // Wait briefly, then verify no message was received by trying to read with a short timeout.
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        viewer.expect_parameter_values(),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "should not receive parameter values after unsubscribing"
+    );
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
+// ===========================================================================
+// Legacy Listener parameter callbacks
+// ===========================================================================
+//
+// These tests cover the deprecated `Listener::on_*_parameters*` paths in
+// `session.rs`. They duplicate a representative subset of the
+// `ParameterHandler` tests above so each legacy branch keeps integration
+// coverage until the callbacks are removed. Delete this section when the
+// listener parameter callbacks are removed.
+
+/// Mock [`Listener`] that handles parameter get/set requests synchronously and
+/// records subscribe/unsubscribe callbacks.
+struct ParameterListener {
+    stored_parameters: Mutex<Vec<Parameter>>,
+    subscribed: Mutex<Vec<Vec<String>>>,
+    unsubscribed: Mutex<Vec<Vec<String>>>,
+}
+
+impl ParameterListener {
+    fn new(initial_parameters: Vec<Parameter>) -> Self {
+        Self {
+            stored_parameters: Mutex::new(initial_parameters),
+            subscribed: Mutex::new(Vec::new()),
+            unsubscribed: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn take_subscribed(&self) -> Vec<Vec<String>> {
+        std::mem::take(&mut *self.subscribed.lock().unwrap())
+    }
+
+    fn take_unsubscribed(&self) -> Vec<Vec<String>> {
+        std::mem::take(&mut *self.unsubscribed.lock().unwrap())
+    }
+}
+
+impl Listener for ParameterListener {
+    fn on_get_parameters(
+        &self,
+        _client: &Client,
+        param_names: Vec<String>,
+        _request_id: Option<&str>,
+    ) -> Vec<Parameter> {
+        let params = self.stored_parameters.lock().unwrap();
+        if param_names.is_empty() {
+            params.clone()
+        } else {
+            params
+                .iter()
+                .filter(|p| param_names.contains(&p.name))
+                .cloned()
+                .collect()
+        }
+    }
+
+    fn on_set_parameters(
+        &self,
+        _client: &Client,
+        parameters: Vec<Parameter>,
+        _request_id: Option<&str>,
+    ) -> Vec<Parameter> {
+        let mut stored = self.stored_parameters.lock().unwrap();
+        for param in &parameters {
+            if let Some(existing) = stored.iter_mut().find(|p| p.name == param.name) {
+                *existing = param.clone();
+            } else {
+                stored.push(param.clone());
+            }
+        }
+        stored.clone()
+    }
+
+    fn on_parameters_subscribe(&self, param_names: Vec<String>) {
+        self.subscribed.lock().unwrap().push(param_names);
+    }
+
+    fn on_parameters_unsubscribe(&self, param_names: Vec<String>) {
+        self.unsubscribed.lock().unwrap().push(param_names);
+    }
+}
+
+/// Listener variant of [`livekit_parameter_get_parameters`].
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_parameter_get_parameters_via_listener() -> Result<()> {
+    let ctx = foxglove::Context::new();
+    let listener = Arc::new(ParameterListener::new(vec![
+        Parameter::string("foo", "hello"),
+        Parameter::float64("bar", 42.0),
+    ]));
+    let gw = TestGateway::start_with_options(
+        &ctx,
+        TestGatewayOptions {
+            capabilities: vec![Capability::Parameters],
+            listener: Some(listener),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+    let _server_info = viewer.expect_server_info().await?;
+
+    viewer
+        .send_get_parameters_with_id(&["foo"], "req-1")
+        .await?;
+    let response = viewer.expect_parameter_values().await?;
+    info!("ParameterValues: {response:?}");
+
+    assert_eq!(response.id.as_deref(), Some("req-1"));
+    assert_eq!(response.parameters.len(), 1);
+    assert_eq!(response.parameters[0].name, "foo");
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
+/// Listener variant of [`livekit_parameter_set_parameters`].
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_parameter_set_parameters_via_listener() -> Result<()> {
+    let ctx = foxglove::Context::new();
+    let listener = Arc::new(ParameterListener::new(vec![Parameter::string(
+        "color", "red",
+    )]));
+    let gw = TestGateway::start_with_options(
+        &ctx,
+        TestGatewayOptions {
+            capabilities: vec![Capability::Parameters],
+            listener: Some(listener),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+    let _server_info = viewer.expect_server_info().await?;
+
+    viewer
+        .send_set_parameters_with_id(vec![Parameter::string("color", "blue")], "set-1")
+        .await?;
+    let response = viewer.expect_parameter_values().await?;
+    info!("ParameterValues: {response:?}");
+
+    assert_eq!(response.id.as_deref(), Some("set-1"));
+    assert!(
+        response.parameters.iter().any(|p| p.name == "color"),
+        "response should include the 'color' parameter"
+    );
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
+/// Listener variant of [`livekit_parameter_subscribe_and_publish`].
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_parameter_subscribe_and_publish_via_listener() -> Result<()> {
+    let ctx = foxglove::Context::new();
+    let listener = Arc::new(ParameterListener::new(vec![]));
+    let gw = TestGateway::start_with_options(
+        &ctx,
+        TestGatewayOptions {
+            capabilities: vec![Capability::Parameters],
+            listener: Some(listener.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+    let _server_info = viewer.expect_server_info().await?;
+
+    viewer
+        .send_subscribe_parameter_updates(&["speed", "mode"])
+        .await?;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let subscribed = listener.take_subscribed();
+    assert!(
+        !subscribed.is_empty(),
+        "listener should have received on_parameters_subscribe"
+    );
+
+    gw.handle
+        .publish_parameter_values(vec![Parameter::float64("speed", 99.0)]);
+
+    let response = viewer.expect_parameter_values().await?;
+    info!("ParameterValues after publish: {response:?}");
+    assert_eq!(response.parameters.len(), 1);
+    assert_eq!(response.parameters[0].name, "speed");
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
+/// Listener variant of [`livekit_parameter_unsubscribe_stops_delivery`].
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_parameter_unsubscribe_stops_delivery_via_listener() -> Result<()> {
+    let ctx = foxglove::Context::new();
+    let listener = Arc::new(ParameterListener::new(vec![]));
+    let gw = TestGateway::start_with_options(
+        &ctx,
+        TestGatewayOptions {
+            capabilities: vec![Capability::Parameters],
+            listener: Some(listener.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+    let _server_info = viewer.expect_server_info().await?;
+
+    viewer.send_subscribe_parameter_updates(&["temp"]).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    gw.handle
+        .publish_parameter_values(vec![Parameter::float64("temp", 20.0)]);
+    let response = viewer.expect_parameter_values().await?;
+    assert_eq!(response.parameters.len(), 1);
+
+    viewer.send_unsubscribe_parameter_updates(&["temp"]).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let unsubscribed = listener.take_unsubscribed();
+    assert!(
+        !unsubscribed.is_empty(),
+        "listener should have received on_parameters_unsubscribe"
+    );
+
+    gw.handle
+        .publish_parameter_values(vec![Parameter::float64("temp", 30.0)]);
+
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(2),
         viewer.expect_parameter_values(),

--- a/rust/remote_access_tests/tests/parameter_test.rs
+++ b/rust/remote_access_tests/tests/parameter_test.rs
@@ -12,7 +12,9 @@ use foxglove::remote_access::{
     AnyClient, Capability, GetParametersResponder, Listener, Parameter, ParameterHandler,
     SetParametersResponder,
 };
-use remote_access_tests::test_helpers::{TestGateway, TestGatewayOptions, ViewerConnection};
+use remote_access_tests::test_helpers::{
+    TestGateway, TestGatewayOptions, ViewerConnection, poll_until,
+};
 use serial_test::serial;
 use tracing::info;
 use tracing_test::traced_test;
@@ -26,6 +28,10 @@ use tracing_test::traced_test;
 struct ParameterListener {
     /// Parameters returned by `on_get_parameters`. Set by the test before sending requests.
     stored_parameters: Mutex<Vec<Parameter>>,
+    /// Records parameter names from `on_get_parameters` calls.
+    get_calls: Mutex<Vec<Vec<String>>>,
+    /// Records parameters from `on_set_parameters` calls.
+    set_calls: Mutex<Vec<Vec<Parameter>>>,
     /// Records parameter names from subscribe callbacks.
     subscribed: Mutex<Vec<Vec<String>>>,
     /// Records parameter names from unsubscribe callbacks.
@@ -36,9 +42,27 @@ impl ParameterListener {
     fn new(initial_parameters: Vec<Parameter>) -> Self {
         Self {
             stored_parameters: Mutex::new(initial_parameters),
+            get_calls: Mutex::new(Vec::new()),
+            set_calls: Mutex::new(Vec::new()),
             subscribed: Mutex::new(Vec::new()),
             unsubscribed: Mutex::new(Vec::new()),
         }
+    }
+
+    fn get_calls_len(&self) -> usize {
+        self.get_calls.lock().unwrap().len()
+    }
+
+    fn set_calls_len(&self) -> usize {
+        self.set_calls.lock().unwrap().len()
+    }
+
+    fn subscribed_len(&self) -> usize {
+        self.subscribed.lock().unwrap().len()
+    }
+
+    fn unsubscribed_len(&self) -> usize {
+        self.unsubscribed.lock().unwrap().len()
     }
 
     fn take_subscribed(&self) -> Vec<Vec<String>> {
@@ -57,6 +81,7 @@ impl Listener for ParameterListener {
         param_names: Vec<String>,
         _request_id: Option<&str>,
     ) -> Vec<Parameter> {
+        self.get_calls.lock().unwrap().push(param_names.clone());
         let params = self.stored_parameters.lock().unwrap();
         if param_names.is_empty() {
             params.clone()
@@ -75,6 +100,7 @@ impl Listener for ParameterListener {
         parameters: Vec<Parameter>,
         _request_id: Option<&str>,
     ) -> Vec<Parameter> {
+        self.set_calls.lock().unwrap().push(parameters.clone());
         let mut stored = self.stored_parameters.lock().unwrap();
         for param in &parameters {
             if let Some(existing) = stored.iter_mut().find(|p| p.name == param.name) {
@@ -103,13 +129,27 @@ impl Listener for ParameterListener {
 struct ParameterHandlerImpl {
     /// Parameters returned by `get`. Set by the test before sending requests.
     stored_parameters: Mutex<Vec<Parameter>>,
+    /// Records parameter names from `get` calls.
+    get_calls: Mutex<Vec<Vec<String>>>,
+    /// Records parameters from `set` calls.
+    set_calls: Mutex<Vec<Vec<Parameter>>>,
 }
 
 impl ParameterHandlerImpl {
     fn new(initial_parameters: Vec<Parameter>) -> Self {
         Self {
             stored_parameters: Mutex::new(initial_parameters),
+            get_calls: Mutex::new(Vec::new()),
+            set_calls: Mutex::new(Vec::new()),
         }
+    }
+
+    fn get_calls_len(&self) -> usize {
+        self.get_calls.lock().unwrap().len()
+    }
+
+    fn set_calls_len(&self) -> usize {
+        self.set_calls.lock().unwrap().len()
     }
 }
 
@@ -121,6 +161,7 @@ impl ParameterHandler for ParameterHandlerImpl {
         _request_id: Option<String>,
         responder: GetParametersResponder,
     ) {
+        self.get_calls.lock().unwrap().push(names.clone());
         let params = self.stored_parameters.lock().unwrap();
         let values = if names.is_empty() {
             params.clone()
@@ -141,6 +182,7 @@ impl ParameterHandler for ParameterHandlerImpl {
         _request_id: Option<String>,
         responder: SetParametersResponder,
     ) {
+        self.set_calls.lock().unwrap().push(parameters.clone());
         let mut stored = self.stored_parameters.lock().unwrap();
         for param in &parameters {
             if let Some(existing) = stored.iter_mut().find(|p| p.name == param.name) {
@@ -435,6 +477,56 @@ async fn livekit_parameter_unsubscribe_stops_delivery() -> Result<()> {
         result.is_err(),
         "should not receive parameter values after unsubscribing"
     );
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
+/// Test that when both a `ParameterHandler` and a `Listener` are registered,
+/// the handler wins for get/set while the listener still receives sub/unsub.
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_parameter_handler_takes_precedence_over_listener() -> Result<()> {
+    let ctx = foxglove::Context::new();
+    let handler = Arc::new(ParameterHandlerImpl::new(vec![Parameter::float64(
+        "foo", 1.0,
+    )]));
+    let listener = Arc::new(ParameterListener::new(vec![]));
+    let gw = TestGateway::start_with_options(
+        &ctx,
+        TestGatewayOptions {
+            capabilities: vec![Capability::Parameters],
+            parameter_handler: Some(handler.clone()),
+            listener: Some(listener.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+    let _server_info = viewer.expect_server_info().await?;
+
+    viewer.send_subscribe_parameter_updates(&["foo"]).await?;
+    viewer.send_get_parameters_with_id(&["foo"], "g1").await?;
+    viewer
+        .send_set_parameters_with_id(vec![Parameter::float64("foo", 3.0)], "s1")
+        .await?;
+    viewer.send_unsubscribe_parameter_updates(&["foo"]).await?;
+
+    poll_until(|| {
+        handler.get_calls_len() >= 1
+            && handler.set_calls_len() >= 1
+            && listener.subscribed_len() >= 1
+            && listener.unsubscribed_len() >= 1
+    })
+    .await;
+
+    // Listener get/set methods were never invoked.
+    assert_eq!(listener.get_calls_len(), 0);
+    assert_eq!(listener.set_calls_len(), 0);
 
     viewer.close().await?;
     gw.stop().await?;


### PR DESCRIPTION
### Changelog
- rust: Added ParameterHandler trait with responder-based get/set. Available on both WebSocketServer and the remote-access Gateway.

### Docs
Covered by rustdocs.

### Description
Adds a new ParameterHandler trait that mirrors the AssetHandler pattern: get/set return responders that the implementer can complete asynchronously. Like AssetHandler, the trait is transport-agnostic, so a single implementation can be registered with both a WebSocketServer and a remote-access Gateway.

When a parameter handler is registered, it takes precedence over the older ServerListener/remote_access::Listener parameter callbacks. Those legacy callbacks continue to work; a follow-up commit marks them deprecated.

It's tempting to move the subscribe/unsubscribe methods to the ParameterHandler, but it's not a good idea. These callbacks represent subscriptions that are aggregated _per-sink_, so it makes sense to keep them on the per-sink listener.

Note that the SetParametersResponder _does not_ broadcast parameter updates to subscribers. This is deliberate. The responder is necessarily associated with a single sink, whereas a ParameterHandler may be associated with multiple sinks. It is the implementer's job to publish parameter updates across all sinks. This is actually of benefit to the bridge, which has been [trying to work around the old behavior](https://github.com/foxglove/foxglove-sdk/blob/f446ad5ab87157537b4e34e87f6ece8f33d0ef3b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp#L1147-L1168) in order to avoid double-broadcasting parameter updates.

### Links
Part of FLE-532.