### PR TITLE
rust: Clean up reqwest features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,6 +3871,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4155,6 +4156,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,15 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enumset"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,7 +3871,6 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4151,7 +4141,6 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4164,10 +4153,8 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ mcap = { version = "0.24", default-features = false }
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
+reqwest = { version = "0.13.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 # We restrict serde_with version so we can stay on rust 1.85 for longer. Upgrading it requires 1.88
 serde_with = { version = ">=3.14, <3.18", features = ["macros", "base64"] }

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -143,7 +143,7 @@ image = { version = "0.25.9", default-features = false, optional = true }
 yuv = { version = "0.8.9", optional = true }
 regex = { version = "1", optional = true }
 cdr = { version = "0.2.4", optional = true }
-reqwest = { version = "0.13.1", features = ["json", "query", "rustls", "stream"], optional = true }
+reqwest = { workspace = true, features = ["http2", "json", "query", "rustls-no-provider", "stream", "system-proxy"], optional = true }
 semver = { version = "1.0", optional = true }
 sysinfo = { workspace = true, optional = true }
 

--- a/rust/foxglove/Cargo.toml
+++ b/rust/foxglove/Cargo.toml
@@ -119,7 +119,16 @@ mcap.workspace = true
 parking_lot = "0.12.4"
 prost-types.workspace = true
 prost.workspace = true
+reqwest = { workspace = true, features = [
+  "http2",
+  "json",
+  "query",
+  "rustls-no-provider",
+  "stream",
+  "system-proxy",
+], optional = true }
 schemars = { version = "1.0.4", optional = true }
+semver = { version = "1.0", optional = true }
 serde_json = "1.0"
 serde_repr = { version = "0.1.19", optional = true }
 serde-constant = { version = "0.1.0", optional = true }
@@ -127,6 +136,7 @@ serde_with = { workspace = true, optional = true }
 serde.workspace = true
 smallvec = "1.15.1"
 smallbytes = "0.1.0"
+sysinfo = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio-rustls = { version = "0.26.0", optional = true, default-features = false, features = [
   "logging",
@@ -143,13 +153,11 @@ image = { version = "0.25.9", default-features = false, optional = true }
 yuv = { version = "0.8.9", optional = true }
 regex = { version = "1", optional = true }
 cdr = { version = "0.2.4", optional = true }
-reqwest = { workspace = true, features = ["http2", "json", "query", "rustls-no-provider", "stream", "system-proxy"], optional = true }
-semver = { version = "1.0", optional = true }
-sysinfo = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 rcgen = { version = "0.14.3", features = ["crypto", "pem", "x509-parser"] }
+reqwest = { workspace = true, features = ["rustls"] }
 insta.workspace = true
 axum = "0.8.8"
 hexdump = "0.1.2"

--- a/rust/remote_access_tests/Cargo.toml
+++ b/rust/remote_access_tests/Cargo.toml
@@ -9,7 +9,7 @@ foxglove = { path = "../foxglove", features = ["remote-access", "_protocol"] }
 livekit = { version = "0.7.37", features = ["rustls-tls-native-roots"] }
 livekit-api = { version = "0.4", default-features = false, features = ["access-token"] }
 axum = "0.8"
-reqwest = { workspace = true, features = ["http2", "json", "rustls-no-provider", "system-proxy"] }
+reqwest = { workspace = true, features = ["http2", "json", "rustls", "system-proxy"] }
 tokio.workspace = true
 serde.workspace = true
 serde_json = "1.0"

--- a/rust/remote_access_tests/Cargo.toml
+++ b/rust/remote_access_tests/Cargo.toml
@@ -9,7 +9,7 @@ foxglove = { path = "../foxglove", features = ["remote-access", "_protocol"] }
 livekit = { version = "0.7.37", features = ["rustls-tls-native-roots"] }
 livekit-api = { version = "0.4", default-features = false, features = ["access-token"] }
 axum = "0.8"
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { workspace = true, features = ["http2", "json", "rustls-no-provider", "system-proxy"] }
 tokio.workspace = true
 serde.workspace = true
 serde_json = "1.0"

--- a/rust/remote_data_loader_backend_conformance/Cargo.toml
+++ b/rust/remote_data_loader_backend_conformance/Cargo.toml
@@ -11,5 +11,5 @@ foxglove = { path = "../foxglove", features = ["remote_data_loader_backend"] }
 jsonschema = { version = "0.42", default-features = false }
 libtest-mimic = "0.8"
 mcap.workspace = true
-reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json"] }
+reqwest = { workspace = true, features = ["blocking", "json"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
I noticed that trying to build with --features remote-access,ring
doesn't actually exclude aws-lc-rs, because reqwest is pulling that in
via the rustls feature. What we actually want is rustls-no-provider.

This felt like a good opportunity to move reqwest up to the workspace
and specify the particular features we're actually using. For example,
we're not using charset.

### Testing
Tested `example_remote_access` built with `ring`.