### PR TITLE
bridge: Handle parameter operations asynchronously

### DIFF
--- a/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -188,6 +188,14 @@ private:
   using ParameterOp =
     std::variant<GetParamsOp, SetParamsOp, SubscribeParamsOp, UnsubscribeParamsOp>;
 
+  // Wire the parameter-related callbacks/handler on a server or gateway options struct.
+  // Both options structs share these field types; this helper keeps the WS and gateway
+  // sites in sync.
+  void wireParameterCallbacks(
+    std::function<void(const std::vector<std::string_view>&)>& onSubscribe,
+    std::function<void(const std::vector<std::string_view>&)>& onUnsubscribe,
+    foxglove::ParameterHandler& handler);
+
   void enqueueParameterOp(ParameterOp&& op);
   void parameterWorkerLoop();
   void handleGetParams(GetParamsOp&& op);

--- a/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -2,12 +2,16 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <deque>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <queue>
 #include <regex>
 #include <thread>
 #include <unordered_set>
+#include <variant>
 
 #include <rclcpp/rclcpp.hpp>
 #include <rmw/types.h>
@@ -17,6 +21,7 @@
 
 #include <foxglove/fetch_asset.hpp>
 #include <foxglove/foxglove.hpp>
+#include <foxglove/parameter_handler.hpp>
 #include <foxglove/system_info.hpp>
 #include <foxglove/websocket.hpp>
 #ifdef FOXGLOVE_REMOTE_ACCESS
@@ -163,19 +168,50 @@ private:
   void clientMessage(ClientId clientId, ChannelId clientChannelId, const std::byte* data,
                      size_t dataLen);
 
-  std::vector<foxglove::Parameter> setParameters(
-    const uint32_t clientId, const std::optional<std::string_view>& requestId,
-    const std::vector<foxglove::ParameterView>& parameterViews);
+  // Each parameter op carries enough state to be handled by the worker thread.
+  // Get and Set ops own their responders; Subscribe/Unsubscribe carry just the
+  // parameter names so they serialize with get/set on the same queue.
+  struct GetParamsOp {
+    std::vector<std::string> names;
+    foxglove::GetParametersResponder responder;
+  };
+  struct SetParamsOp {
+    std::vector<foxglove::Parameter> parameters;
+    foxglove::SetParametersResponder responder;
+  };
+  struct SubscribeParamsOp {
+    std::vector<std::string> names;
+  };
+  struct UnsubscribeParamsOp {
+    std::vector<std::string> names;
+  };
+  using ParameterOp =
+    std::variant<GetParamsOp, SetParamsOp, SubscribeParamsOp, UnsubscribeParamsOp>;
 
-  std::vector<foxglove::Parameter> getParameters(
-    const uint32_t clientId, const std::optional<std::string_view>& requestId,
-    const std::vector<std::string_view>& parameterNames);
-
-  void subscribeParameters(const std::vector<std::string_view>& parameterNames);
-
-  void unsubscribeParameters(const std::vector<std::string_view>& parameterNames);
+  void enqueueParameterOp(ParameterOp&& op);
+  void parameterWorkerLoop();
+  void handleGetParams(GetParamsOp&& op);
+  void handleSetParams(SetParamsOp&& op);
+  void handleSubscribeParams(SubscribeParamsOp&& op);
+  void handleUnsubscribeParams(UnsubscribeParamsOp&& op);
 
   void parameterUpdates(const std::vector<foxglove::Parameter>& parameters);
+
+  std::mutex _paramOpMutex;
+  std::condition_variable _paramOpCv;
+  std::queue<ParameterOp> _paramOpQueue;
+  bool _paramOpShutdown = false;
+  std::unique_ptr<std::thread> _paramWorkerThread;
+
+  // Parameter subscription refcount, owned by the worker thread.
+  //
+  // The websocket server and remote access gateway each independently maintain
+  // state about parameter subscriptions on behalf of clients. They each fire
+  // onParametersSubscribe when the first subscriber subscribes to a particular
+  // parameter, and onParametersUnsubscribe when the last subscriber
+  // unsubscribes. We use this map to aggregate subscriptions across the two
+  // transports.
+  std::unordered_map<std::string, int> _paramSubscriberCount;
 
   void rosMessageHandler(ChannelId channelId, std::shared_ptr<const rclcpp::SerializedMessage> msg,
                          const rclcpp::MessageInfo& messageInfo);

