### PR TITLE
Document what the sysinfo publisher publishes in sdk docs

### DIFF
--- a/cpp/foxglove/include/foxglove/system_info.hpp
+++ b/cpp/foxglove/include/foxglove/system_info.hpp
@@ -32,6 +32,8 @@ struct SystemInfoOptions final {
   std::optional<std::chrono::milliseconds> refresh_interval;
 };
 
+// Keep this comment in sync with rust/foxglove/src/system_info.rs
+
 /// @brief A publisher that periodically logs process and system statistics on a channel.
 ///
 /// The publisher creates a channel on the configured Context (defaulting to `/sysinfo`)

--- a/cpp/foxglove/include/foxglove/system_info.hpp
+++ b/cpp/foxglove/include/foxglove/system_info.hpp
@@ -38,7 +38,7 @@ struct SystemInfoOptions final {
 /// and spawns a background task that logs a `SystemInfo` message at the configured
 /// interval with stats on CPU and memory usage for the process and the system.
 ///
-/// Published metrics
+/// @par Published metrics
 ///
 /// Each message is a JSON object with a JSON Schema attached to the channel.
 /// The following fields are published:

--- a/cpp/foxglove/include/foxglove/system_info.hpp
+++ b/cpp/foxglove/include/foxglove/system_info.hpp
@@ -36,7 +36,34 @@ struct SystemInfoOptions final {
 ///
 /// The publisher creates a channel on the configured Context (defaulting to `/sysinfo`)
 /// and spawns a background task that logs a `SystemInfo` message at the configured
-/// interval.
+/// interval with stats on CPU and memory usage for the process and the system.
+///
+/// Published metrics
+///
+/// Each message is a JSON object with a JSON Schema attached to the channel.
+/// The following fields are published:
+///
+/// - `process_memory` (number): Resident memory used by the SDK process, in bytes.
+/// - `process_virtual_memory` (number): Virtual memory used by the SDK process, in bytes.
+/// - `process_cpu_percent` (number): CPU usage for the SDK process, as a percent of total
+///   system CPU capacity (0.0 to 100.0).
+/// - `process_cpu_cores` (number): CPU usage for the SDK process, expressed in
+///   core-equivalents (0.0 to `num_cpus`). 1.0 means a single logical CPU is fully utilized.
+/// - `total_cpu_percent` (number): Total CPU usage across all logical CPUs on the system,
+///   as a percent (0.0 to 100.0).
+/// - `total_cpu_cores` (number): Total CPU usage across the system, expressed in
+///   core-equivalents (0.0 to `num_cpus`). 1.0 means one logical CPU's worth of work is being
+///   done.
+/// - `num_cpus` (integer): Number of logical CPUs on the system.
+/// - `total_memory` (number): Total physical memory on the system, in bytes.
+/// - `used_memory` (number): Used physical memory on the system, in bytes.
+/// - `total_swap` (number): Total swap space on the system, in bytes.
+/// - `used_swap` (number): Used swap space on the system, in bytes.
+/// - `kernel_version` (string): Kernel version string, or empty if unknown.
+/// - `os_version` (string): OS version string, or empty if unknown.
+///
+/// CPU usage values are computed from the difference between consecutive samples, so they
+/// reflect activity over the most recent refresh interval.
 ///
 /// The publisher runs until it is explicitly stopped via `stop()`. Destroying this
 /// object does **not** stop the publisher: the background task continues running

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -181,6 +181,7 @@ try:
     from ._foxglove_py import SystemInfoPublisher
     from ._foxglove_py import start_sysinfo_publisher as _start_sysinfo_publisher
 
+    # Keep this doc string in sync with rust/foxglove/src/system_info.rs
     def start_sysinfo_publisher(
         *,
         topic: str | None = None,

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -220,7 +220,8 @@ try:
         CPU usage values are computed from the difference between consecutive samples, so they
         reflect activity over the most recent refresh interval.
 
-        The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
+        The caller is responsible for calling stop() on the returned handle when done;
+        dropping the handle does not stop the background task.
 
         :param topic: The channel topic name. Defaults to ``/sysinfo``.
         :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``.

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -222,9 +222,12 @@ try:
 
         :param topic: The channel topic name. Defaults to ``/sysinfo``.
         :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``.
-            Clamped to a minimum of 200ms.
+            Clamped to a minimum of 0.2s.
         :param context: The context on which the publisher creates its channel. Defaults to
             the global default context.
+        :returns: A handle that can be used to stop the publisher.
+
+        The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
         """
         return _start_sysinfo_publisher(
             topic=topic,

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -220,14 +220,14 @@ try:
         CPU usage values are computed from the difference between consecutive samples, so they
         reflect activity over the most recent refresh interval.
 
+        The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
+
         :param topic: The channel topic name. Defaults to ``/sysinfo``.
         :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``.
             Clamped to a minimum of 0.2s.
         :param context: The context on which the publisher creates its channel. Defaults to
             the global default context.
         :returns: A handle that can be used to stop the publisher.
-
-        The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
         """
         return _start_sysinfo_publisher(
             topic=topic,

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -178,10 +178,59 @@ except ImportError:
 
 
 try:
-    from ._foxglove_py import (
-        SystemInfoPublisher,
-        start_sysinfo_publisher,
-    )
+    from ._foxglove_py import SystemInfoPublisher
+    from ._foxglove_py import start_sysinfo_publisher as _start_sysinfo_publisher
+
+    def start_sysinfo_publisher(
+        *,
+        topic: str | None = None,
+        refresh_interval: float | None = None,
+        context: Context | None = None,
+    ) -> SystemInfoPublisher:
+        """
+        Start the system info publisher.
+
+        Periodically publishes a ``SystemInfo`` message to a channel containing process and
+        system statistics (memory, CPU, OS info).
+
+        .. rubric:: Published metrics
+
+        Each message is a JSON object with a JSON Schema attached to the channel.
+        The following fields are published:
+
+        - ``process_memory`` (number): Resident memory used by the SDK process, in bytes.
+        - ``process_virtual_memory`` (number): Virtual memory used by the SDK process, in bytes.
+        - ``process_cpu_percent`` (number): CPU usage for the SDK process, as a percent of total
+          system CPU capacity (0.0 to 100.0).
+        - ``process_cpu_cores`` (number): CPU usage for the SDK process, expressed in
+          core-equivalents (0.0 to ``num_cpus``). 1.0 means a single logical CPU is fully utilized.
+        - ``total_cpu_percent`` (number): Total CPU usage across all logical CPUs on the system,
+          as a percent (0.0 to 100.0).
+        - ``total_cpu_cores`` (number): Total CPU usage across the system, expressed in
+          core-equivalents (0.0 to ``num_cpus``). 1.0 means one logical CPU's worth of work is
+          being done.
+        - ``num_cpus`` (integer): Number of logical CPUs on the system.
+        - ``total_memory`` (number): Total physical memory on the system, in bytes.
+        - ``used_memory`` (number): Used physical memory on the system, in bytes.
+        - ``total_swap`` (number): Total swap space on the system, in bytes.
+        - ``used_swap`` (number): Used swap space on the system, in bytes.
+        - ``kernel_version`` (string): Kernel version string, or empty if unknown.
+        - ``os_version`` (string): OS version string, or empty if unknown.
+
+        CPU usage values are computed from the difference between consecutive samples, so they
+        reflect activity over the most recent refresh interval.
+
+        :param topic: The channel topic name. Defaults to ``/sysinfo``.
+        :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``.
+            Clamped to a minimum of 200ms.
+        :param context: The context on which the publisher creates its channel. Defaults to
+            the global default context.
+        """
+        return _start_sysinfo_publisher(
+            topic=topic,
+            refresh_interval=refresh_interval,
+            context=context,
+        )
 
     __all__ += [
         "SystemInfoPublisher",

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -406,9 +406,11 @@ def start_server(
 
 class SystemInfoPublisher:
     """
-    Handle to a running system info publisher.
+    A handle to a running system info publisher.
 
-    See :py:func:`foxglove.start_sysinfo_publisher` for full documentation.
+    The publisher is started by :py:func:`foxglove.start_sysinfo_publisher` and runs in
+    the background until :py:meth:`stop` is called.
+    The caller is responsible for calling stop() when done; dropping the handle does not stop the background task.
     """
 
     def stop(self) -> None:
@@ -426,42 +428,13 @@ def start_sysinfo_publisher(
     """
     Start the system info publisher.
 
-    Periodically publishes a ``SystemInfo`` message to a channel containing process and
-    system statistics (memory, CPU, OS info).
+    Periodically publishes process and system statistics (memory, CPU, OS info) to a channel.
 
-    Published metrics:
+    :param topic: Channel topic name. Defaults to ``/sysinfo``.
+    :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``. Clamped to a minimum of 0.2.
+    :param context: The context on which the publisher creates its channel. Defaults to the global default context.
 
-    Each message is a JSON object with a JSON Schema attached to the channel.
-    The following fields are published:
-
-    - ``process_memory`` (number): Resident memory used by the SDK process, in bytes.
-    - ``process_virtual_memory`` (number): Virtual memory used by the SDK process, in bytes.
-    - ``process_cpu_percent`` (number): CPU usage for the SDK process, as a percent of total
-      system CPU capacity (0.0 to 100.0).
-    - ``process_cpu_cores`` (number): CPU usage for the SDK process, expressed in
-      core-equivalents (0.0 to ``num_cpus``). 1.0 means a single logical CPU is fully utilized.
-    - ``total_cpu_percent`` (number): Total CPU usage across all logical CPUs on the system,
-      as a percent (0.0 to 100.0).
-    - ``total_cpu_cores`` (number): Total CPU usage across the system, expressed in
-      core-equivalents (0.0 to ``num_cpus``). 1.0 means one logical CPU's worth of work is being
-      done.
-    - ``num_cpus`` (integer): Number of logical CPUs on the system.
-    - ``total_memory`` (number): Total physical memory on the system, in bytes.
-    - ``used_memory`` (number): Used physical memory on the system, in bytes.
-    - ``total_swap`` (number): Total swap space on the system, in bytes.
-    - ``used_swap`` (number): Used swap space on the system, in bytes.
-    - ``kernel_version`` (string): Kernel version string, or empty if unknown.
-    - ``os_version`` (string): OS version string, or empty if unknown.
-
-    CPU usage values are computed from the difference between consecutive samples, so they
-    reflect activity over the most recent refresh interval.
-
-    :param topic: The channel topic name. Defaults to ``/sysinfo``.
-    :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``.
-        Clamped to a minimum of 200ms.
-    :param context: The context on which the publisher creates its channel. Defaults to
-        the global default context.
-    :return: A handle that can be used to stop the publisher.
+    The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
     """
     ...
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -430,11 +430,11 @@ def start_sysinfo_publisher(
 
     Periodically publishes process and system statistics (memory, CPU, OS info) to a channel.
 
+    The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
+
     :param topic: Channel topic name. Defaults to ``/sysinfo``.
     :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``. Clamped to a minimum of 0.2.
     :param context: The context on which the publisher creates its channel. Defaults to the global default context.
-
-    The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
     """
     ...
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -426,7 +426,42 @@ def start_sysinfo_publisher(
     """
     Start the system info publisher.
 
-    See the runtime docstring or API reference for parameters and published metrics.
+    Periodically publishes a ``SystemInfo`` message to a channel containing process and
+    system statistics (memory, CPU, OS info).
+
+    Published metrics:
+
+    Each message is a JSON object with a JSON Schema attached to the channel.
+    The following fields are published:
+
+    - ``process_memory`` (number): Resident memory used by the SDK process, in bytes.
+    - ``process_virtual_memory`` (number): Virtual memory used by the SDK process, in bytes.
+    - ``process_cpu_percent`` (number): CPU usage for the SDK process, as a percent of total
+      system CPU capacity (0.0 to 100.0).
+    - ``process_cpu_cores`` (number): CPU usage for the SDK process, expressed in
+      core-equivalents (0.0 to ``num_cpus``). 1.0 means a single logical CPU is fully utilized.
+    - ``total_cpu_percent`` (number): Total CPU usage across all logical CPUs on the system,
+      as a percent (0.0 to 100.0).
+    - ``total_cpu_cores`` (number): Total CPU usage across the system, expressed in
+      core-equivalents (0.0 to ``num_cpus``). 1.0 means one logical CPU's worth of work is being
+      done.
+    - ``num_cpus`` (integer): Number of logical CPUs on the system.
+    - ``total_memory`` (number): Total physical memory on the system, in bytes.
+    - ``used_memory`` (number): Used physical memory on the system, in bytes.
+    - ``total_swap`` (number): Total swap space on the system, in bytes.
+    - ``used_swap`` (number): Used swap space on the system, in bytes.
+    - ``kernel_version`` (string): Kernel version string, or empty if unknown.
+    - ``os_version`` (string): OS version string, or empty if unknown.
+
+    CPU usage values are computed from the difference between consecutive samples, so they
+    reflect activity over the most recent refresh interval.
+
+    :param topic: The channel topic name. Defaults to ``/sysinfo``.
+    :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``.
+        Clamped to a minimum of 200ms.
+    :param context: The context on which the publisher creates its channel. Defaults to
+        the global default context.
+    :return: A handle that can be used to stop the publisher.
     """
     ...
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -406,13 +406,9 @@ def start_server(
 
 class SystemInfoPublisher:
     """
-    A handle to a running system info publisher.
+    Handle to a running system info publisher.
 
-    The publisher is started by :py:func:`foxglove.start_sysinfo_publisher` and runs in
-    the background until :py:meth:`stop` is called. See :py:func:`foxglove.start_sysinfo_publisher`
-    for the list of metrics published on the channel.
-
-    The caller is responsible for calling stop() when done; dropping the handle does not stop the background task.
+    See :py:func:`foxglove.start_sysinfo_publisher` for full documentation.
     """
 
     def stop(self) -> None:
@@ -430,41 +426,7 @@ def start_sysinfo_publisher(
     """
     Start the system info publisher.
 
-    Periodically publishes process and system statistics (memory, CPU, OS info) to a channel.
-
-    Published metrics
-    -----------------
-
-    Each message is a JSON object with a JSON Schema attached to the channel.
-    The following fields are published:
-
-    - ``process_memory`` (number): Resident memory used by the SDK process, in bytes.
-    - ``process_virtual_memory`` (number): Virtual memory used by the SDK process, in bytes.
-    - ``process_cpu_percent`` (number): CPU usage for the SDK process, as a percent of total
-      system CPU capacity (0.0 to 100.0).
-    - ``process_cpu_cores`` (number): CPU usage for the SDK process, expressed in
-      core-equivalents (0.0 to ``num_cpus``). 1.0 means a single logical CPU is fully utilized.
-    - ``total_cpu_percent`` (number): Total CPU usage across all logical CPUs on the system,
-      as a percent (0.0 to 100.0).
-    - ``total_cpu_cores`` (number): Total CPU usage across the system, expressed in
-      core-equivalents (0.0 to ``num_cpus``). 1.0 means one logical CPU's worth of work is being
-      done.
-    - ``num_cpus`` (integer): Number of logical CPUs on the system.
-    - ``total_memory`` (number): Total physical memory on the system, in bytes.
-    - ``used_memory`` (number): Used physical memory on the system, in bytes.
-    - ``total_swap`` (number): Total swap space on the system, in bytes.
-    - ``used_swap`` (number): Used swap space on the system, in bytes.
-    - ``kernel_version`` (string): Kernel version string, or empty if unknown.
-    - ``os_version`` (string): OS version string, or empty if unknown.
-
-    CPU usage values are computed from the difference between consecutive samples, so they
-    reflect activity over the most recent refresh interval.
-
-    :param topic: Channel topic name. Defaults to ``/sysinfo``.
-    :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``. Clamped to a minimum of 0.2.
-    :param context: The context on which the publisher creates its channel. Defaults to the global default context.
-
-    The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
+    See the runtime docstring or API reference for parameters and published metrics.
     """
     ...
 

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -409,7 +409,9 @@ class SystemInfoPublisher:
     A handle to a running system info publisher.
 
     The publisher is started by :py:func:`foxglove.start_sysinfo_publisher` and runs in
-    the background until :py:meth:`stop` is called.
+    the background until :py:meth:`stop` is called. See :py:func:`foxglove.start_sysinfo_publisher`
+    for the list of metrics published on the channel.
+
     The caller is responsible for calling stop() when done; dropping the handle does not stop the background task.
     """
 
@@ -429,6 +431,34 @@ def start_sysinfo_publisher(
     Start the system info publisher.
 
     Periodically publishes process and system statistics (memory, CPU, OS info) to a channel.
+
+    Published metrics
+    -----------------
+
+    Each message is a JSON object with a JSON Schema attached to the channel.
+    The following fields are published:
+
+    - ``process_memory`` (number): Resident memory used by the SDK process, in bytes.
+    - ``process_virtual_memory`` (number): Virtual memory used by the SDK process, in bytes.
+    - ``process_cpu_percent`` (number): CPU usage for the SDK process, as a percent of total
+      system CPU capacity (0.0 to 100.0).
+    - ``process_cpu_cores`` (number): CPU usage for the SDK process, expressed in
+      core-equivalents (0.0 to ``num_cpus``). 1.0 means a single logical CPU is fully utilized.
+    - ``total_cpu_percent`` (number): Total CPU usage across all logical CPUs on the system,
+      as a percent (0.0 to 100.0).
+    - ``total_cpu_cores`` (number): Total CPU usage across the system, expressed in
+      core-equivalents (0.0 to ``num_cpus``). 1.0 means one logical CPU's worth of work is being
+      done.
+    - ``num_cpus`` (integer): Number of logical CPUs on the system.
+    - ``total_memory`` (number): Total physical memory on the system, in bytes.
+    - ``used_memory`` (number): Used physical memory on the system, in bytes.
+    - ``total_swap`` (number): Total swap space on the system, in bytes.
+    - ``used_swap`` (number): Used swap space on the system, in bytes.
+    - ``kernel_version`` (string): Kernel version string, or empty if unknown.
+    - ``os_version`` (string): OS version string, or empty if unknown.
+
+    CPU usage values are computed from the difference between consecutive samples, so they
+    reflect activity over the most recent refresh interval.
 
     :param topic: Channel topic name. Defaults to ``/sysinfo``.
     :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``. Clamped to a minimum of 0.2.

--- a/python/foxglove-sdk/src/system_info.rs
+++ b/python/foxglove-sdk/src/system_info.rs
@@ -32,6 +32,8 @@ impl PySystemInfoPublisher {
 /// system statistics (memory, CPU, OS info). See :py:func:`foxglove.start_sysinfo_publisher`
 /// for the full list of published metrics.
 ///
+/// The caller is responsible for calling stop() on the returned handle when done; dropping the handle does not stop the background task.
+///
 /// :param topic: The channel topic name. Defaults to ``/sysinfo``.
 /// :type topic: str | None
 /// :param refresh_interval: How often to publish, in seconds. Defaults to ``0.5``.

--- a/python/foxglove-sdk/src/system_info.rs
+++ b/python/foxglove-sdk/src/system_info.rs
@@ -29,34 +29,8 @@ impl PySystemInfoPublisher {
 /// Start the system info publisher.
 ///
 /// Periodically publishes a ``SystemInfo`` message to a channel containing process and
-/// system statistics (memory, CPU, OS info).
-///
-/// Published metrics
-///
-/// Each message is a JSON object with a JSON Schema attached to the channel.
-/// The following fields are published:
-///
-/// - ``process_memory`` (number): Resident memory used by the SDK process, in bytes.
-/// - ``process_virtual_memory`` (number): Virtual memory used by the SDK process, in bytes.
-/// - ``process_cpu_percent`` (number): CPU usage for the SDK process, as a percent of total
-///   system CPU capacity (0.0 to 100.0).
-/// - ``process_cpu_cores`` (number): CPU usage for the SDK process, expressed in
-///   core-equivalents (0.0 to ``num_cpus``). 1.0 means a single logical CPU is fully utilized.
-/// - ``total_cpu_percent`` (number): Total CPU usage across all logical CPUs on the system,
-///   as a percent (0.0 to 100.0).
-/// - ``total_cpu_cores`` (number): Total CPU usage across the system, expressed in
-///   core-equivalents (0.0 to ``num_cpus``). 1.0 means one logical CPU's worth of work is being
-///   done.
-/// - ``num_cpus`` (integer): Number of logical CPUs on the system.
-/// - ``total_memory`` (number): Total physical memory on the system, in bytes.
-/// - ``used_memory`` (number): Used physical memory on the system, in bytes.
-/// - ``total_swap`` (number): Total swap space on the system, in bytes.
-/// - ``used_swap`` (number): Used swap space on the system, in bytes.
-/// - ``kernel_version`` (string): Kernel version string, or empty if unknown.
-/// - ``os_version`` (string): OS version string, or empty if unknown.
-///
-/// CPU usage values are computed from the difference between consecutive samples, so they
-/// reflect activity over the most recent refresh interval.
+/// system statistics (memory, CPU, OS info). See :py:func:`foxglove.start_sysinfo_publisher`
+/// for the full list of published metrics.
 ///
 /// :param topic: The channel topic name. Defaults to ``/sysinfo``.
 /// :type topic: str | None

--- a/python/foxglove-sdk/src/system_info.rs
+++ b/python/foxglove-sdk/src/system_info.rs
@@ -9,7 +9,8 @@ use crate::PyContext;
 /// A handle to a running system info publisher.
 ///
 /// The publisher is started by :py:func:`foxglove.start_sysinfo_publisher` and runs in
-/// the background until :py:meth:`stop` is called.
+/// the background until :py:meth:`stop` is called. See :py:func:`foxglove.start_sysinfo_publisher`
+/// for the list of metrics published on the channel.
 #[pyclass(name = "SystemInfoPublisher", module = "foxglove")]
 pub struct PySystemInfoPublisher(Option<SystemInfoHandle>);
 
@@ -29,6 +30,33 @@ impl PySystemInfoPublisher {
 ///
 /// Periodically publishes a ``SystemInfo`` message to a channel containing process and
 /// system statistics (memory, CPU, OS info).
+///
+/// Published metrics
+///
+/// Each message is a JSON object with a JSON Schema attached to the channel.
+/// The following fields are published:
+///
+/// - ``process_memory`` (number): Resident memory used by the SDK process, in bytes.
+/// - ``process_virtual_memory`` (number): Virtual memory used by the SDK process, in bytes.
+/// - ``process_cpu_percent`` (number): CPU usage for the SDK process, as a percent of total
+///   system CPU capacity (0.0 to 100.0).
+/// - ``process_cpu_cores`` (number): CPU usage for the SDK process, expressed in
+///   core-equivalents (0.0 to ``num_cpus``). 1.0 means a single logical CPU is fully utilized.
+/// - ``total_cpu_percent`` (number): Total CPU usage across all logical CPUs on the system,
+///   as a percent (0.0 to 100.0).
+/// - ``total_cpu_cores`` (number): Total CPU usage across the system, expressed in
+///   core-equivalents (0.0 to ``num_cpus``). 1.0 means one logical CPU's worth of work is being
+///   done.
+/// - ``num_cpus`` (integer): Number of logical CPUs on the system.
+/// - ``total_memory`` (number): Total physical memory on the system, in bytes.
+/// - ``used_memory`` (number): Used physical memory on the system, in bytes.
+/// - ``total_swap`` (number): Total swap space on the system, in bytes.
+/// - ``used_swap`` (number): Used swap space on the system, in bytes.
+/// - ``kernel_version`` (string): Kernel version string, or empty if unknown.
+/// - ``os_version`` (string): OS version string, or empty if unknown.
+///
+/// CPU usage values are computed from the difference between consecutive samples, so they
+/// reflect activity over the most recent refresh interval.
 ///
 /// :param topic: The channel topic name. Defaults to ``/sysinfo``.
 /// :type topic: str | None

--- a/rust/foxglove/src/system_info.rs
+++ b/rust/foxglove/src/system_info.rs
@@ -162,6 +162,30 @@ impl Encode for SystemInfo {
 /// background task that periodically logs a SystemInfo message to the channel
 /// with stats on CPU and memory usage for the process and the system.
 ///
+/// # Published metrics
+///
+/// Each message is a JSON object with a JSON Schema attached to the channel.
+/// The following fields are published:
+///
+/// | Field | Type | Description |
+/// | --- | --- | --- |
+/// | `process_memory` | number | Resident memory used by the SDK process, in bytes. |
+/// | `process_virtual_memory` | number | Virtual memory used by the SDK process, in bytes. |
+/// | `process_cpu_percent` | number | CPU usage for the SDK process, as a percent of total system CPU capacity (0.0 to 100.0). |
+/// | `process_cpu_cores` | number | CPU usage for the SDK process, expressed in core-equivalents (0.0 to `num_cpus`). 1.0 means a single logical CPU is fully utilized. |
+/// | `total_cpu_percent` | number | Total CPU usage across all logical CPUs on the system, as a percent (0.0 to 100.0). |
+/// | `total_cpu_cores` | number | Total CPU usage across the system, expressed in core-equivalents (0.0 to `num_cpus`). 1.0 means one logical CPU's worth of work is being done. |
+/// | `num_cpus` | integer | Number of logical CPUs on the system. |
+/// | `total_memory` | number | Total physical memory on the system, in bytes. |
+/// | `used_memory` | number | Used physical memory on the system, in bytes. |
+/// | `total_swap` | number | Total swap space on the system, in bytes. |
+/// | `used_swap` | number | Used swap space on the system, in bytes. |
+/// | `kernel_version` | string | Kernel version string, or empty if unknown. |
+/// | `os_version` | string | OS version string, or empty if unknown. |
+///
+/// CPU usage values are computed from the difference between consecutive
+/// samples, so they reflect activity over the most recent refresh interval.
+///
 /// # Example
 ///
 /// ```no_run


### PR DESCRIPTION
### Changelog

None

### Docs

We (I) didn't document what the system info publisher publishes. So this documents that for Rust, C++, and Python. The bridge docs will then link to the sdk docs to describe what is published in a [follow-up PR](https://github.com/foxglove/app/pull/14751) in that repo.