### PR TITLE
rust: Expose foxglove::remote_common

### DIFF
--- a/rust/examples/param_server/src/main.rs
+++ b/rust/examples/param_server/src/main.rs
@@ -28,7 +28,7 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 #[cfg(feature = "remote-access")]
 use foxglove::remote_access::{Gateway, GatewayHandle};
-use foxglove::websocket::{
+use foxglove::remote_common::{
     AnyClient, GetParametersResponder, Parameter, ParameterHandler, ParameterType, ParameterValue,
     SetParametersResponder,
 };

--- a/rust/foxglove/src/lib.rs
+++ b/rust/foxglove/src/lib.rs
@@ -487,7 +487,7 @@ mod protocol;
     docsrs,
     doc(cfg(any(feature = "remote-access", feature = "websocket")))
 )]
-mod remote_common;
+pub mod remote_common;
 #[cfg(any(feature = "_remote-common", feature = "sysinfo"))]
 mod runtime;
 #[cfg(any(feature = "_remote-common", feature = "sysinfo"))]

--- a/rust/foxglove/src/remote_access.rs
+++ b/rust/foxglove/src/remote_access.rs
@@ -17,27 +17,17 @@ mod sse;
 mod watch;
 mod watch_loop;
 
-pub use crate::remote_common::AnyClient;
-pub use crate::remote_common::ClientId;
-pub use crate::remote_common::connection_graph::ConnectionGraph;
+pub use crate::remote_common::{
+    AnyClient, AssetHandler, AssetResponder, ClientId, ConnectionGraph, GetParametersResponder,
+    Parameter, ParameterDecodeError, ParameterHandler, ParameterType, ParameterValue,
+    SetParametersResponder, Status, StatusLevel,
+};
 pub use capability::Capability;
 pub use client::Client;
 pub use connection::ConnectionStatus;
 pub use gateway::{Gateway, GatewayHandle};
 pub use listener::Listener;
 pub use qos::{QosClassifier, QosProfile, QosProfileBuilder, Reliability};
-
-// Re-export parameter types so callers can construct parameter values.
-pub use crate::protocol::v2::parameter::{Parameter, ParameterType, ParameterValue};
-
-// Re-export status types so callers can publish and remove status messages.
-pub use crate::protocol::v2::server::status::{Level as StatusLevel, Status};
-
-// Re-export fetch-asset and parameter handler types.
-pub use crate::remote_common::fetch_asset::{AssetHandler, AssetResponder};
-pub use crate::remote_common::parameters::{
-    GetParametersResponder, ParameterHandler, SetParametersResponder,
-};
 
 use reqwest::StatusCode;
 use thiserror::Error;

--- a/rust/foxglove/src/remote_common.rs
+++ b/rust/foxglove/src/remote_common.rs
@@ -1,4 +1,9 @@
-//! Common types shared between the WebSocket and remote access modules.
+//! Types shared between the WebSocket server and the remote-access gateway.
+//!
+//! Handler traits and supporting types in this module are transport-agnostic: an implementation
+//! of [`ParameterHandler`], [`AssetHandler`], or service [`Handler`] can be registered with either
+//! sink. The transport-specific [`crate::websocket`] and [`crate::remote_access`] modules
+//! re-export the same items for convenience.
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -14,6 +19,17 @@ pub(crate) mod service;
 
 #[cfg(any(feature = "websocket", feature = "remote-access"))]
 pub use any_client::AnyClient;
+pub use connection_graph::ConnectionGraph;
+#[cfg(any(feature = "websocket", feature = "remote-access"))]
+pub use fetch_asset::{AssetHandler, AssetResponder};
+#[cfg(any(feature = "websocket", feature = "remote-access"))]
+pub use parameters::{GetParametersResponder, ParameterHandler, SetParametersResponder};
+pub use service::{
+    CallId, Handler, Request, Responder, Service, ServiceBuilder, ServiceSchema, SyncHandler,
+};
+
+pub use crate::protocol::common::parameter::{Parameter, ParameterType, ParameterValue};
+pub use crate::protocol::common::server::status::{Level as StatusLevel, Status};
 
 /// Identifies a client connection. Unique for the duration of the server's lifetime.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/rust/foxglove/src/remote_common.rs
