### PR TITLE
rust: Deprecate listener parameter callbacks and update example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "clap",
  "env_logger",
  "foxglove 0.24.0",
+ "log",
  "tokio",
  "tokio-util",
 ]

--- a/rust/examples/param_server/Cargo.toml
+++ b/rust/examples/param_server/Cargo.toml
@@ -6,9 +6,14 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+default = []
+remote-access = ["foxglove/remote-access"]
+
 [dependencies]
 foxglove = { path = "../../foxglove", features = ["unstable"] }
 tokio = { version = "1.47", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"
+log.workspace = true

--- a/rust/examples/param_server/src/main.rs
+++ b/rust/examples/param_server/src/main.rs
@@ -2,9 +2,10 @@
 //!
 //! The handler implements [`ParameterHandler`] by enqueueing each get/set request on an mpsc
 //! channel and returning immediately. A single worker task drains the channel, mutates a local
-//! parameter store, and fulfils each responder. The same worker also publishes a periodic
-//! "elapsed" update to subscribers, so the parameter store has exactly one owner and no
-//! synchronization is required.
+//! parameter store, and fulfils each responder. Because [`SetParametersResponder`] only echoes
+//! the applied values to the requester, the worker is also responsible for publishing those
+//! updates to other parameter subscribers; the same path is used to publish a periodic
+//! "elapsed" tick. The parameter store has exactly one owner, so no synchronization is required.
 //!
 //! This is the recommended shape for handlers that need to perform non-trivial work to compute a
 //! response: it keeps the SDK's internal threads unblocked.
@@ -90,10 +91,10 @@ impl ParameterHandler for ParamHandler {
     }
 }
 
-/// Owns the parameter store. Drains parameter ops one at a time, and on a separate tick updates
-/// the "elapsed" parameter and broadcasts it to subscribers. Shutdown is signalled via a
-/// `CancellationToken`; after the loop exits, the worker stops the server (and the gateway, if
-/// configured).
+/// Owns the parameter store. Drains parameter ops one at a time, broadcasting any applied
+/// set-updates to subscribers, and on a separate tick updates the "elapsed" parameter and
+/// broadcasts it as well. Shutdown is signalled via a `CancellationToken`; after the loop
+/// exits, the worker stops the server (and the gateway, if configured).
 struct ParamWorker {
     store: HashMap<String, Parameter>,
     rx: mpsc::Receiver<ParameterOp>,
@@ -150,6 +151,7 @@ impl ParamWorker {
     fn handle_set(&mut self, mut parameters: Vec<Parameter>, responder: SetParametersResponder) {
         let names: Vec<&str> = parameters.iter().map(|p| p.name.as_str()).collect();
         log::info!("set: {names:?}");
+        let mut applied = Vec::with_capacity(parameters.len());
         for param in &mut parameters {
             if let Some(existing) = self.store.get_mut(&param.name) {
                 if param.name.starts_with("read_only_") {
@@ -159,15 +161,21 @@ impl ParamWorker {
                         .send_warning(format!("parameter {} is read only", param.name));
                     param.value.clone_from(&existing.value);
                     param.r#type.clone_from(&existing.r#type);
-                } else {
-                    existing.value.clone_from(&param.value);
-                    existing.r#type.clone_from(&param.r#type);
+                    continue;
                 }
+                existing.value.clone_from(&param.value);
+                existing.r#type.clone_from(&param.r#type);
             } else {
                 self.store.insert(param.name.clone(), param.clone());
             }
+            applied.push(param.clone());
         }
         responder.respond(parameters);
+        // SetParametersResponder echoes only to the requester, so the worker must publish the
+        // applied updates to subscribers itself.
+        if !applied.is_empty() {
+            self.publish(applied);
+        }
     }
 
     fn update_and_publish_elapsed(&mut self, start: Instant) {
@@ -177,11 +185,15 @@ impl ParamWorker {
             r#type: Some(ParameterType::Float64),
         };
         self.store.insert(elapsed.name.clone(), elapsed.clone());
+        self.publish(vec![elapsed]);
+    }
+
+    fn publish(&self, parameters: Vec<Parameter>) {
         #[cfg(feature = "remote-access")]
         if let Some(gateway) = &self.gateway {
-            gateway.publish_parameter_values(vec![elapsed.clone()]);
+            gateway.publish_parameter_values(parameters.clone());
         }
-        self.server.publish_parameter_values(vec![elapsed]);
+        self.server.publish_parameter_values(parameters);
     }
 }
 

--- a/rust/examples/param_server/src/main.rs
+++ b/rust/examples/param_server/src/main.rs
@@ -1,21 +1,38 @@
 //! Example of a parameter server using the Foxglove SDK.
 //!
-//! This example uses the 'unstable' feature to expose capabilities.
+//! The handler implements [`ParameterHandler`] by enqueueing each get/set request on an mpsc
+//! channel and returning immediately. A single worker task drains the channel, mutates a local
+//! parameter store, and fulfils each responder. The same worker also publishes a periodic
+//! "elapsed" update to subscribers, so the parameter store has exactly one owner and no
+//! synchronization is required.
+//!
+//! This is the recommended shape for handlers that need to perform non-trivial work to compute a
+//! response: it keeps the SDK's internal threads unblocked.
+//!
+//! With the `remote-access` feature enabled, the example additionally spawns a remote-access
+//! gateway and registers the same handler with it, so the parameter store is shared between
+//! WebSocket clients and remote-access participants. The gateway reads `FOXGLOVE_DEVICE_TOKEN`
+//! (and optionally `FOXGLOVE_API_URL` / `FOXGLOVE_API_TIMEOUT`) from the environment.
 //!
 //! Usage:
 //! ```text
 //! cargo run -p example_param_server
+//! cargo run -p example_param_server --features remote-access
 //! ```
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::Parser;
+#[cfg(feature = "remote-access")]
+use foxglove::remote_access::{Gateway, GatewayHandle};
 use foxglove::websocket::{
-    Capability, Client, Parameter, ParameterType, ParameterValue, ServerListener,
+    AnyClient, GetParametersResponder, Parameter, ParameterHandler, ParameterType, ParameterValue,
+    SetParametersResponder,
 };
 use foxglove::{WebSocketServer, WebSocketServerHandle};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Parser)]