--- a/ros/src/foxglove_bridge/src/parameter_interface.cpp
+++ b/ros/src/foxglove_bridge/src/parameter_interface.cpp
@@ -286,7 +286,7 @@ void ParameterInterface::setParams(const ParameterList& parameters,
   rclcpp::ParameterMap paramsByNode;
   for (const auto& param : parameters) {
     if (!isWhitelisted(std::string(param.name()), _paramWhitelistPatterns)) {
-      return;
+      continue;
     }
 
     const auto rosParam = toRosParam(param);
@@ -324,7 +324,7 @@ void ParameterInterface::subscribeParams(const std::vector<std::string_view>& pa
   std::unordered_set<std::string> nodesToSubscribe;
   for (const auto& paramName : paramNames) {
     if (!isWhitelisted(std::string(paramName), _paramWhitelistPatterns)) {
-      return;
+      continue;
     }
 
     const auto& [nodeName, paramN] = getNodeAndParamName(paramName);

--- a/ros/src/foxglove_bridge/src/parameter_interface.cpp
+++ b/ros/src/foxglove_bridge/src/parameter_interface.cpp
@@ -377,13 +377,18 @@ void ParameterInterface::unsubscribeParams(const std::vector<std::string_view>& 
     const auto& [nodeName, paramN] = getNodeAndParamName(paramName);
 
     const auto subscribedNodeParamsIt = _subscribedParamsByNode.find(nodeName);
-    if (subscribedNodeParamsIt != _subscribedParamsByNode.end()) {
-      subscribedNodeParamsIt->second.erase(subscribedNodeParamsIt->second.find(paramN));
+    if (subscribedNodeParamsIt == _subscribedParamsByNode.end()) {
+      continue;
+    }
+    const auto innerIt = subscribedNodeParamsIt->second.find(paramN);
+    if (innerIt == subscribedNodeParamsIt->second.end()) {
+      continue;
+    }
+    subscribedNodeParamsIt->second.erase(innerIt);
 
-      if (subscribedNodeParamsIt->second.empty()) {
-        _subscribedParamsByNode.erase(subscribedNodeParamsIt);
-        _paramSubscriptionsByNode.erase(_paramSubscriptionsByNode.find(nodeName));
-      }
+    if (subscribedNodeParamsIt->second.empty()) {
+      _subscribedParamsByNode.erase(subscribedNodeParamsIt);
+      _paramSubscriptionsByNode.erase(nodeName);
     }
   }
 }

--- a/ros/src/foxglove_bridge/src/parameter_interface.cpp
+++ b/ros/src/foxglove_bridge/src/parameter_interface.cpp
@@ -249,7 +249,8 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string_view>&
                            paramClientIt->second, nodeName, nodeParamNames, timeout));
   }
 
-  // Don't hold _mutex across blocking waits; parameter-event callbacks may need it to make progress.
+  // Don't hold _mutex across blocking waits; parameter-event callbacks may need it to make
+  // progress.
   lock.unlock();
 
   ParameterList result;
@@ -320,7 +321,8 @@ void ParameterInterface::setParams(const ParameterList& parameters,
                                                 paramClientIt->second, nodeName, params, timeout));
   }
 
-  // Don't hold _mutex across blocking waits; parameter-event callbacks may need it to make progress.
+  // Don't hold _mutex across blocking waits; parameter-event callbacks may need it to make
+  // progress.
   lock.unlock();
 
   for (auto& future : setParametersFuture) {

--- a/ros/src/foxglove_bridge/src/parameter_interface.cpp
+++ b/ros/src/foxglove_bridge/src/parameter_interface.cpp
@@ -178,7 +178,7 @@ ParameterInterface::ParameterInterface(rclcpp::Node* node,
 
 ParameterList ParameterInterface::getParams(const std::vector<std::string_view>& paramNames,
                                             const std::chrono::duration<double>& timeout) {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::unique_lock<std::mutex> lock(_mutex);
 
   std::unordered_map<std::string, std::vector<std::string>> paramNamesByNodeName;
   const auto thisNode = _node->get_fully_qualified_name();
@@ -249,7 +249,11 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string_view>&
                            paramClientIt->second, nodeName, nodeParamNames, timeout));
   }
 
+  // Don't hold _mutex across blocking waits; parameter-event callbacks may need it to make progress.
+  lock.unlock();
+
   ParameterList result;