+++ b/rust/foxglove/src/remote_common.rs
@@ -1,9 +1,11 @@
 //! Types shared between the WebSocket server and the remote-access gateway.
 //!
-//! Handler traits and supporting types in this module are transport-agnostic: an implementation
-//! of [`ParameterHandler`], [`AssetHandler`], or service [`Handler`] can be registered with either
-//! sink. The transport-specific [`crate::websocket`] and [`crate::remote_access`] modules
-//! re-export the same items for convenience.
+//! Everything in this module is transport-agnostic: handler traits ([`ParameterHandler`],
+//! [`AssetHandler`], service [`Handler`]) implemented against these types can be registered with
+//! either the WebSocket server or the remote-access gateway, and data and identity types
+//! ([`Parameter`], [`Status`], [`ConnectionGraph`], [`ClientId`], [`Service`], ...) are the same
+//! concrete types used by both. The transport-specific [`crate::websocket`] and
+//! [`crate::remote_access`] modules re-export the same items for convenience.
 
 use std::sync::atomic::{AtomicU32, Ordering};
 

--- a/rust/foxglove/src/remote_common.rs
+++ b/rust/foxglove/src/remote_common.rs
@@ -1,10 +1,10 @@
 //! Types shared between the WebSocket server and the remote-access gateway.
 //!
 //! Everything in this module is transport-agnostic: handler traits ([`ParameterHandler`],
-//! [`AssetHandler`], service [`Handler`]) implemented against these types can be registered with
+//! [`AssetHandler`], [`service::Handler`]) implemented against these types can be registered with
 //! either the WebSocket server or the remote-access gateway, and data and identity types
-//! ([`Parameter`], [`Status`], [`ConnectionGraph`], [`ClientId`], [`Service`], ...) are the same
-//! concrete types used by both. The transport-specific [`crate::websocket`] and
+//! ([`Parameter`], [`Status`], [`ConnectionGraph`], [`ClientId`], [`service::Service`], ...) are
+//! the same concrete types used by both. The transport-specific [`crate::websocket`] and
 //! [`crate::remote_access`] modules re-export the same items for convenience.
 
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -17,7 +17,7 @@ pub(crate) mod fetch_asset;
 #[cfg(any(feature = "websocket", feature = "remote-access"))]
 pub(crate) mod parameters;
 pub(crate) mod semaphore;
-pub(crate) mod service;
+pub mod service;
 
 #[cfg(any(feature = "websocket", feature = "remote-access"))]
 pub use any_client::AnyClient;
@@ -26,9 +26,6 @@ pub use connection_graph::ConnectionGraph;
 pub use fetch_asset::{AssetHandler, AssetResponder};
 #[cfg(any(feature = "websocket", feature = "remote-access"))]
 pub use parameters::{GetParametersResponder, ParameterHandler, SetParametersResponder};