@@ -26,132 +43,196 @@ struct Cli {
     host: String,
 }
 
-struct ParamListener {
-    param_store: Mutex<HashMap<String, Parameter>>,
+const QUEUE_CAPACITY: usize = 32;
+
+/// Work item handed from the [`ParameterHandler`] callback to the worker task.
+enum ParameterOp {
+    Get {
+        names: Vec<String>,
+        responder: GetParametersResponder,
+    },
+    Set {
+        parameters: Vec<Parameter>,
+        responder: SetParametersResponder,
+    },
 }
 
-impl ParamListener {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            param_store: Mutex::new(HashMap::new()),
-        })
+/// Handler registered with the SDK to handle parameter get/set operations asynchronously.
+struct ParamHandler {
+    tx: mpsc::Sender<ParameterOp>,
+}
+
+impl ParameterHandler for ParamHandler {
+    fn get(
+        &self,
+        _client: AnyClient,
+        names: Vec<String>,
+        _request_id: Option<String>,
+        responder: GetParametersResponder,
+    ) {
+        // A real implementation might handle overflow by sending a specific error status to the
+        // client. This implementation simply drops the responder, which sends a generic error
+        // status to the client about how the server failed to send a response.
+        let _ = self.tx.try_send(ParameterOp::Get { names, responder });
+    }
+
+    fn set(
+        &self,
+        _client: AnyClient,
+        parameters: Vec<Parameter>,
+        _request_id: Option<String>,
+        responder: SetParametersResponder,
+    ) {
+        let _ = self.tx.try_send(ParameterOp::Set {
+            parameters,
+            responder,
+        });
     }
 }
 
