### PR TITLE
cpp: Refactor RemoteAccessGateway::create and WebSocketServer::create

### DIFF
--- a/cpp/cmake/foxglove-sources.cmake
+++ b/cpp/cmake/foxglove-sources.cmake
@@ -10,6 +10,7 @@
 # Add new source files here. The in-tree build and the dist both pick them up.
 
 set(FOXGLOVE_CPP_HANDWRITTEN_SOURCES
+  callback_forwarders.cpp
   channel.cpp
   connection_graph.cpp
   context.cpp

--- a/cpp/foxglove/include/foxglove/fetch_asset.hpp
+++ b/cpp/foxglove/include/foxglove/fetch_asset.hpp
@@ -9,6 +9,12 @@ struct foxglove_fetch_asset_responder;
 
 namespace foxglove {
 
+/// @cond foxglove_internal
+namespace internal {
+struct ForwarderAccess;
+}
+/// @endcond
+
 /// @brief A fetch asset responder.
 ///
 /// This is the means by which a fetch asset implementation responds to a
@@ -46,6 +52,7 @@ public:
 private:
   friend class WebSocketServer;
   friend class RemoteAccessGateway;
+  friend struct internal::ForwarderAccess;
 
   struct Deleter {
     void operator()(foxglove_fetch_asset_responder* ptr) const noexcept;

--- a/cpp/foxglove/include/foxglove/parameter.hpp
+++ b/cpp/foxglove/include/foxglove/parameter.hpp
@@ -21,6 +21,12 @@ struct foxglove_parameter_array;
 
 namespace foxglove {
 
+/// @cond foxglove_internal
+namespace internal {
+struct ForwarderAccess;
+}
+/// @endcond
+
 /// @brief An optional type hint for a `Parameter`, used to disambiguate values whose intended
 /// type cannot be inferred from the wire representation alone.
 ///
@@ -720,6 +726,7 @@ private:
   friend class RemoteAccessGateway;
   friend class GetParametersResponder;
   friend class SetParametersResponder;
+  friend struct internal::ForwarderAccess;
 
   struct Deleter {
     void operator()(foxglove_parameter_array* ptr) const noexcept;

--- a/cpp/foxglove/include/foxglove/parameter_handler.hpp
+++ b/cpp/foxglove/include/foxglove/parameter_handler.hpp
@@ -14,6 +14,12 @@ struct foxglove_set_parameters_responder;
 
 namespace foxglove {
 
+/// @cond foxglove_internal
+namespace internal {
+struct ForwarderAccess;
+}
+/// @endcond
+
 /// @brief Responder for a client `getParameters` request.
 ///
 /// This is the means by which a parameter handler responds to a get request
@@ -47,6 +53,7 @@ public:
 private:
   friend class WebSocketServer;
   friend class RemoteAccessGateway;
+  friend struct internal::ForwarderAccess;
 
   struct Deleter {
     void operator()(foxglove_get_parameters_responder* ptr) const noexcept;
@@ -102,6 +109,7 @@ public:
 private:
   friend class WebSocketServer;
   friend class RemoteAccessGateway;
+  friend struct internal::ForwarderAccess;
 
   struct Deleter {
     void operator()(foxglove_set_parameters_responder* ptr) const noexcept;

--- a/cpp/foxglove/src/callback_forwarders.cpp
+++ b/cpp/foxglove/src/callback_forwarders.cpp
@@ -1,0 +1,97 @@
+#include "callback_forwarders.hpp"
+
+#include <foxglove-c/foxglove-c.h>
+#include <foxglove/channel.hpp>
+#include <foxglove/error.hpp>
+#include <foxglove/fetch_asset.hpp>
+#include <foxglove/parameter.hpp>
+#include <foxglove/parameter_handler.hpp>
+
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace foxglove::internal {
+
+void forwardFetchAsset(
+  const void* context, const foxglove_string* c_uri, foxglove_fetch_asset_responder* c_responder
+) {
+  const auto* handler = static_cast<const FetchAssetHandler*>(context);
+  std::string_view uri{c_uri->data, c_uri->len};
+  auto responder = ForwarderAccess::makeFetchAssetResponder(c_responder);
+  try {
+    (*handler)(uri, std::move(responder));
+  } catch (const std::exception& exc) {
+    warn() << "Fetch asset callback failed: " << exc.what();
+    constexpr std::string_view kErrMessage{"Fetch asset callback failed"};
+    if (auto* ptr = ForwarderAccess::releaseFetchAsset(responder)) {
+      foxglove_fetch_asset_respond_error(ptr, {kErrMessage.data(), kErrMessage.size()});
+    }
+  }
+}
+
+bool forwardSinkChannelFilter(const void* context, const foxglove_channel_descriptor* channel) {
+  if (!context) {
+    return true;
+  }
+  try {
+    const auto* filter = static_cast<const SinkChannelFilterFn*>(context);
+    auto cpp_channel = ChannelDescriptor(channel);
+    return (*filter)(cpp_channel);
+  } catch (const std::exception& exc) {
+    warn() << "Sink channel filter failed: " << exc.what();
+    return false;
+  }
+}
+
+void forwardParameterHandlerGet(
+  const void* context, uint32_t client_id, const foxglove_string* c_request_id,
+  const foxglove_string* c_param_names, size_t param_names_len,
+  foxglove_get_parameters_responder* c_responder
+) {
+  // Take ownership of the responder before any throwable work, so its destructor
+  // sends the generic error to the client if anything below throws.
+  auto responder = ForwarderAccess::makeGetResponder(c_responder);
+  callbackGuard("ParameterHandler.onGet", [&] {
+    std::optional<std::string_view> request_id;
+    if (c_request_id != nullptr) {
+      request_id.emplace(c_request_id->data, c_request_id->len);
+    }
+    std::vector<std::string_view> param_names;
+    if (c_param_names != nullptr) {
+      param_names.reserve(param_names_len);
+      for (size_t i = 0; i < param_names_len; ++i) {
+        param_names.emplace_back(c_param_names[i].data, c_param_names[i].len);
+      }
+    }
+    (static_cast<const ParameterHandler*>(context))
+      ->onGet(client_id, request_id, param_names, std::move(responder));
+  });
+}
+
+void forwardParameterHandlerSet(
+  const void* context, uint32_t client_id, const foxglove_string* c_request_id,
+  const foxglove_parameter_array* c_params, foxglove_set_parameters_responder* c_responder
+) {
+  // Take ownership of the responder before any throwable work, so its destructor
+  // sends the generic error to the client if anything below throws.
+  auto responder = ForwarderAccess::makeSetResponder(c_responder);
+  callbackGuard("ParameterHandler.onSet", [&] {
+    if (c_params == nullptr) {
+      // Should not happen; the C implementation never passes a null pointer.
+      std::move(responder).respond({});
+      return;
+    }
+    std::optional<std::string_view> request_id;
+    if (c_request_id != nullptr) {
+      request_id.emplace(c_request_id->data, c_request_id->len);
+    }
+    (static_cast<const ParameterHandler*>(context))
+      ->onSet(
+        client_id, request_id, ParameterArrayView(c_params).parameters(), std::move(responder)
+      );
+  });
+}
+
+}  // namespace foxglove::internal

--- a/cpp/foxglove/src/callback_forwarders.cpp
+++ b/cpp/foxglove/src/callback_forwarders.cpp
@@ -32,7 +32,7 @@ void forwardFetchAsset(
 }
 
 bool forwardSinkChannelFilter(const void* context, const foxglove_channel_descriptor* channel) {
-  if (!context) {
+  if (context == nullptr) {
     return true;
   }
   try {
@@ -78,15 +78,11 @@ void forwardParameterHandlerSet(
   // sends the generic error to the client if anything below throws.
   auto responder = ForwarderAccess::makeSetResponder(c_responder);
   callbackGuard("ParameterHandler.onSet", [&] {
-    if (c_params == nullptr) {
-      // Should not happen; the C implementation never passes a null pointer.
-      std::move(responder).respond({});
-      return;
-    }
     std::optional<std::string_view> request_id;
     if (c_request_id != nullptr) {
       request_id.emplace(c_request_id->data, c_request_id->len);
     }
+    // The C ABI guarantees that c_params is never null.
     (static_cast<const ParameterHandler*>(context))
       ->onSet(
         client_id, request_id, ParameterArrayView(c_params).parameters(), std::move(responder)

--- a/cpp/foxglove/src/callback_forwarders.hpp
+++ b/cpp/foxglove/src/callback_forwarders.hpp
@@ -217,9 +217,9 @@ void wireSinkChannelFilter(
 
 /// Validate and wire a ParameterHandler. Returns ValueError if exactly one of
 /// onGet/onSet is set. If both are unset, leaves c_options.parameter_handler
-/// untouched and returns nullopt.
+/// untouched and returns Ok.
 template<class COptions>
-std::optional<FoxgloveError> wireParameterHandler(
+FoxgloveError wireParameterHandler(
   COptions& c_options, foxglove_parameter_handler& c_handler, ParameterHandler&& cpp_handler,
   std::unique_ptr<ParameterHandler>& out
 ) {
@@ -230,14 +230,14 @@ std::optional<FoxgloveError> wireParameterHandler(
     return FoxgloveError::ValueError;
   }
   if (!has_on_get) {
-    return std::nullopt;
+    return FoxgloveError::Ok;
   }
   out = std::make_unique<ParameterHandler>(std::move(cpp_handler));
   c_handler.context = out.get();
   c_handler.get = &forwardParameterHandlerGet;
   c_handler.set = &forwardParameterHandlerSet;
   c_options.parameter_handler = &c_handler;
-  return std::nullopt;
+  return FoxgloveError::Ok;
 }
 
 }  // namespace foxglove::internal

--- a/cpp/foxglove/src/callback_forwarders.hpp
+++ b/cpp/foxglove/src/callback_forwarders.hpp
@@ -1,0 +1,245 @@
+#pragma once
+
+/// @cond foxglove_internal
+
+#include <foxglove-c/foxglove-c.h>
+#include <foxglove/channel.hpp>
+#include <foxglove/error.hpp>
+#include <foxglove/fetch_asset.hpp>
+#include <foxglove/parameter.hpp>
+#include <foxglove/parameter_handler.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace foxglove::internal {
+
+/// Grants the forwarder functions access to the responder and ParameterArray
+/// types' private raw-pointer accessors. Declared as a friend by each of those
+/// classes via its public header.
+struct ForwarderAccess {
+  static FetchAssetResponder makeFetchAssetResponder(foxglove_fetch_asset_responder* p) {
+    return FetchAssetResponder(p);
+  }
+  static foxglove_fetch_asset_responder* releaseFetchAsset(FetchAssetResponder& r) {
+    return r.impl_.release();
+  }
+  static GetParametersResponder makeGetResponder(foxglove_get_parameters_responder* p) {
+    return GetParametersResponder(p);
+  }
+  static SetParametersResponder makeSetResponder(foxglove_set_parameters_responder* p) {
+    return SetParametersResponder(p);
+  }
+  static foxglove_parameter_array* releaseParameterArray(ParameterArray& a) {
+    return a.release();
+  }
+};
+
+/// try/catch wrapper for callback bodies. Catches std::exception so an
+/// exception thrown by user code never propagates back into Rust.
+template<class F>
+inline void callbackGuard(const char* name, F&& f) noexcept {
+  try {
+    std::forward<F>(f)();
+  } catch (const std::exception& exc) {
+    warn() << name << " callback failed: " << exc.what();
+  }
+}
+
+// Forwarders are pointed to by C ABI function pointer fields. The `context`
+// argument is the C++ handler object owned by the create() caller.
+
+void forwardFetchAsset(
+  const void* context, const foxglove_string* c_uri, foxglove_fetch_asset_responder* c_responder
+);
+
+bool forwardSinkChannelFilter(const void* context, const foxglove_channel_descriptor* channel);
+
+void forwardParameterHandlerGet(
+  const void* context, uint32_t client_id, const foxglove_string* c_request_id,
+  const foxglove_string* c_param_names, size_t param_names_len,
+  foxglove_get_parameters_responder* c_responder
+);
+
+void forwardParameterHandlerSet(
+  const void* context, uint32_t client_id, const foxglove_string* c_request_id,
+  const foxglove_parameter_array* c_params, foxglove_set_parameters_responder* c_responder
+);
+
+// Forwarders shared between the WebSocket server and the remote access gateway:
+// they have callback fields with identical signatures, and the C ABI uses the
+// same function-pointer types. Templated on the C++ callbacks struct
+// (WebSocketServerCallbacks or RemoteAccessGatewayCallbacks).
+
+template<class Callbacks>
+void forwardParametersSubscribe(
+  const void* context, const foxglove_string* c_names, size_t names_len
+) {
+  callbackGuard("onParametersSubscribe", [&] {
+    std::vector<std::string_view> names;
+    names.reserve(names_len);
+    for (size_t i = 0; i < names_len; ++i) {
+      names.emplace_back(c_names[i].data, c_names[i].len);
+    }
+    (static_cast<const Callbacks*>(context))->onParametersSubscribe(names);
+  });
+}
+
+template<class Callbacks>
+void forwardParametersUnsubscribe(
+  const void* context, const foxglove_string* c_names, size_t names_len
+) {
+  callbackGuard("onParametersUnsubscribe", [&] {
+    std::vector<std::string_view> names;
+    names.reserve(names_len);
+    for (size_t i = 0; i < names_len; ++i) {
+      names.emplace_back(c_names[i].data, c_names[i].len);
+    }
+    (static_cast<const Callbacks*>(context))->onParametersUnsubscribe(names);
+  });
+}
+
+template<class Callbacks>
+void forwardConnectionGraphSubscribe(const void* context) {
+  callbackGuard("onConnectionGraphSubscribe", [&] {
+    (static_cast<const Callbacks*>(context))->onConnectionGraphSubscribe();
+  });
+}
+
+template<class Callbacks>
+void forwardConnectionGraphUnsubscribe(const void* context) {
+  callbackGuard("onConnectionGraphUnsubscribe", [&] {
+    (static_cast<const Callbacks*>(context))->onConnectionGraphUnsubscribe();
+  });
+}
+
+// The legacy forwarders reference [[deprecated]] fields on the C++ callbacks
+// structs (onGetParameters/onSetParameters). This file is the internal C-ABI
+// forwarder and must keep reading them, so silence the warning at the
+// template definition.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+// Build the result entirely inside callbackGuard so that allocation failure
+// (e.g. building param_names, or the ParameterArray itself) cannot propagate
+// an exception back across the C ABI. On any throw, returns nullptr.
+template<class Callbacks>
+foxglove_parameter_array* forwardLegacyGetParameters(
+  const void* context, uint32_t client_id, const foxglove_string* c_request_id,
+  const foxglove_string* c_param_names, size_t param_names_len
+) {
+  foxglove_parameter_array* result = nullptr;
+  callbackGuard("onGetParameters", [&] {
+    std::optional<std::string_view> request_id;
+    if (c_request_id != nullptr) {
+      request_id.emplace(c_request_id->data, c_request_id->len);
+    }
+    std::vector<std::string_view> param_names;
+    if (c_param_names != nullptr) {
+      param_names.reserve(param_names_len);
+      for (size_t i = 0; i < param_names_len; ++i) {
+        param_names.emplace_back(c_param_names[i].data, c_param_names[i].len);
+      }
+    }
+    auto params =
+      (static_cast<const Callbacks*>(context))->onGetParameters(client_id, request_id, param_names);
+    auto array = ParameterArray(std::move(params));
+    result = ForwarderAccess::releaseParameterArray(array);
+  });
+  return result;
+}
+
+template<class Callbacks>
+foxglove_parameter_array* forwardLegacySetParameters(
+  const void* context, uint32_t client_id, const foxglove_string* c_request_id,
+  const foxglove_parameter_array* c_params
+) {
+  if (c_params == nullptr) {
+    return nullptr;
+  }
+  foxglove_parameter_array* result = nullptr;
+  callbackGuard("onSetParameters", [&] {
+    std::optional<std::string_view> request_id;
+    if (c_request_id != nullptr) {
+      request_id.emplace(c_request_id->data, c_request_id->len);
+    }
+    auto params =
+      (static_cast<const Callbacks*>(context))
+        ->onSetParameters(client_id, request_id, ParameterArrayView(c_params).parameters());
+    auto array = ParameterArray(std::move(params));
+    result = ForwarderAccess::releaseParameterArray(array);
+  });
+  return result;
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+// Wiring helpers. Templated on the C options struct because foxglove_server_options
+// and foxglove_gateway_options share field names but are distinct types.
+
+template<class COptions>
+void wireFetchAsset(
+  COptions& c_options, FetchAssetHandler&& cpp_handler, std::unique_ptr<FetchAssetHandler>& out
+) {
+  if (!cpp_handler) {
+    return;
+  }
+  out = std::make_unique<FetchAssetHandler>(std::move(cpp_handler));
+  c_options.fetch_asset_context = out.get();
+  c_options.fetch_asset = &forwardFetchAsset;
+}
+
+template<class COptions>
+void wireSinkChannelFilter(
+  COptions& c_options, SinkChannelFilterFn&& cpp_handler, std::unique_ptr<SinkChannelFilterFn>& out
+) {
+  if (!cpp_handler) {
+    return;
+  }
+  out = std::make_unique<SinkChannelFilterFn>(std::move(cpp_handler));
+  c_options.sink_channel_filter_context = out.get();
+  c_options.sink_channel_filter = &forwardSinkChannelFilter;
+}
+
+/// Validate and wire a ParameterHandler. Returns ValueError if exactly one of
+/// onGet/onSet is set. If both are unset, leaves c_options.parameter_handler
+/// untouched and returns nullopt.
+template<class COptions>
+std::optional<FoxgloveError> wireParameterHandler(
+  COptions& c_options, foxglove_parameter_handler& c_handler, ParameterHandler&& cpp_handler,
+  std::unique_ptr<ParameterHandler>& out
+) {
+  const bool has_on_get = bool(cpp_handler.onGet);
+  const bool has_on_set = bool(cpp_handler.onSet);
+  if (has_on_get != has_on_set) {
+    warn() << "ParameterHandler requires both onGet and onSet to be set";
+    return FoxgloveError::ValueError;
+  }
+  if (!has_on_get) {
+    return std::nullopt;
+  }
+  out = std::make_unique<ParameterHandler>(std::move(cpp_handler));
+  c_handler.context = out.get();
+  c_handler.get = &forwardParameterHandlerGet;
+  c_handler.set = &forwardParameterHandlerSet;
+  c_options.parameter_handler = &c_handler;
+  return std::nullopt;
+}
+
+}  // namespace foxglove::internal
+
+/// @endcond

--- a/cpp/foxglove/src/remote_access.cpp
+++ b/cpp/foxglove/src/remote_access.cpp
@@ -12,17 +12,101 @@
 #include <foxglove/error.hpp>
 #include <foxglove/remote_access.hpp>
 
+#include "callback_forwarders.hpp"
+
 namespace foxglove {
+namespace {
 
-FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
-  RemoteAccessGatewayOptions&&
-    options  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+void forwardOnConnectionStatusChanged(const void* context, foxglove_connection_status status) {
+  internal::callbackGuard("onConnectionStatusChanged", [&] {
+    static_cast<const RemoteAccessGatewayCallbacks*>(context)->onConnectionStatusChanged(
+      static_cast<RemoteAccessConnectionStatus>(status)
+    );
+  });
+}
+
+void forwardOnSubscribe(
+  const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel
 ) {
-  foxglove_internal_register_cpp_wrapper();
+  internal::callbackGuard("onSubscribe", [&] {
+    auto cpp_channel = ChannelDescriptor(channel);
+    static_cast<const RemoteAccessGatewayCallbacks*>(context)->onSubscribe(client_id, cpp_channel);
+  });
+}
 
-// The legacy onGetParameters/onSetParameters callbacks below are marked
-// [[deprecated]] for consumers, but this file is the internal bridge that
-// forwards them to the C ABI and must keep reading them.
+void forwardOnUnsubscribe(
+  const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel
+) {
+  internal::callbackGuard("onUnsubscribe", [&] {
+    auto cpp_channel = ChannelDescriptor(channel);
+    static_cast<const RemoteAccessGatewayCallbacks*>(context)->onUnsubscribe(
+      client_id, cpp_channel
+    );
+  });
+}
+
+void forwardOnMessageData(
+  const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel,
+  const uint8_t* payload, size_t payload_len
+) {
+  internal::callbackGuard("onMessageData", [&] {
+    auto cpp_channel = ChannelDescriptor(channel);
+    static_cast<const RemoteAccessGatewayCallbacks*>(context)->onMessageData(
+      client_id, cpp_channel, reinterpret_cast<const std::byte*>(payload), payload_len
+    );
+  });
+}
+
+void forwardOnClientAdvertise(
+  const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel
+) {
+  internal::callbackGuard("onClientAdvertise", [&] {
+    auto cpp_channel = ChannelDescriptor(channel);
+    static_cast<const RemoteAccessGatewayCallbacks*>(context)->onClientAdvertise(
+      client_id, cpp_channel
+    );
+  });
+}
+
+void forwardOnClientUnadvertise(
+  const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel
+) {
+  internal::callbackGuard("onClientUnadvertise", [&] {
+    auto cpp_channel = ChannelDescriptor(channel);
+    static_cast<const RemoteAccessGatewayCallbacks*>(context)->onClientUnadvertise(
+      client_id, cpp_channel
+    );
+  });
+}
+
+foxglove_qos_profile forwardQosClassifier(
+  const void* context, const foxglove_channel_descriptor* channel
+) {
+  if (!context) {
+    return {FOXGLOVE_RELIABILITY_LOSSY};
+  }
+  try {
+    const auto* classifier = static_cast<const QosClassifierFn*>(context);
+    auto cpp_channel = ChannelDescriptor(channel);
+    auto profile = (*classifier)(cpp_channel);
+    return {static_cast<foxglove_reliability>(profile.reliability)};
+  } catch (const std::exception& exc) {
+    warn() << "QoS classifier failed: " << exc.what();
+    return {FOXGLOVE_RELIABILITY_LOSSY};
+  }
+}
+
+// Populates `c` with forward function pointers for every callback set on `cb`,
+// and reports whether any callback was set. Callers should leave both the
+// heap-allocated callbacks wrapper unallocated and `c_options.callbacks` null
+// when this returns false: the Rust side skips registering a listener entirely
+// for a null callbacks pointer, so we want to match that "no listener at all"
+// path rather than registering an empty one. `c.context` is left untouched;
+// the caller sets it once it has constructed the wrapper.
+//
+// The legacy onGetParameters/onSetParameters fields are [[deprecated]] for
+// consumers, but this file is the internal C-ABI forward and must keep
+// reading them.
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -30,226 +114,90 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
 #pragma warning(push)
 #pragma warning(disable : 4996)
 #endif
+bool wireGatewayCallbacks(foxglove_gateway_callbacks& c, const RemoteAccessGatewayCallbacks& cb) {
+  bool any = false;
+  if (cb.onConnectionStatusChanged) {
+    c.on_connection_status_changed = &forwardOnConnectionStatusChanged;
+    any = true;
+  }
+  if (cb.onSubscribe) {
+    c.on_subscribe = &forwardOnSubscribe;
+    any = true;
+  }
+  if (cb.onUnsubscribe) {
+    c.on_unsubscribe = &forwardOnUnsubscribe;
+    any = true;
+  }
+  if (cb.onMessageData) {
+    c.on_message_data = &forwardOnMessageData;
+    any = true;
+  }
+  if (cb.onClientAdvertise) {
+    c.on_client_advertise = &forwardOnClientAdvertise;
+    any = true;
+  }
+  if (cb.onClientUnadvertise) {
+    c.on_client_unadvertise = &forwardOnClientUnadvertise;
+    any = true;
+  }
+  if (cb.onGetParameters) {
+    c.on_get_parameters = &internal::forwardLegacyGetParameters<RemoteAccessGatewayCallbacks>;
+    any = true;
+  }
+  if (cb.onSetParameters) {
+    c.on_set_parameters = &internal::forwardLegacySetParameters<RemoteAccessGatewayCallbacks>;
+    any = true;
+  }
+  if (cb.onParametersSubscribe) {
+    c.on_parameters_subscribe = &internal::forwardParametersSubscribe<RemoteAccessGatewayCallbacks>;
+    any = true;
+  }
+  if (cb.onParametersUnsubscribe) {
+    c.on_parameters_unsubscribe =
+      &internal::forwardParametersUnsubscribe<RemoteAccessGatewayCallbacks>;
+    any = true;
+  }
+  if (cb.onConnectionGraphSubscribe) {
+    c.on_connection_graph_subscribe =
+      &internal::forwardConnectionGraphSubscribe<RemoteAccessGatewayCallbacks>;
+    any = true;
+  }
+  if (cb.onConnectionGraphUnsubscribe) {
+    c.on_connection_graph_unsubscribe =
+      &internal::forwardConnectionGraphUnsubscribe<RemoteAccessGatewayCallbacks>;
+    any = true;
+  }
+  return any;
+}
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
-  bool has_any_callbacks =
-    options.callbacks.onConnectionStatusChanged || options.callbacks.onSubscribe ||
-    options.callbacks.onUnsubscribe || options.callbacks.onMessageData ||
-    options.callbacks.onClientAdvertise || options.callbacks.onClientUnadvertise ||
-    options.callbacks.onGetParameters || options.callbacks.onSetParameters ||
-    options.callbacks.onParametersSubscribe || options.callbacks.onParametersUnsubscribe ||
-    options.callbacks.onConnectionGraphSubscribe || options.callbacks.onConnectionGraphUnsubscribe;
+}  // namespace
 
+FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(RemoteAccessGatewayOptions&& options
+) {
+  foxglove_internal_register_cpp_wrapper();
+
+  foxglove_gateway_callbacks c_callbacks = {};
   std::unique_ptr<RemoteAccessGatewayCallbacks> callbacks;
+  if (wireGatewayCallbacks(c_callbacks, options.callbacks)) {
+    callbacks = std::make_unique<RemoteAccessGatewayCallbacks>(std::move(options.callbacks));
+    c_callbacks.context = callbacks.get();
+  }
+
   std::unique_ptr<FetchAssetHandler> fetch_asset;
   std::unique_ptr<SinkChannelFilterFn> sink_channel_filter;
   std::unique_ptr<ParameterHandler> parameter_handler;
-
-  foxglove_gateway_callbacks c_callbacks = {};
-
-  if (has_any_callbacks) {
-    callbacks = std::make_unique<RemoteAccessGatewayCallbacks>(std::move(options.callbacks));
-    c_callbacks.context = callbacks.get();
-
-    if (callbacks->onConnectionStatusChanged) {
-      c_callbacks.on_connection_status_changed =
-        [](const void* context, foxglove_connection_status status) {
-          try {
-            (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-              ->onConnectionStatusChanged(static_cast<RemoteAccessConnectionStatus>(status));
-          } catch (const std::exception& exc) {
-            warn() << "onConnectionStatusChanged callback failed: " << exc.what();
-          }
-        };
-    }
-
-    if (callbacks->onSubscribe) {
-      c_callbacks.on_subscribe =
-        [](const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel) {
-          try {
-            auto cpp_channel = ChannelDescriptor(channel);
-            (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-              ->onSubscribe(client_id, cpp_channel);
-          } catch (const std::exception& exc) {
-            warn() << "onSubscribe callback failed: " << exc.what();
-          }
-        };
-    }
-
-    if (callbacks->onUnsubscribe) {
-      c_callbacks.on_unsubscribe =
-        [](const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel) {
-          try {
-            auto cpp_channel = ChannelDescriptor(channel);
-            (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-              ->onUnsubscribe(client_id, cpp_channel);
-          } catch (const std::exception& exc) {
-            warn() << "onUnsubscribe callback failed: " << exc.what();
-          }
-        };
-    }
-
-    if (callbacks->onMessageData) {
-      c_callbacks.on_message_data = [](
-                                      const void* context,
-                                      uint32_t client_id,
-                                      const foxglove_channel_descriptor* channel,
-                                      const uint8_t* payload,
-                                      size_t payload_len
-                                    ) {
-        try {
-          auto cpp_channel = ChannelDescriptor(channel);
-          (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-            ->onMessageData(
-              client_id, cpp_channel, reinterpret_cast<const std::byte*>(payload), payload_len
-            );
-        } catch (const std::exception& exc) {
-          warn() << "onMessageData callback failed: " << exc.what();
-        }
-      };
-    }
-
-    if (callbacks->onClientAdvertise) {
-      c_callbacks.on_client_advertise =
-        [](const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel) {
-          try {
-            auto cpp_channel = ChannelDescriptor(channel);
-            (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-              ->onClientAdvertise(client_id, cpp_channel);
-          } catch (const std::exception& exc) {
-            warn() << "onClientAdvertise callback failed: " << exc.what();
-          }
-        };
-    }
-
-    if (callbacks->onClientUnadvertise) {
-      c_callbacks.on_client_unadvertise =
-        [](const void* context, uint32_t client_id, const foxglove_channel_descriptor* channel) {
-          try {
-            auto cpp_channel = ChannelDescriptor(channel);
-            (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-              ->onClientUnadvertise(client_id, cpp_channel);
-          } catch (const std::exception& exc) {
-            warn() << "onClientUnadvertise callback failed: " << exc.what();
-          }
-        };
-    }
-    if (callbacks->onGetParameters) {
-      c_callbacks.on_get_parameters = [](
-                                        const void* context,
-                                        uint32_t client_id,
-                                        const foxglove_string* c_request_id,
-                                        const foxglove_string* c_param_names,
-                                        size_t param_names_len
-                                      ) -> foxglove_parameter_array* {
-        std::optional<std::string_view> request_id;
-        if (c_request_id != nullptr) {
-          request_id.emplace(c_request_id->data, c_request_id->len);
-        }
-        std::vector<std::string_view> param_names;
-        if (c_param_names != nullptr) {
-          param_names.reserve(param_names_len);
-          for (size_t i = 0; i < param_names_len; ++i) {
-            param_names.emplace_back(c_param_names[i].data, c_param_names[i].len);
-          }
-        }
-        std::vector<foxglove::Parameter> params;
-        try {
-          params = (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-                     ->onGetParameters(client_id, request_id, param_names);
-        } catch (const std::exception& exc) {
-          warn() << "onGetParameters callback failed: " << exc.what();
-        }
-        auto array = ParameterArray(std::move(params));
-        return array.release();
-      };
-    }
-    if (callbacks->onSetParameters) {
-      c_callbacks.on_set_parameters = [](
-                                        const void* context,
-                                        uint32_t client_id,
-                                        const foxglove_string* c_request_id,
-                                        const foxglove_parameter_array* c_params
-                                      ) -> foxglove_parameter_array* {
-        std::optional<std::string_view> request_id;
-        if (c_request_id != nullptr) {
-          request_id.emplace(c_request_id->data, c_request_id->len);
-        }
-        if (c_params == nullptr) {
-          return nullptr;
-        }
-        std::vector<foxglove::Parameter> params;
-        try {
-          params =
-            (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-              ->onSetParameters(client_id, request_id, ParameterArrayView(c_params).parameters());
-        } catch (const std::exception& exc) {
-          warn() << "onSetParameters callback failed: " << exc.what();
-        }
-        auto array = ParameterArray(std::move(params));
-        return array.release();
-      };
-    }
-    if (callbacks->onParametersSubscribe) {
-      c_callbacks.on_parameters_subscribe = [](
-                                              const void* context,
-                                              const foxglove_string* c_names,
-                                              size_t names_len
-                                            ) {
-        std::vector<std::string_view> names;
-        names.reserve(names_len);
-        for (size_t i = 0; i < names_len; ++i) {
-          names.emplace_back(c_names[i].data, c_names[i].len);
-        }
-        try {
-          (static_cast<const RemoteAccessGatewayCallbacks*>(context))->onParametersSubscribe(names);
-        } catch (const std::exception& exc) {
-          warn() << "onParametersSubscribe callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onParametersUnsubscribe) {
-      c_callbacks.on_parameters_unsubscribe =
-        [](const void* context, const foxglove_string* c_names, size_t names_len) {
-          std::vector<std::string_view> names;
-          names.reserve(names_len);
-          for (size_t i = 0; i < names_len; ++i) {
-            names.emplace_back(c_names[i].data, c_names[i].len);
-          }
-          try {
-            (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-              ->onParametersUnsubscribe(names);
-          } catch (const std::exception& exc) {
-            warn() << "onParametersUnsubscribe callback failed: " << exc.what();
-          }
-        };
-    }
-    if (callbacks->onConnectionGraphSubscribe) {
-      c_callbacks.on_connection_graph_subscribe = [](const void* context) {
-        try {
-          (static_cast<const RemoteAccessGatewayCallbacks*>(context))->onConnectionGraphSubscribe();
-        } catch (const std::exception& exc) {
-          warn() << "onConnectionGraphSubscribe callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onConnectionGraphUnsubscribe) {
-      c_callbacks.on_connection_graph_unsubscribe = [](const void* context) {
-        try {
-          (static_cast<const RemoteAccessGatewayCallbacks*>(context))
-            ->onConnectionGraphUnsubscribe();
-        } catch (const std::exception& exc) {
-          warn() << "onConnectionGraphUnsubscribe callback failed: " << exc.what();
-        }
-      };
-    }
-  }
 
   // Build C options
   foxglove_gateway_options c_options = {};
   c_options.context = options.context.getInner();
   c_options.name = {options.name.c_str(), options.name.length()};
   c_options.device_token = {options.device_token.c_str(), options.device_token.length()};
-  c_options.callbacks = has_any_callbacks ? &c_callbacks : nullptr;
+  c_options.callbacks = callbacks ? &c_callbacks : nullptr;
   c_options.capabilities = {
     static_cast<std::underlying_type_t<decltype(options.capabilities)>>(options.capabilities)
   };
@@ -264,142 +212,26 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
   c_options.supported_encodings_count = supported_encodings.size();
 
   // Sink channel filter
-  if (options.sink_channel_filter) {
-    sink_channel_filter = std::make_unique<SinkChannelFilterFn>(options.sink_channel_filter);
-
-    c_options.sink_channel_filter_context = sink_channel_filter.get();
-    c_options.sink_channel_filter =
-      [](const void* context, const struct foxglove_channel_descriptor* channel) -> bool {
-      try {
-        if (!context) {
-          return true;
-        }
-        const auto* filter_func = static_cast<const SinkChannelFilterFn*>(context);
-        auto cpp_channel = ChannelDescriptor(channel);
-        return (*filter_func)(cpp_channel);
-      } catch (const std::exception& exc) {
-        warn() << "Sink channel filter failed: " << exc.what();
-        return false;
-      }
-    };
-  }
+  internal::wireSinkChannelFilter(
+    c_options, std::move(options.sink_channel_filter), sink_channel_filter
+  );
 
   // QoS classifier
   std::unique_ptr<QosClassifierFn> qos_classifier;
   if (options.qos_classifier) {
-    qos_classifier = std::make_unique<QosClassifierFn>(options.qos_classifier);
-
+    qos_classifier = std::make_unique<QosClassifierFn>(std::move(options.qos_classifier));
     c_options.qos_classifier_context = qos_classifier.get();
-    c_options.qos_classifier = [](
-                                 const void* context,
-                                 const struct foxglove_channel_descriptor* channel
-                               ) -> foxglove_qos_profile {
-      try {
-        if (!context) {
-          return {FOXGLOVE_RELIABILITY_LOSSY};
-        }
-        const auto* classifier_func = static_cast<const QosClassifierFn*>(context);
-        auto cpp_channel = ChannelDescriptor(channel);
-        auto profile = (*classifier_func)(cpp_channel);
-        return {static_cast<foxglove_reliability>(profile.reliability)};
-      } catch (const std::exception& exc) {
-        warn() << "QoS classifier failed: " << exc.what();
-        return {FOXGLOVE_RELIABILITY_LOSSY};
-      }
-    };
+    c_options.qos_classifier = &forwardQosClassifier;
   }
 
   // Fetch asset handler
-  if (options.fetch_asset) {
-    fetch_asset = std::make_unique<FetchAssetHandler>(options.fetch_asset);
-    c_options.fetch_asset_context = fetch_asset.get();
-    c_options.fetch_asset = [](
-                              const void* context,
-                              const struct foxglove_string* c_uri,
-                              struct foxglove_fetch_asset_responder* c_responder
-                            ) {
-      const auto* handler = static_cast<const FetchAssetHandler*>(context);
-      std::string_view uri{c_uri->data, c_uri->len};
-      FetchAssetResponder responder(c_responder);
-      try {
-        (*handler)(uri, std::move(responder));
-      } catch (const std::exception& exc) {
-        warn() << "Fetch asset callback failed: " << exc.what();
-        auto* ptr = responder.impl_.release();
-        if (ptr) {
-          std::string message = std::string("Fetch asset callback failed: ") + exc.what();
-          foxglove_fetch_asset_respond_error(ptr, {message.data(), message.length()});
-        }
-      }
-    };
-  }
+  internal::wireFetchAsset(c_options, std::move(options.fetch_asset), fetch_asset);
 
   foxglove_parameter_handler c_parameter_handler = {};
-  {
-    const bool has_on_get = bool(options.parameter_handler.onGet);
-    const bool has_on_set = bool(options.parameter_handler.onSet);
-    if (has_on_get != has_on_set) {
-      warn() << "ParameterHandler requires both onGet and onSet to be set";
-      return tl::unexpected(FoxgloveError::ValueError);
-    }
-  }
-  if (options.parameter_handler.onGet && options.parameter_handler.onSet) {
-    parameter_handler = std::make_unique<ParameterHandler>(std::move(options.parameter_handler));
-    c_parameter_handler.context = parameter_handler.get();
-    c_parameter_handler.get = [](
-                                const void* context,
-                                uint32_t client_id,
-                                const struct foxglove_string* c_request_id,
-                                const struct foxglove_string* c_param_names,
-                                size_t param_names_len,
-                                foxglove_get_parameters_responder* c_responder
-                              ) {
-      std::optional<std::string_view> request_id;
-      if (c_request_id != nullptr) {
-        request_id.emplace(c_request_id->data, c_request_id->len);
-      }
-      std::vector<std::string_view> param_names;
-      if (c_param_names != nullptr) {
-        param_names.reserve(param_names_len);
-        for (size_t i = 0; i < param_names_len; ++i) {
-          param_names.emplace_back(c_param_names[i].data, c_param_names[i].len);
-        }
-      }
-      GetParametersResponder responder(c_responder);
-      try {
-        (static_cast<const ParameterHandler*>(context))
-          ->onGet(client_id, request_id, param_names, std::move(responder));
-      } catch (const std::exception& exc) {
-        warn() << "ParameterHandler.onGet callback failed: " << exc.what();
-      }
-    };
-    c_parameter_handler.set = [](
-                                const void* context,
-                                uint32_t client_id,
-                                const struct foxglove_string* c_request_id,
-                                const foxglove_parameter_array* c_params,
-                                foxglove_set_parameters_responder* c_responder
-                              ) {
-      std::optional<std::string_view> request_id;
-      if (c_request_id != nullptr) {
-        request_id.emplace(c_request_id->data, c_request_id->len);
-      }
-      SetParametersResponder responder(c_responder);
-      if (c_params == nullptr) {
-        // Should not happen; the C implementation never passes a null pointer.
-        std::move(responder).respond({});
-        return;
-      }
-      try {
-        (static_cast<const ParameterHandler*>(context))
-          ->onSet(
-            client_id, request_id, ParameterArrayView(c_params).parameters(), std::move(responder)
-          );
-      } catch (const std::exception& exc) {
-        warn() << "ParameterHandler.onSet callback failed: " << exc.what();
-      }
-    };
-    c_options.parameter_handler = &c_parameter_handler;
+  if (auto err = internal::wireParameterHandler(
+        c_options, c_parameter_handler, std::move(options.parameter_handler), parameter_handler
+      )) {
+    return tl::unexpected(*err);
   }
 
   // Optional API URL
@@ -443,12 +275,6 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
     std::move(qos_classifier),
     std::move(parameter_handler)
   );
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 }
 
 RemoteAccessGateway::RemoteAccessGateway(

--- a/cpp/foxglove/src/remote_access.cpp
+++ b/cpp/foxglove/src/remote_access.cpp
@@ -82,7 +82,7 @@ void forwardOnClientUnadvertise(
 foxglove_qos_profile forwardQosClassifier(
   const void* context, const foxglove_channel_descriptor* channel
 ) {
-  if (!context) {
+  if (context == nullptr) {
     return {FOXGLOVE_RELIABILITY_LOSSY};
   }
   try {
@@ -177,7 +177,9 @@ bool wireGatewayCallbacks(foxglove_gateway_callbacks& c, const RemoteAccessGatew
 
 }  // namespace
 
-FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(RemoteAccessGatewayOptions&& options
+FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
+  RemoteAccessGatewayOptions&&
+    options  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
 ) {
   foxglove_internal_register_cpp_wrapper();
 
@@ -230,8 +232,9 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(RemoteAccessGate
   foxglove_parameter_handler c_parameter_handler = {};
   if (auto err = internal::wireParameterHandler(
         c_options, c_parameter_handler, std::move(options.parameter_handler), parameter_handler
-      )) {
-    return tl::unexpected(*err);
+      );
+      err != FoxgloveError::Ok) {
+    return tl::unexpected(err);
   }
 
   // Optional API URL

--- a/cpp/foxglove/src/websocket.cpp
+++ b/cpp/foxglove/src/websocket.cpp
@@ -6,16 +6,126 @@
 
 #include <type_traits>
 
+#include "callback_forwarders.hpp"
+
 namespace foxglove {
+namespace {
 
-FoxgloveResult<WebSocketServer> WebSocketServer::create(
-  WebSocketServerOptions&& options  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+void forwardOnSubscribe(
+  const void* context, uint64_t channel_id, foxglove_client_metadata c_client_metadata
 ) {
-  foxglove_internal_register_cpp_wrapper();
+  internal::callbackGuard("onSubscribe", [&] {
+    ClientMetadata client_metadata{
+      c_client_metadata.id,
+      c_client_metadata.sink_id == 0 ? std::nullopt
+                                     : std::make_optional<uint64_t>(c_client_metadata.sink_id)
+    };
+    static_cast<const WebSocketServerCallbacks*>(context)->onSubscribe(channel_id, client_metadata);
+  });
+}
 
-// The legacy onGetParameters/onSetParameters callbacks below are marked
-// [[deprecated]] for consumers, but this file is the internal bridge that
-// forwards them to the C ABI and must keep reading them.
+void forwardOnUnsubscribe(
+  const void* context, uint64_t channel_id, foxglove_client_metadata c_client_metadata
+) {
+  internal::callbackGuard("onUnsubscribe", [&] {
+    ClientMetadata client_metadata{
+      c_client_metadata.id,
+      c_client_metadata.sink_id == 0 ? std::nullopt
+                                     : std::make_optional<uint64_t>(c_client_metadata.sink_id)
+    };
+    static_cast<const WebSocketServerCallbacks*>(context)->onUnsubscribe(
+      channel_id, client_metadata
+    );
+  });
+}
+
+void forwardOnClientAdvertise(
+  const void* context, uint32_t client_id, const foxglove_client_channel* channel
+) {
+  internal::callbackGuard("onClientAdvertise", [&] {
+    ClientChannel cpp_channel = {
+      channel->id,
+      channel->topic,
+      channel->encoding,
+      channel->schema_name,
+      channel->schema_encoding == nullptr ? std::string_view{} : channel->schema_encoding,
+      reinterpret_cast<const std::byte*>(channel->schema),
+      channel->schema_len
+    };
+    static_cast<const WebSocketServerCallbacks*>(context)->onClientAdvertise(
+      client_id, cpp_channel
+    );
+  });
+}
+
+void forwardOnMessageData(
+  const void* context, uint32_t client_id, uint32_t client_channel_id, const uint8_t* payload,
+  size_t payload_len
+) {
+  internal::callbackGuard("onMessageData", [&] {
+    static_cast<const WebSocketServerCallbacks*>(context)->onMessageData(
+      client_id, client_channel_id, reinterpret_cast<const std::byte*>(payload), payload_len
+    );
+  });
+}
+
+// The C ABI signature for on_client_unadvertise places context after the ids,
+// not first; we preserve that to match the C header.
+void forwardOnClientUnadvertise(
+  uint32_t client_id, uint32_t client_channel_id, const void* context
+) {
+  internal::callbackGuard("onClientUnadvertise", [&] {
+    static_cast<const WebSocketServerCallbacks*>(context)->onClientUnadvertise(
+      client_id, client_channel_id
+    );
+  });
+}
+
+void forwardOnClientConnect(const void* context) {
+  internal::callbackGuard("onClientConnect", [&] {
+    static_cast<const WebSocketServerCallbacks*>(context)->onClientConnect();
+  });
+}
+
+void forwardOnClientDisconnect(const void* context) {
+  internal::callbackGuard("onClientDisconnect", [&] {
+    static_cast<const WebSocketServerCallbacks*>(context)->onClientDisconnect();
+  });
+}
+
+void forwardOnPlaybackControlRequest(
+  const void* context, const foxglove_playback_control_request* c_request,
+  foxglove_playback_state* c_state
+) {
+  if (c_request == nullptr) {
+    return;
+  }
+  std::optional<PlaybackState> maybe_state;
+  internal::callbackGuard("onPlaybackControlRequest", [&] {
+    const auto* ctx = static_cast<const WebSocketServerCallbacks*>(context);
+    maybe_state = ctx->onPlaybackControlRequest(PlaybackControlRequest::from(*c_request));
+  });
+  if (!maybe_state.has_value()) {
+    return;
+  }
+  const auto& state = *maybe_state;
+  c_state->status = static_cast<uint8_t>(state.status);
+  c_state->current_time = state.current_time;
+  c_state->playback_speed = state.playback_speed;
+  c_state->did_seek = state.did_seek;
+}
+
+// Populates `c` with forward function pointers for every callback set on `cb`,
+// and reports whether any callback was set. Callers should leave both the
+// heap-allocated callbacks wrapper unallocated and `c_options.callbacks` null
+// when this returns false: the Rust side skips registering a listener entirely
+// for a null callbacks pointer, so we want to match that "no listener at all"
+// path rather than registering an empty one. `c.context` is left untouched;
+// the caller sets it once it has constructed the wrapper.
+//
+// The legacy onGetParameters/onSetParameters fields are [[deprecated]] for
+// consumers, but this file is the internal C-ABI forward and must keep
+// reading them.
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -23,274 +133,96 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
 #pragma warning(push)
 #pragma warning(disable : 4996)
 #endif
+bool wireServerCallbacks(foxglove_server_callbacks& c, const WebSocketServerCallbacks& cb) {
+  bool any = false;
+  if (cb.onSubscribe) {
+    c.on_subscribe = &forwardOnSubscribe;
+    any = true;
+  }
+  if (cb.onUnsubscribe) {
+    c.on_unsubscribe = &forwardOnUnsubscribe;
+    any = true;
+  }
+  if (cb.onClientAdvertise) {
+    c.on_client_advertise = &forwardOnClientAdvertise;
+    any = true;
+  }
+  if (cb.onMessageData) {
+    c.on_message_data = &forwardOnMessageData;
+    any = true;
+  }
+  if (cb.onClientUnadvertise) {
+    c.on_client_unadvertise = &forwardOnClientUnadvertise;
+    any = true;
+  }
+  if (cb.onGetParameters) {
+    c.on_get_parameters = &internal::forwardLegacyGetParameters<WebSocketServerCallbacks>;
+    any = true;
+  }
+  if (cb.onSetParameters) {
+    c.on_set_parameters = &internal::forwardLegacySetParameters<WebSocketServerCallbacks>;
+    any = true;
+  }
+  if (cb.onParametersSubscribe) {
+    c.on_parameters_subscribe = &internal::forwardParametersSubscribe<WebSocketServerCallbacks>;
+    any = true;
+  }
+  if (cb.onParametersUnsubscribe) {
+    c.on_parameters_unsubscribe = &internal::forwardParametersUnsubscribe<WebSocketServerCallbacks>;
+    any = true;
+  }
+  if (cb.onConnectionGraphSubscribe) {
+    c.on_connection_graph_subscribe =
+      &internal::forwardConnectionGraphSubscribe<WebSocketServerCallbacks>;
+    any = true;
+  }
+  if (cb.onConnectionGraphUnsubscribe) {
+    c.on_connection_graph_unsubscribe =
+      &internal::forwardConnectionGraphUnsubscribe<WebSocketServerCallbacks>;
+    any = true;
+  }
+  if (cb.onClientConnect) {
+    c.on_client_connect = &forwardOnClientConnect;
+    any = true;
+  }
+  if (cb.onClientDisconnect) {
+    c.on_client_disconnect = &forwardOnClientDisconnect;
+    any = true;
+  }
+  if (cb.onPlaybackControlRequest) {
+    c.on_playback_control_request = &forwardOnPlaybackControlRequest;
+    any = true;
+  }
+  return any;
+}
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
-  bool has_any_callbacks =
-    options.callbacks.onSubscribe || options.callbacks.onUnsubscribe ||
-    options.callbacks.onClientAdvertise || options.callbacks.onMessageData ||
-    options.callbacks.onClientUnadvertise || options.callbacks.onGetParameters ||
-    options.callbacks.onSetParameters || options.callbacks.onParametersSubscribe ||
-    options.callbacks.onParametersUnsubscribe || options.callbacks.onConnectionGraphSubscribe ||
-    options.callbacks.onConnectionGraphUnsubscribe || options.callbacks.onClientConnect ||
-    options.callbacks.onClientDisconnect || options.callbacks.onPlaybackControlRequest;
+}  // namespace
 
+FoxgloveResult<WebSocketServer> WebSocketServer::create(WebSocketServerOptions&& options) {
+  foxglove_internal_register_cpp_wrapper();
+
+  foxglove_server_callbacks c_callbacks = {};
   std::unique_ptr<WebSocketServerCallbacks> callbacks;
+  if (wireServerCallbacks(c_callbacks, options.callbacks)) {
+    callbacks = std::make_unique<WebSocketServerCallbacks>(std::move(options.callbacks));
+    c_callbacks.context = callbacks.get();
+  }
+
   std::unique_ptr<FetchAssetHandler> fetch_asset;
   std::unique_ptr<SinkChannelFilterFn> sink_channel_filter;
   std::unique_ptr<ParameterHandler> parameter_handler;
-
-  foxglove_server_callbacks c_callbacks = {};
-
-  if (has_any_callbacks) {
-    callbacks = std::make_unique<WebSocketServerCallbacks>(std::move(options.callbacks));
-    c_callbacks.context = callbacks.get();
-    if (callbacks->onSubscribe) {
-      c_callbacks.on_subscribe = [](
-                                   const void* context,
-                                   uint64_t channel_id,
-                                   const foxglove_client_metadata c_client_metadata
-                                 ) {
-        try {
-          ClientMetadata client_metadata{
-            c_client_metadata.id,
-            c_client_metadata.sink_id == 0 ? std::nullopt
-                                           : std::make_optional<uint64_t>(c_client_metadata.sink_id)
-          };
-          (static_cast<const WebSocketServerCallbacks*>(context))
-            ->onSubscribe(channel_id, client_metadata);
-        } catch (const std::exception& exc) {
-          warn() << "onSubscribe callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onUnsubscribe) {
-      c_callbacks.on_unsubscribe =
-        [](const void* context, uint64_t channel_id, foxglove_client_metadata c_client_metadata) {
-          try {
-            ClientMetadata client_metadata{
-              c_client_metadata.id,
-              c_client_metadata.sink_id == 0
-                ? std::nullopt
-                : std::make_optional<uint64_t>(c_client_metadata.sink_id)
-            };
-            (static_cast<const WebSocketServerCallbacks*>(context))
-              ->onUnsubscribe(channel_id, client_metadata);
-          } catch (const std::exception& exc) {
-            warn() << "onUnsubscribe callback failed: " << exc.what();
-          }
-        };
-    }
-    if (callbacks->onClientAdvertise) {
-      c_callbacks.on_client_advertise =
-        [](const void* context, uint32_t client_id, const foxglove_client_channel* channel) {
-          ClientChannel cpp_channel = {
-            channel->id,
-            channel->topic,
-            channel->encoding,
-            channel->schema_name,
-            channel->schema_encoding == nullptr ? std::string_view{} : channel->schema_encoding,
-            reinterpret_cast<const std::byte*>(channel->schema),
-            channel->schema_len
-          };
-          try {
-            (static_cast<const WebSocketServerCallbacks*>(context))
-              ->onClientAdvertise(client_id, cpp_channel);
-          } catch (const std::exception& exc) {
-            warn() << "onClientAdvertise callback failed: " << exc.what();
-          }
-        };
-    }
-    if (callbacks->onMessageData) {
-      c_callbacks.on_message_data = [](
-                                      const void* context,
-                                      uint32_t client_id,
-                                      uint32_t client_channel_id,
-                                      const uint8_t* payload,
-                                      size_t payload_len
-                                    ) {
-        try {
-          (static_cast<const WebSocketServerCallbacks*>(context))
-            ->onMessageData(
-              client_id, client_channel_id, reinterpret_cast<const std::byte*>(payload), payload_len
-            );
-        } catch (const std::exception& exc) {
-          warn() << "onMessageData callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onClientUnadvertise) {
-      c_callbacks.on_client_unadvertise =
-        [](uint32_t client_id, uint32_t client_channel_id, const void* context) {
-          try {
-            (static_cast<const WebSocketServerCallbacks*>(context))
-              ->onClientUnadvertise(client_id, client_channel_id);
-          } catch (const std::exception& exc) {
-            warn() << "onClientUnadvertise callback failed: " << exc.what();
-          }
-        };
-    }
-    if (callbacks->onGetParameters) {
-      c_callbacks.on_get_parameters = [](
-                                        const void* context,
-                                        uint32_t client_id,
-                                        const struct foxglove_string* c_request_id,
-                                        const struct foxglove_string* c_param_names,
-                                        size_t param_names_len
-                                      ) -> foxglove_parameter_array* {
-        std::optional<std::string_view> request_id;
-        if (c_request_id != nullptr) {
-          request_id.emplace(c_request_id->data, c_request_id->len);
-        }
-        std::vector<std::string_view> param_names;
-        if (c_param_names != nullptr) {
-          param_names.reserve(param_names_len);
-          for (size_t i = 0; i < param_names_len; ++i) {
-            param_names.emplace_back(c_param_names[i].data, c_param_names[i].len);
-          }
-        }
-        std::vector<foxglove::Parameter> params;
-        try {
-          params = (static_cast<const WebSocketServerCallbacks*>(context))
-                     ->onGetParameters(client_id, request_id, param_names);
-        } catch (const std::exception& exc) {
-          warn() << "onGetParameters callback failed: " << exc.what();
-        }
-        auto array = ParameterArray(std::move(params));
-        return array.release();
-      };
-    }
-    if (callbacks->onSetParameters) {
-      c_callbacks.on_set_parameters = [](
-                                        const void* context,
-                                        uint32_t client_id,
-                                        const struct foxglove_string* c_request_id,
-                                        const foxglove_parameter_array* c_params
-                                      ) -> foxglove_parameter_array* {
-        std::optional<std::string_view> request_id;
-        if (c_request_id != nullptr) {
-          request_id.emplace(c_request_id->data, c_request_id->len);
-        }
-        if (c_params == nullptr) {
-          // Should not happen; the C implementation never passes a null pointer.
-          return nullptr;
-        }
-        std::vector<foxglove::Parameter> params;
-        try {
-          params =
-            (static_cast<const WebSocketServerCallbacks*>(context))
-              ->onSetParameters(client_id, request_id, ParameterArrayView(c_params).parameters());
-        } catch (const std::exception& exc) {
-          warn() << "onSetParameters callback failed: " << exc.what();
-        }
-        auto array = ParameterArray(std::move(params));
-        return array.release();
-      };
-    }
-    if (callbacks->onParametersSubscribe) {
-      c_callbacks.on_parameters_subscribe =
-        [](const void* context, const struct foxglove_string* c_names, size_t names_len) {
-          std::vector<std::string_view> names;
-          names.reserve(names_len);
-          for (size_t i = 0; i < names_len; ++i) {
-            names.emplace_back(c_names[i].data, c_names[i].len);
-          }
-          try {
-            (static_cast<const WebSocketServerCallbacks*>(context))->onParametersSubscribe(names);
-          } catch (const std::exception& exc) {
-            warn() << "onParametersSubscribe callback failed: " << exc.what();
-          }
-        };
-    }
-    if (callbacks->onParametersUnsubscribe) {
-      c_callbacks.on_parameters_unsubscribe =
-        [](const void* context, const struct foxglove_string* c_names, size_t names_len) {
-          std::vector<std::string_view> names;
-          names.reserve(names_len);
-          for (size_t i = 0; i < names_len; ++i) {
-            names.emplace_back(c_names[i].data, c_names[i].len);
-          }
-          try {
-            (static_cast<const WebSocketServerCallbacks*>(context))->onParametersUnsubscribe(names);
-          } catch (const std::exception& exc) {
-            warn() << "onParametersUnsubscribe callback failed: " << exc.what();
-          }
-        };
-    }
-    if (callbacks->onConnectionGraphSubscribe) {
-      c_callbacks.on_connection_graph_subscribe = [](const void* context) {
-        try {
-          (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphSubscribe();
-        } catch (const std::exception& exc) {
-          warn() << "onConnectionGraphSubscribe callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onConnectionGraphUnsubscribe) {
-      c_callbacks.on_connection_graph_unsubscribe = [](const void* context) {
-        try {
-          (static_cast<const WebSocketServerCallbacks*>(context))->onConnectionGraphUnsubscribe();
-        } catch (const std::exception& exc) {
-          warn() << "onConnectionGraphUnsubscribe callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onClientConnect) {
-      c_callbacks.on_client_connect = [](const void* context) {
-        try {
-          (static_cast<const WebSocketServerCallbacks*>(context))->onClientConnect();
-        } catch (const std::exception& exc) {
-          warn() << "onClientConnect callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onClientDisconnect) {
-      c_callbacks.on_client_disconnect = [](const void* context) {
-        try {
-          (static_cast<const WebSocketServerCallbacks*>(context))->onClientDisconnect();
-        } catch (const std::exception& exc) {
-          warn() << "onClientDisconnect callback failed: " << exc.what();
-        }
-      };
-    }
-    if (callbacks->onPlaybackControlRequest) {
-      c_callbacks.on_playback_control_request =
-        [](
-          const void* context,
-          const foxglove_playback_control_request* c_playback_control_request,
-          foxglove_playback_state* c_playback_state
-        ) {
-          if (c_playback_control_request == nullptr) {
-            return;
-          }
-
-          std::optional<PlaybackState> maybe_playback_state = std::nullopt;
-          try {
-            const auto* ctx = (static_cast<const WebSocketServerCallbacks*>(context));
-            maybe_playback_state =
-              ctx->onPlaybackControlRequest(PlaybackControlRequest::from(*c_playback_control_request
-              ));
-          } catch (const std::exception& exc) {
-            warn() << "onPlaybackControlRequest callback failed: " << exc.what();
-          }
-
-          if (!maybe_playback_state.has_value()) {
-            return;
-          }
-
-          const PlaybackState& playback_state = maybe_playback_state.value();
-          c_playback_state->status = static_cast<uint8_t>(playback_state.status);
-          c_playback_state->current_time = playback_state.current_time;
-          c_playback_state->playback_speed = playback_state.playback_speed;
-          c_playback_state->did_seek = playback_state.did_seek;
-        };
-    }
-  }
 
   foxglove_server_options c_options = {};
   c_options.context = options.context.getInner();
   c_options.name = {options.name.c_str(), options.name.length()};
   c_options.host = {options.host.c_str(), options.host.length()};
   c_options.port = options.port;
-  c_options.callbacks = has_any_callbacks ? &c_callbacks : nullptr;
+  c_options.callbacks = callbacks ? &c_callbacks : nullptr;
   c_options.capabilities =
     static_cast<std::underlying_type_t<decltype(options.capabilities)>>(options.capabilities);
   std::vector<foxglove_string> supported_encodings;
@@ -300,29 +232,7 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
   }
   c_options.supported_encodings = supported_encodings.data();
   c_options.supported_encodings_count = supported_encodings.size();
-  if (options.fetch_asset) {
-    fetch_asset = std::make_unique<FetchAssetHandler>(options.fetch_asset);
-    c_options.fetch_asset_context = fetch_asset.get();
-    c_options.fetch_asset = [](
-                              const void* context,
-                              const struct foxglove_string* c_uri,
-                              struct foxglove_fetch_asset_responder* c_responder
-                            ) {
-      const auto* handler = static_cast<const FetchAssetHandler*>(context);
-      std::string_view uri{c_uri->data, c_uri->len};
-      FetchAssetResponder responder(c_responder);
-      try {
-        (*handler)(uri, std::move(responder));
-      } catch (const std::exception& exc) {
-        warn() << "Fetch asset callback failed: " << exc.what();
-        auto* ptr = responder.impl_.release();
-        if (ptr) {
-          std::string message = std::string("Fetch asset callback failed: ") + exc.what();
-          foxglove_fetch_asset_respond_error(ptr, {message.data(), message.length()});
-        }
-      }
-    };
-  }
+  internal::wireFetchAsset(c_options, std::move(options.fetch_asset), fetch_asset);
 
   if (options.playback_time_range) {
     c_options.playback_start_time = &options.playback_time_range->first;
@@ -330,71 +240,10 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
   }
 
   foxglove_parameter_handler c_parameter_handler = {};
-  {
-    const bool has_on_get = bool(options.parameter_handler.onGet);
-    const bool has_on_set = bool(options.parameter_handler.onSet);
-    if (has_on_get != has_on_set) {
-      warn() << "ParameterHandler requires both onGet and onSet to be set";
-      return tl::unexpected(FoxgloveError::ValueError);
-    }
-  }
-  if (options.parameter_handler.onGet && options.parameter_handler.onSet) {
-    parameter_handler = std::make_unique<ParameterHandler>(std::move(options.parameter_handler));
-    c_parameter_handler.context = parameter_handler.get();
-    c_parameter_handler.get = [](
-                                const void* context,
-                                uint32_t client_id,
-                                const struct foxglove_string* c_request_id,
-                                const struct foxglove_string* c_param_names,
-                                size_t param_names_len,
-                                foxglove_get_parameters_responder* c_responder
-                              ) {
-      std::optional<std::string_view> request_id;
-      if (c_request_id != nullptr) {
-        request_id.emplace(c_request_id->data, c_request_id->len);
-      }
-      std::vector<std::string_view> param_names;
-      if (c_param_names != nullptr) {
-        param_names.reserve(param_names_len);
-        for (size_t i = 0; i < param_names_len; ++i) {
-          param_names.emplace_back(c_param_names[i].data, c_param_names[i].len);
-        }
-      }
-      GetParametersResponder responder(c_responder);
-      try {
-        (static_cast<const ParameterHandler*>(context))
-          ->onGet(client_id, request_id, param_names, std::move(responder));
-      } catch (const std::exception& exc) {
-        warn() << "ParameterHandler.onGet callback failed: " << exc.what();
-      }
-    };
-    c_parameter_handler.set = [](
-                                const void* context,
-                                uint32_t client_id,
-                                const struct foxglove_string* c_request_id,
-                                const foxglove_parameter_array* c_params,
-                                foxglove_set_parameters_responder* c_responder
-                              ) {
-      std::optional<std::string_view> request_id;
-      if (c_request_id != nullptr) {
-        request_id.emplace(c_request_id->data, c_request_id->len);
-      }
-      SetParametersResponder responder(c_responder);
-      if (c_params == nullptr) {
-        // Should not happen; the C implementation never passes a null pointer.
-        std::move(responder).respond({});
-        return;
-      }
-      try {
-        (static_cast<const ParameterHandler*>(context))
-          ->onSet(
-            client_id, request_id, ParameterArrayView(c_params).parameters(), std::move(responder)
-          );
-      } catch (const std::exception& exc) {
-        warn() << "ParameterHandler.onSet callback failed: " << exc.what();
-      }
-    };
-    c_options.parameter_handler = &c_parameter_handler;
+  if (auto err = internal::wireParameterHandler(
+        c_options, c_parameter_handler, std::move(options.parameter_handler), parameter_handler
+      )) {
+    return tl::unexpected(*err);
   }
 
   std::vector<foxglove_key_value> server_info;
@@ -414,25 +263,9 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
     c_options.tls_key_len = options.tls_identity->key.size();
   }
 
-  if (options.sink_channel_filter) {
-    sink_channel_filter = std::make_unique<SinkChannelFilterFn>(options.sink_channel_filter);
-
-    c_options.sink_channel_filter_context = sink_channel_filter.get();
-    c_options.sink_channel_filter =
-      [](const void* context, const struct foxglove_channel_descriptor* channel) -> bool {
-      try {
-        if (!context) {
-          return true;  // Default to allowing if no filter
-        }
-        const auto* filter_func = static_cast<const SinkChannelFilterFn*>(context);
-        auto cpp_channel = ChannelDescriptor(channel);
-        return (*filter_func)(cpp_channel);
-      } catch (const std::exception& exc) {
-        warn() << "Sink channel filter failed: " << exc.what();
-        return false;
-      }
-    };
-  }
+  internal::wireSinkChannelFilter(
+    c_options, std::move(options.sink_channel_filter), sink_channel_filter
+  );
 
   std::optional<foxglove_string> session_id;
   if (options.session_id) {
@@ -453,12 +286,6 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(
     std::move(sink_channel_filter),
     std::move(parameter_handler)
   );
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 }
 
 WebSocketServer::WebSocketServer(

--- a/cpp/foxglove/src/websocket.cpp
+++ b/cpp/foxglove/src/websocket.cpp
@@ -203,7 +203,9 @@ bool wireServerCallbacks(foxglove_server_callbacks& c, const WebSocketServerCall
 
 }  // namespace
 
-FoxgloveResult<WebSocketServer> WebSocketServer::create(WebSocketServerOptions&& options) {
+FoxgloveResult<WebSocketServer> WebSocketServer::create(
+  WebSocketServerOptions&& options  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+) {
   foxglove_internal_register_cpp_wrapper();
 
   foxglove_server_callbacks c_callbacks = {};
@@ -242,8 +244,9 @@ FoxgloveResult<WebSocketServer> WebSocketServer::create(WebSocketServerOptions&&
   foxglove_parameter_handler c_parameter_handler = {};
   if (auto err = internal::wireParameterHandler(
         c_options, c_parameter_handler, std::move(options.parameter_handler), parameter_handler
-      )) {
-    return tl::unexpected(*err);
+      );
+      err != FoxgloveError::Ok) {
+    return tl::unexpected(err);
   }
 
   std::vector<foxglove_key_value> server_info;


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
This change refactors the create method for the RemoteAccessGateway and
WebSocketServer. These methods were fairly long and complicated, and
shared some commonality that we were able to factor out.

There's some ugliness here with the introduction of the new
foxglove::internal namespace and ForwarderAccess dummy struct, which we
use to grant friend access to the responders and ParameterArray.