### PR TITLE
python: Apply -ObjC linker flag on macOS via build.rs

### DIFF
--- a/python/foxglove-sdk/build.rs
+++ b/python/foxglove-sdk/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+
+fn main() {
+    // Workaround for livekit/rust-sdks#795: the prebuilt WebRTC binaries in the
+    // `livekit` crate define ObjC category methods that require `-ObjC` to be
+    // linked. Without this flag, macOS strips the categories at link time,
+    // causing an `unrecognized selector` crash at runtime.
+    //
+    // The workspace-root `.cargo/config.toml` sets this for in-repo cargo
+    // builds, but isn't shipped in the sdist — so wheels built from the sdist
+    // (including the published macOS wheels) don't get it. Emitting it from
+    // build.rs ensures it's applied wherever this crate is built.
+    //
+    // Upstream fix: https://github.com/livekit/rust-sdks/pull/847
+    // Remove this once a livekit release includes that PR.
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "macos" {
+        println!("cargo:rustc-cdylib-link-arg=-ObjC");
+    }
+}


### PR DESCRIPTION
### Changelog

Fix `+[NSString stringForAbslStringView:]: unrecognized selector` crash in the Python SDK on macOS when using remote-access.

### Docs

None

### Description

#944 added a workspace-root `.cargo/config.toml` to pass `-ObjC` to the linker on macOS, working around livekit/rust-sdks#795. That fixes in-repo cargo builds (e.g. `cargo test -p remote_access_tests`), but `.cargo/config.toml` isn't included in the maturin sdist — so the published macOS wheels for foxglove-sdk 0.24.0 are still built without `-ObjC`, and Python users on macOS hit the same `+[NSString stringForAbslStringView:]: unrecognized selector` crash the moment a viewer connects to a `start_gateway()`.

This moves the workaround for the Python crate into a `build.rs` that emits `cargo:rustc-cdylib-link-arg=-ObjC` on macOS targets. `build.rs` is part of the crate, so it's included in the sdist automatically (verified) and applies wherever the cdylib is linked — local builds, sdist installs, and CI-built wheels.

The workspace `.cargo/config.toml` stays in place because `cargo test -p remote_access_tests` builds a test executable (not a cdylib), so `rustc-cdylib-link-arg` wouldn't apply there.

#### TODO for reviewers

- [x] On a fresh macOS environment, install the wheel built by CI for this PR and run a script that calls `foxglove.start_gateway(...)` with a real device token, then connect a viewer. It should connect without the ObjC selector crash.

Refs: https://github.com/foxglove/foxglove-sdk/pull/944

🤖 Generated with [Claude Code](https://claude.com/claude-code)