-impl ServerListener for ParamListener {
-    fn on_get_parameters(
-        &self,
-        _client: Client,
-        param_names: Vec<String>,
-        request_id: Option<&str>,
-    ) -> Vec<Parameter> {
-        println!(
-            "on_get_parameters called with parameter names: {:?}; request_id: {}",
-            param_names,
-            request_id.unwrap_or("None")
-        );
+/// Owns the parameter store. Drains parameter ops one at a time, and on a separate tick updates
+/// the "elapsed" parameter and broadcasts it to subscribers. Shutdown is signalled via a
+/// `CancellationToken`; after the loop exits, the worker stops the server (and the gateway, if
+/// configured).
+struct ParamWorker {
+    store: HashMap<String, Parameter>,
+    rx: mpsc::Receiver<ParameterOp>,
+    server: WebSocketServerHandle,
+    #[cfg(feature = "remote-access")]
+    gateway: Option<GatewayHandle>,
+    shutdown: CancellationToken,
+}
 
-        let params = self.param_store.lock().unwrap();
-        if param_names.is_empty() {
-            params.values().cloned().collect()
-        } else {
-            param_names
-                .iter()
-                .filter_map(|name| params.get(name).cloned())
-                .collect()
-        }
-    }
-
-    fn on_set_parameters(
-        &self,
-        _client: Client,
-        mut parameters: Vec<Parameter>,
-        request_id: Option<&str>,
-    ) -> Vec<Parameter> {
-        let param_names: Vec<String> = parameters.iter().map(|param| param.name.clone()).collect();
-        println!(
-            "on_set_parameters called with parameter names: {:?}; request_id: {}",
-            param_names,
-            request_id.unwrap_or("None")
-        );
-
-        let mut params = self.param_store.lock().unwrap();
-        for param in &mut parameters {
-            if let Some(old_param) = params.get_mut(&param.name) {
-                if param.name.starts_with("read_only_") {
-                    // Return the old value
-                    param.value.clone_from(&old_param.value);
-                    param.r#type.clone_from(&old_param.r#type);
-                } else {
-                    // Update the value
-                    old_param.value.clone_from(&param.value);
-                    old_param.r#type.clone_from(&param.r#type);
-                }
-            } else {
-                params.insert(param.name.clone(), param.clone());
+impl ParamWorker {
+    async fn run(mut self) {
+        let start = Instant::now();
+        let mut tick = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            tokio::select! {
+                () = self.shutdown.cancelled() => break,
+                op = self.rx.recv() => match op {
+                    Some(op) => self.handle_op(op),
+                    None => break,
+                },
+                _ = tick.tick() => self.update_and_publish_elapsed(start),
             }
         }
-        parameters
+        #[cfg(feature = "remote-access")]
+        if let Some(gateway) = self.gateway.take() {
+            let _ = gateway.stop().await;
+        }
+        self.server.stop().wait().await;
     }
 
-    fn on_parameters_subscribe(&self, param_names: Vec<String>) {
-        println!("on_parameters_subscribe called with parameter names: {param_names:?}",);
+    fn handle_op(&mut self, op: ParameterOp) {
+        match op {
+            ParameterOp::Get { names, responder } => self.handle_get(names, responder),
+            ParameterOp::Set {
+                parameters,
+                responder,
+            } => self.handle_set(parameters, responder),
+        }
     }
 
-    fn on_parameters_unsubscribe(&self, param_names: Vec<String>) {
-        println!("on_parameters_unsubscribe called with parameter names: {param_names:?}",);
+    fn handle_get(&self, names: Vec<String>, responder: GetParametersResponder) {
+        log::info!("get: {names:?}");
+        let values = if names.is_empty() {
+            self.store.values().cloned().collect()
+        } else {
+            names
+                .iter()
+                .filter_map(|name| self.store.get(name).cloned())
+                .collect()
+        };
+        responder.respond(values);
+    }
+
+    fn handle_set(&mut self, mut parameters: Vec<Parameter>, responder: SetParametersResponder) {
+        let names: Vec<&str> = parameters.iter().map(|p| p.name.as_str()).collect();
+        log::info!("set: {names:?}");
+        for param in &mut parameters {
+            if let Some(existing) = self.store.get_mut(&param.name) {
+                if param.name.starts_with("read_only_") {
+                    // Send a warning, and echo back the existing value so the client sees no change.
+                    responder
+                        .client()
+                        .send_warning(format!("parameter {} is read only", param.name));
+                    param.value.clone_from(&existing.value);
+                    param.r#type.clone_from(&existing.r#type);
+                } else {
+                    existing.value.clone_from(&param.value);
+                    existing.r#type.clone_from(&param.r#type);
+                }
+            } else {
+                self.store.insert(param.name.clone(), param.clone());
+            }
+        }
+        responder.respond(parameters);
+    }
+
+    fn update_and_publish_elapsed(&mut self, start: Instant) {
+        let elapsed = Parameter {
+            name: "elapsed".to_string(),
+            value: Some(ParameterValue::Float64(start.elapsed().as_secs_f64())),
+            r#type: Some(ParameterType::Float64),
+        };
+        self.store.insert(elapsed.name.clone(), elapsed.clone());
+        #[cfg(feature = "remote-access")]
+        if let Some(gateway) = &self.gateway {
+            gateway.publish_parameter_values(vec![elapsed.clone()]);
+        }
+        self.server.publish_parameter_values(vec![elapsed]);
     }
 }
 
 #[tokio::main]
 async fn main() {
-    let env = env_logger::Env::default().default_filter_or("debug");
+    let env =
+        env_logger::Env::default().default_filter_or("example_param_server=info,foxglove=info");
     env_logger::init_from_env(env);
 
     let args = Cli::parse();
-    let listener = ParamListener::new();
 
-    // Initialize the parameter store with some example parameters
-    {
-        let params = [
-            Parameter::string("read_only_str_param", "can't change me"),
-            Parameter::float64("elapsed", 0.0),
-            Parameter::float64_array("float_array_param", [1.0, 2.0, 3.0]),
-        ];
-        let mut param_store = listener.param_store.lock().unwrap();
-        param_store.extend(params.into_iter().map(|p| (p.name.clone(), p)));
-    }
+    let initial_store: HashMap<String, Parameter> = [
+        Parameter::string("read_only_str_param", "can't change me"),
+        Parameter::float64("elapsed", 0.0),
+        Parameter::float64_array("float_array_param", [1.0, 2.0, 3.0]),
+    ]
+    .into_iter()
+    .map(|p| (p.name.clone(), p))
+    .collect();
 
+    let (tx, rx) = mpsc::channel(QUEUE_CAPACITY);
+    let handler = Arc::new(ParamHandler { tx });
+
+    // `parameter_handler` automatically enables Capability::Parameters.
     let server = WebSocketServer::new()
         .name(env!("CARGO_PKG_NAME"))
-        .capabilities([Capability::Parameters])
-        .listener(listener.clone())
+        .parameter_handler(handler.clone())
         .bind(args.host, args.port)
         .start()
         .await
         .expect("Failed to start server");
 
+    #[cfg(feature = "remote-access")]
+    let gateway = Some(
+        Gateway::new()
+            .name(env!("CARGO_PKG_NAME"))
+            .parameter_handler(handler.clone())
+            .start()
+            .expect("Failed to start remote-access gateway"),
+    );
+
     let shutdown = watch_ctrl_c();
-    tokio::select! {
-        () = shutdown.cancelled() => (),
-        () = update_parameters(&server, listener) => (),
+    let worker = ParamWorker {
+        store: initial_store,
+        rx,
+        server,
+        #[cfg(feature = "remote-access")]
+        gateway,
+        shutdown,
     };
-
-    server.stop().wait().await;
-}
-
-async fn update_parameters(server: &WebSocketServerHandle, _listener: Arc<ParamListener>) {
-    let start = Instant::now();
-    let mut interval = tokio::time::interval(Duration::from_secs(1));
-    loop {
-        interval.tick().await;
-        let parameter = Parameter {
-            name: "elapsed".to_string(),
-            value: Some(ParameterValue::Float64(start.elapsed().as_secs_f64())),
-            r#type: Some(ParameterType::Float64),
-        };
-        server.publish_parameter_values(vec![parameter]);
-    }
+    worker.run().await;
 }
 
 fn watch_ctrl_c() -> CancellationToken {

--- a/rust/foxglove/src/remote_access/listener.rs
+++ b/rust/foxglove/src/remote_access/listener.rs
@@ -9,6 +9,11 @@ use super::connection::ConnectionStatus;
 /// These methods are invoked from time-sensitive contexts and must not block. If blocking or
 /// long-running behavior is required, the implementation should use [`tokio::task::spawn`] (or
 /// [`tokio::task::spawn_blocking`]).
+///
+/// The parameter get/set callbacks ([`Self::on_get_parameters`], [`Self::on_set_parameters`]) are
+/// deprecated. Use [`ParameterHandler`](super::ParameterHandler) instead, which provides
+/// responder-based asynchronous completion. When a `ParameterHandler` is registered on the
+/// gateway, the deprecated callbacks are not invoked.
 pub trait Listener: Send + Sync {
     /// Callback invoked when the gateway connection status changes.
     fn on_connection_status_changed(&self, _status: ConnectionStatus) {}
@@ -26,6 +31,10 @@ pub trait Listener: Send + Sync {
     /// Callback invoked when a client requests parameters. Requires
     /// [`Capability::Parameters`][super::Capability::Parameters]. Should return the named
     /// parameters, or all parameters if `param_names` is empty.
+    #[deprecated(
+        since = "0.25.0",
+        note = "Use ParameterHandler instead. This callback is not invoked when a ParameterHandler is registered on the gateway."
+    )]
     fn on_get_parameters(
         &self,
         _client: &Client,
@@ -43,6 +52,10 @@ pub trait Listener: Send + Sync {
     ///
     /// Note that only `parameters` which have changed are included in the callback, but the return
     /// value must include all parameters.
+    #[deprecated(
+        since = "0.25.0",
+        note = "Use ParameterHandler instead. This callback is not invoked when a ParameterHandler is registered on the gateway."
+    )]
     fn on_set_parameters(
         &self,
         _client: &Client,

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1832,6 +1832,7 @@ impl RemoteAccessSession {
             return;
         }
 
+        #[allow(deprecated)]
         if let Some(listener) = self.listener.as_ref() {
             let client = Client::new(
                 participant.client_id(),
@@ -1874,6 +1875,7 @@ impl RemoteAccessSession {
             return;
         }
 
+        #[allow(deprecated)]
         let updated_parameters = if let Some(listener) = self.listener.as_ref() {
             let client = Client::new(
                 participant.client_id(),

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -528,6 +528,7 @@ impl ConnectedClient {
             return;
         }
 
+        #[allow(deprecated)]
         if let Some(handler) = server.listener() {
             let parameters =
                 handler.on_get_parameters(Client::new(self), param_names, request_id.as_deref());
@@ -558,6 +559,7 @@ impl ConnectedClient {
             return;
         }
 
+        #[allow(deprecated)]
         let updated_parameters = if let Some(handler) = server.listener() {
             let updated =
                 handler.on_set_parameters(Client::new(self), parameters, request_id.as_deref());

--- a/rust/foxglove/src/websocket/server_listener.rs
+++ b/rust/foxglove/src/websocket/server_listener.rs
@@ -7,6 +7,11 @@ use crate::websocket::PlaybackState;
 /// These methods are invoked from the client's main poll loop and must not block. If blocking or
 /// long-running behavior is required, the implementation should use [`tokio::task::spawn`] (or
 /// [`tokio::task::spawn_blocking`]).
+///
+/// The parameter get/set callbacks ([`Self::on_get_parameters`], [`Self::on_set_parameters`]) are
+/// deprecated. Use [`ParameterHandler`](super::ParameterHandler) instead, which provides
+/// responder-based asynchronous completion. When a `ParameterHandler` is registered on the server,
+/// the deprecated callbacks are not invoked.
 pub trait ServerListener: Send + Sync {
     /// Callback invoked when a client message is received.
     fn on_message_data(&self, _client: Client, _client_channel: &ClientChannel, _payload: &[u8]) {}
@@ -26,6 +31,10 @@ pub trait ServerListener: Send + Sync {
     /// Callback invoked when a client requests parameters. Requires
     /// [`Capability::Parameters`][super::Capability::Parameters]. Should return the named
     /// parameters, or all parameters if param_names is empty.
+    #[deprecated(
+        since = "0.25.0",
+        note = "Use ParameterHandler instead. This callback is not invoked when a ParameterHandler is registered on the server."
+    )]
     fn on_get_parameters(
         &self,
         _client: Client,
@@ -44,6 +53,10 @@ pub trait ServerListener: Send + Sync {
     ///
     /// Note that only `parameters` which have changed are included in the callback, but the return
     /// value must include all parameters.
+    #[deprecated(
+        since = "0.25.0",
+        note = "Use ParameterHandler instead. This callback is not invoked when a ParameterHandler is registered on the server."
+    )]
     fn on_set_parameters(
         &self,
         _client: Client,

--- a/rust/remote_access_tests/tests/parameter_test.rs
+++ b/rust/remote_access_tests/tests/parameter_test.rs
@@ -74,6 +74,7 @@ impl ParameterListener {
     }
 }
 
+#[allow(deprecated)]
 impl Listener for ParameterListener {
     fn on_get_parameters(
         &self,


### PR DESCRIPTION
### Changelog
- rust: Marked parameter callbacks on ServerListener and remote_access::Listener as deprecated. Use ParameterHandler instead.
- rust: Updated the param_server example to use ParameterHandler, and added an optional remote-access feature flag that shares the same handler with a Gateway.

### Docs
Covered by rustdocs.

### Description
With ParameterHandler in place, mark the four parameter callbacks on
ServerListener (websocket) and Listener (remote-access) as
`#[deprecated]`, and add a docstring note pointing readers at the new
trait. Internal call sites that still invoke the legacy paths get
`#[allow(deprecated)]` to silence the warnings within the SDK.

The param_server example is rewritten to demonstrate the new async
pattern: the handler enqueues each get/set on an mpsc channel and a
single worker task owns the parameter store. An opt-in `remote-access`
feature flag additionally spawns a remote-access gateway with the same
`Arc<ParamHandler>`, so a single store backs both transports.

### Links
Fixes: FLE-532.