### PR TITLE
netem: Add connect_and_await_startup retry helper to fix flaky impairment tests

### DIFF
--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -303,6 +303,9 @@ impl ViewerConnection {
 
     /// Connects and completes the handshake (ServerInfo + Advertise), retrying
     /// the entire flow if the byte stream drops under network impairment.
+    ///
+    /// Only use this when the gateway has at least one channel — the gateway
+    /// skips the Advertise message when there are no channels to advertise.
     pub async fn connect_and_handshake(
         room_name: &str,
         viewer_identity: &str,

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -301,14 +301,14 @@ impl ViewerConnection {
         }
     }
 
-    /// Connects and waits for the handshake (ServerInfo, plus Advertise when
-    /// `expect_advertise` is set), retrying the entire flow if the byte stream
-    /// drops under network impairment.
+    /// Connects and waits for the server's startup messages (ServerInfo, plus
+    /// Advertise when `expect_advertise` is set), retrying the entire flow if
+    /// the byte stream drops under network impairment.
     ///
     /// Set `expect_advertise` to `true` only when the gateway has at least one
     /// channel — it skips the Advertise message when there are no channels to
     /// advertise. When `false`, the returned `Advertise` is empty.
-    pub async fn connect_and_handshake(
+    pub async fn connect_and_await_startup(
         room_name: &str,
         viewer_identity: &str,
         expect_advertise: bool,
@@ -325,7 +325,7 @@ impl ViewerConnection {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             let mut viewer =
                 Self::connect_with_timeout(room_name, viewer_identity, remaining).await?;
-            let handshake = async {
+            let startup = async {
                 let server_info = viewer.expect_server_info().await?;
                 let advertise = if expect_advertise {
                     viewer.expect_advertise().await?
@@ -334,17 +334,17 @@ impl ViewerConnection {
                 };
                 anyhow::Ok((server_info, advertise))
             };
-            match handshake.await {
+            match startup.await {
                 Ok((server_info, advertise)) => {
                     return Ok((viewer, server_info, advertise));
                 }
                 Err(e) if tokio::time::Instant::now() < deadline => {
-                    info!("byte stream dropped during handshake ({e:#}), retrying");
+                    info!("byte stream dropped during startup ({e:#}), retrying");
                     let _ = viewer.close().await;
                     continue;
                 }
                 Err(e) => {
-                    return Err(e).context("handshake failed under impairment");
+                    return Err(e).context("startup failed under impairment");
                 }
             }
         }

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -301,14 +301,17 @@ impl ViewerConnection {
         }
     }
 
-    /// Connects and completes the handshake (ServerInfo + Advertise), retrying
-    /// the entire flow if the byte stream drops under network impairment.
+    /// Connects and waits for the handshake (ServerInfo, plus Advertise when
+    /// `expect_advertise` is set), retrying the entire flow if the byte stream
+    /// drops under network impairment.
     ///
-    /// Only use this when the gateway has at least one channel — the gateway
-    /// skips the Advertise message when there are no channels to advertise.
+    /// Set `expect_advertise` to `true` only when the gateway has at least one
+    /// channel — it skips the Advertise message when there are no channels to
+    /// advertise. When `false`, the returned `Advertise` is empty.
     pub async fn connect_and_handshake(
         room_name: &str,
         viewer_identity: &str,
+        expect_advertise: bool,
         timeout: Duration,
     ) -> Result<(
         Self,
@@ -317,12 +320,20 @@ impl ViewerConnection {
     )> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let remaining = deadline - tokio::time::Instant::now();
+            // `saturating_duration_since` (rather than `-`) avoids a panic if
+            // a prior iteration's `close().await` pushed us past the deadline.
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             let mut viewer =
                 Self::connect_with_timeout(room_name, viewer_identity, remaining).await?;
             let handshake = async {
                 let server_info = viewer.expect_server_info().await?;
-                let advertise = viewer.expect_advertise().await?;
+                let advertise = if expect_advertise {
+                    viewer.expect_advertise().await?
+                } else {
+                    foxglove::protocol::v2::server::Advertise {
+                        channels: Vec::new(),
+                    }
+                };
                 anyhow::Ok((server_info, advertise))
             };
             match handshake.await {

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -330,9 +330,7 @@ impl ViewerConnection {
                 let advertise = if expect_advertise {
                     viewer.expect_advertise().await?
                 } else {
-                    foxglove::protocol::v2::server::Advertise {
-                        channels: Vec::new(),
-                    }
+                    foxglove::protocol::v2::server::Advertise::new([])
                 };
                 anyhow::Ok((server_info, advertise))
             };

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -301,6 +301,43 @@ impl ViewerConnection {
         }
     }
 
+    /// Connects and completes the handshake (ServerInfo + Advertise), retrying
+    /// the entire flow if the byte stream drops under network impairment.
+    pub async fn connect_and_handshake(
+        room_name: &str,
+        viewer_identity: &str,
+        timeout: Duration,
+    ) -> Result<(
+        Self,
+        foxglove::protocol::v2::server::ServerInfo,
+        foxglove::protocol::v2::server::Advertise<'static>,
+    )> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline - tokio::time::Instant::now();
+            let mut viewer =
+                Self::connect_with_timeout(room_name, viewer_identity, remaining).await?;
+            let handshake = async {
+                let server_info = viewer.expect_server_info().await?;
+                let advertise = viewer.expect_advertise().await?;
+                anyhow::Ok((server_info, advertise))
+            };
+            match handshake.await {
+                Ok((server_info, advertise)) => {
+                    return Ok((viewer, server_info, advertise));
+                }
+                Err(e) if tokio::time::Instant::now() < deadline => {
+                    info!("byte stream dropped during handshake ({e:#}), retrying");
+                    let _ = viewer.close().await;
+                    continue;
+                }
+                Err(e) => {
+                    return Err(e).context("handshake failed under impairment");
+                }
+            }
+        }
+    }
+
     /// Reads and validates the initial ServerInfo message.
     pub async fn expect_server_info(
         &mut self,

--- a/rust/remote_access_tests/tests/netem_perlink_test.rs
+++ b/rust/remote_access_tests/tests/netem_perlink_test.rs
@@ -327,7 +327,7 @@ async fn perlink_product_viewer_connects_under_classful_qdisc() -> Result<()> {
 
     // This test has no channels, so the gateway won't send an Advertise.
     let expect_advertise = false;
-    let (viewer, server_info, _advertise) = ViewerConnection::connect_and_handshake(
+    let (viewer, server_info, _advertise) = ViewerConnection::connect_and_await_startup(
         &gw.room_name,
         "viewer-1",
         expect_advertise,
@@ -365,7 +365,7 @@ async fn perlink_product_data_track_delivery_under_classful_qdisc() -> Result<()
     let gw = TestGateway::start(&ctx).await?;
 
     let expect_advertise = true;
-    let (mut viewer, _server_info, advertise) = ViewerConnection::connect_and_handshake(
+    let (mut viewer, _server_info, advertise) = ViewerConnection::connect_and_await_startup(
         &gw.room_name,
         "viewer-1",
         expect_advertise,

--- a/rust/remote_access_tests/tests/netem_perlink_test.rs
+++ b/rust/remote_access_tests/tests/netem_perlink_test.rs
@@ -325,15 +325,33 @@ async fn perlink_product_viewer_connects_under_classful_qdisc() -> Result<()> {
     let ctx = foxglove::Context::new();
     let gw = TestGateway::start(&ctx).await?;
 
-    let (viewer, server_info, _advertise) =
-        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
-            .await?;
-
-    assert!(
-        server_info.session_id.is_some(),
-        "session_id should be present"
-    );
-    info!("ServerInfo received under classful qdisc: {server_info:?}");
+    // This test has no channels, so the gateway won't send an Advertise.
+    // Use connect_with_timeout with an inline retry for ServerInfo instead
+    // of connect_and_handshake (which waits for Advertise).
+    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
+    let viewer = loop {
+        let remaining = deadline - tokio::time::Instant::now();
+        let mut v =
+            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
+        match v.expect_server_info().await {
+            Ok(server_info) => {
+                assert!(
+                    server_info.session_id.is_some(),
+                    "session_id should be present"
+                );
+                info!("ServerInfo received under classful qdisc: {server_info:?}");
+                break v;
+            }
+            Err(e) if tokio::time::Instant::now() < deadline => {
+                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
+                let _ = v.close().await;
+                continue;
+            }
+            Err(e) => {
+                return Err(e).context("ServerInfo not received under classful qdisc");
+            }
+        }
+    };
 
     viewer.close().await?;
     gw.stop().await?;

--- a/rust/remote_access_tests/tests/netem_perlink_test.rs
+++ b/rust/remote_access_tests/tests/netem_perlink_test.rs
@@ -326,32 +326,19 @@ async fn perlink_product_viewer_connects_under_classful_qdisc() -> Result<()> {
     let gw = TestGateway::start(&ctx).await?;
 
     // This test has no channels, so the gateway won't send an Advertise.
-    // Use connect_with_timeout with an inline retry for ServerInfo instead
-    // of connect_and_handshake (which waits for Advertise).
-    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
-    let viewer = loop {
-        let remaining = deadline - tokio::time::Instant::now();
-        let mut v =
-            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
-        match v.expect_server_info().await {
-            Ok(server_info) => {
-                assert!(
-                    server_info.session_id.is_some(),
-                    "session_id should be present"
-                );
-                info!("ServerInfo received under classful qdisc: {server_info:?}");
-                break v;
-            }
-            Err(e) if tokio::time::Instant::now() < deadline => {
-                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
-                let _ = v.close().await;
-                continue;
-            }
-            Err(e) => {
-                return Err(e).context("ServerInfo not received under classful qdisc");
-            }
-        }
-    };
+    let expect_advertise = false;
+    let (viewer, server_info, _advertise) = ViewerConnection::connect_and_handshake(
+        &gw.room_name,
+        "viewer-1",
+        expect_advertise,
+        NETEM_EVENT_TIMEOUT,
+    )
+    .await?;
+    assert!(
+        server_info.session_id.is_some(),
+        "session_id should be present"
+    );
+    info!("ServerInfo received under classful qdisc: {server_info:?}");
 
     viewer.close().await?;
     gw.stop().await?;
@@ -377,9 +364,14 @@ async fn perlink_product_data_track_delivery_under_classful_qdisc() -> Result<()
 
     let gw = TestGateway::start(&ctx).await?;
 
-    let (mut viewer, _server_info, advertise) =
-        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
-            .await?;
+    let expect_advertise = true;
+    let (mut viewer, _server_info, advertise) = ViewerConnection::connect_and_handshake(
+        &gw.room_name,
+        "viewer-1",
+        expect_advertise,
+        NETEM_EVENT_TIMEOUT,
+    )
+    .await?;
     let channel_id = advertise.channels[0].id;
 
     viewer.subscribe_and_wait(&[channel_id], &channel).await?;

--- a/rust/remote_access_tests/tests/netem_perlink_test.rs
+++ b/rust/remote_access_tests/tests/netem_perlink_test.rs
@@ -317,10 +317,6 @@ fn perlink_infra_link_a_has_more_packet_loss_than_link_b() -> Result<()> {
 
 /// Verify that a viewer can connect and receive a valid `ServerInfo` message
 /// under the classful qdisc hierarchy.
-///
-/// Under network impairment the byte stream may open but drop before
-/// `ServerInfo` arrives. The test retries the full connect + handshake flow
-/// to tolerate transient stream drops without masking real failures.
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -329,32 +325,17 @@ async fn perlink_product_viewer_connects_under_classful_qdisc() -> Result<()> {
     let ctx = foxglove::Context::new();
     let gw = TestGateway::start(&ctx).await?;
 
-    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
-    loop {
-        let remaining = deadline - tokio::time::Instant::now();
-        let mut viewer =
-            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
-        match viewer.expect_server_info().await {
-            Ok(server_info) => {
-                assert!(
-                    server_info.session_id.is_some(),
-                    "session_id should be present"
-                );
-                info!("ServerInfo received under classful qdisc: {server_info:?}");
-                viewer.close().await?;
-                break;
-            }
-            Err(e) if tokio::time::Instant::now() < deadline => {
-                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
-                let _ = viewer.close().await;
-                continue;
-            }
-            Err(e) => {
-                return Err(e).context("ServerInfo not received under classful qdisc");
-            }
-        }
-    }
+    let (viewer, server_info, _advertise) =
+        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
+            .await?;
 
+    assert!(
+        server_info.session_id.is_some(),
+        "session_id should be present"
+    );
+    info!("ServerInfo received under classful qdisc: {server_info:?}");
+
+    viewer.close().await?;
     gw.stop().await?;
     Ok(())
 }
@@ -364,10 +345,6 @@ async fn perlink_product_viewer_connects_under_classful_qdisc() -> Result<()> {
 /// viewer receives it (or the test times out). This validates that the data plane
 /// functions correctly under classful qdiscs (HTB root + netem leaf), which is
 /// structurally different from the flat `root netem` tested in `netem_test.rs`.
-///
-/// Under network impairment the byte stream may open but drop before the
-/// handshake completes. The test retries the connect + handshake flow to
-/// tolerate transient stream drops without masking real failures.
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -382,53 +359,31 @@ async fn perlink_product_data_track_delivery_under_classful_qdisc() -> Result<()
 
     let gw = TestGateway::start(&ctx).await?;
 
-    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
-    loop {
-        let remaining = deadline - tokio::time::Instant::now();
-        let mut viewer =
-            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
-
-        let handshake = async {
-            let _server_info = viewer.expect_server_info().await?;
-            let advertise = viewer.expect_advertise().await?;
-            let channel_id = advertise.channels[0].id;
-            viewer.subscribe_and_wait(&[channel_id], &channel).await?;
-            anyhow::Ok(channel_id)
-        };
-
-        let channel_id = match handshake.await {
-            Ok(id) => id,
-            Err(e) if tokio::time::Instant::now() < deadline => {
-                info!("byte stream dropped during handshake ({e:#}), retrying");
-                let _ = viewer.close().await;
-                continue;
-            }
-            Err(e) => {
-                return Err(e).context("handshake failed under classful qdisc");
-            }
-        };
-
-        let payload = b"perlink-hello";
-        let sender_channel = channel.clone();
-        let sender = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_millis(50));
-            loop {
-                interval.tick().await;
-                sender_channel.log(payload);
-            }
-        });
-
-        let msg = viewer
-            .expect_new_data_track_and_message_data(channel_id)
+    let (mut viewer, _server_info, advertise) =
+        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
             .await?;
-        sender.abort();
-        assert_eq!(msg.data.as_ref(), payload);
-        info!("data track message delivered under classful qdisc");
+    let channel_id = advertise.channels[0].id;
 
-        viewer.close().await?;
-        break;
-    }
+    viewer.subscribe_and_wait(&[channel_id], &channel).await?;
 
+    let payload = b"perlink-hello";
+    let sender_channel = channel.clone();
+    let sender = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_millis(50));
+        loop {
+            interval.tick().await;
+            sender_channel.log(payload);
+        }
+    });
+
+    let msg = viewer
+        .expect_new_data_track_and_message_data(channel_id)
+        .await?;
+    sender.abort();
+    assert_eq!(msg.data.as_ref(), payload);
+    info!("data track message delivered under classful qdisc");
+
+    viewer.close().await?;
     gw.stop().await?;
     Ok(())
 }

--- a/rust/remote_access_tests/tests/netem_test.rs
+++ b/rust/remote_access_tests/tests/netem_test.rs
@@ -177,7 +177,7 @@ async fn netem_viewer_connects_under_impairment() -> Result<()> {
 
     // This test has no channels, so the gateway won't send an Advertise.
     let expect_advertise = false;
-    let (viewer, server_info, _advertise) = ViewerConnection::connect_and_handshake(
+    let (viewer, server_info, _advertise) = ViewerConnection::connect_and_await_startup(
         &gw.room_name,
         "viewer-1",
         expect_advertise,
@@ -211,7 +211,7 @@ async fn netem_channel_advertisement_under_impairment() -> Result<()> {
 
     let gw = TestGateway::start(&ctx).await?;
     let expect_advertise = true;
-    let (viewer, _server_info, advertise) = ViewerConnection::connect_and_handshake(
+    let (viewer, _server_info, advertise) = ViewerConnection::connect_and_await_startup(
         &gw.room_name,
         "viewer-1",
         expect_advertise,
@@ -246,7 +246,7 @@ async fn netem_message_delivery_under_impairment() -> Result<()> {
 
     let gw = TestGateway::start(&ctx).await?;
     let expect_advertise = true;
-    let (mut viewer, _server_info, advertise) = ViewerConnection::connect_and_handshake(
+    let (mut viewer, _server_info, advertise) = ViewerConnection::connect_and_await_startup(
         &gw.room_name,
         "viewer-1",
         expect_advertise,
@@ -301,7 +301,7 @@ async fn netem_burst_delivery_under_impairment() -> Result<()> {
 
     // This test has no channels, so the gateway won't send an Advertise.
     let expect_advertise = false;
-    let (mut viewer, _server_info, _advertise) = ViewerConnection::connect_and_handshake(
+    let (mut viewer, _server_info, _advertise) = ViewerConnection::connect_and_await_startup(
         &gw.room_name,
         "viewer-1",
         expect_advertise,

--- a/rust/remote_access_tests/tests/netem_test.rs
+++ b/rust/remote_access_tests/tests/netem_test.rs
@@ -175,15 +175,31 @@ async fn netem_viewer_connects_under_impairment() -> Result<()> {
     let ctx = foxglove::Context::new();
     let gw = TestGateway::start(&ctx).await?;
 
-    let (viewer, server_info, _advertise) =
-        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
-            .await?;
-
-    assert!(
-        server_info.session_id.is_some(),
-        "session_id should be present"
-    );
-    info!("ServerInfo received under impairment: {server_info:?}");
+    // This test has no channels, so the gateway won't send an Advertise.
+    // Use connect_with_timeout with an inline retry for ServerInfo instead
+    // of connect_and_handshake (which waits for Advertise).
+    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
+    let viewer = loop {
+        let remaining = deadline - tokio::time::Instant::now();
+        let mut v =
+            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
+        match v.expect_server_info().await {
+            Ok(server_info) => {
+                assert!(
+                    server_info.session_id.is_some(),
+                    "session_id should be present"
+                );
+                info!("ServerInfo received under impairment: {server_info:?}");
+                break v;
+            }
+            Err(e) if tokio::time::Instant::now() < deadline => {
+                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
+                let _ = v.close().await;
+                continue;
+            }
+            Err(e) => return Err(e).context("ServerInfo not received under impairment"),
+        }
+    };
 
     viewer.close().await?;
     gw.stop().await?;
@@ -284,9 +300,24 @@ async fn netem_burst_delivery_under_impairment() -> Result<()> {
     )
     .await?;
 
-    let (mut viewer, _server_info, _advertise) =
-        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
-            .await?;
+    // This test has no channels, so the gateway won't send an Advertise.
+    // Use connect_with_timeout with an inline retry for ServerInfo instead
+    // of connect_and_handshake (which waits for Advertise).
+    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
+    let mut viewer = loop {
+        let remaining = deadline - tokio::time::Instant::now();
+        let mut v =
+            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
+        match v.expect_server_info().await {
+            Ok(_) => break v,
+            Err(e) if tokio::time::Instant::now() < deadline => {
+                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
+                let _ = v.close().await;
+                continue;
+            }
+            Err(e) => return Err(e).context("ServerInfo not received under impairment"),
+        }
+    };
 
     viewer.send_subscribe_connection_graph().await?;
     let _initial = viewer.expect_connection_graph_update().await?;

--- a/rust/remote_access_tests/tests/netem_test.rs
+++ b/rust/remote_access_tests/tests/netem_test.rs
@@ -176,30 +176,19 @@ async fn netem_viewer_connects_under_impairment() -> Result<()> {
     let gw = TestGateway::start(&ctx).await?;
 
     // This test has no channels, so the gateway won't send an Advertise.
-    // Use connect_with_timeout with an inline retry for ServerInfo instead
-    // of connect_and_handshake (which waits for Advertise).
-    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
-    let viewer = loop {
-        let remaining = deadline - tokio::time::Instant::now();
-        let mut v =
-            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
-        match v.expect_server_info().await {
-            Ok(server_info) => {
-                assert!(
-                    server_info.session_id.is_some(),
-                    "session_id should be present"
-                );
-                info!("ServerInfo received under impairment: {server_info:?}");
-                break v;
-            }
-            Err(e) if tokio::time::Instant::now() < deadline => {
-                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
-                let _ = v.close().await;
-                continue;
-            }
-            Err(e) => return Err(e).context("ServerInfo not received under impairment"),
-        }
-    };
+    let expect_advertise = false;
+    let (viewer, server_info, _advertise) = ViewerConnection::connect_and_handshake(
+        &gw.room_name,
+        "viewer-1",
+        expect_advertise,
+        NETEM_EVENT_TIMEOUT,
+    )
+    .await?;
+    assert!(
+        server_info.session_id.is_some(),
+        "session_id should be present"
+    );
+    info!("ServerInfo received under impairment: {server_info:?}");
 
     viewer.close().await?;
     gw.stop().await?;
@@ -221,9 +210,14 @@ async fn netem_channel_advertisement_under_impairment() -> Result<()> {
         .context("create channel")?;
 
     let gw = TestGateway::start(&ctx).await?;
-    let (viewer, _server_info, advertise) =
-        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
-            .await?;
+    let expect_advertise = true;
+    let (viewer, _server_info, advertise) = ViewerConnection::connect_and_handshake(
+        &gw.room_name,
+        "viewer-1",
+        expect_advertise,
+        NETEM_EVENT_TIMEOUT,
+    )
+    .await?;
 
     assert_eq!(advertise.channels.len(), 1);
     assert_eq!(advertise.channels[0].topic, "/netem-test");
@@ -251,9 +245,14 @@ async fn netem_message_delivery_under_impairment() -> Result<()> {
         .context("create channel")?;
 
     let gw = TestGateway::start(&ctx).await?;
-    let (mut viewer, _server_info, advertise) =
-        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
-            .await?;
+    let expect_advertise = true;
+    let (mut viewer, _server_info, advertise) = ViewerConnection::connect_and_handshake(
+        &gw.room_name,
+        "viewer-1",
+        expect_advertise,
+        NETEM_EVENT_TIMEOUT,
+    )
+    .await?;
     let channel_id = advertise.channels[0].id;
 
     viewer.subscribe_and_wait(&[channel_id], &channel).await?;
@@ -301,23 +300,14 @@ async fn netem_burst_delivery_under_impairment() -> Result<()> {
     .await?;
 
     // This test has no channels, so the gateway won't send an Advertise.
-    // Use connect_with_timeout with an inline retry for ServerInfo instead
-    // of connect_and_handshake (which waits for Advertise).
-    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
-    let mut viewer = loop {
-        let remaining = deadline - tokio::time::Instant::now();
-        let mut v =
-            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
-        match v.expect_server_info().await {
-            Ok(_) => break v,
-            Err(e) if tokio::time::Instant::now() < deadline => {
-                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
-                let _ = v.close().await;
-                continue;
-            }
-            Err(e) => return Err(e).context("ServerInfo not received under impairment"),
-        }
-    };
+    let expect_advertise = false;
+    let (mut viewer, _server_info, _advertise) = ViewerConnection::connect_and_handshake(
+        &gw.room_name,
+        "viewer-1",
+        expect_advertise,
+        NETEM_EVENT_TIMEOUT,
+    )
+    .await?;
 
     viewer.send_subscribe_connection_graph().await?;
     let _initial = viewer.expect_connection_graph_update().await?;

--- a/rust/remote_access_tests/tests/netem_test.rs
+++ b/rust/remote_access_tests/tests/netem_test.rs
@@ -175,10 +175,9 @@ async fn netem_viewer_connects_under_impairment() -> Result<()> {
     let ctx = foxglove::Context::new();
     let gw = TestGateway::start(&ctx).await?;
 
-    let mut viewer =
-        ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
+    let (viewer, server_info, _advertise) =
+        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
             .await?;
-    let server_info = viewer.expect_server_info().await?;
 
     assert!(
         server_info.session_id.is_some(),
@@ -206,12 +205,9 @@ async fn netem_channel_advertisement_under_impairment() -> Result<()> {
         .context("create channel")?;
 
     let gw = TestGateway::start(&ctx).await?;
-    let mut viewer =
-        ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
+    let (viewer, _server_info, advertise) =
+        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
             .await?;
-
-    let _server_info = viewer.expect_server_info().await?;
-    let advertise = viewer.expect_advertise().await?;
 
     assert_eq!(advertise.channels.len(), 1);
     assert_eq!(advertise.channels[0].topic, "/netem-test");
@@ -239,12 +235,9 @@ async fn netem_message_delivery_under_impairment() -> Result<()> {
         .context("create channel")?;
 
     let gw = TestGateway::start(&ctx).await?;
-    let mut viewer =
-        ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
+    let (mut viewer, _server_info, advertise) =
+        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
             .await?;
-
-    let _server_info = viewer.expect_server_info().await?;
-    let advertise = viewer.expect_advertise().await?;
     let channel_id = advertise.channels[0].id;
 
     viewer.subscribe_and_wait(&[channel_id], &channel).await?;
@@ -291,11 +284,21 @@ async fn netem_burst_delivery_under_impairment() -> Result<()> {
     )
     .await?;
 
-    let mut viewer =
-        ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
-            .await?;
-
-    let _server_info = viewer.expect_server_info().await?;
+    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
+    let mut viewer = loop {
+        let remaining = deadline - tokio::time::Instant::now();
+        let mut v =
+            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
+        match v.expect_server_info().await {
+            Ok(_server_info) => break v,
+            Err(e) if tokio::time::Instant::now() < deadline => {
+                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
+                let _ = v.close().await;
+                continue;
+            }
+            Err(e) => return Err(e).context("ServerInfo not received under impairment"),
+        }
+    };
 
     viewer.send_subscribe_connection_graph().await?;
     let _initial = viewer.expect_connection_graph_update().await?;

--- a/rust/remote_access_tests/tests/netem_test.rs
+++ b/rust/remote_access_tests/tests/netem_test.rs
@@ -284,21 +284,9 @@ async fn netem_burst_delivery_under_impairment() -> Result<()> {
     )
     .await?;
 
-    let deadline = tokio::time::Instant::now() + NETEM_EVENT_TIMEOUT;
-    let mut viewer = loop {
-        let remaining = deadline - tokio::time::Instant::now();
-        let mut v =
-            ViewerConnection::connect_with_timeout(&gw.room_name, "viewer-1", remaining).await?;
-        match v.expect_server_info().await {
-            Ok(_server_info) => break v,
-            Err(e) if tokio::time::Instant::now() < deadline => {
-                info!("byte stream dropped before ServerInfo ({e:#}), retrying");
-                let _ = v.close().await;
-                continue;
-            }
-            Err(e) => return Err(e).context("ServerInfo not received under impairment"),
-        }
-    };
+    let (mut viewer, _server_info, _advertise) =
+        ViewerConnection::connect_and_handshake(&gw.room_name, "viewer-1", NETEM_EVENT_TIMEOUT)
+            .await?;
 
     viewer.send_subscribe_connection_graph().await?;
     let _initial = viewer.expect_connection_graph_update().await?;


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

The netem product tests were flaky under network impairment: a viewer's reliable byte stream can drop mid-handshake, and the tests failed instead of reconnecting (FLE-538: "waiting for gateway byte stream" timeout).

`connect_and_handshake` retries the full connect → ServerInfo (→ Advertise) flow when the byte stream drops. An `expect_advertise` flag covers the no-channel tests — the gateway omits Advertise when there are no channels to advertise — so all six netem callsites share one retry path instead of three hand-rolling the same ServerInfo loop. The deadline math also uses `saturating_duration_since` so a slow `close().await` under impairment can't push it past the deadline and panic on `Instant` subtraction.

**Manual testing** (Apple M5, 10 cores, 24 GB, macOS 26.5, Docker 29.1.5):

- Flat stack (`docker-compose.netem.yml`, default `delay 80ms 20ms loss 2%`): `netem_test` suite — including the formerly-flaky `netem_viewer_connects_under_impairment` and `netem_burst_delivery_under_impairment` — run 6 consecutive times, 36 test executions, 0 failures.
- Per-link stack (`docker-compose.netem-perlink.yml`, link A `delay 200ms 50ms loss 5%`, link B `delay 10ms 2ms`): `netem_perlink_test` full suite once plus `perlink_product` twice — `perlink_product_viewer_connects_under_classful_qdisc` and `perlink_product_data_track_delivery_under_classful_qdisc` passed 3× — 0 failures.

Fixes: [FLE-538](https://linear.app/foxglove/issue/FLE-538)