-pub use service::{
-    CallId, Handler, Request, Responder, Service, ServiceBuilder, ServiceSchema, SyncHandler,
-};
 
 pub use crate::protocol::common::parameter::{
     DecodeError as ParameterDecodeError, Parameter, ParameterType, ParameterValue,

--- a/rust/foxglove/src/remote_common.rs
+++ b/rust/foxglove/src/remote_common.rs
@@ -28,7 +28,9 @@ pub use service::{
     CallId, Handler, Request, Responder, Service, ServiceBuilder, ServiceSchema, SyncHandler,
 };
 
-pub use crate::protocol::common::parameter::{Parameter, ParameterType, ParameterValue};
+pub use crate::protocol::common::parameter::{
+    DecodeError as ParameterDecodeError, Parameter, ParameterType, ParameterValue,
+};
 pub use crate::protocol::common::server::status::{Level as StatusLevel, Status};
 
 /// Identifies a client connection. Unique for the duration of the server's lifetime.

--- a/rust/foxglove/src/remote_common/fetch_asset.rs
+++ b/rust/foxglove/src/remote_common/fetch_asset.rs
@@ -1,3 +1,5 @@
+//! Shared asset-fetching primitives.
+
 use std::fmt::Display;
 use std::future::Future;
 use std::sync::Arc;

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -6,7 +6,6 @@ mod channel_view;
 mod client;
 mod client_channel;
 mod connected_client;
-mod connection_graph;
 mod cow_vec;
 pub(crate) mod handshake;
 mod server;
@@ -19,25 +18,19 @@ mod tests;
 #[doc(hidden)]
 pub mod ws_protocol;
 
-pub use crate::remote_common::AnyClient;
-pub use crate::remote_common::fetch_asset::{AssetHandler, AssetResponder};
-pub(crate) use crate::remote_common::fetch_asset::{AsyncAssetHandlerFn, BlockingAssetHandlerFn};
-pub use crate::remote_common::parameters::{
-    GetParametersResponder, ParameterHandler, SetParametersResponder,
+pub use crate::remote_common::{
+    AnyClient, AssetHandler, AssetResponder, ClientId, ConnectionGraph, GetParametersResponder,
+    Parameter, ParameterDecodeError, ParameterHandler, ParameterType, ParameterValue,
+    SetParametersResponder, Status, StatusLevel,
 };
+pub(crate) use crate::remote_common::fetch_asset::{AsyncAssetHandlerFn, BlockingAssetHandlerFn};
 pub use capability::Capability;
 pub use channel_view::ChannelView;
-pub use client::{Client, ClientId};
+pub use client::Client;
 pub use client_channel::{ClientChannel, ClientChannelId};
-pub use connection_graph::ConnectionGraph;
 pub use server::ShutdownHandle;
 pub(crate) use server::{Server, ServerOptions, create_server};
 pub use server_listener::ServerListener;
 pub use streams::TlsIdentity;
 pub use ws_protocol::client::{PlaybackCommand, PlaybackControlRequest};
-pub use ws_protocol::parameter::{
-    DecodeError as ParameterDecodeError, Parameter, ParameterType, ParameterValue,
-};
-pub use ws_protocol::server::status::{Level as StatusLevel, Status};
-
 pub use ws_protocol::server::playback_state::{PlaybackState, PlaybackStatus};

--- a/rust/foxglove/src/websocket.rs
+++ b/rust/foxglove/src/websocket.rs
@@ -18,12 +18,12 @@ mod tests;
 #[doc(hidden)]
 pub mod ws_protocol;
 
+pub(crate) use crate::remote_common::fetch_asset::{AsyncAssetHandlerFn, BlockingAssetHandlerFn};
 pub use crate::remote_common::{
     AnyClient, AssetHandler, AssetResponder, ClientId, ConnectionGraph, GetParametersResponder,
     Parameter, ParameterDecodeError, ParameterHandler, ParameterType, ParameterValue,
     SetParametersResponder, Status, StatusLevel,
 };
-pub(crate) use crate::remote_common::fetch_asset::{AsyncAssetHandlerFn, BlockingAssetHandlerFn};
 pub use capability::Capability;
 pub use channel_view::ChannelView;
 pub use client::Client;

--- a/rust/foxglove/src/websocket/client.rs
+++ b/rust/foxglove/src/websocket/client.rs
@@ -4,7 +4,7 @@ use super::Parameter;
 use super::Status;
 use super::connected_client::ConnectedClient;
 use crate::SinkId;
-pub use crate::remote_common::ClientId;
+use crate::remote_common::ClientId;
 use crate::remote_common::fetch_asset::SendAssetResponse;
 use crate::remote_common::parameters::SendParameterResponse;
 

--- a/rust/foxglove/src/websocket/connection_graph.rs
+++ b/rust/foxglove/src/websocket/connection_graph.rs
@@ -1,4 +1,0 @@
-//! WebSocket connection graph.
-
-// Re-export all public types from the common connection graph module.
-pub use crate::remote_common::connection_graph::ConnectionGraph;


### PR DESCRIPTION
### Changelog
- rust: Exposed foxglove::remote_common

### Docs
None

### Description
This change makes foxglove::remote_common a public module. The rationale
is that there are several structs under here which might be used in a
program that hosts both a remote access gateway and websocket server.
While all of these symbols are re-exported under `remote_access` and
`websocket` for convenience, this obscures the fact that these types are
actually common, and makes managing imports difficult. Imagine, for
example, that the user program had its own feature flags for selecting
websocket or remote access.

A diff of the summarized public API (`cargo public-api -sss`) is
available here: https://gist.github.com/gasmith/18198137fce3726385bd3cd2455b1aad