### PR TITLE
Use rustup minimal profile for local docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
 ARG MSRV_RUST_VERSION=1.85.0
 RUN curl https://sh.rustup.rs -fsS | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup set profile minimal
 RUN rustup toolchain install nightly --component rust-src
 RUN rustup toolchain install ${MSRV_RUST_VERSION}
 RUN rustup component add rustfmt clippy

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,8 @@ ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
 
 # rust
 ARG MSRV_RUST_VERSION=1.85.0
-RUN curl https://sh.rustup.rs -fsS | bash -s -- -y
+RUN curl https://sh.rustup.rs -fsS | bash -s -- -y --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup set profile minimal
 RUN rustup toolchain install nightly --component rust-src
 RUN rustup toolchain install ${MSRV_RUST_VERSION}
 RUN rustup component add rustfmt clippy


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
The docker image we use for local development installs three rust
toolchains. Whenever this runs, it always thrashes my disk writing out
millions of little rust doc files that we won't actually use.

By setting the rustup profile to minimal, we reduce the image size by
1.5G, and reduce the docker build time by several minutes.