+  std::vector<std::string> nodesToIgnore;
   for (auto& [nodeName, future] : getParametersFuture) {
     try {
       // Move the parameters from the future into result. Must be done using rvalue reference
@@ -262,12 +266,12 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string_view>&
                    nodeName.c_str(), e.what());
 
       if (_unresponsiveNodePolicy == UnresponsiveNodePolicy::Ignore) {
-        // Certain nodes may fail to handle incoming service requests — for example, if they're
+        // Certain nodes may fail to handle incoming service requests, for example, if they're
         // stuck in a busy loop or otherwise unresponsive. In such cases, attempting to retrieve
         // parameter names or values can result in timeouts. To avoid repeated failures, these nodes
         // are added to an ignore list, and future parameter-related service calls to them will be
         // skipped.
-        _ignoredNodeNames.insert(nodeName);
+        nodesToIgnore.push_back(nodeName);
         RCLCPP_WARN(_node->get_logger(),
                     "Adding node %s to the ignore list to prevent repeated timeouts or failures in "
                     "future parameter requests.",
@@ -276,12 +280,19 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string_view>&
     }
   }
 
+  if (!nodesToIgnore.empty()) {
+    lock.lock();
+    for (auto& nodeName : nodesToIgnore) {
+      _ignoredNodeNames.insert(std::move(nodeName));
+    }
+  }
+
   return result;
 }
 
 void ParameterInterface::setParams(const ParameterList& parameters,
                                    const std::chrono::duration<double>& timeout) {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::unique_lock<std::mutex> lock(_mutex);
 
   rclcpp::ParameterMap paramsByNode;
   for (const auto& param : parameters) {
@@ -308,6 +319,9 @@ void ParameterInterface::setParams(const ParameterList& parameters,
                                                 &ParameterInterface::setNodeParameters, this,
                                                 paramClientIt->second, nodeName, params, timeout));
   }
+
+  // Don't hold _mutex across blocking waits; parameter-event callbacks may need it to make progress.
+  lock.unlock();
 
   for (auto& future : setParametersFuture) {
     try {
@@ -355,16 +369,25 @@ void ParameterInterface::subscribeParams(const std::vector<std::string_view>& pa
                      nodeName.c_str(), msg->changed_parameters.size());
 
         ParameterList result;
-        const auto& subscribedNodeParams = _subscribedParamsByNode[nodeName];
-        for (const auto& param : msg->changed_parameters) {
-          if (subscribedNodeParams.find(param.name) != subscribedNodeParams.end()) {
-            result.push_back(fromRosParam(
-              rclcpp::Parameter(prependNodeNameToParamName(param.name, nodeName), param.value)));
+        ParamUpdateFunc paramUpdateFunc;
+        {
+          std::lock_guard<std::mutex> lock(_mutex);
+          const auto it = _subscribedParamsByNode.find(nodeName);
+          if (it == _subscribedParamsByNode.end()) {
+            return;
           }
+          const auto& subscribedNodeParams = it->second;
+          for (const auto& param : msg->changed_parameters) {
+            if (subscribedNodeParams.find(param.name) != subscribedNodeParams.end()) {
+              result.push_back(fromRosParam(
+                rclcpp::Parameter(prependNodeNameToParamName(param.name, nodeName), param.value)));
+            }
+          }
+          paramUpdateFunc = _paramUpdateFunc;
         }
 
-        if (!result.empty() && _paramUpdateFunc) {
-          _paramUpdateFunc(result);
+        if (!result.empty() && paramUpdateFunc) {
+          paramUpdateFunc(result);
         }
       });
   }

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -200,32 +200,55 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   if (hasCapability(sdkServerOptions.capabilities,
                     foxglove::WebSocketServerCapabilities::Parameters)) {
     sdkServerOptions.callbacks.onParametersSubscribe =
-      std::bind(&FoxgloveBridge::subscribeParameters, this, _1);
+      [this](const std::vector<std::string_view>& names) {
+        SubscribeParamsOp op;
+        op.names.reserve(names.size());
+        for (const auto& name : names) {
+          op.names.emplace_back(name);
+        }
+        enqueueParameterOp(std::move(op));
+      };
     sdkServerOptions.callbacks.onParametersUnsubscribe =
-      std::bind(&FoxgloveBridge::unsubscribeParameters, this, _1);
-    // FLE-534: migrate to ParameterHandler
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-    sdkServerOptions.callbacks.onGetParameters =
-      std::bind(&FoxgloveBridge::getParameters, this, _1, _2, _3);
-    sdkServerOptions.callbacks.onSetParameters =
-      std::bind(&FoxgloveBridge::setParameters, this, _1, _2, _3);
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
+      [this](const std::vector<std::string_view>& names) {
+        UnsubscribeParamsOp op;
+        op.names.reserve(names.size());
+        for (const auto& name : names) {
+          op.names.emplace_back(name);
+        }
+        enqueueParameterOp(std::move(op));
+      };
+    sdkServerOptions.parameter_handler.onGet =
+      [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
+             const std::vector<std::string_view>& names,
+             foxglove::GetParametersResponder&& responder) {
+        GetParamsOp op{{}, std::move(responder)};
+        op.names.reserve(names.size());
+        for (const auto& name : names) {
+          op.names.emplace_back(name);
+        }
+        enqueueParameterOp(std::move(op));
+      };
+    sdkServerOptions.parameter_handler.onSet =
+      [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
+             const std::vector<foxglove::ParameterView>& params,
+             foxglove::SetParametersResponder&& responder) {
+        SetParamsOp op{{}, std::move(responder)};
+        op.parameters.reserve(params.size());
+        for (const auto& param : params) {
+          op.parameters.emplace_back(param.clone());
+        }
+        enqueueParameterOp(std::move(op));
+      };
 
     _paramInterface = std::make_shared<ParameterInterface>(this, paramWhitelistPatterns,
                                                            ignoreUnresponsiveParamNodes
                                                              ? UnresponsiveNodePolicy::Ignore
                                                              : UnresponsiveNodePolicy::Retry);
     _paramInterface->setParamUpdateCallback(std::bind(&FoxgloveBridge::parameterUpdates, this, _1));
+
+    // Start the worker thread that drains the queue and dispatches into _paramInterface.
+    _paramWorkerThread =
+      std::make_unique<std::thread>(std::bind(&FoxgloveBridge::parameterWorkerLoop, this));
   }
 
   if (publishClientCount) {
@@ -372,26 +395,45 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
 
     if (hasCapability(_capabilities, foxglove::WebSocketServerCapabilities::Parameters)) {
       gatewayOptions.callbacks.onParametersSubscribe =
-        std::bind(&FoxgloveBridge::subscribeParameters, this, _1);
+        [this](const std::vector<std::string_view>& names) {
+          SubscribeParamsOp op;
+          op.names.reserve(names.size());
+          for (const auto& name : names) {
+            op.names.emplace_back(name);
+          }
+          enqueueParameterOp(std::move(op));
+        };
       gatewayOptions.callbacks.onParametersUnsubscribe =
-        std::bind(&FoxgloveBridge::unsubscribeParameters, this, _1);
-      // FLE-534: migrate to ParameterHandler
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-      gatewayOptions.callbacks.onGetParameters =
-        std::bind(&FoxgloveBridge::getParameters, this, _1, _2, _3);
-      gatewayOptions.callbacks.onSetParameters =
-        std::bind(&FoxgloveBridge::setParameters, this, _1, _2, _3);
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
+        [this](const std::vector<std::string_view>& names) {
+          UnsubscribeParamsOp op;
+          op.names.reserve(names.size());
+          for (const auto& name : names) {
+            op.names.emplace_back(name);
+          }
+          enqueueParameterOp(std::move(op));
+        };
+      gatewayOptions.parameter_handler.onGet =
+        [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
+               const std::vector<std::string_view>& names,
+               foxglove::GetParametersResponder&& responder) {
+          GetParamsOp op{{}, std::move(responder)};
+          op.names.reserve(names.size());
+          for (const auto& name : names) {
+            op.names.emplace_back(name);
+          }
+          enqueueParameterOp(std::move(op));
+        };
+      gatewayOptions.parameter_handler.onSet =
+        [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
+               const std::vector<foxglove::ParameterView>& params,
+               foxglove::SetParametersResponder&& responder) {
+          SetParamsOp op{{}, std::move(responder)};
+          op.parameters.reserve(params.size());
+          for (const auto& param : params) {
+            op.parameters.emplace_back(param.clone());
+          }
+          enqueueParameterOp(std::move(op));
+        };
     }
 
     if (hasCapability(_capabilities, foxglove::WebSocketServerCapabilities::ConnectionGraph)) {
@@ -427,6 +469,18 @@ FoxgloveBridge::~FoxgloveBridge() {
   }
 #endif
   _server->stop();
+  // Stop the parameter worker after the server and gateway are stopped, so no new ops
+  // arrive while we're shutting it down. Any ops still in the queue get dropped.
+  if (_paramWorkerThread) {
+    {
+      std::lock_guard<std::mutex> lock(_paramOpMutex);
+      _paramOpShutdown = true;
+      std::queue<ParameterOp> drained;
+      std::swap(_paramOpQueue, drained);
+    }
+    _paramOpCv.notify_all();
+    _paramWorkerThread->join();
+  }
   RCLCPP_INFO(this->get_logger(), "Shutdown complete");
 }
 
@@ -1158,55 +1212,125 @@ void FoxgloveBridge::clientMessage(ClientId clientId, ChannelId clientChannelId,
   }
 }
 
-std::vector<foxglove::Parameter> FoxgloveBridge::setParameters(
-  const ClientId clientId [[maybe_unused]], const std::optional<std::string_view>& requestId,
-  const std::vector<foxglove::ParameterView>& parameterViews) {
-  // Copy parameters to a vector
-  std::vector<foxglove::Parameter> parameters;
-  std::transform(parameterViews.cbegin(), parameterViews.cend(), std::back_inserter(parameters),
-                 [](const foxglove::ParameterView& pv) {
-                   return pv.clone();
-                 });
-
-  _paramInterface->setParams(parameters, std::chrono::seconds(5));
-
-  // REVIEW: The previous implementation would publish updated parameters to the client only if a
-  // request ID was passed. Since the SDK server publishes any parameters returned from this
-  // function, to maintain the same behavior, we only return a non-empty vector if a request ID was
-  // passed. If feels like too much of a kludge, we can remove this check but will need to either:
-  //
-  // (1) Update tests/client implementations to be robust to multiple parameter updates being
-  // received if they are subscribed to parameter updates AND set a parameter, or (2) Update the SDK
-  // server to avoid double-publishing parameters to a client that's setting a param and is
-  // subscribed to parameter updates.
-  if (requestId.has_value()) {
-    // Get parameters again and publish them to the SDK server
-    std::vector<std::string_view> parameterNames;
-    parameterNames.reserve(parameters.size());
-    for (const auto& param : parameters) {
-      parameterNames.push_back(param.name());
+void FoxgloveBridge::enqueueParameterOp(ParameterOp&& op) {
+  {
+    std::lock_guard<std::mutex> lock(_paramOpMutex);
+    if (_paramOpShutdown) {
+      // Worker is gone; drop the op. Get/Set responders will send the requesting client an
+      // error status on destruction; Subscribe/Unsubscribe are fire-and-forget.
+      return;
     }
-
-    auto updatedParameters = _paramInterface->getParams(parameterNames, std::chrono::seconds(5));
-    return updatedParameters;
+    _paramOpQueue.push(std::move(op));
   }
-
-  return {};
+  _paramOpCv.notify_one();
 }
 
-std::vector<foxglove::Parameter> FoxgloveBridge::getParameters(
-  const ClientId clientId [[maybe_unused]],
-  const std::optional<std::string_view>& requestId [[maybe_unused]],
-  const std::vector<std::string_view>& parameterNames) {
-  return _paramInterface->getParams(parameterNames, std::chrono::seconds(5));
+void FoxgloveBridge::parameterWorkerLoop() {
+  std::unique_lock<std::mutex> lock(_paramOpMutex);
+  while (true) {
+    _paramOpCv.wait(lock, [&] {
+      return _paramOpShutdown || !_paramOpQueue.empty();
+    });
+    if (_paramOpShutdown && _paramOpQueue.empty()) {
+      return;
+    }
+    auto op = std::move(_paramOpQueue.front());
+    _paramOpQueue.pop();
+    lock.unlock();
+
+    std::visit(
+      [this](auto& concrete) {
+        using T = std::decay_t<decltype(concrete)>;
+        if constexpr (std::is_same_v<T, GetParamsOp>) {
+          this->handleGetParams(std::move(concrete));
+        } else if constexpr (std::is_same_v<T, SetParamsOp>) {
+          this->handleSetParams(std::move(concrete));
+        } else if constexpr (std::is_same_v<T, SubscribeParamsOp>) {
+          this->handleSubscribeParams(std::move(concrete));
+        } else if constexpr (std::is_same_v<T, UnsubscribeParamsOp>) {
+          this->handleUnsubscribeParams(std::move(concrete));
+        }
+      },
+      op);
+
+    lock.lock();
+  }
 }
 
-void FoxgloveBridge::subscribeParameters(const std::vector<std::string_view>& parameterNames) {
-  _paramInterface->subscribeParams(parameterNames);
+void FoxgloveBridge::handleGetParams(GetParamsOp&& op) {
+  std::vector<std::string_view> views(op.names.begin(), op.names.end());
+  try {
+    auto values = _paramInterface->getParams(views, std::chrono::seconds(5));
+    std::move(op.responder).respond(std::move(values));
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR(this->get_logger(), "getParams failed: %s", ex.what());
+    // Dropping the responder sends the client an error status.
+  }
 }
 
-void FoxgloveBridge::unsubscribeParameters(const std::vector<std::string_view>& parameterNames) {
-  _paramInterface->unsubscribeParams(parameterNames);
+void FoxgloveBridge::handleSetParams(SetParamsOp&& op) {
+  if (op.parameters.empty()) {
+    // Nothing to apply; avoid the degenerate getParams({}, ...) which would enumerate every
+    // parameter on every node.
+    std::move(op.responder).respond({});
+    return;
+  }
+  try {
+    _paramInterface->setParams(op.parameters, std::chrono::seconds(5));
+    // Fetch the actually-applied values so we can echo them back to the requester.
+    std::vector<std::string_view> names;
+    names.reserve(op.parameters.size());
+    for (const auto& param : op.parameters) {
+      names.emplace_back(param.name());
+    }
+    auto updated = _paramInterface->getParams(names, std::chrono::seconds(5));
+    std::move(op.responder).respond(std::move(updated));
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR(this->get_logger(), "setParams failed: %s", ex.what());
+    // Dropping the responder sends the client an error status.
+  }
+}
+
+void FoxgloveBridge::handleSubscribeParams(SubscribeParamsOp&& op) {
+  std::vector<std::string_view> toForward;
+  toForward.reserve(op.names.size());
+  for (const auto& name : op.names) {
+    if (++_paramSubscriberCount[name] == 1) {
+      toForward.emplace_back(name);
+    }
+  }
+  if (toForward.empty()) {
+    return;
+  }
+  try {
+    _paramInterface->subscribeParams(toForward);
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR(this->get_logger(), "subscribeParams failed: %s", ex.what());
+  }
+}
+
+void FoxgloveBridge::handleUnsubscribeParams(UnsubscribeParamsOp&& op) {
+  std::vector<std::string_view> toForward;
+  toForward.reserve(op.names.size());
+  for (const auto& name : op.names) {
+    auto it = _paramSubscriberCount.find(name);
+    if (it == _paramSubscriberCount.end()) {
+      RCLCPP_WARN(this->get_logger(), "Unsubscribe for untracked parameter '%s'", name.c_str());
+      continue;
+    }
+    if (--it->second == 0) {
+      toForward.emplace_back(name);  // `name` lives in `op.names` until this function returns
+      _paramSubscriberCount.erase(it);
+    }
+  }
+  if (toForward.empty()) {
+    return;
+  }
+  try {
+    _paramInterface->unsubscribeParams(toForward);
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR(this->get_logger(), "unsubscribeParams failed: %s", ex.what());
+  }
 }
 
 void FoxgloveBridge::parameterUpdates(const std::vector<foxglove::Parameter>& parameters) {

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -245,10 +245,6 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
                                                              ? UnresponsiveNodePolicy::Ignore
                                                              : UnresponsiveNodePolicy::Retry);
     _paramInterface->setParamUpdateCallback(std::bind(&FoxgloveBridge::parameterUpdates, this, _1));
-
-    // Start the worker thread that drains the queue and dispatches into _paramInterface.
-    _paramWorkerThread =
-      std::make_unique<std::thread>(std::bind(&FoxgloveBridge::parameterWorkerLoop, this));
   }
 
   if (publishClientCount) {
@@ -294,10 +290,6 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     _clientCountPublisher->publish(
       init_msg);  // Initialize transient local topic to current connection count
   }
-
-  // Start the thread polling for rosgraph changes
-  _rosgraphPollThread =
-    std::make_unique<std::thread>(std::bind(&FoxgloveBridge::rosgraphPollThread, this));
 
   _subscriptionCallbackGroup = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
   _clientPublishCallbackGroup =
@@ -452,6 +444,14 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     RCLCPP_INFO(this->get_logger(), "Remote access gateway started");
   }
 #endif
+
+  if (_paramInterface) {
+    _paramWorkerThread =
+      std::make_unique<std::thread>(std::bind(&FoxgloveBridge::parameterWorkerLoop, this));
+  }
+
+  _rosgraphPollThread =
+    std::make_unique<std::thread>(std::bind(&FoxgloveBridge::rosgraphPollThread, this));
 }
 
 FoxgloveBridge::~FoxgloveBridge() {
@@ -472,10 +472,10 @@ FoxgloveBridge::~FoxgloveBridge() {
   // Stop the parameter worker after the server and gateway are stopped, so no new ops
   // arrive while we're shutting it down. Any ops still in the queue get dropped.
   if (_paramWorkerThread) {
+    std::queue<ParameterOp> drained;
     {
       std::lock_guard<std::mutex> lock(_paramOpMutex);
       _paramOpShutdown = true;
-      std::queue<ParameterOp> drained;
       std::swap(_paramOpQueue, drained);
     }
     _paramOpCv.notify_all();

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <fstream>
+#include <type_traits>
 #include <unordered_set>
 
 #include <rclcpp/version.h>

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -199,46 +199,9 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
 
   if (hasCapability(sdkServerOptions.capabilities,
                     foxglove::WebSocketServerCapabilities::Parameters)) {
-    sdkServerOptions.callbacks.onParametersSubscribe =
-      [this](const std::vector<std::string_view>& names) {
-        SubscribeParamsOp op;
-        op.names.reserve(names.size());
-        for (const auto& name : names) {
-          op.names.emplace_back(name);
-        }
-        enqueueParameterOp(std::move(op));
-      };
-    sdkServerOptions.callbacks.onParametersUnsubscribe =
-      [this](const std::vector<std::string_view>& names) {
-        UnsubscribeParamsOp op;
-        op.names.reserve(names.size());
-        for (const auto& name : names) {
-          op.names.emplace_back(name);
-        }
-        enqueueParameterOp(std::move(op));
-      };
-    sdkServerOptions.parameter_handler.onGet =
-      [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
-             const std::vector<std::string_view>& names,
-             foxglove::GetParametersResponder&& responder) {
-        GetParamsOp op{{}, std::move(responder)};
-        op.names.reserve(names.size());
-        for (const auto& name : names) {
-          op.names.emplace_back(name);
-        }
-        enqueueParameterOp(std::move(op));
-      };
-    sdkServerOptions.parameter_handler.onSet =
-      [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
-             const std::vector<foxglove::ParameterView>& params,
-             foxglove::SetParametersResponder&& responder) {
-        SetParamsOp op{{}, std::move(responder)};
-        op.parameters.reserve(params.size());
-        for (const auto& param : params) {
-          op.parameters.emplace_back(param.clone());
-        }
-        enqueueParameterOp(std::move(op));
-      };
+    wireParameterCallbacks(sdkServerOptions.callbacks.onParametersSubscribe,
+                           sdkServerOptions.callbacks.onParametersUnsubscribe,
+                           sdkServerOptions.parameter_handler);
 
     _paramInterface = std::make_shared<ParameterInterface>(this, paramWhitelistPatterns,
                                                            ignoreUnresponsiveParamNodes
@@ -386,46 +349,9 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     }
 
     if (hasCapability(_capabilities, foxglove::WebSocketServerCapabilities::Parameters)) {
-      gatewayOptions.callbacks.onParametersSubscribe =
-        [this](const std::vector<std::string_view>& names) {
-          SubscribeParamsOp op;
-          op.names.reserve(names.size());
-          for (const auto& name : names) {
-            op.names.emplace_back(name);
-          }
-          enqueueParameterOp(std::move(op));
-        };
-      gatewayOptions.callbacks.onParametersUnsubscribe =
-        [this](const std::vector<std::string_view>& names) {
-          UnsubscribeParamsOp op;
-          op.names.reserve(names.size());
-          for (const auto& name : names) {
-            op.names.emplace_back(name);
-          }
-          enqueueParameterOp(std::move(op));
-        };
-      gatewayOptions.parameter_handler.onGet =
-        [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
-               const std::vector<std::string_view>& names,
-               foxglove::GetParametersResponder&& responder) {
-          GetParamsOp op{{}, std::move(responder)};
-          op.names.reserve(names.size());
-          for (const auto& name : names) {
-            op.names.emplace_back(name);
-          }
-          enqueueParameterOp(std::move(op));
-        };
-      gatewayOptions.parameter_handler.onSet =
-        [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
-               const std::vector<foxglove::ParameterView>& params,
-               foxglove::SetParametersResponder&& responder) {
-          SetParamsOp op{{}, std::move(responder)};
-          op.parameters.reserve(params.size());
-          for (const auto& param : params) {
-            op.parameters.emplace_back(param.clone());
-          }
-          enqueueParameterOp(std::move(op));
-        };
+      wireParameterCallbacks(gatewayOptions.callbacks.onParametersSubscribe,
+                             gatewayOptions.callbacks.onParametersUnsubscribe,
+                             gatewayOptions.parameter_handler);
     }
 
     if (hasCapability(_capabilities, foxglove::WebSocketServerCapabilities::ConnectionGraph)) {
@@ -1210,6 +1136,48 @@ void FoxgloveBridge::clientMessage(ClientId clientId, ChannelId clientChannelId,
                              std::to_string(clientChannelId) + " from client ID " +
                              std::to_string(clientId) + ": " + ex.what());
   }
+}
+
+void FoxgloveBridge::wireParameterCallbacks(
+  std::function<void(const std::vector<std::string_view>&)>& onSubscribe,
+  std::function<void(const std::vector<std::string_view>&)>& onUnsubscribe,
+  foxglove::ParameterHandler& handler) {
+  onSubscribe = [this](const std::vector<std::string_view>& names) {
+    SubscribeParamsOp op;
+    op.names.reserve(names.size());
+    for (const auto& name : names) {
+      op.names.emplace_back(name);
+    }
+    enqueueParameterOp(std::move(op));
+  };
+  onUnsubscribe = [this](const std::vector<std::string_view>& names) {
+    UnsubscribeParamsOp op;
+    op.names.reserve(names.size());
+    for (const auto& name : names) {
+      op.names.emplace_back(name);
+    }
+    enqueueParameterOp(std::move(op));
+  };
+  handler.onGet = [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
+                         const std::vector<std::string_view>& names,
+                         foxglove::GetParametersResponder&& responder) {
+    GetParamsOp op{{}, std::move(responder)};
+    op.names.reserve(names.size());
+    for (const auto& name : names) {
+      op.names.emplace_back(name);
+    }
+    enqueueParameterOp(std::move(op));
+  };
+  handler.onSet = [this](uint32_t /*clientId*/, std::optional<std::string_view> /*requestId*/,
+                         const std::vector<foxglove::ParameterView>& params,
+                         foxglove::SetParametersResponder&& responder) {
+    SetParamsOp op{{}, std::move(responder)};
+    op.parameters.reserve(params.size());
+    for (const auto& param : params) {
+      op.parameters.emplace_back(param.clone());
+    }
+    enqueueParameterOp(std::move(op));
+  };
 }
 
 void FoxgloveBridge::enqueueParameterOp(ParameterOp&& op) {


### PR DESCRIPTION
### Changelog
- Fixed an issue where the `parameters` implementation would
  occasionally stall message forwarding for several seconds.
- Fixed an issue where the bridge was not refcounting subscriptions
  properly when a websocket server and remote access gateway were
  simultaneously in use.
- Fixed an issue where the parameter whitelist would randomly prevent
  subscribing to or setting unrelated parameters.

### Docs
None

### Description
This change updates the bridge to use the new ParameterHandler interface
for handling parameter get/set requests. The new interfaces allows for
asynchronous handling, which is particularly useful in the bridge,
because get and set both require fan-out requests to other ROS nodes.

This change also fixes a related bug in the way that the bridge was
tracking parameter subscriptions. The websocket server and remote access
gateway each aggregate subscriptions independently. The bridge must
implement another aggregation layer on top of that.

The new interface has the benefit that it does not attempt to broadcast
parameter updates when responding to a set request. This means the
bridge no longer has to attempt to work around that behavior.

There are also two drive-by fixes here. A fix for the parameter whitelist
(two `return` statements that ought to have been `continue` statements),
and an initialization ordering problem for the rosgraphPollThread.

### Links
Fixes: FLE-534