### PR TITLE
netem: Add MCAP streaming tooling for uplink congestion testing

### DIFF
--- a/docker-compose.netem-egress.yml
+++ b/docker-compose.netem-egress.yml
@@ -52,6 +52,8 @@ services:
     cap_add:
       - NET_ADMIN
     environment:
+      # Default mirrors the `starlink` profile in scripts/netemImpairArgs.ts —
+      # keep them in sync. Override with NETEM_EGRESS.
       NETEM_ARGS: "${NETEM_EGRESS:-delay 30ms 10ms loss 2% rate 15mbit}"
       # Skip loopback — the WebRTC stack uses lo internally for ICE.
       NETEM_SKIP_LOOPBACK: "1"

--- a/docker-compose.netem-egress.yml
+++ b/docker-compose.netem-egress.yml
@@ -1,0 +1,83 @@
+# Compose override that shapes the egress of a single gateway program with
+# netem: a `runner` container plus a `runner-netem` sidecar on its network
+# namespace. This is the common case — a device on a constrained uplink to the
+# SFU — with no per-link network, viewer container, or relay.
+#
+# `yarn stream-mcap` drives this to replay a recording; the same overlay shapes
+# any gateway program you exec into the runner. See the runbook in
+# rust/remote_access_tests/NETEM.md. Tune the impairment with NETEM_EGRESS, or
+# live with `yarn netem-impair`.
+#
+# The runner reaches whatever SFU FOXGLOVE_API_URL resolves: a deployed instance
+# (the recommended path — browser playback works out of the box), or a local
+# --dev LiveKit you bring up yourself.
+
+volumes:
+  # Persistent Rust build caches, shared with the other netem runner containers
+  # so builds stay incremental across `docker compose down`.
+  netem-cargo-registry:
+  netem-cargo-git:
+  netem-target:
+
+services:
+  runner:
+    image: rust:1.93.0-bookworm
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+      - netem-cargo-registry:/usr/local/cargo/registry
+      - netem-cargo-git:/usr/local/cargo/git
+      - netem-target:/workspace/target-docker
+      # The mount target lives outside the `.:/workspace` repo bind on purpose —
+      # a target nested under /workspace makes Docker create a stray mountpoint
+      # stub in the repo root. `yarn stream-mcap` sets MCAP_HOST_PATH; with no
+      # override the empty fixture keeps the container coming up cleanly.
+      - ${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}:/data/recording.mcap:ro
+    environment:
+      CARGO_TARGET_DIR: /workspace/target-docker
+      CARGO_TERM_COLOR: always
+      # The webrtc-sys crate compiles C++ code that requires Clang.
+      CXX: clang++
+      CC: clang
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        if ! command -v clang++ > /dev/null 2>&1; then
+          apt-get update -qq && apt-get install -y -qq clang libva-dev libprotobuf-dev protobuf-compiler libglib2.0-dev > /dev/null 2>&1
+        fi
+        exec sleep infinity
+    healthcheck:
+      test: ["CMD-SHELL", "command -v clang++ && test -d /workspace/rust"]
+      interval: 5s
+      timeout: 10s
+      retries: 12
+      start_period: 30s
+
+  # Shares the runner's network namespace and shapes its egress (= the gateway
+  # program's uplink to the SFU).
+  runner-netem:
+    image: python:3-alpine
+    network_mode: "service:runner"
+    cap_add:
+      - NET_ADMIN
+    environment:
+      NETEM_ARGS: "${NETEM_EGRESS:-delay 30ms 10ms loss 2% rate 15mbit}"
+      # Skip loopback — the WebRTC stack uses lo internally for ICE.
+      NETEM_SKIP_LOOPBACK: "1"
+    volumes:
+      - ./scripts/container/netem_setup.py:/netem_setup.py:ro
+      - ./scripts/container/netem_impair.py:/netem_impair.py:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache iproute2 > /dev/null 2>&1
+        python3 /netem_setup.py || exit 1
+        exec sleep infinity
+    healthcheck:
+      test: ["CMD-SHELL", "tc qdisc show | grep -q netem"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    depends_on:
+      runner:
+        condition: service_healthy

--- a/docker-compose.netem-egress.yml
+++ b/docker-compose.netem-egress.yml
@@ -1,20 +1,11 @@
-# Compose override that shapes the egress of a single gateway program with
-# netem: a `runner` container plus a `runner-netem` sidecar on its network
-# namespace. This is the common case — a device on a constrained uplink to the
-# SFU — with no per-link network, viewer container, or relay.
-#
-# `yarn stream-mcap` drives this to replay a recording; the same overlay shapes
-# any gateway program you exec into the runner. See the runbook in
-# rust/remote_access_tests/NETEM.md. Tune the impairment with NETEM_EGRESS, or
-# live with `yarn netem-impair`.
-#
-# The runner reaches whatever SFU FOXGLOVE_API_URL resolves: a deployed instance
-# (the recommended path — browser playback works out of the box), or a local
-# --dev LiveKit you bring up yourself.
+# Shapes the egress of a single gateway program with netem: a `runner` plus a
+# `runner-netem` sidecar in its network namespace. The common case — a device on
+# a constrained uplink — with no per-link network, viewer, or relay.
+# `yarn stream-mcap` drives it; the same overlay shapes any program exec'd into
+# the runner. Runbook: rust/remote_access_tests/NETEM.md.
 
 volumes:
-  # Persistent Rust build caches, shared with the other netem runner containers
-  # so builds stay incremental across `docker compose down`.
+  # Persistent Rust build caches so builds stay incremental across `down`.
   netem-cargo-registry:
   netem-cargo-git:
   netem-target:
@@ -28,10 +19,10 @@ services:
       - netem-cargo-registry:/usr/local/cargo/registry
       - netem-cargo-git:/usr/local/cargo/git
       - netem-target:/workspace/target-docker
-      # The mount target lives outside the `.:/workspace` repo bind on purpose —
-      # a target nested under /workspace makes Docker create a stray mountpoint
-      # stub in the repo root. `yarn stream-mcap` sets MCAP_HOST_PATH; with no
-      # override the empty fixture keeps the container coming up cleanly.
+      # Target lives outside the `.:/workspace` bind on purpose — nesting it
+      # under /workspace makes Docker leave a stray mountpoint stub in the repo
+      # root. `yarn stream-mcap` sets MCAP_HOST_PATH; the empty fixture is the
+      # no-override default so the container still comes up.
       - ${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}:/data/recording.mcap:ro
     environment:
       CARGO_TARGET_DIR: /workspace/target-docker

--- a/docker-compose.netem-livekit.yml
+++ b/docker-compose.netem-livekit.yml
@@ -25,8 +25,10 @@
 #
 # MCAP mount:
 #   gateway-runner bind-mounts `${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}`
-#   at `/workspace/recording.mcap` so the `remote_access_stream_mcap` example
-#   can play back a host-side recording from inside the container. Set
+#   at `/data/recording.mcap` so the `remote_access_stream_mcap` example can play
+#   back a host-side recording from inside the container. The mount target lives
+#   outside the `.:/workspace` repo bind on purpose — a target nested under
+#   /workspace makes Docker create a stray mountpoint stub in the repo root. Set
 #   MCAP_HOST_PATH to an absolute path before `yarn start-netem --perlink` (or
 #   use `yarn stream-mcap`, which sets it for you). With no override, the empty
 #   fixture is mounted so the stack still comes up cleanly.
@@ -66,7 +68,7 @@ services:
       - netem-cargo-registry:/usr/local/cargo/registry
       - netem-cargo-git:/usr/local/cargo/git
       - netem-target:/workspace/target-docker
-      - ${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}:/workspace/recording.mcap:ro
+      - ${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}:/data/recording.mcap:ro
     environment:
       CARGO_TARGET_DIR: /workspace/target-docker
       LIVEKIT_URL: "http://10.99.0.2:7880"

--- a/docker-compose.netem-livekit.yml
+++ b/docker-compose.netem-livekit.yml
@@ -22,6 +22,14 @@
 #     network (e.g., fiber).
 #   - The netem sidecar classifies egress from LiveKit by destination IP using
 #     HTB + u32 filters, applying configurable impairment per link.
+#
+# MCAP mount:
+#   gateway-runner bind-mounts `${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}`
+#   at `/workspace/recording.mcap` so the `remote_access_stream_mcap` example
+#   can play back a host-side recording from inside the container. Set
+#   MCAP_HOST_PATH to an absolute path before `yarn start-netem --perlink` (or
+#   use `yarn stream-mcap`, which sets it for you). With no override, the empty
+#   fixture is mounted so the stack still comes up cleanly.
 
 networks:
   perlink:
@@ -58,6 +66,7 @@ services:
       - netem-cargo-registry:/usr/local/cargo/registry
       - netem-cargo-git:/usr/local/cargo/git
       - netem-target:/workspace/target-docker
+      - ${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}:/workspace/recording.mcap:ro
     environment:
       CARGO_TARGET_DIR: /workspace/target-docker
       LIVEKIT_URL: "http://10.99.0.2:7880"

--- a/docker-compose.netem-livekit.yml
+++ b/docker-compose.netem-livekit.yml
@@ -22,16 +22,6 @@
 #     network (e.g., fiber).
 #   - The netem sidecar classifies egress from LiveKit by destination IP using
 #     HTB + u32 filters, applying configurable impairment per link.
-#
-# MCAP mount:
-#   gateway-runner bind-mounts `${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}`
-#   at `/data/recording.mcap` so the `remote_access_stream_mcap` example can play
-#   back a host-side recording from inside the container. The mount target lives
-#   outside the `.:/workspace` repo bind on purpose — a target nested under
-#   /workspace makes Docker create a stray mountpoint stub in the repo root. Set
-#   MCAP_HOST_PATH to an absolute path before `yarn start-netem --perlink` (or
-#   use `yarn stream-mcap`, which sets it for you). With no override, the empty
-#   fixture is mounted so the stack still comes up cleanly.
 
 networks:
   perlink:
@@ -68,7 +58,6 @@ services:
       - netem-cargo-registry:/usr/local/cargo/registry
       - netem-cargo-git:/usr/local/cargo/git
       - netem-target:/workspace/target-docker
-      - ${MCAP_HOST_PATH:-./scripts/fixtures/empty.mcap}:/data/recording.mcap:ro
     environment:
       CARGO_TARGET_DIR: /workspace/target-docker
       LIVEKIT_URL: "http://10.99.0.2:7880"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "generate": "ts-node ./scripts/generate.ts",
     "lint:ci": "eslint .",
     "lint": "eslint --fix .",
+    "netem-impair": "ts-node ./scripts/netemImpair.ts",
     "run-python-sdk-examples": "ts-node ./scripts/runPythonSdkExamples.ts --install-sdk-from-path",
     "start-netem": "ts-node ./scripts/startNetem.ts",
+    "stream-mcap": "ts-node ./scripts/streamMcap.ts",
     "test": "jest"
   },
   "devDependencies": {

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -128,7 +128,7 @@ yarn start-netem --perlink
 
 Update impairment without restarting containers or dropping connections. Only newly enqueued packets use the updated parameters.
 
-Each update replaces _all_ settings. Replacing "delay 500ms loss 20%" with "delay 400ms" (loss is not mentioned) _resets_ loss to 0%.
+Each update replaces _all_ settings. Replacing "delay 500ms loss 20%" with "delay 400ms" (loss is not mentioned) _resets_ loss to 0%. `rate` is a kernel special case — it persists across a bare `tc qdisc change` — so `netem_impair.py` appends an uncapped rate whenever you don't pass one. Omitting `rate` (e.g. `delay 0ms`) therefore clears any prior cap and restores an unshaped link.
 
 ```sh
 COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.netem.yml -f docker-compose.netem-livekit.yml"

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -250,7 +250,7 @@ LiveKit's WebRTC ICE candidates, which are container-internal addresses
   to Docker bridge networks. Note that `host.docker.internal` is provided to
   containers by Docker Desktop, not by the native engine, so the
   `FOXGLOVE_API_URL` values above need an `extra_hosts: host-gateway` entry
-  (tracked in [FLE-588](https://linear.app/foxglove/issue/FLE-588)), and the
+  (tracked in FLE-588), and the
   hosts-file line from the per-link prerequisites applies on Linux too.
 - **macOS (Docker Desktop), and Docker Desktop for Linux:** containers run
   inside a virtual machine, so the candidate addresses are not routable from
@@ -258,8 +258,7 @@ LiveKit's WebRTC ICE candidates, which are container-internal addresses
   gateway → LiveKit path is unaffected (it stays container-to-container). To
   watch playback from a Mac, use a Linux machine, run the browser in a
   container on the perlink network, or set up a routed tunnel into the
-  perlink subnet — options and tradeoffs are written up in
-  [FLE-588](https://linear.app/foxglove/issue/FLE-588).
+  perlink subnet — options and tradeoffs are written up in FLE-588.
 
 When playback does connect, confirm in `chrome://webrtc-internals` that the
 selected candidate pair uses `10.99.x.x` addresses. If the host can also

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -209,10 +209,12 @@ yarn netem-impair -- delay 500ms loss 10%
 
 `severe` is tuned to saturate heavy-topic uplinks; adjust from there.
 
-> **Limitation:** `yarn netem-impair` only affects the gateway upload link.
-> Per-link downloads (`NETEM_GATEWAY_DOWNLOAD`, `NETEM_VIEWER_DOWNLOAD`) and
-> the viewer upload (`NETEM_VIEWER_UPLOAD`) require restarting the stack with
-> new env vars — see "Changing impairment live" above for why.
+> **Scope:** `yarn netem-impair` hardcodes the `gateway-netem` sidecar, so it
+> only retunes the gateway upload link. The underlying `netem_impair.py` is not
+> limited to uploads — exec'd into the LiveKit-side `netem` sidecar it updates
+> all download links at once (see "Changing impairment live" above). Per-link
+> viewer/download retuning still requires a stack restart with new
+> `NETEM_VIEWER_UPLOAD` / `NETEM_*_DOWNLOAD` env vars.
 
 ## Scenarios
 

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -158,14 +158,15 @@ Point it at a deployed instance — its SFU's ICE candidates are publicly
 routable, so a host browser can watch the device directly:
 
 ```sh
-FOXGLOVE_API_URL=https://api.foxglove.dev \
 FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
 yarn stream-mcap /abs/path/to/heavy.mcap
 ```
 
-The device token must come from that instance, for a device with remote access
-enabled in an org whose plan includes it. For a local SFU instead, run the app
-and `--dev` LiveKit yourself and point `FOXGLOVE_API_URL` at them.
+`FOXGLOVE_API_URL` defaults to `https://api.foxglove.dev`; set it to target
+another instance. The device token must come from whichever instance you use,
+for a device with remote access enabled in an org whose plan includes it. For a
+local SFU, run the app and `--dev` LiveKit yourself and point `FOXGLOVE_API_URL`
+at them.
 
 The stack starts shaped at the `starlink` profile (the `NETEM_EGRESS` default).
 Retune live without restarting — each call replaces all settings, and

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -174,7 +174,7 @@ yarn stream-mcap
 
 `yarn stream-mcap` owns the stack lifecycle: it brings up (or refreshes) the
 per-link compose stack with the file bind-mounted at
-`/workspace/recording.mcap` inside `gateway-runner`, builds
+`/data/recording.mcap` inside `gateway-runner`, builds
 `example_remote_access_stream_mcap` (~90s the first time, incremental
 thereafter), and runs it.
 

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -238,6 +238,33 @@ yarn netem-impair -- delay 500ms loss 10%
 > viewer/download retuning still requires a stack restart with new
 > `NETEM_VIEWER_UPLOAD` / `NETEM_*_DOWNLOAD` env vars.
 
+### Streaming against a deployed Foxglove instance
+
+The recipe above runs everything locally, but nothing requires that: the SDK
+gateway discovers the SFU through whatever API `FOXGLOVE_API_URL` points at,
+and the `gateway-netem` sidecar shapes all of `gateway-runner`'s egress
+regardless of destination. Pointing the streamer at a deployed instance
+(production, or an internal staging environment) exercises the most
+field-realistic shape — an impaired device uplink into the real SFU, with
+viewers on a clean connection — and needs none of the local app/web setup
+from the prerequisites above:
+
+```sh
+FOXGLOVE_API_URL=https://api.foxglove.dev \
+FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
+yarn stream-mcap /abs/path/to/heavy.mcap
+```
+
+- The device token must be issued by that same instance, for a device with
+  remote access enabled in an org whose plan includes it.
+- Watch the device from that instance's web app. `yarn netem-impair` works
+  exactly as in the local flow — it shapes the runner's uplink wherever the
+  traffic is headed.
+- The local LiveKit and viewer containers still start (`gateway-runner`
+  declares a dependency on them) but carry no traffic in this mode.
+- A deployed SFU can behave differently from the local `--dev` LiveKit, which
+  is part of the point of testing this way.
+
 ## Verifying browser playback
 
 The flows above verify the gateway side (stream established, lease granted)

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -31,7 +31,6 @@ graph TD
 ```
 
 **Traffic flow (gateway example):**
-
 - gateway → LiveKit: runner sends, passes through gateway netem sidecar egress (upload shaping)
 - LiveKit → gateway: LiveKit sends, passes through LiveKit netem sidecar egress, classified to gateway class (download shaping)
 
@@ -74,15 +73,9 @@ sudo sh -c 'echo "127.0.0.1 host.docker.internal" >> /etc/hosts'
 # Terminal 1: start LiveKit + netem with per-link sidecars
 yarn start-netem --perlink
 
-# Terminal 2: start the Foxglove app with the LiveKit overrides.
+# Terminal 2: start the Foxglove app with LiveKit URL override
 # host.docker.internal resolves to the host from both macOS and Docker containers.
-# All three LiveKit variables are required, or the server reports remote access
-# as unconfigured (403); devkey/secret are the LiveKit --dev defaults.
-(cd ../app && docker compose up -d && \
-  LIVEKIT_HOST=ws://host.docker.internal:7880 \
-  LIVEKIT_API_KEY=devkey \
-  LIVEKIT_API_SECRET=secret \
-  yarn start)
+(cd ../app && docker compose up -d && LIVEKIT_HOST=ws://host.docker.internal:7880 yarn start)
 
 # Terminal 3: start the web frontend
 (cd ../app && yarn web serve:local)
@@ -101,27 +94,21 @@ $COMPOSE exec \
 Open `http://localhost:8080` in a browser and connect to the device. The test
 card traffic traverses the impaired gateway link (upload shaped by
 `gateway-netem`, download shaped by the LiveKit netem sidecar's gateway class).
-The device-token and org-plan prerequisites from the MCAP streaming section
-below apply here too (locally issued `fox_dt_…` token; org plan with remote
-access). Whether the browser can show the stream depends on the host
-platform — see "Verifying browser playback" below.
 
-> **Note:** The first `cargo build` inside the container compiles the example
-> and its native WebRTC dependencies from a cold cache, which can take several
-> minutes — cargo's progress output shows it is still working. Subsequent
-> builds are incremental (the target directory is cached in a Docker volume).
-> Requires Docker Desktop with at least 12 GB of memory allocated.
+> **Note:** The first `cargo build` inside the container takes ~90 seconds.
+> Subsequent builds are incremental (the target directory is cached in a Docker
+> volume). Requires Docker Desktop with at least 12 GB of memory allocated.
 
 ## Default impairment profiles
 
-When no NETEM\_\* environment (see Custom Impairment) variables are set, the impairment is:
+When no NETEM_* environment (see Custom Impairment) variables are set, the impairment is:
 
-| Link               | Direction               | Default                              | Simulates          |
-| ------------------ | ----------------------- | ------------------------------------ | ------------------ |
-| Gateway ↔ LiveKit | upload (gateway → LK)   | delay 30ms 10ms loss 2% rate 15mbit  | Device on Starlink |
+| Link | Direction | Default | Simulates |
+|------|-----------|---------|-----------|
+| Gateway ↔ LiveKit | upload (gateway → LK) | delay 30ms 10ms loss 2% rate 15mbit | Device on Starlink |
 | Gateway ↔ LiveKit | download (LK → gateway) | delay 30ms 10ms loss 2% rate 100mbit | Device on Starlink |
-| Viewer ↔ LiveKit  | upload (viewer → LK)    | delay 5ms rate 100mbit               | User on fiber      |
-| Viewer ↔ LiveKit  | download (LK → viewer)  | delay 5ms rate 500mbit               | User on fiber      |
+| Viewer ↔ LiveKit | upload (viewer → LK) | delay 5ms rate 100mbit | User on fiber |
+| Viewer ↔ LiveKit | download (LK → viewer) | delay 5ms rate 500mbit | User on fiber |
 
 ## Custom impairment
 
@@ -140,7 +127,7 @@ yarn start-netem --perlink
 
 Update impairment without restarting containers or dropping connections. Only newly enqueued packets use the updated parameters.
 
-Each update replaces _all_ settings. Replacing "delay 500ms loss 20%" with "delay 400ms" (loss is not mentioned) _resets_ loss to 0%. `rate` is a kernel special case — it persists across a bare `tc qdisc change` — so `netem_impair.py` appends an uncapped rate whenever you don't pass one. Omitting `rate` (e.g. `delay 0ms`) therefore clears any prior cap and restores an unshaped link.
+Each update replaces *all* settings. Replacing "delay 500ms loss 20%" with "delay 400ms" (loss is not mentioned) *resets* loss to 0%.
 
 ```sh
 COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.netem.yml -f docker-compose.netem-livekit.yml"
@@ -159,95 +146,16 @@ $COMPOSE exec netem python3 /netem_impair.py delay 100ms loss 3%
 > with `netem_impair.py`. It updates all netem qdiscs at once. To change a
 > single link's download, restart the stack with updated env vars.
 
-## Streaming heavy topics under uplink congestion
+## Replaying an MCAP under a shaped uplink
 
-Play back a heavy MCAP recording (e.g. point clouds) from inside the
-`gateway-runner` container so its egress to LiveKit traverses the
-`gateway-netem` sidecar. Use this to experience Foxglove under bandwidth-bound
-conditions and to compare profiles live.
+`yarn stream-mcap` replays a recording through a gateway program whose egress to
+the SFU is shaped by netem — the common "device on a constrained uplink" case,
+with no per-link network or relay. It uses `docker-compose.netem-egress.yml`: a
+`runner` container plus a `runner-netem` sidecar on its egress. (The same overlay
+shapes any gateway program — `docker compose -f docker-compose.yaml -f docker-compose.netem-egress.yml exec runner <cmd>`.)
 
-### Prerequisites
-
-- `host.docker.internal` set up on macOS (see the per-link Quick start above).
-- The Foxglove app stack running on the host with all three LiveKit variables
-  set, using the same Terminal 2 command as in the per-link Quick start above.
-  The server treats remote access as unconfigured (403) unless `LIVEKIT_HOST`,
-  `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` are all non-empty; the netem
-  stack's LiveKit runs in `--dev` mode, whose default credentials are
-  `devkey` / `secret`.
-- A device token (`fox_dt_…`) issued by that local app instance — tokens from
-  other instances fail with 401 Unauthorized. The device must have remote
-  access enabled, and its org's plan must support remote access (for local
-  testing, set the org plan to `enterprise` in `console_dev`; reversible).
-- An MCAP recording on the host. Provide its **absolute** path via
-  `MCAP_HOST_PATH` (or as the positional arg to `yarn stream-mcap`).
-
-### Run it
-
-```sh
-# In one terminal: stream a heavy MCAP through gateway-runner.
-FOXGLOVE_API_URL=http://host.docker.internal:3000/api \
-FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
-MCAP_HOST_PATH=/abs/path/to/heavy.mcap \
-yarn stream-mcap
-```
-
-`yarn stream-mcap` owns the stack lifecycle: it brings up (or refreshes) the
-per-link compose stack with the file bind-mounted at
-`/data/recording.mcap` inside `gateway-runner`, builds
-`example_remote_access_stream_mcap` (the first build from a cold cache can
-take several minutes; incremental thereafter), and runs it. When it brings the stack up fresh, download links
-start flat (unshaped) — this is intentional for an uplink-focused test; see
-the Scope note below for retuning downloads.
-
-Once the stream is up, apply the impairment profile you want with
-`yarn netem-impair` (see next section). Don't try to set
-`NETEM_GATEWAY_UPLOAD` in a separate `yarn start-netem --perlink` terminal:
-`yarn stream-mcap` runs `docker compose up` itself, sees a config drift, and
-recreates `gateway-runner` — which also restarts `gateway-netem` and resets
-its qdisc to whatever `NETEM_GATEWAY_UPLOAD` resolves to _in stream-mcap's
-environment_ (the Starlink default if unset). The cleanest workflow is:
-`yarn stream-mcap` to start, then `yarn netem-impair --profile severe` to
-apply impairment.
-
-Open `http://localhost:8080` and connect to the device to watch the
-playback (platform-dependent — see "Verifying browser playback" below).
-
-### Switch profiles mid-stream
-
-While the stream is running, change the gateway-upload impairment without
-restarting the stack:
-
-```sh
-yarn netem-impair --profile starlink     # delay 30ms 10ms loss 2% rate 15mbit
-yarn netem-impair --profile 4g           # delay 50ms 15ms loss 3% rate 10mbit
-yarn netem-impair --profile wifi-walls   # delay 15ms 10ms loss 8% rate 2mbit
-yarn netem-impair --profile severe       # delay 100ms 30ms loss 5% rate 2mbit
-yarn netem-impair --profile pristine     # delay 0ms
-
-# Or pass raw netem args:
-yarn netem-impair -- delay 500ms loss 10%
-```
-
-`severe` is tuned to saturate heavy-topic uplinks; adjust from there.
-
-> **Scope:** `yarn netem-impair` hardcodes the `gateway-netem` sidecar, so it
-> only retunes the gateway upload link. The underlying `netem_impair.py` is not
-> limited to uploads — exec'd into the LiveKit-side `netem` sidecar it updates
-> all download links at once (see "Changing impairment live" above). Per-link
-> viewer/download retuning still requires a stack restart with new
-> `NETEM_VIEWER_UPLOAD` / `NETEM_*_DOWNLOAD` env vars.
-
-### Streaming against a deployed Foxglove instance
-
-The recipe above runs everything locally, but nothing requires that: the SDK
-gateway discovers the SFU through whatever API `FOXGLOVE_API_URL` points at,
-and the `gateway-netem` sidecar shapes all of `gateway-runner`'s egress
-regardless of destination. Pointing the streamer at a deployed instance
-(an internal staging environment, or production) exercises the most
-field-realistic shape — an impaired device uplink into the real SFU, with
-viewers on a clean connection — and needs none of the local app/web setup
-from the prerequisites above:
+Point it at a deployed instance — browser playback works out of the box, since
+the SFU's ICE candidates are publicly routable:
 
 ```sh
 FOXGLOVE_API_URL=https://api.foxglove.dev \
@@ -255,49 +163,19 @@ FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
 yarn stream-mcap /abs/path/to/heavy.mcap
 ```
 
-- Prefer a staging instance when one is available: streaming a heavy
-  recording deliberately saturates an uplink, and that load lands on the
-  target instance's SFU. Point at production on purpose, not by default.
-- The device token must be issued by that same instance, for a device with
-  remote access enabled in an org whose plan includes it.
-- Watch the device from that instance's web app. `yarn netem-impair` works
-  exactly as in the local flow — it shapes the runner's uplink wherever the
-  traffic is headed.
-- Unlike the local flow, browser playback works from a macOS host here: the
-  deployed SFU's ICE candidates are publicly routable, so the macOS caveat
-  in "Verifying browser playback" below does not apply.
-- The local LiveKit and viewer containers still start (`gateway-runner`
-  declares a dependency on them) but carry no traffic in this mode.
-- A deployed SFU can behave differently from the local `--dev` LiveKit, which
-  is part of the point of testing this way.
+The device token must come from that instance, for a device with remote access
+enabled in an org whose plan includes it. For a local SFU instead, run the app
+and `--dev` LiveKit yourself and point `FOXGLOVE_API_URL` at them.
 
-## Verifying browser playback
+Retune the uplink live without restarting (default profile is `starlink`):
 
-The flows above verify the gateway side (stream established, lease granted)
-and the impairment itself (live `tc` qdisc state). Seeing the playback at
-`http://localhost:8080` additionally requires that the host browser can reach
-LiveKit's WebRTC ICE candidates, which are container-internal addresses
-(e.g. `10.99.0.2` on the perlink network):
+```sh
+yarn netem-impair --profile severe     # delay 100ms 30ms loss 5% rate 2mbit
+yarn netem-impair --profile pristine   # unshaped
+yarn netem-impair -- delay 500ms loss 10%
+```
 
-- **Linux with the native Docker Engine:** works — the host has direct routes
-  to Docker bridge networks. Note that `host.docker.internal` is provided to
-  containers by Docker Desktop, not by the native engine, so the
-  `FOXGLOVE_API_URL` values above need an `extra_hosts: host-gateway` entry
-  (tracked in FLE-588), and the
-  hosts-file line from the per-link prerequisites applies on Linux too.
-- **macOS (Docker Desktop), and Docker Desktop for Linux:** containers run
-  inside a virtual machine, so the candidate addresses are not routable from
-  the host and the browser's WebRTC connection cannot be established. The
-  gateway → LiveKit path is unaffected (it stays container-to-container). To
-  watch playback from a Mac, use a Linux machine, run the browser in a
-  container on the perlink network, or set up a routed tunnel into the
-  perlink subnet — options and tradeoffs are written up in FLE-588.
-
-When playback does connect, confirm in `chrome://webrtc-internals` that the
-selected candidate pair uses `10.99.x.x` addresses. If the host can also
-route to the default compose network (e.g. via tooling that exposes all
-container IPs), ICE may select an unimpaired path and the impairment
-profiles will not apply to what you see.
+Tear down with `docker compose -f docker-compose.yaml -f docker-compose.netem-egress.yml down`.
 
 ## Scenarios
 

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -74,9 +74,15 @@ sudo sh -c 'echo "127.0.0.1 host.docker.internal" >> /etc/hosts'
 # Terminal 1: start LiveKit + netem with per-link sidecars
 yarn start-netem --perlink
 
-# Terminal 2: start the Foxglove app with LiveKit URL override
+# Terminal 2: start the Foxglove app with the LiveKit overrides.
 # host.docker.internal resolves to the host from both macOS and Docker containers.
-(cd ../app && docker compose up -d && LIVEKIT_HOST=ws://host.docker.internal:7880 yarn start)
+# All three LiveKit variables are required, or the server reports remote access
+# as unconfigured (403); devkey/secret are the LiveKit --dev defaults.
+(cd ../app && docker compose up -d && \
+  LIVEKIT_HOST=ws://host.docker.internal:7880 \
+  LIVEKIT_API_KEY=devkey \
+  LIVEKIT_API_SECRET=secret \
+  yarn start)
 
 # Terminal 3: start the web frontend
 (cd ../app && yarn web serve:local)
@@ -95,6 +101,10 @@ $COMPOSE exec \
 Open `http://localhost:8080` in a browser and connect to the device. The test
 card traffic traverses the impaired gateway link (upload shaped by
 `gateway-netem`, download shaped by the LiveKit netem sidecar's gateway class).
+The device-token and org-plan prerequisites from the MCAP streaming section
+below apply here too (locally issued `fox_dt_…` token; org plan with remote
+access). Whether the browser can show the stream depends on the host
+platform — see "Verifying browser playback" below.
 
 > **Note:** The first `cargo build` inside the container takes ~90 seconds.
 > Subsequent builds are incremental (the target directory is cached in a Docker
@@ -157,8 +167,16 @@ conditions and to compare profiles live.
 ### Prerequisites
 
 - `host.docker.internal` set up on macOS (see the per-link Quick start above).
-- The Foxglove app stack running on the host with `LIVEKIT_HOST` overridden,
-  same as in the per-link Quick start.
+- The Foxglove app stack running on the host with all three LiveKit variables
+  set, using the same Terminal 2 command as in the per-link Quick start above.
+  The server treats remote access as unconfigured (403) unless `LIVEKIT_HOST`,
+  `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` are all non-empty; the netem
+  stack's LiveKit runs in `--dev` mode, whose default credentials are
+  `devkey` / `secret`.
+- A device token (`fox_dt_…`) issued by that local app instance — tokens from
+  other instances fail with 401 Unauthorized. The device must have remote
+  access enabled, and its org's plan must support remote access (for local
+  testing, set the org plan to `enterprise` in `console_dev`; reversible).
 - An MCAP recording on the host. Provide its **absolute** path via
   `MCAP_HOST_PATH` (or as the positional arg to `yarn stream-mcap`).
 
@@ -176,7 +194,9 @@ yarn stream-mcap
 per-link compose stack with the file bind-mounted at
 `/data/recording.mcap` inside `gateway-runner`, builds
 `example_remote_access_stream_mcap` (~90s the first time, incremental
-thereafter), and runs it.
+thereafter), and runs it. When it brings the stack up fresh, download links
+start flat (unshaped) — this is intentional for an uplink-focused test; see
+the Scope note below for retuning downloads.
 
 Once the stream is up, apply the impairment profile you want with
 `yarn netem-impair` (see next section). Don't try to set
@@ -189,7 +209,7 @@ environment_ (the Starlink default if unset). The cleanest workflow is:
 apply impairment.
 
 Open `http://localhost:8080` and connect to the device to watch the
-playback.
+playback (platform-dependent — see "Verifying browser playback" below).
 
 ### Switch profiles mid-stream
 
@@ -215,6 +235,35 @@ yarn netem-impair -- delay 500ms loss 10%
 > all download links at once (see "Changing impairment live" above). Per-link
 > viewer/download retuning still requires a stack restart with new
 > `NETEM_VIEWER_UPLOAD` / `NETEM_*_DOWNLOAD` env vars.
+
+## Verifying browser playback
+
+The flows above verify the gateway side (stream established, lease granted)
+and the impairment itself (live `tc` qdisc state). Seeing the playback at
+`http://localhost:8080` additionally requires that the host browser can reach
+LiveKit's WebRTC ICE candidates, which are container-internal addresses
+(e.g. `10.99.0.2` on the perlink network):
+
+- **Linux with the native Docker Engine:** works — the host has direct routes
+  to Docker bridge networks. Note that `host.docker.internal` is provided to
+  containers by Docker Desktop, not by the native engine, so the
+  `FOXGLOVE_API_URL` values above need an `extra_hosts: host-gateway` entry
+  (tracked in [FLE-588](https://linear.app/foxglove/issue/FLE-588)), and the
+  hosts-file line from the per-link prerequisites applies on Linux too.
+- **macOS (Docker Desktop), and Docker Desktop for Linux:** containers run
+  inside a virtual machine, so the candidate addresses are not routable from
+  the host and the browser's WebRTC connection cannot be established. The
+  gateway → LiveKit path is unaffected (it stays container-to-container). To
+  watch playback from a Mac, use a Linux machine, run the browser in a
+  container on the perlink network, or set up a routed tunnel into the
+  perlink subnet — options and tradeoffs are written up in
+  [FLE-588](https://linear.app/foxglove/issue/FLE-588).
+
+When playback does connect, confirm in `chrome://webrtc-internals` that the
+selected candidate pair uses `10.99.x.x` addresses. If the host can also
+route to the default compose network (e.g. via tooling that exposes all
+container IPs), ICE may select an unimpaired path and the impairment
+profiles will not apply to what you see.
 
 ## Scenarios
 

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -244,7 +244,7 @@ The recipe above runs everything locally, but nothing requires that: the SDK
 gateway discovers the SFU through whatever API `FOXGLOVE_API_URL` points at,
 and the `gateway-netem` sidecar shapes all of `gateway-runner`'s egress
 regardless of destination. Pointing the streamer at a deployed instance
-(production, or an internal staging environment) exercises the most
+(an internal staging environment, or production) exercises the most
 field-realistic shape — an impaired device uplink into the real SFU, with
 viewers on a clean connection — and needs none of the local app/web setup
 from the prerequisites above:
@@ -255,11 +255,17 @@ FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
 yarn stream-mcap /abs/path/to/heavy.mcap
 ```
 
+- Prefer a staging instance when one is available: streaming a heavy
+  recording deliberately saturates an uplink, and that load lands on the
+  target instance's SFU. Point at production on purpose, not by default.
 - The device token must be issued by that same instance, for a device with
   remote access enabled in an org whose plan includes it.
 - Watch the device from that instance's web app. `yarn netem-impair` works
   exactly as in the local flow — it shapes the runner's uplink wherever the
   traffic is headed.
+- Unlike the local flow, browser playback works from a macOS host here: the
+  deployed SFU's ICE candidates are publicly routable, so the macOS caveat
+  in "Verifying browser playback" below does not apply.
 - The local LiveKit and viewer containers still start (`gateway-runner`
   declares a dependency on them) but carry no traffic in this mode.
 - A deployed SFU can behave differently from the local `--dev` LiveKit, which

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -31,6 +31,7 @@ graph TD
 ```
 
 **Traffic flow (gateway example):**
+
 - gateway → LiveKit: runner sends, passes through gateway netem sidecar egress (upload shaping)
 - LiveKit → gateway: LiveKit sends, passes through LiveKit netem sidecar egress, classified to gateway class (download shaping)
 
@@ -101,14 +102,14 @@ card traffic traverses the impaired gateway link (upload shaped by
 
 ## Default impairment profiles
 
-When no NETEM_* environment (see Custom Impairment) variables are set, the impairment is:
+When no NETEM\_\* environment (see Custom Impairment) variables are set, the impairment is:
 
-| Link | Direction | Default | Simulates |
-|------|-----------|---------|-----------|
-| Gateway ↔ LiveKit | upload (gateway → LK) | delay 30ms 10ms loss 2% rate 15mbit | Device on Starlink |
+| Link               | Direction               | Default                              | Simulates          |
+| ------------------ | ----------------------- | ------------------------------------ | ------------------ |
+| Gateway ↔ LiveKit | upload (gateway → LK)   | delay 30ms 10ms loss 2% rate 15mbit  | Device on Starlink |
 | Gateway ↔ LiveKit | download (LK → gateway) | delay 30ms 10ms loss 2% rate 100mbit | Device on Starlink |
-| Viewer ↔ LiveKit | upload (viewer → LK) | delay 5ms rate 100mbit | User on fiber |
-| Viewer ↔ LiveKit | download (LK → viewer) | delay 5ms rate 500mbit | User on fiber |
+| Viewer ↔ LiveKit  | upload (viewer → LK)    | delay 5ms rate 100mbit               | User on fiber      |
+| Viewer ↔ LiveKit  | download (LK → viewer)  | delay 5ms rate 500mbit               | User on fiber      |
 
 ## Custom impairment
 
@@ -127,7 +128,7 @@ yarn start-netem --perlink
 
 Update impairment without restarting containers or dropping connections. Only newly enqueued packets use the updated parameters.
 
-Each update replaces *all* settings. Replacing "delay 500ms loss 20%" with "delay 400ms" (loss is not mentioned) *resets* loss to 0%.
+Each update replaces _all_ settings. Replacing "delay 500ms loss 20%" with "delay 400ms" (loss is not mentioned) _resets_ loss to 0%.
 
 ```sh
 COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.netem.yml -f docker-compose.netem-livekit.yml"
@@ -145,6 +146,64 @@ $COMPOSE exec netem python3 /netem_impair.py delay 100ms loss 3%
 > **Limitation:** Per-link download impairment cannot be updated independently
 > with `netem_impair.py`. It updates all netem qdiscs at once. To change a
 > single link's download, restart the stack with updated env vars.
+
+## Streaming heavy topics under uplink congestion
+
+Play back a heavy MCAP recording (e.g. point clouds) from inside the
+`gateway-runner` container so its egress to LiveKit traverses the
+`gateway-netem` sidecar. Use this to experience Foxglove under bandwidth-bound
+conditions and to compare profiles live.
+
+### Prerequisites
+
+- `host.docker.internal` set up on macOS (see the per-link Quick start above).
+- The Foxglove app stack running on the host with `LIVEKIT_HOST` overridden,
+  same as in the per-link Quick start.
+- An MCAP recording on the host. Provide its **absolute** path via
+  `MCAP_HOST_PATH` (or as the positional arg to `yarn stream-mcap`).
+
+### Run it
+
+```sh
+# Terminal 1: start the per-link stack with severe gateway upload.
+NETEM_GATEWAY_UPLOAD="delay 100ms 30ms loss 5% rate 2mbit" \
+yarn start-netem --perlink
+
+# Terminal 2: stream a heavy MCAP through gateway-runner.
+FOXGLOVE_API_URL=http://localhost:3000/api \
+FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
+MCAP_HOST_PATH=/abs/path/to/heavy.mcap \
+yarn stream-mcap
+```
+
+`yarn stream-mcap` bind-mounts the file at `/workspace/recording.mcap` inside
+the container (via `MCAP_HOST_PATH` on `docker-compose.netem-livekit.yml`),
+builds `example_remote_access_stream_mcap` (~90s the first time, incremental
+thereafter), and runs it. Open `http://localhost:8080` and connect to the
+device to watch the playback under the active impairment.
+
+### Switch profiles mid-stream
+
+While the stream is running, change the gateway-upload impairment without
+restarting the stack:
+
+```sh
+yarn netem-impair --profile starlink     # delay 30ms 10ms loss 2% rate 15mbit
+yarn netem-impair --profile 4g           # delay 50ms 15ms loss 3% rate 10mbit
+yarn netem-impair --profile wifi-walls   # delay 15ms 10ms loss 8% rate 2mbit
+yarn netem-impair --profile severe       # delay 100ms 30ms loss 5% rate 2mbit
+yarn netem-impair --profile pristine     # delay 0ms
+
+# Or pass raw netem args:
+yarn netem-impair -- delay 500ms loss 10%
+```
+
+`severe` is tuned to saturate heavy-topic uplinks; adjust from there.
+
+> **Limitation:** `yarn netem-impair` only affects the gateway upload link.
+> Per-link downloads (`NETEM_GATEWAY_DOWNLOAD`, `NETEM_VIEWER_DOWNLOAD`) and
+> the viewer upload (`NETEM_VIEWER_UPLOAD`) require restarting the stack with
+> new env vars — see "Changing impairment live" above for why.
 
 ## Scenarios
 

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -106,9 +106,11 @@ below apply here too (locally issued `fox_dt_…` token; org plan with remote
 access). Whether the browser can show the stream depends on the host
 platform — see "Verifying browser playback" below.
 
-> **Note:** The first `cargo build` inside the container takes ~90 seconds.
-> Subsequent builds are incremental (the target directory is cached in a Docker
-> volume). Requires Docker Desktop with at least 12 GB of memory allocated.
+> **Note:** The first `cargo build` inside the container compiles the example
+> and its native WebRTC dependencies from a cold cache, which can take several
+> minutes — cargo's progress output shows it is still working. Subsequent
+> builds are incremental (the target directory is cached in a Docker volume).
+> Requires Docker Desktop with at least 12 GB of memory allocated.
 
 ## Default impairment profiles
 
@@ -193,8 +195,8 @@ yarn stream-mcap
 `yarn stream-mcap` owns the stack lifecycle: it brings up (or refreshes) the
 per-link compose stack with the file bind-mounted at
 `/data/recording.mcap` inside `gateway-runner`, builds
-`example_remote_access_stream_mcap` (~90s the first time, incremental
-thereafter), and runs it. When it brings the stack up fresh, download links
+`example_remote_access_stream_mcap` (the first build from a cold cache can
+take several minutes; incremental thereafter), and runs it. When it brings the stack up fresh, download links
 start flat (unshaped) — this is intentional for an uplink-focused test; see
 the Scope note below for retuning downloads.
 

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -165,22 +165,31 @@ conditions and to compare profiles live.
 ### Run it
 
 ```sh
-# Terminal 1: start the per-link stack with severe gateway upload.
-NETEM_GATEWAY_UPLOAD="delay 100ms 30ms loss 5% rate 2mbit" \
-yarn start-netem --perlink
-
-# Terminal 2: stream a heavy MCAP through gateway-runner.
-FOXGLOVE_API_URL=http://localhost:3000/api \
+# In one terminal: stream a heavy MCAP through gateway-runner.
+FOXGLOVE_API_URL=http://host.docker.internal:3000/api \
 FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
 MCAP_HOST_PATH=/abs/path/to/heavy.mcap \
 yarn stream-mcap
 ```
 
-`yarn stream-mcap` bind-mounts the file at `/workspace/recording.mcap` inside
-the container (via `MCAP_HOST_PATH` on `docker-compose.netem-livekit.yml`),
-builds `example_remote_access_stream_mcap` (~90s the first time, incremental
-thereafter), and runs it. Open `http://localhost:8080` and connect to the
-device to watch the playback under the active impairment.
+`yarn stream-mcap` owns the stack lifecycle: it brings up (or refreshes) the
+per-link compose stack with the file bind-mounted at
+`/workspace/recording.mcap` inside `gateway-runner`, builds
+`example_remote_access_stream_mcap` (~90s the first time, incremental
+thereafter), and runs it.
+
+Once the stream is up, apply the impairment profile you want with
+`yarn netem-impair` (see next section). Don't try to set
+`NETEM_GATEWAY_UPLOAD` in a separate `yarn start-netem --perlink` terminal:
+`yarn stream-mcap` runs `docker compose up` itself, sees a config drift, and
+recreates `gateway-runner` — which also restarts `gateway-netem` and resets
+its qdisc to whatever `NETEM_GATEWAY_UPLOAD` resolves to _in stream-mcap's
+environment_ (the Starlink default if unset). The cleanest workflow is:
+`yarn stream-mcap` to start, then `yarn netem-impair --profile severe` to
+apply impairment.
+
+Open `http://localhost:8080` and connect to the device to watch the
+playback.
 
 ### Switch profiles mid-stream
 

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -162,8 +162,8 @@ FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
 yarn stream-mcap /abs/path/to/heavy.mcap
 ```
 
-`FOXGLOVE_API_URL` defaults to `https://api.foxglove.dev`; set it to target
-another instance. The device token must come from whichever instance you use,
+`FOXGLOVE_API_URL` defaults to `https://api.foxglove.dev`; point it at another
+instance to override. The device token must come from whichever instance you use,
 for a device with remote access enabled in an org whose plan includes it. For a
 local SFU, run the app and `--dev` LiveKit yourself and point `FOXGLOVE_API_URL`
 at them.

--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -150,12 +150,12 @@ $COMPOSE exec netem python3 /netem_impair.py delay 100ms loss 3%
 
 `yarn stream-mcap` replays a recording through a gateway program whose egress to
 the SFU is shaped by netem — the common "device on a constrained uplink" case,
-with no per-link network or relay. It uses `docker-compose.netem-egress.yml`: a
-`runner` container plus a `runner-netem` sidecar on its egress. (The same overlay
-shapes any gateway program — `docker compose -f docker-compose.yaml -f docker-compose.netem-egress.yml exec runner <cmd>`.)
+with no per-link network or relay. It uses `docker-compose.netem-egress.yml` — a
+`runner` plus a `runner-netem` sidecar that shapes the runner's egress; the same
+overlay shapes any gateway program you exec into it.
 
-Point it at a deployed instance — browser playback works out of the box, since
-the SFU's ICE candidates are publicly routable:
+Point it at a deployed instance — its SFU's ICE candidates are publicly
+routable, so a host browser can watch the device directly:
 
 ```sh
 FOXGLOVE_API_URL=https://api.foxglove.dev \
@@ -167,7 +167,9 @@ The device token must come from that instance, for a device with remote access
 enabled in an org whose plan includes it. For a local SFU instead, run the app
 and `--dev` LiveKit yourself and point `FOXGLOVE_API_URL` at them.
 
-Retune the uplink live without restarting (default profile is `starlink`):
+The stack starts shaped at the `starlink` profile (the `NETEM_EGRESS` default).
+Retune live without restarting — each call replaces all settings, and
+`netem-impair` needs an explicit profile or raw args:
 
 ```sh
 yarn netem-impair --profile severe     # delay 100ms 30ms loss 5% rate 2mbit
@@ -175,7 +177,7 @@ yarn netem-impair --profile pristine   # unshaped
 yarn netem-impair -- delay 500ms loss 10%
 ```
 
-Tear down with `docker compose -f docker-compose.yaml -f docker-compose.netem-egress.yml down`.
+Tear down with `docker compose -f docker-compose.netem-egress.yml down`.
 
 ## Scenarios
 

--- a/scripts/container/netem_impair.py
+++ b/scripts/container/netem_impair.py
@@ -27,12 +27,27 @@ def main() -> None:
 
     # Arguments are already a list from sys.argv — no shell parsing needed.
     netem_args = args
+
+    # Normalize `rate` so every invocation fully replaces the qdisc settings.
+    #
+    # `tc qdisc change` overwrites delay/loss/jitter unconditionally — they live
+    # in the base tc_netem_qopt struct. But `rate` rides a separate
+    # TCA_NETEM_RATE attribute that the kernel only re-applies when `rate` is on
+    # the command line; a bare change leaves any previous rate cap in place. That
+    # silently breaks A/B comparisons: e.g. `delay 100ms rate 2mbit` followed by
+    # `delay 0ms` leaves the 2mbit cap intact instead of clearing it. When the
+    # caller omits `rate`, append an effectively-uncapped value so "no rate" means
+    # "no rate limit" — matching the uncapped HTB classes in netem_setup.py.
+    if "rate" not in netem_args:
+        netem_args = [*netem_args, "rate", "1000gbit"]
+
     errors = 0
 
     for iface in sorted(p.name for p in Path("/sys/class/net").iterdir()):
         result = subprocess.run(
             ["tc", "qdisc", "show", "dev", iface],  # noqa: S603, S607
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         for line in result.stdout.splitlines():
             if "qdisc netem" not in line:
@@ -50,9 +65,20 @@ def main() -> None:
                 continue
 
             change_result = subprocess.run(
-                ["tc", "qdisc", "change", "dev", iface, *parent_args,  # noqa: S603, S607
-                 "handle", handle, "netem", *netem_args],
-                capture_output=True, text=True,
+                [
+                    "tc",
+                    "qdisc",
+                    "change",
+                    "dev",
+                    iface,
+                    *parent_args,  # noqa: S603, S607
+                    "handle",
+                    handle,
+                    "netem",
+                    *netem_args,
+                ],
+                capture_output=True,
+                text=True,
             )
             if change_result.returncode == 0:
                 print(f"  {iface} {handle}: netem {' '.join(netem_args)}")

--- a/scripts/container/netem_impair.py
+++ b/scripts/container/netem_impair.py
@@ -28,20 +28,13 @@ def main() -> None:
     # Arguments are already a list from sys.argv — no shell parsing needed.
     netem_args = args
 
-    # Normalize `rate` so every invocation fully replaces the qdisc settings.
-    #
-    # `tc qdisc change` overwrites delay/loss/jitter unconditionally — they live
-    # in the base tc_netem_qopt struct. But `rate` rides a separate
-    # TCA_NETEM_RATE attribute that the kernel only re-applies when `rate` is on
-    # the command line; a bare change leaves any previous rate cap in place. That
-    # silently breaks A/B comparisons: e.g. `delay 100ms rate 2mbit` followed by
-    # `delay 0ms` leaves the 2mbit cap intact instead of clearing it. When the
-    # caller omits `rate`, append an effectively-uncapped value so "no rate" means
-    # "no rate limit". 1000gbit is deliberately far above the `rate 10gbit` HTB
-    # classes in netem_setup.py: in classful (per-link) mode that HTB ceiling
-    # bounds throughput regardless of this value, while in flat mode netem is the
-    # root qdisc with nothing above it, so this value itself must be high enough
-    # to never be the bottleneck.
+    # `rate` rides a separate netlink attribute the kernel only rewrites when
+    # it's on the command line, so a bare `tc qdisc change` leaves a prior rate
+    # cap in place (delay/loss/jitter are always overwritten). Append an
+    # effectively-uncapped rate when the caller omits one, so "no rate" means
+    # "no limit" — e.g. `delay 0ms` after a capped profile really clears it.
+    # 1000gbit sits well above netem_setup.py's HTB ceilings, so it's never the
+    # bottleneck in either flat or classful mode.
     if "rate" not in netem_args:
         netem_args = [*netem_args, "rate", "1000gbit"]
 

--- a/scripts/container/netem_impair.py
+++ b/scripts/container/netem_impair.py
@@ -37,7 +37,11 @@ def main() -> None:
     # silently breaks A/B comparisons: e.g. `delay 100ms rate 2mbit` followed by
     # `delay 0ms` leaves the 2mbit cap intact instead of clearing it. When the
     # caller omits `rate`, append an effectively-uncapped value so "no rate" means
-    # "no rate limit" — matching the uncapped HTB classes in netem_setup.py.
+    # "no rate limit". 1000gbit is deliberately far above the `rate 10gbit` HTB
+    # classes in netem_setup.py: in classful (per-link) mode that HTB ceiling
+    # bounds throughput regardless of this value, while in flat mode netem is the
+    # root qdisc with nothing above it, so this value itself must be high enough
+    # to never be the bottleneck.
     if "rate" not in netem_args:
         netem_args = [*netem_args, "rate", "1000gbit"]
 

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -8,9 +8,13 @@
 //   yarn netem-impair --profile pristine
 //   yarn netem-impair -- delay 500ms loss 10%       # raw netem args
 //
-// Each invocation REPLACES all netem settings on the qdisc. Unmentioned
-// settings reset to 0 — for example, switching from "delay 500ms loss 20%"
-// to "delay 400ms" resets loss to 0%.
+// Each invocation REPLACES all netem settings on the qdisc — unmentioned
+// settings reset to their defaults. For example, switching from
+// "delay 500ms loss 20%" to "delay 400ms" resets loss to 0%. `rate` is a kernel
+// special case (it persists across a bare `tc qdisc change`), so `netem_impair.py`
+// appends an uncapped rate when none is given; omitting `rate` here therefore
+// means "no rate limit", consistent with the other settings. So `pristine`
+// (`delay 0ms`) really does restore an unshaped link.
 //
 // Scope: this wrapper hardcodes the `gateway-netem` sidecar, so it only
 // retunes the gateway-upload link. The underlying `netem_impair.py` is not so

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -1,6 +1,6 @@
-// Live-update the gateway-upload netem impairment without restarting the
-// per-link stack. Targets the `gateway-netem` sidecar, which shapes the
-// gateway-runner's egress to LiveKit (the "uplink" in the FLE-372 scenario).
+// Live-update the egress netem impairment on the running netem-egress stack
+// without restarting it. Targets the `runner-netem` sidecar, which shapes the
+// runner's egress to the SFU (the "uplink").
 //
 // Usage:
 //   yarn netem-impair --profile starlink
@@ -15,29 +15,15 @@
 // appends an uncapped rate when none is given; omitting `rate` here therefore
 // means "no rate limit", consistent with the other settings. So `pristine`
 // (`delay 0ms`) really does restore an unshaped link.
-//
-// Scope: this wrapper hardcodes the `gateway-netem` sidecar, so it only
-// retunes the gateway-upload link. The underlying `netem_impair.py` is not so
-// limited — exec'd into the LiveKit-side `netem` sidecar it updates all
-// download links at once (see "Changing impairment live" in
-// rust/remote_access_tests/NETEM.md). Per-link viewer/download retuning still
-// requires a stack restart with new NETEM_* env vars.
 
 import { program } from "commander";
 import { execFileSync } from "node:child_process";
 
-const COMPOSE_FILES = [
-  "-f",
-  "docker-compose.yaml",
-  "-f",
-  "docker-compose.netem.yml",
-  "-f",
-  "docker-compose.netem-livekit.yml",
-];
+const COMPOSE_FILES = ["-f", "docker-compose.yaml", "-f", "docker-compose.netem-egress.yml"];
 
-// Named profiles map to gateway-upload netem args. Presets mirror the
-// scenarios documented in rust/remote_access_tests/NETEM.md; `severe` is
-// tuned to saturate heavy-topic uplinks (FLE-372).
+// Named profiles map to egress netem args. Presets mirror the scenarios
+// documented in rust/remote_access_tests/NETEM.md; `severe` is tuned to
+// saturate heavy-topic uplinks.
 const PROFILES: Record<string, string> = {
   pristine: "delay 0ms",
   starlink: "delay 30ms 10ms loss 2% rate 15mbit",
@@ -102,22 +88,21 @@ function run(opts: Options, trailing: string[]): void {
   // python script with its own error already on stderr).
   let sidecarId = "";
   try {
-    sidecarId = composeCapture("ps", "gateway-netem", "-q").trim();
+    sidecarId = composeCapture("ps", "runner-netem", "-q").trim();
   } catch {
     // docker/compose unavailable or the query failed; treat as "not running".
   }
   if (sidecarId === "") {
     console.error(
-      "Error: the gateway-netem sidecar isn't running.\n" +
-        "  Start the per-link stack with `yarn stream-mcap` or\n" +
-        "  `yarn start-netem --perlink` first.",
+      "Error: the runner-netem sidecar isn't running.\n" +
+        "  Start it with `yarn stream-mcap` first.",
     );
     process.exit(1);
   }
 
-  console.log(`gateway upload: netem ${netemArgs.join(" ")}`);
+  console.log(`egress: netem ${netemArgs.join(" ")}`);
   try {
-    compose("exec", "gateway-netem", "python3", "/netem_impair.py", ...netemArgs);
+    compose("exec", "runner-netem", "python3", "/netem_impair.py", ...netemArgs);
   } catch (err) {
     // The sidecar is running, so the failure came from netem_impair.py itself
     // (most likely rejected args). Its stderr is already inherited, so just
@@ -127,7 +112,7 @@ function run(opts: Options, trailing: string[]): void {
 }
 
 program
-  .description("Live-update the gateway-upload netem impairment on the running per-link stack.")
+  .description("Live-update the egress netem impairment on the running netem-egress stack.")
   .option("-p, --profile <name>", `Named profile (one of: ${Object.keys(PROFILES).join(", ")})`)
   .argument("[netem-args...]", "Raw netem args (after `--`)")
   .action((trailing: string[], opts: Options) => {

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -53,6 +53,15 @@ function compose(...args: string[]): void {
   });
 }
 
+// Like `compose`, but captures stdout instead of inheriting it. Used for
+// queries (e.g. `ps -q`) whose output we need to inspect.
+function composeCapture(...args: string[]): string {
+  return execFileSync("docker", ["compose", ...COMPOSE_FILES, ...args], {
+    encoding: "utf8",
+    env: process.env,
+  });
+}
+
 function resolveArgs(opts: Options, trailing: string[]): string[] {
   const hasProfile = opts.profile != null;
   const hasTrailing = trailing.length > 0;
@@ -82,19 +91,35 @@ function resolveArgs(opts: Options, trailing: string[]): string[] {
 
 function run(opts: Options, trailing: string[]): void {
   const netemArgs = resolveArgs(opts, trailing);
-  console.log(`gateway upload: netem ${netemArgs.join(" ")}`);
+
+  // Check the sidecar is up front. `ps -q` prints its container ID when
+  // running and nothing otherwise, so we can give the "stack not running"
+  // hint only when that's actually the cause — rather than blaming the stack
+  // for every failure (e.g. rejected netem args, which exit non-zero from the
+  // python script with its own error already on stderr).
+  let sidecarId = "";
   try {
-    compose("exec", "gateway-netem", "python3", "/netem_impair.py", ...netemArgs);
+    sidecarId = composeCapture("ps", "gateway-netem", "-q").trim();
   } catch {
-    // The most common cause is that the per-link stack isn't running, which
-    // produces an opaque docker error. Point the operator at the fix instead
-    // of dumping a node stack trace.
+    sidecarId = "";
+  }
+  if (sidecarId === "") {
     console.error(
-      "\nError: could not reach the gateway-netem sidecar.\n" +
-        "  Is the per-link stack running? Start it with `yarn stream-mcap` or\n" +
+      "Error: the gateway-netem sidecar isn't running.\n" +
+        "  Start the per-link stack with `yarn stream-mcap` or\n" +
         "  `yarn start-netem --perlink` first.",
     );
     process.exit(1);
+  }
+
+  console.log(`gateway upload: netem ${netemArgs.join(" ")}`);
+  try {
+    compose("exec", "gateway-netem", "python3", "/netem_impair.py", ...netemArgs);
+  } catch (err) {
+    // The sidecar is running, so the failure came from netem_impair.py itself
+    // (most likely rejected args). Its stderr is already inherited, so just
+    // exit with its status instead of dumping a node stack trace on top.
+    process.exit((err as { status?: number }).status ?? 1);
   }
 }
 

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -63,17 +63,16 @@ function composeCapture(...args: string[]): string {
 }
 
 function resolveArgs(opts: Options, trailing: string[]): string[] {
-  const hasProfile = opts.profile != null;
   const hasTrailing = trailing.length > 0;
-  if (hasProfile && hasTrailing) {
+  if (opts.profile != null && hasTrailing) {
     console.error("Error: pass either --profile or raw netem args, not both.");
     process.exit(1);
   }
-  if (hasProfile) {
-    const preset = PROFILES[opts.profile!];
+  if (opts.profile != null) {
+    const preset = PROFILES[opts.profile];
     if (preset == null) {
       const known = Object.keys(PROFILES).join(", ");
-      console.error(`Error: unknown profile '${opts.profile!}'. Known: ${known}`);
+      console.error(`Error: unknown profile '${opts.profile}'. Known: ${known}`);
       process.exit(1);
     }
     return preset.split(" ");
@@ -101,7 +100,7 @@ function run(opts: Options, trailing: string[]): void {
   try {
     sidecarId = composeCapture("ps", "gateway-netem", "-q").trim();
   } catch {
-    sidecarId = "";
+    // docker/compose unavailable or the query failed; treat as "not running".
   }
   if (sidecarId === "") {
     console.error(

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -1,0 +1,93 @@
+// Live-update the gateway-upload netem impairment without restarting the
+// per-link stack. Targets the `gateway-netem` sidecar, which shapes the
+// gateway-runner's egress to LiveKit (the "uplink" in the FLE-372 scenario).
+//
+// Usage:
+//   yarn netem-impair --profile starlink
+//   yarn netem-impair --profile severe
+//   yarn netem-impair --profile pristine
+//   yarn netem-impair -- delay 500ms loss 10%       # raw netem args
+//
+// Each invocation REPLACES all netem settings on the qdisc. Unmentioned
+// settings reset to 0 — for example, switching from "delay 500ms loss 20%"
+// to "delay 400ms" resets loss to 0%.
+//
+// Limitation: only the gateway-upload link can be updated live. To change
+// gateway-download or viewer-* impairment, restart the stack with new
+// NETEM_* environment variables (see rust/remote_access_tests/NETEM.md).
+
+import { program } from "commander";
+import { execFileSync } from "node:child_process";
+
+const COMPOSE_FILES = [
+  "-f",
+  "docker-compose.yaml",
+  "-f",
+  "docker-compose.netem.yml",
+  "-f",
+  "docker-compose.netem-livekit.yml",
+];
+
+// Named profiles map to gateway-upload netem args. Presets mirror the
+// scenarios documented in rust/remote_access_tests/NETEM.md; `severe` is
+// tuned to saturate heavy-topic uplinks (FLE-372).
+const PROFILES: Record<string, string> = {
+  pristine: "delay 0ms",
+  starlink: "delay 30ms 10ms loss 2% rate 15mbit",
+  "4g": "delay 50ms 15ms loss 3% rate 10mbit",
+  "wifi-walls": "delay 15ms 10ms loss 8% rate 2mbit",
+  severe: "delay 100ms 30ms loss 5% rate 2mbit",
+};
+
+interface Options {
+  profile?: string;
+}
+
+function compose(...args: string[]): void {
+  execFileSync("docker", ["compose", ...COMPOSE_FILES, ...args], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
+
+function resolveArgs(opts: Options, trailing: string[]): string[] {
+  const hasProfile = opts.profile != null;
+  const hasTrailing = trailing.length > 0;
+  if (hasProfile && hasTrailing) {
+    console.error("Error: pass either --profile or raw netem args, not both.");
+    process.exit(1);
+  }
+  if (hasProfile) {
+    const preset = PROFILES[opts.profile!];
+    if (preset == null) {
+      const known = Object.keys(PROFILES).join(", ");
+      console.error(`Error: unknown profile '${opts.profile!}'. Known: ${known}`);
+      process.exit(1);
+    }
+    return preset.split(" ");
+  }
+  if (hasTrailing) {
+    return trailing;
+  }
+  console.error(
+    "Error: nothing to apply.\n" +
+      `  Use --profile <name> (one of: ${Object.keys(PROFILES).join(", ")}), or\n` +
+      "  pass raw netem args after `--`, e.g.: yarn netem-impair -- delay 500ms loss 10%",
+  );
+  process.exit(1);
+}
+
+function run(opts: Options, trailing: string[]): void {
+  const netemArgs = resolveArgs(opts, trailing);
+  console.log(`gateway upload: netem ${netemArgs.join(" ")}`);
+  compose("exec", "gateway-netem", "python3", "/netem_impair.py", ...netemArgs);
+}
+
+program
+  .description("Live-update the gateway-upload netem impairment on the running per-link stack.")
+  .option("-p, --profile <name>", `Named profile (one of: ${Object.keys(PROFILES).join(", ")})`)
+  .argument("[netem-args...]", "Raw netem args (after `--`)")
+  .action((trailing: string[], opts: Options) => {
+    run(opts, trailing);
+  })
+  .parse();

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -12,9 +12,12 @@
 // settings reset to 0 — for example, switching from "delay 500ms loss 20%"
 // to "delay 400ms" resets loss to 0%.
 //
-// Limitation: only the gateway-upload link can be updated live. To change
-// gateway-download or viewer-* impairment, restart the stack with new
-// NETEM_* environment variables (see rust/remote_access_tests/NETEM.md).
+// Scope: this wrapper hardcodes the `gateway-netem` sidecar, so it only
+// retunes the gateway-upload link. The underlying `netem_impair.py` is not so
+// limited — exec'd into the LiveKit-side `netem` sidecar it updates all
+// download links at once (see "Changing impairment live" in
+// rust/remote_access_tests/NETEM.md). Per-link viewer/download retuning still
+// requires a stack restart with new NETEM_* env vars.
 
 import { program } from "commander";
 import { execFileSync } from "node:child_process";
@@ -80,7 +83,19 @@ function resolveArgs(opts: Options, trailing: string[]): string[] {
 function run(opts: Options, trailing: string[]): void {
   const netemArgs = resolveArgs(opts, trailing);
   console.log(`gateway upload: netem ${netemArgs.join(" ")}`);
-  compose("exec", "gateway-netem", "python3", "/netem_impair.py", ...netemArgs);
+  try {
+    compose("exec", "gateway-netem", "python3", "/netem_impair.py", ...netemArgs);
+  } catch {
+    // The most common cause is that the per-link stack isn't running, which
+    // produces an opaque docker error. Point the operator at the fix instead
+    // of dumping a node stack trace.
+    console.error(
+      "\nError: could not reach the gateway-netem sidecar.\n" +
+        "  Is the per-link stack running? Start it with `yarn stream-mcap` or\n" +
+        "  `yarn start-netem --perlink` first.",
+    );
+    process.exit(1);
+  }
 }
 
 program

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -8,29 +8,18 @@
 //   yarn netem-impair --profile pristine
 //   yarn netem-impair -- delay 500ms loss 10%       # raw netem args
 //
-// Each invocation REPLACES all netem settings on the qdisc — unmentioned
-// settings reset to their defaults. For example, switching from
-// "delay 500ms loss 20%" to "delay 400ms" resets loss to 0%. `rate` is a kernel
-// special case (it persists across a bare `tc qdisc change`), so `netem_impair.py`
-// appends an uncapped rate when none is given; omitting `rate` here therefore
-// means "no rate limit", consistent with the other settings. So `pristine`
-// (`delay 0ms`) really does restore an unshaped link.
+// Each invocation REPLACES all netem settings — unmentioned ones reset to
+// default (e.g. dropping `loss` from the args clears it). `rate` is the
+// exception: `netem_impair.py` appends an uncapped rate when none is given, so
+// omitting it means "no rate limit" and `pristine` (`delay 0ms`) is unshaped.
 
 import { program } from "commander";
 import { execFileSync } from "node:child_process";
 
-const COMPOSE_FILES = ["-f", "docker-compose.yaml", "-f", "docker-compose.netem-egress.yml"];
+import { PROFILES, resolveArgs } from "./netemImpairArgs";
 
-// Named profiles map to egress netem args. Presets mirror the scenarios
-// documented in rust/remote_access_tests/NETEM.md; `severe` is tuned to
-// saturate heavy-topic uplinks.
-const PROFILES: Record<string, string> = {
-  pristine: "delay 0ms",
-  starlink: "delay 30ms 10ms loss 2% rate 15mbit",
-  "4g": "delay 50ms 15ms loss 3% rate 10mbit",
-  "wifi-walls": "delay 15ms 10ms loss 8% rate 2mbit",
-  severe: "delay 100ms 30ms loss 5% rate 2mbit",
-};
+// Self-contained overlay; the base docker-compose.yaml isn't needed here.
+const COMPOSE_FILES = ["-f", "docker-compose.netem-egress.yml"];
 
 interface Options {
   profile?: string;
@@ -52,40 +41,18 @@ function composeCapture(...args: string[]): string {
   });
 }
 
-function resolveArgs(opts: Options, trailing: string[]): string[] {
-  const hasTrailing = trailing.length > 0;
-  if (opts.profile != null && hasTrailing) {
-    console.error("Error: pass either --profile or raw netem args, not both.");
+function run(opts: Options, trailing: string[]): void {
+  let netemArgs: string[];
+  try {
+    netemArgs = resolveArgs(opts, trailing);
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
     process.exit(1);
   }
-  if (opts.profile != null) {
-    const preset = PROFILES[opts.profile];
-    if (preset == null) {
-      const known = Object.keys(PROFILES).join(", ");
-      console.error(`Error: unknown profile '${opts.profile}'. Known: ${known}`);
-      process.exit(1);
-    }
-    return preset.split(" ");
-  }
-  if (hasTrailing) {
-    return trailing;
-  }
-  console.error(
-    "Error: nothing to apply.\n" +
-      `  Use --profile <name> (one of: ${Object.keys(PROFILES).join(", ")}), or\n` +
-      "  pass raw netem args after `--`, e.g.: yarn netem-impair -- delay 500ms loss 10%",
-  );
-  process.exit(1);
-}
 
-function run(opts: Options, trailing: string[]): void {
-  const netemArgs = resolveArgs(opts, trailing);
-
-  // Check the sidecar is up front. `ps -q` prints its container ID when
-  // running and nothing otherwise, so we can give the "stack not running"
-  // hint only when that's actually the cause — rather than blaming the stack
-  // for every failure (e.g. rejected netem args, which exit non-zero from the
-  // python script with its own error already on stderr).
+  // Check the sidecar is up first, so we only blame "stack not running" when
+  // that's the actual cause — not for e.g. rejected netem args, which fail in
+  // the python script with their own error on stderr.
   let sidecarId = "";
   try {
     sidecarId = composeCapture("ps", "runner-netem", "-q").trim();

--- a/scripts/netemImpairArgs.test.ts
+++ b/scripts/netemImpairArgs.test.ts
@@ -1,0 +1,32 @@
+import { resolveArgs } from "./netemImpairArgs";
+
+describe("resolveArgs", () => {
+  it("resolves a known profile to its netem args", () => {
+    expect(resolveArgs({ profile: "pristine" }, [])).toEqual(["delay", "0ms"]);
+    expect(resolveArgs({ profile: "severe" }, [])).toEqual([
+      "delay",
+      "100ms",
+      "30ms",
+      "loss",
+      "5%",
+      "rate",
+      "2mbit",
+    ]);
+  });
+
+  it("passes raw trailing args through unchanged", () => {
+    expect(resolveArgs({}, ["delay", "5ms", "loss", "1%"])).toEqual(["delay", "5ms", "loss", "1%"]);
+  });
+
+  it("rejects an unknown profile", () => {
+    expect(() => resolveArgs({ profile: "bogus" }, [])).toThrow(/unknown profile 'bogus'/);
+  });
+
+  it("rejects combining a profile with raw args", () => {
+    expect(() => resolveArgs({ profile: "severe" }, ["delay", "5ms"])).toThrow(/either/);
+  });
+
+  it("rejects when neither a profile nor args are given", () => {
+    expect(() => resolveArgs({}, [])).toThrow(/nothing to apply/);
+  });
+});

--- a/scripts/netemImpairArgs.ts
+++ b/scripts/netemImpairArgs.ts
@@ -1,0 +1,46 @@
+// Pure profile/argument resolution for `yarn netem-impair`, kept free of CLI
+// and docker side effects so it is unit-testable. The CLI is in
+// scripts/netemImpair.ts.
+
+// Named profiles map to egress netem args. Presets mirror the scenarios in
+// rust/remote_access_tests/NETEM.md; `severe` is tuned to saturate heavy-topic
+// uplinks.
+export const PROFILES: Record<string, string> = {
+  pristine: "delay 0ms",
+  starlink: "delay 30ms 10ms loss 2% rate 15mbit",
+  "4g": "delay 50ms 15ms loss 3% rate 10mbit",
+  "wifi-walls": "delay 15ms 10ms loss 8% rate 2mbit",
+  severe: "delay 100ms 30ms loss 5% rate 2mbit",
+};
+
+export interface ResolveArgsInput {
+  profile?: string;
+}
+
+/**
+ * Resolve the netem args to apply, from a `--profile` name or raw trailing
+ * args. Throws with an operator-facing message on invalid input; the CLI turns
+ * that into an `Error: …` line and a non-zero exit.
+ */
+export function resolveArgs(opts: ResolveArgsInput, trailing: string[]): string[] {
+  const hasTrailing = trailing.length > 0;
+  if (opts.profile != null && hasTrailing) {
+    throw new Error("pass either --profile or raw netem args, not both.");
+  }
+  if (opts.profile != null) {
+    const preset = PROFILES[opts.profile];
+    if (preset == null) {
+      throw new Error(
+        `unknown profile '${opts.profile}'. Known: ${Object.keys(PROFILES).join(", ")}`,
+      );
+    }
+    return preset.split(" ");
+  }
+  if (hasTrailing) {
+    return trailing;
+  }
+  throw new Error(
+    `nothing to apply.\n  Use --profile <name> (one of: ${Object.keys(PROFILES).join(", ")}), or\n` +
+      "  pass raw netem args after `--`, e.g.: yarn netem-impair -- delay 500ms loss 10%",
+  );
+}

--- a/scripts/netemImpairArgs.ts
+++ b/scripts/netemImpairArgs.ts
@@ -27,12 +27,11 @@ export function resolveArgs(opts: ResolveArgsInput, trailing: string[]): string[
   if (opts.profile != null && hasTrailing) {
     throw new Error("pass either --profile or raw netem args, not both.");
   }
+  const known = Object.keys(PROFILES).join(", ");
   if (opts.profile != null) {
     const preset = PROFILES[opts.profile];
     if (preset == null) {
-      throw new Error(
-        `unknown profile '${opts.profile}'. Known: ${Object.keys(PROFILES).join(", ")}`,
-      );
+      throw new Error(`unknown profile '${opts.profile}'. Known: ${known}`);
     }
     return preset.split(" ");
   }
@@ -40,7 +39,7 @@ export function resolveArgs(opts: ResolveArgsInput, trailing: string[]): string[
     return trailing;
   }
   throw new Error(
-    `nothing to apply.\n  Use --profile <name> (one of: ${Object.keys(PROFILES).join(", ")}), or\n` +
+    `nothing to apply.\n  Use --profile <name> (one of: ${known}), or\n` +
       "  pass raw netem args after `--`, e.g.: yarn netem-impair -- delay 500ms loss 10%",
   );
 }

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -53,10 +53,9 @@ const COMPOSE_FILES = [
   "docker-compose.netem-livekit.yml",
 ];
 const PROFILE_ARGS = ["--profile", "perlink"];
-const DOWN_HINT =
-  "Tear down the stack when done: docker compose " +
-  COMPOSE_FILES.join(" ") +
-  " --profile perlink down";
+const DOWN_HINT = `Tear down the stack when done: docker compose ${COMPOSE_FILES.join(
+  " ",
+)} --profile perlink down`;
 
 interface Options {
   rustLog: string;
@@ -110,8 +109,9 @@ function resolveMcapPath(positional: string | undefined): string {
   return abs;
 }
 
-function requireEnv(name: string): void {
-  if (process.env[name] == null || process.env[name] === "") {
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value == null || value === "") {
     console.error(
       `Error: ${name} is not set.\n` +
         "  Both FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are required; for example:\n" +
@@ -120,11 +120,12 @@ function requireEnv(name: string): void {
     );
     process.exit(1);
   }
+  return value;
 }
 
 function run(opts: Options, positional: string | undefined): void {
-  requireEnv("FOXGLOVE_API_URL");
-  requireEnv("FOXGLOVE_DEVICE_TOKEN");
+  const apiUrl = requireEnv("FOXGLOVE_API_URL");
+  const deviceToken = requireEnv("FOXGLOVE_DEVICE_TOKEN");
   const mcapPath = resolveMcapPath(positional);
 
   // Bring up (or refresh) the stack with the bind-mount pointing at the host
@@ -164,9 +165,9 @@ function run(opts: Options, positional: string | undefined): void {
       upEnv,
       "exec",
       "-e",
-      `FOXGLOVE_API_URL=${process.env.FOXGLOVE_API_URL ?? ""}`,
+      `FOXGLOVE_API_URL=${apiUrl}`,
       "-e",
-      `FOXGLOVE_DEVICE_TOKEN=${process.env.FOXGLOVE_DEVICE_TOKEN ?? ""}`,
+      `FOXGLOVE_DEVICE_TOKEN=${deviceToken}`,
       "-e",
       `RUST_LOG=${opts.rustLog}`,
       "gateway-runner",

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -180,7 +180,13 @@ function run(opts: Options, positional: string | undefined): void {
       console.log(DOWN_HINT);
       return;
     }
-    throw err;
+    // A non-signal failure (cargo build error, `up --wait` healthcheck
+    // timeout, streamer panic) already printed its own error to the inherited
+    // stderr. Exit with the child's status so that error stays the last thing
+    // the operator sees, instead of throwing and dumping a node stack trace on
+    // top of it.
+    console.error("\n" + DOWN_HINT);
+    process.exit((err as { status?: number }).status ?? 1);
   }
 
   console.log("");

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -1,65 +1,42 @@
-// Stream a host-side MCAP file through the gateway under the per-link netem
-// stack so the operator can experience Foxglove under poor uplink conditions.
+// Replay a host-side MCAP file through a gateway program whose egress to the
+// SFU is shaped by netem, so the operator can experience Foxglove under a
+// constrained uplink. Uses docker-compose.netem-egress.yml (a `runner` plus a
+// `runner-netem` sidecar) — no per-link network or relay.
 //
 // Usage:
-//   MCAP_HOST_PATH=/abs/path/to/heavy.mcap \
-//   FOXGLOVE_API_URL=http://host.docker.internal:3000/api \
+//   FOXGLOVE_API_URL=https://api.foxglove.dev \
 //   FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
-//   yarn stream-mcap
-//
-//   # Or pass the MCAP path positionally:
 //   yarn stream-mcap /abs/path/to/heavy.mcap
 //
+//   # MCAP_HOST_PATH is an alternative to the positional path.
+//
 // Prerequisites:
-//   - FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are set in the environment.
-//     The API URL must be reachable from inside `gateway-runner`, which only
-//     joins the `perlink` network — use `http://host.docker.internal:3000/api`,
-//     not `http://localhost:3000/api`.
-//   - The Foxglove app + web frontend are running on the host. See
-//     rust/remote_access_tests/NETEM.md for the full setup.
+//   - FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN set in the environment. A
+//     deployed instance is the simplest target (browser playback works out of
+//     the box); for a local SFU, run the app yourself and point the API URL at
+//     it. See rust/remote_access_tests/NETEM.md.
 //
 // What it does:
-//   1. Resolves the MCAP path to an absolute path and validates it.
-//   2. Brings up (or refreshes) the per-link stack with MCAP_HOST_PATH exported
-//      so the file is bind-mounted at /data/recording.mcap inside
-//      gateway-runner. This invocation owns the stack — `yarn start-netem
-//      --perlink` from a separate terminal is NOT required, and any
-//      NETEM_GATEWAY_UPLOAD set in that other terminal would be wiped here
-//      when compose recreates the runner. To set a non-default starting
-//      profile, export NETEM_GATEWAY_UPLOAD before invoking this command, or
-//      use `yarn netem-impair --profile <name>` after the stack is up.
-//   3. Builds `example_remote_access_stream_mcap` inside the container.
-//      The first build from a cold cargo cache is slow (it compiles the SDK's
-//      remote-access stack, including native WebRTC code) — cargo's progress
-//      output streams to the terminal, so a quiet-looking wait means it's
-//      still compiling. Later builds are incremental via the persistent
-//      cargo volumes.
+//   1. Resolves and validates the MCAP path.
+//   2. Brings up the runner + netem sidecar with the file bind-mounted at
+//      /data/recording.mcap. Set NETEM_EGRESS for a non-default starting
+//      profile, or retune live with `yarn netem-impair` once it's up.
+//   3. Builds `example_remote_access_stream_mcap` in the container (the first
+//      build from a cold cache is slow — it compiles native WebRTC code; later
+//      builds are incremental via the persistent cargo volumes).
 //   4. Execs the streamer with the bind-mounted file.
 //
-// Unlike `yarn start-netem`, this script intentionally LEAVES THE STACK
-// RUNNING when the streamer exits, so `yarn netem-impair` keeps working and
-// re-running `yarn stream-mcap` is fast. Tear the stack down yourself when
-// done:
-//   docker compose -f docker-compose.yaml -f docker-compose.netem.yml \
-//     -f docker-compose.netem-livekit.yml --profile perlink down
+// The stack is LEFT RUNNING when the streamer exits, so `yarn netem-impair`
+// keeps working and re-running is fast. Tear it down with:
+//   docker compose -f docker-compose.yaml -f docker-compose.netem-egress.yml down
 
 import { program } from "commander";
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const COMPOSE_FILES = [
-  "-f",
-  "docker-compose.yaml",
-  "-f",
-  "docker-compose.netem.yml",
-  "-f",
-  "docker-compose.netem-livekit.yml",
-];
-const PROFILE_ARGS = ["--profile", "perlink"];
-const DOWN_HINT = `Tear down the stack when done: docker compose ${COMPOSE_FILES.join(
-  " ",
-)} --profile perlink down`;
+const COMPOSE_FILES = ["-f", "docker-compose.yaml", "-f", "docker-compose.netem-egress.yml"];
+const DOWN_HINT = `Tear down when done: docker compose ${COMPOSE_FILES.join(" ")} down`;
 const STREAMER_BIN = "/workspace/target-docker/release/example_remote_access_stream_mcap";
 
 interface Options {
@@ -82,7 +59,7 @@ function wasSignaled(err: unknown): boolean {
   return status === 130 || status === 143 || signal === "SIGINT" || signal === "SIGTERM";
 }
 
-// Best-effort: stop any streamer still running inside gateway-runner. The
+// Best-effort: stop any streamer still running inside the runner. The
 // streamer runs via `docker compose exec` and loops MCAP playback forever, so an
 // interrupted or hard-killed run can leave it alive — holding the gateway lease
 // and making the next run fail with "another gateway holds the lease". `pkill`
@@ -92,7 +69,7 @@ function stopStreamer(env: NodeJS.ProcessEnv): void {
   try {
     execFileSync(
       "docker",
-      ["compose", ...COMPOSE_FILES, "exec", "-T", "gateway-runner", "pkill", "-f", STREAMER_BIN],
+      ["compose", ...COMPOSE_FILES, "exec", "-T", "runner", "pkill", "-f", STREAMER_BIN],
       { stdio: "ignore", env },
     );
   } catch {
@@ -140,7 +117,7 @@ function requireEnv(name: string): string {
     console.error(
       `Error: ${name} is not set.\n` +
         "  Both FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are required; for example:\n" +
-        "    export FOXGLOVE_API_URL=http://host.docker.internal:3000/api\n" +
+        "    export FOXGLOVE_API_URL=https://api.foxglove.dev\n" +
         "    export FOXGLOVE_DEVICE_TOKEN=fox_dt_...",
     );
     process.exit(1);
@@ -153,11 +130,10 @@ function run(opts: Options, positional: string | undefined): void {
   const deviceToken = requireEnv("FOXGLOVE_DEVICE_TOKEN");
   const mcapPath = resolveMcapPath(positional);
 
-  // Bring up (or refresh) the stack with the bind-mount pointing at the host
-  // file. Compose expands ${MCAP_HOST_PATH} here; gateway-runner is recreated
-  // if any compose-visible config (including this mount source) changed since
-  // the last `up`. That recreation also restarts `gateway-netem`, resetting
-  // its qdisc to NETEM_GATEWAY_UPLOAD's value in *this* env.
+  // Bring up (or refresh) the runner with the bind-mount pointing at the host
+  // file. Compose expands ${MCAP_HOST_PATH} here; the runner is recreated if
+  // any compose-visible config (including this mount source) changed, which
+  // also restarts `runner-netem` and resets its qdisc to NETEM_EGRESS.
   const upEnv: NodeJS.ProcessEnv = { ...process.env, MCAP_HOST_PATH: mcapPath };
 
   // Registering SIGINT/SIGTERM handlers replaces Node's default action (die
@@ -183,14 +159,14 @@ function run(opts: Options, positional: string | undefined): void {
   // node stack trace.
   try {
     console.log(`Mounting ${mcapPath} -> /data/recording.mcap`);
-    compose(upEnv, ...PROFILE_ARGS, "up", "-d", "--wait");
+    compose(upEnv, "up", "-d", "--wait", "runner", "runner-netem");
 
     console.log("");
-    console.log("Building example_remote_access_stream_mcap inside gateway-runner...");
+    console.log("Building example_remote_access_stream_mcap inside the runner...");
     compose(
       upEnv,
       "exec",
-      "gateway-runner",
+      "runner",
       "cargo",
       "build",
       "-p",
@@ -218,7 +194,7 @@ function run(opts: Options, positional: string | undefined): void {
       `FOXGLOVE_DEVICE_TOKEN=${deviceToken}`,
       "-e",
       `RUST_LOG=${opts.rustLog}`,
-      "gateway-runner",
+      "runner",
       STREAMER_BIN,
       "--file",
       "/data/recording.mcap",
@@ -252,7 +228,7 @@ function run(opts: Options, positional: string | undefined): void {
 }
 
 program
-  .description("Stream a host-side MCAP file through the per-link netem stack's gateway-runner.")
+  .description("Replay a host-side MCAP file through a netem-shaped gateway egress.")
   .argument("[mcap-path]", "Absolute path to an MCAP file (overrides MCAP_HOST_PATH)")
   .option("--rust-log <value>", "RUST_LOG value passed into the container", "foxglove=debug,info")
   .action((positional: string | undefined, opts: Options) => {

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -21,7 +21,7 @@
 // What it does:
 //   1. Resolves the MCAP path to an absolute path and validates it.
 //   2. Brings up (or refreshes) the per-link stack with MCAP_HOST_PATH exported
-//      so the file is bind-mounted at /workspace/recording.mcap inside
+//      so the file is bind-mounted at /data/recording.mcap inside
 //      gateway-runner. This invocation owns the stack — `yarn start-netem
 //      --perlink` from a separate terminal is NOT required, and any
 //      NETEM_GATEWAY_UPLOAD set in that other terminal would be wiped here
@@ -139,7 +139,7 @@ function run(opts: Options, positional: string | undefined): void {
   // A single try/catch keeps a Ctrl-C (or container failure) from burying that
   // output under a node stack trace.
   try {
-    console.log(`Mounting ${mcapPath} -> /workspace/recording.mcap`);
+    console.log(`Mounting ${mcapPath} -> /data/recording.mcap`);
     compose(upEnv, ...PROFILE_ARGS, "up", "-d", "--wait");
 
     console.log("");
@@ -173,7 +173,7 @@ function run(opts: Options, positional: string | undefined): void {
       "gateway-runner",
       "/workspace/target-docker/release/example_remote_access_stream_mcap",
       "--file",
-      "/workspace/recording.mcap",
+      "/data/recording.mcap",
     );
   } catch (err) {
     if (wasSignaled(err)) {

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -39,11 +39,10 @@ function compose(env: NodeJS.ProcessEnv, ...args: string[]): void {
 
 /** True if the error from `execFileSync` means the child was interrupted (Ctrl-C or SIGTERM). */
 function wasSignaled(err: unknown): boolean {
-  const status = (err as { status?: number; signal?: string }).status;
-  const signal = (err as { status?: number; signal?: string }).signal;
+  const e = err as { status?: number; signal?: string };
   // 130/143 are the conventional exit codes for SIGINT/SIGTERM, reported as
   // a plain status when an intermediary (e.g. docker exec) absorbs the signal.
-  return status === 130 || status === 143 || signal === "SIGINT" || signal === "SIGTERM";
+  return e.status === 130 || e.status === 143 || e.signal === "SIGINT" || e.signal === "SIGTERM";
 }
 
 // Best-effort: kill any streamer still looping inside the runner. An

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -1,0 +1,147 @@
+// Stream a host-side MCAP file through the gateway under the per-link netem
+// stack so the operator can experience Foxglove under poor uplink conditions.
+//
+// Usage:
+//   MCAP_HOST_PATH=/abs/path/to/heavy.mcap \
+//   FOXGLOVE_API_URL=http://localhost:3000/api \
+//   FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
+//   yarn stream-mcap
+//
+//   # Or pass the MCAP path positionally:
+//   yarn stream-mcap /abs/path/to/heavy.mcap
+//
+// Prerequisites:
+//   - The per-link stack from `yarn start-netem --perlink` is running, OR
+//     this command will bring it up (with default impairment profiles).
+//   - FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are set in the environment.
+//   - The Foxglove app + web frontend are running on the host. See
+//     rust/remote_access_tests/NETEM.md for the full setup.
+//
+// What it does:
+//   1. Resolves the MCAP path to an absolute path and validates it.
+//   2. Re-ups the per-link stack with MCAP_HOST_PATH exported so the file is
+//      bind-mounted at /workspace/recording.mcap inside gateway-runner.
+//   3. Builds `example_remote_access_stream_mcap` inside the container
+//      (incremental after the first run, ~90s the first time).
+//   4. Execs the streamer with the bind-mounted file.
+
+import { program } from "commander";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const COMPOSE_FILES = [
+  "-f",
+  "docker-compose.yaml",
+  "-f",
+  "docker-compose.netem.yml",
+  "-f",
+  "docker-compose.netem-livekit.yml",
+];
+const PROFILE_ARGS = ["--profile", "perlink"];
+
+interface Options {
+  rustLog: string;
+}
+
+function compose(env: NodeJS.ProcessEnv, ...args: string[]): void {
+  execFileSync("docker", ["compose", ...COMPOSE_FILES, ...args], {
+    stdio: "inherit",
+    env,
+  });
+}
+
+function resolveMcapPath(positional: string | undefined): string {
+  const raw = positional ?? process.env.MCAP_HOST_PATH;
+  if (raw == null || raw.length === 0) {
+    console.error(
+      "Error: no MCAP file provided.\n" +
+        "  Set MCAP_HOST_PATH=/abs/path/to/file.mcap, or pass the path positionally:\n" +
+        "    yarn stream-mcap /abs/path/to/file.mcap",
+    );
+    process.exit(1);
+  }
+  const abs = path.resolve(raw);
+  try {
+    fs.accessSync(abs, fs.constants.R_OK);
+  } catch {
+    console.error(`Error: cannot read MCAP file at ${abs}`);
+    process.exit(1);
+  }
+  const stat = fs.statSync(abs);
+  if (!stat.isFile()) {
+    console.error(`Error: ${abs} is not a regular file`);
+    process.exit(1);
+  }
+  return abs;
+}
+
+function requireEnv(name: string): void {
+  if (process.env[name] == null || process.env[name] === "") {
+    console.error(
+      `Error: ${name} is not set.\n` +
+        "  Both FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are required; for example:\n" +
+        "    export FOXGLOVE_API_URL=http://localhost:3000/api\n" +
+        "    export FOXGLOVE_DEVICE_TOKEN=fox_dt_...",
+    );
+    process.exit(1);
+  }
+}
+
+function run(opts: Options, positional: string | undefined): void {
+  requireEnv("FOXGLOVE_API_URL");
+  requireEnv("FOXGLOVE_DEVICE_TOKEN");
+  const mcapPath = resolveMcapPath(positional);
+
+  // Re-up the stack with the bind-mount pointing at the host file. Compose
+  // expands ${MCAP_HOST_PATH} at this point; the gateway-runner restarts only
+  // if the mount source actually changed.
+  const upEnv: NodeJS.ProcessEnv = { ...process.env, MCAP_HOST_PATH: mcapPath };
+  console.log(`Mounting ${mcapPath} -> /workspace/recording.mcap`);
+  compose(upEnv, ...PROFILE_ARGS, "up", "-d", "--wait");
+
+  // Build the streamer inside the container. Inherits stdio so the operator
+  // sees cargo progress in real time.
+  console.log("");
+  console.log("Building example_remote_access_stream_mcap inside gateway-runner...");
+  compose(
+    upEnv,
+    "exec",
+    "gateway-runner",
+    "cargo",
+    "build",
+    "-p",
+    "example_remote_access_stream_mcap",
+    "--release",
+  );
+
+  // Forward only the env vars the streamer needs; everything else stays in
+  // the container's default environment.
+  console.log("");
+  console.log("Starting MCAP stream. Open http://localhost:8080 to view.");
+  console.log("Switch profiles mid-stream with: yarn netem-impair --profile <name>");
+  console.log("");
+  compose(
+    upEnv,
+    "exec",
+    "-e",
+    `FOXGLOVE_API_URL=${process.env.FOXGLOVE_API_URL ?? ""}`,
+    "-e",
+    `FOXGLOVE_DEVICE_TOKEN=${process.env.FOXGLOVE_DEVICE_TOKEN ?? ""}`,
+    "-e",
+    `RUST_LOG=${opts.rustLog}`,
+    "gateway-runner",
+    "/workspace/target-docker/release/example_remote_access_stream_mcap",
+    "--file",
+    "/workspace/recording.mcap",
+  );
+}
+
+program
+  .description("Stream a host-side MCAP file through the per-link netem stack's gateway-runner.")
+  .argument("[mcap-path]", "Absolute path to an MCAP file (overrides MCAP_HOST_PATH)")
+  .option("--rust-log <value>", "RUST_LOG value passed into the container", "foxglove=info,info")
+  .action((positional: string | undefined, opts: Options) => {
+    run(opts, positional);
+  })
+  .parse();

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -3,7 +3,7 @@
 //
 // Usage:
 //   MCAP_HOST_PATH=/abs/path/to/heavy.mcap \
-//   FOXGLOVE_API_URL=http://localhost:3000/api \
+//   FOXGLOVE_API_URL=http://host.docker.internal:3000/api \
 //   FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
 //   yarn stream-mcap
 //
@@ -11,16 +11,23 @@
 //   yarn stream-mcap /abs/path/to/heavy.mcap
 //
 // Prerequisites:
-//   - The per-link stack from `yarn start-netem --perlink` is running, OR
-//     this command will bring it up (with default impairment profiles).
 //   - FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are set in the environment.
+//     The API URL must be reachable from inside `gateway-runner`, which only
+//     joins the `perlink` network — use `http://host.docker.internal:3000/api`,
+//     not `http://localhost:3000/api`.
 //   - The Foxglove app + web frontend are running on the host. See
 //     rust/remote_access_tests/NETEM.md for the full setup.
 //
 // What it does:
 //   1. Resolves the MCAP path to an absolute path and validates it.
-//   2. Re-ups the per-link stack with MCAP_HOST_PATH exported so the file is
-//      bind-mounted at /workspace/recording.mcap inside gateway-runner.
+//   2. Brings up (or refreshes) the per-link stack with MCAP_HOST_PATH exported
+//      so the file is bind-mounted at /workspace/recording.mcap inside
+//      gateway-runner. This invocation owns the stack — `yarn start-netem
+//      --perlink` from a separate terminal is NOT required, and any
+//      NETEM_GATEWAY_UPLOAD set in that other terminal would be wiped here
+//      when compose recreates the runner. To set a non-default starting
+//      profile, export NETEM_GATEWAY_UPLOAD before invoking this command, or
+//      use `yarn netem-impair --profile <name>` after the stack is up.
 //   3. Builds `example_remote_access_stream_mcap` inside the container
 //      (incremental after the first run, ~90s the first time).
 //   4. Execs the streamer with the bind-mounted file.
@@ -61,6 +68,14 @@ function resolveMcapPath(positional: string | undefined): string {
     );
     process.exit(1);
   }
+  // Compose splits bind-mount specs on `:` (host:container:options), so a `:`
+  // in the host path silently corrupts the mount. Reject up front.
+  if (raw.includes(":")) {
+    console.error(
+      `Error: MCAP path must not contain ':' (compose treats ':' as a bind-mount separator): ${raw}`,
+    );
+    process.exit(1);
+  }
   const abs = path.resolve(raw);
   try {
     fs.accessSync(abs, fs.constants.R_OK);
@@ -81,7 +96,7 @@ function requireEnv(name: string): void {
     console.error(
       `Error: ${name} is not set.\n` +
         "  Both FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are required; for example:\n" +
-        "    export FOXGLOVE_API_URL=http://localhost:3000/api\n" +
+        "    export FOXGLOVE_API_URL=http://host.docker.internal:3000/api\n" +
         "    export FOXGLOVE_DEVICE_TOKEN=fox_dt_...",
     );
     process.exit(1);
@@ -93,9 +108,11 @@ function run(opts: Options, positional: string | undefined): void {
   requireEnv("FOXGLOVE_DEVICE_TOKEN");
   const mcapPath = resolveMcapPath(positional);
 
-  // Re-up the stack with the bind-mount pointing at the host file. Compose
-  // expands ${MCAP_HOST_PATH} at this point; the gateway-runner restarts only
-  // if the mount source actually changed.
+  // Bring up (or refresh) the stack with the bind-mount pointing at the host
+  // file. Compose expands ${MCAP_HOST_PATH} here; gateway-runner is recreated
+  // if any compose-visible config (including this mount source) changed since
+  // the last `up`. That recreation also restarts `gateway-netem`, resetting
+  // its qdisc to NETEM_GATEWAY_UPLOAD's value in *this* env.
   const upEnv: NodeJS.ProcessEnv = { ...process.env, MCAP_HOST_PATH: mcapPath };
   console.log(`Mounting ${mcapPath} -> /workspace/recording.mcap`);
   compose(upEnv, ...PROFILE_ARGS, "up", "-d", "--wait");
@@ -121,20 +138,33 @@ function run(opts: Options, positional: string | undefined): void {
   console.log("Starting MCAP stream. Open http://localhost:8080 to view.");
   console.log("Switch profiles mid-stream with: yarn netem-impair --profile <name>");
   console.log("");
-  compose(
-    upEnv,
-    "exec",
-    "-e",
-    `FOXGLOVE_API_URL=${process.env.FOXGLOVE_API_URL ?? ""}`,
-    "-e",
-    `FOXGLOVE_DEVICE_TOKEN=${process.env.FOXGLOVE_DEVICE_TOKEN ?? ""}`,
-    "-e",
-    `RUST_LOG=${opts.rustLog}`,
-    "gateway-runner",
-    "/workspace/target-docker/release/example_remote_access_stream_mcap",
-    "--file",
-    "/workspace/recording.mcap",
-  );
+  // Operators stop the streamer with Ctrl-C, which makes `docker exec` exit
+  // 130. Treat that as a clean shutdown rather than throwing an unhandled
+  // exception.
+  try {
+    compose(
+      upEnv,
+      "exec",
+      "-e",
+      `FOXGLOVE_API_URL=${process.env.FOXGLOVE_API_URL ?? ""}`,
+      "-e",
+      `FOXGLOVE_DEVICE_TOKEN=${process.env.FOXGLOVE_DEVICE_TOKEN ?? ""}`,
+      "-e",
+      `RUST_LOG=${opts.rustLog}`,
+      "gateway-runner",
+      "/workspace/target-docker/release/example_remote_access_stream_mcap",
+      "--file",
+      "/workspace/recording.mcap",
+    );
+  } catch (err) {
+    const status = (err as { status?: number; signal?: string }).status;
+    const signal = (err as { status?: number; signal?: string }).signal;
+    if (status === 130 || signal === "SIGINT" || signal === "SIGTERM") {
+      console.log("\nStreamer stopped.");
+      return;
+    }
+    throw err;
+  }
 }
 
 program

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -73,11 +73,13 @@ function compose(env: NodeJS.ProcessEnv, ...args: string[]): void {
   });
 }
 
-/** True if the error from `execFileSync` means the child was interrupted (Ctrl-C). */
+/** True if the error from `execFileSync` means the child was interrupted (Ctrl-C or SIGTERM). */
 function wasSignaled(err: unknown): boolean {
   const status = (err as { status?: number; signal?: string }).status;
   const signal = (err as { status?: number; signal?: string }).signal;
-  return status === 130 || signal === "SIGINT" || signal === "SIGTERM";
+  // 130/143 are the conventional exit codes for SIGINT/SIGTERM, reported as
+  // a plain status when an intermediary (e.g. docker exec) absorbs the signal.
+  return status === 130 || status === 143 || signal === "SIGINT" || signal === "SIGTERM";
 }
 
 // Best-effort: stop any streamer still running inside gateway-runner. The
@@ -230,8 +232,8 @@ function run(opts: Options, positional: string | undefined): void {
     if (wasSignaled(err)) {
       console.log("\nStreamer stopped.");
       console.log(DOWN_HINT);
-      const { signal } = err as { signal?: string };
-      process.exit(signal === "SIGTERM" ? 143 : 130);
+      const { status, signal } = err as { status?: number; signal?: string };
+      process.exit(signal === "SIGTERM" || status === 143 ? 143 : 130);
     }
     // A non-signal failure (cargo build error, `up --wait` healthcheck
     // timeout, streamer panic) already printed its own error to the inherited

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -28,8 +28,12 @@
 //      when compose recreates the runner. To set a non-default starting
 //      profile, export NETEM_GATEWAY_UPLOAD before invoking this command, or
 //      use `yarn netem-impair --profile <name>` after the stack is up.
-//   3. Builds `example_remote_access_stream_mcap` inside the container
-//      (incremental after the first run, ~90s the first time).
+//   3. Builds `example_remote_access_stream_mcap` inside the container.
+//      The first build from a cold cargo cache is slow (it compiles the SDK's
+//      remote-access stack, including native WebRTC code) — cargo's progress
+//      output streams to the terminal, so a quiet-looking wait means it's
+//      still compiling. Later builds are incremental via the persistent
+//      cargo volumes.
 //   4. Execs the streamer with the bind-mounted file.
 //
 // Unlike `yarn start-netem`, this script intentionally LEAVES THE STACK
@@ -154,16 +158,19 @@ function run(opts: Options, positional: string | undefined): void {
   // its qdisc to NETEM_GATEWAY_UPLOAD's value in *this* env.
   const upEnv: NodeJS.ProcessEnv = { ...process.env, MCAP_HOST_PATH: mcapPath };
 
-  // The streamer runs via a synchronous execFileSync, so while it's running this
-  // process is blocked. Node's default SIGINT/SIGTERM action would then kill us
-  // before any cleanup — orphaning the in-container streamer, which keeps looping
-  // playback and holds the gateway lease. Registering handlers overrides that
-  // default so we stop the streamer before exiting. (A hard SIGKILL still skips
-  // this, but the pre-launch stopStreamer() below covers that on the next run.)
+  // Registering SIGINT/SIGTERM handlers replaces Node's default action (die
+  // immediately), which would otherwise kill this wrapper mid-execFileSync and
+  // orphan the in-container streamer — it keeps looping playback and holds the
+  // gateway lease. The handler body itself almost never runs: while a compose
+  // call is blocking, the wrapper's signal is only latched. The child dies
+  // from its own copy of the signal, execFileSync throws, and the catch below
+  // handles the signaled exit — its process.exit ends the process before the
+  // latched signal is ever dispatched. The body only runs when a signal lands
+  // in one of the brief gaps between compose calls, so it cleans up quietly
+  // and exits with the conventional code. (A hard SIGKILL skips all of this,
+  // but the pre-launch stopStreamer() below covers that on the next run.)
   const onSignal = (signal: NodeJS.Signals): void => {
     stopStreamer(upEnv);
-    console.log("\nStreamer stopped.");
-    console.log(DOWN_HINT);
     process.exit(signal === "SIGINT" ? 130 : 143);
   };
   process.on("SIGINT", onSignal);
@@ -215,13 +222,16 @@ function run(opts: Options, positional: string | undefined): void {
       "/data/recording.mcap",
     );
   } catch (err) {
-    // Stop the streamer in case the exec died but left it running. (Ctrl-C /
-    // SIGTERM are handled by onSignal above, which exits before reaching here.)
+    // Stop the streamer in case the exec died but left it running. This is
+    // also the Ctrl-C path: the signal reaches the child first, execFileSync
+    // throws, and this catch runs while the wrapper's own copy of the signal
+    // is still latched (see the onSignal comment above).
     stopStreamer(upEnv);
     if (wasSignaled(err)) {
       console.log("\nStreamer stopped.");
       console.log(DOWN_HINT);
-      return;
+      const { signal } = err as { signal?: string };
+      process.exit(signal === "SIGTERM" ? 143 : 130);
     }
     // A non-signal failure (cargo build error, `up --wait` healthcheck
     // timeout, streamer panic) already printed its own error to the inherited

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -56,6 +56,7 @@ const PROFILE_ARGS = ["--profile", "perlink"];
 const DOWN_HINT = `Tear down the stack when done: docker compose ${COMPOSE_FILES.join(
   " ",
 )} --profile perlink down`;
+const STREAMER_BIN = "/workspace/target-docker/release/example_remote_access_stream_mcap";
 
 interface Options {
   rustLog: string;
@@ -73,6 +74,24 @@ function wasSignaled(err: unknown): boolean {
   const status = (err as { status?: number; signal?: string }).status;
   const signal = (err as { status?: number; signal?: string }).signal;
   return status === 130 || signal === "SIGINT" || signal === "SIGTERM";
+}
+
+// Best-effort: stop any streamer still running inside gateway-runner. The
+// streamer runs via `docker compose exec` and loops MCAP playback forever, so an
+// interrupted or hard-killed run can leave it alive — holding the gateway lease
+// and making the next run fail with "another gateway holds the lease". `pkill`
+// exits non-zero when nothing matches, and the exec fails if the stack is down;
+// both mean "no orphan to clean up", so swallow the error.
+function stopStreamer(env: NodeJS.ProcessEnv): void {
+  try {
+    execFileSync(
+      "docker",
+      ["compose", ...COMPOSE_FILES, "exec", "-T", "gateway-runner", "pkill", "-f", STREAMER_BIN],
+      { stdio: "ignore", env },
+    );
+  } catch {
+    // No matching process, or the stack isn't up — nothing to clean up.
+  }
 }
 
 function resolveMcapPath(positional: string | undefined): string {
@@ -135,9 +154,24 @@ function run(opts: Options, positional: string | undefined): void {
   // its qdisc to NETEM_GATEWAY_UPLOAD's value in *this* env.
   const upEnv: NodeJS.ProcessEnv = { ...process.env, MCAP_HOST_PATH: mcapPath };
 
+  // The streamer runs via a synchronous execFileSync, so while it's running this
+  // process is blocked. Node's default SIGINT/SIGTERM action would then kill us
+  // before any cleanup — orphaning the in-container streamer, which keeps looping
+  // playback and holds the gateway lease. Registering handlers overrides that
+  // default so we stop the streamer before exiting. (A hard SIGKILL still skips
+  // this, but the pre-launch stopStreamer() below covers that on the next run.)
+  const onSignal = (signal: NodeJS.Signals): void => {
+    stopStreamer(upEnv);
+    console.log("\nStreamer stopped.");
+    console.log(DOWN_HINT);
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
   // The compose calls below inherit stdio, so their own errors print directly.
-  // A single try/catch keeps a Ctrl-C (or container failure) from burying that
-  // output under a node stack trace.
+  // The try/catch keeps a container failure from burying that output under a
+  // node stack trace.
   try {
     console.log(`Mounting ${mcapPath} -> /data/recording.mcap`);
     compose(upEnv, ...PROFILE_ARGS, "up", "-d", "--wait");
@@ -155,6 +189,11 @@ function run(opts: Options, positional: string | undefined): void {
       "--release",
     );
 
+    // Clear any streamer left over from an earlier run before claiming the
+    // gateway lease — a lingering one (e.g. from a hard-killed run) would make
+    // the watch stream fail with "another gateway holds the lease".
+    stopStreamer(upEnv);
+
     // Forward only the env vars the streamer needs; everything else stays in
     // the container's default environment.
     console.log("");
@@ -171,11 +210,14 @@ function run(opts: Options, positional: string | undefined): void {
       "-e",
       `RUST_LOG=${opts.rustLog}`,
       "gateway-runner",
-      "/workspace/target-docker/release/example_remote_access_stream_mcap",
+      STREAMER_BIN,
       "--file",
       "/data/recording.mcap",
     );
   } catch (err) {
+    // Stop the streamer in case the exec died but left it running. (Ctrl-C /
+    // SIGTERM are handled by onSignal above, which exits before reaching here.)
+    stopStreamer(upEnv);
     if (wasSignaled(err)) {
       console.log("\nStreamer stopped.");
       console.log(DOWN_HINT);
@@ -190,6 +232,9 @@ function run(opts: Options, positional: string | undefined): void {
     process.exit((err as { status?: number }).status ?? 1);
   }
 
+  // The streamer normally loops forever; reaching here means it exited on its
+  // own, so make sure nothing lingers before pointing at teardown.
+  stopStreamer(upEnv);
   console.log("");
   console.log(DOWN_HINT);
 }

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -4,8 +4,10 @@
 // full runbook is in rust/remote_access_tests/NETEM.md.
 //
 // Usage:
-//   FOXGLOVE_API_URL=https://api.foxglove.dev FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
-//     yarn stream-mcap /abs/path/to/heavy.mcap   # or set MCAP_HOST_PATH
+//   FOXGLOVE_DEVICE_TOKEN=fox_dt_... yarn stream-mcap /abs/path/to/heavy.mcap
+//
+//   FOXGLOVE_API_URL defaults to https://api.foxglove.dev; set it to target
+//   another instance. MCAP_HOST_PATH is an alternative to the positional path.
 //
 // It bind-mounts the file at /data/recording.mcap, brings up the runner +
 // sidecar, builds the streamer (slow on a cold cache — native WebRTC), and
@@ -98,20 +100,17 @@ function resolveMcapPath(positional: string | undefined): string {
 function requireEnv(name: string): string {
   const value = process.env[name];
   if (value == null || value === "") {
-    console.error(
-      `Error: ${name} is not set.\n` +
-        "  Both FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN are required; for example:\n" +
-        "    export FOXGLOVE_API_URL=https://api.foxglove.dev\n" +
-        "    export FOXGLOVE_DEVICE_TOKEN=fox_dt_...",
-    );
+    console.error(`Error: ${name} is not set. Export it before running, e.g. ${name}=...`);
     process.exit(1);
   }
   return value;
 }
 
 function run(opts: Options, positional: string | undefined): void {
-  const apiUrl = requireEnv("FOXGLOVE_API_URL");
   const deviceToken = requireEnv("FOXGLOVE_DEVICE_TOKEN");
+  // Optional: the gateway defaults to https://api.foxglove.dev when this is
+  // unset (see Gateway's foxglove_api_url), so only forward it when provided.
+  const apiUrl = process.env.FOXGLOVE_API_URL;
   const mcapPath = resolveMcapPath(positional);
 
   // Bring up (or refresh) the runner with the bind-mount pointing at the host
@@ -159,25 +158,24 @@ function run(opts: Options, positional: string | undefined): void {
     stopStreamer(upEnv);
 
     // Forward only the env vars the streamer needs; everything else stays in
-    // the container's default environment.
+    // the container's default environment. FOXGLOVE_API_URL is passed only when
+    // set, letting the gateway fall back to its default otherwise.
     console.log("");
     console.log("Starting MCAP stream. Watch the device in your instance's web app.");
     console.log("Switch profiles mid-stream with: yarn netem-impair --profile <name>");
     console.log("");
-    compose(
-      upEnv,
+    const execArgs = [
       "exec",
-      "-e",
-      `FOXGLOVE_API_URL=${apiUrl}`,
       "-e",
       `FOXGLOVE_DEVICE_TOKEN=${deviceToken}`,
       "-e",
       `RUST_LOG=${opts.rustLog}`,
-      "runner",
-      STREAMER_BIN,
-      "--file",
-      "/data/recording.mcap",
-    );
+    ];
+    if (apiUrl != null && apiUrl !== "") {
+      execArgs.push("-e", `FOXGLOVE_API_URL=${apiUrl}`);
+    }
+    execArgs.push("runner", STREAMER_BIN, "--file", "/data/recording.mcap");
+    compose(upEnv, ...execArgs);
   } catch (err) {
     // Also the Ctrl-C path: the signal hits the child first, so execFileSync
     // throws here while the wrapper's own copy is still latched.

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -1,41 +1,28 @@
-// Replay a host-side MCAP file through a gateway program whose egress to the
-// SFU is shaped by netem, so the operator can experience Foxglove under a
-// constrained uplink. Uses docker-compose.netem-egress.yml (a `runner` plus a
-// `runner-netem` sidecar) — no per-link network or relay.
+// Replay a host-side MCAP through a gateway program whose egress to the SFU is
+// shaped by netem, to experience Foxglove under a constrained uplink. Uses
+// docker-compose.netem-egress.yml (a `runner` + `runner-netem` sidecar); the
+// full runbook is in rust/remote_access_tests/NETEM.md.
 //
 // Usage:
-//   FOXGLOVE_API_URL=https://api.foxglove.dev \
-//   FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
-//   yarn stream-mcap /abs/path/to/heavy.mcap
+//   FOXGLOVE_API_URL=https://api.foxglove.dev FOXGLOVE_DEVICE_TOKEN=fox_dt_... \
+//     yarn stream-mcap /abs/path/to/heavy.mcap   # or set MCAP_HOST_PATH
 //
-//   # MCAP_HOST_PATH is an alternative to the positional path.
-//
-// Prerequisites:
-//   - FOXGLOVE_API_URL and FOXGLOVE_DEVICE_TOKEN set in the environment. A
-//     deployed instance is the simplest target (browser playback works out of
-//     the box); for a local SFU, run the app yourself and point the API URL at
-//     it. See rust/remote_access_tests/NETEM.md.
-//
-// What it does:
-//   1. Resolves and validates the MCAP path.
-//   2. Brings up the runner + netem sidecar with the file bind-mounted at
-//      /data/recording.mcap. Set NETEM_EGRESS for a non-default starting
-//      profile, or retune live with `yarn netem-impair` once it's up.
-//   3. Builds `example_remote_access_stream_mcap` in the container (the first
-//      build from a cold cache is slow — it compiles native WebRTC code; later
-//      builds are incremental via the persistent cargo volumes).
-//   4. Execs the streamer with the bind-mounted file.
-//
-// The stack is LEFT RUNNING when the streamer exits, so `yarn netem-impair`
-// keeps working and re-running is fast. Tear it down with:
-//   docker compose -f docker-compose.yaml -f docker-compose.netem-egress.yml down
+// It bind-mounts the file at /data/recording.mcap, brings up the runner +
+// sidecar, builds the streamer (slow on a cold cache — native WebRTC), and
+// execs it. Set NETEM_EGRESS for a non-default starting profile, or retune live
+// with `yarn netem-impair`. The stack is LEFT RUNNING on exit so retuning and
+// re-runs stay fast; tear down with:
+//   docker compose -f docker-compose.netem-egress.yml down
 
 import { program } from "commander";
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const COMPOSE_FILES = ["-f", "docker-compose.yaml", "-f", "docker-compose.netem-egress.yml"];
+// The egress overlay is self-contained — it does not need the base
+// docker-compose.yaml (its only service, `livekit`, isn't used here; the runner
+// reaches the SFU via FOXGLOVE_API_URL).
+const COMPOSE_FILES = ["-f", "docker-compose.netem-egress.yml"];
 const DOWN_HINT = `Tear down when done: docker compose ${COMPOSE_FILES.join(" ")} down`;
 const STREAMER_BIN = "/workspace/target-docker/release/example_remote_access_stream_mcap";
 
@@ -59,12 +46,10 @@ function wasSignaled(err: unknown): boolean {
   return status === 130 || status === 143 || signal === "SIGINT" || signal === "SIGTERM";
 }
 
-// Best-effort: stop any streamer still running inside the runner. The
-// streamer runs via `docker compose exec` and loops MCAP playback forever, so an
-// interrupted or hard-killed run can leave it alive — holding the gateway lease
-// and making the next run fail with "another gateway holds the lease". `pkill`
-// exits non-zero when nothing matches, and the exec fails if the stack is down;
-// both mean "no orphan to clean up", so swallow the error.
+// Best-effort: kill any streamer still looping inside the runner. An
+// interrupted or hard-killed run can leave one alive, holding the gateway lease
+// so the next run fails with "another gateway holds the lease". A non-zero exit
+// (nothing matched, or stack down) just means "nothing to clean up".
 function stopStreamer(env: NodeJS.ProcessEnv): void {
   try {
     execFileSync(
@@ -136,17 +121,12 @@ function run(opts: Options, positional: string | undefined): void {
   // also restarts `runner-netem` and resets its qdisc to NETEM_EGRESS.
   const upEnv: NodeJS.ProcessEnv = { ...process.env, MCAP_HOST_PATH: mcapPath };
 
-  // Registering SIGINT/SIGTERM handlers replaces Node's default action (die
-  // immediately), which would otherwise kill this wrapper mid-execFileSync and
-  // orphan the in-container streamer — it keeps looping playback and holds the
-  // gateway lease. The handler body itself almost never runs: while a compose
-  // call is blocking, the wrapper's signal is only latched. The child dies
-  // from its own copy of the signal, execFileSync throws, and the catch below
-  // handles the signaled exit — its process.exit ends the process before the
-  // latched signal is ever dispatched. The body only runs when a signal lands
-  // in one of the brief gaps between compose calls, so it cleans up quietly
-  // and exits with the conventional code. (A hard SIGKILL skips all of this,
-  // but the pre-launch stopStreamer() below covers that on the next run.)
+  // Without these handlers a Ctrl-C mid-`execFileSync` would kill this wrapper
+  // and orphan the looping in-container streamer, which keeps holding the
+  // gateway lease. In practice the child dies from its own copy of the signal
+  // and the catch below cleans up; this body only runs for a signal landing
+  // between compose calls. (SIGKILL skips all of this — the pre-launch
+  // stopStreamer() covers that next run.)
   const onSignal = (signal: NodeJS.Signals): void => {
     stopStreamer(upEnv);
     process.exit(signal === "SIGINT" ? 130 : 143);
@@ -182,7 +162,7 @@ function run(opts: Options, positional: string | undefined): void {
     // Forward only the env vars the streamer needs; everything else stays in
     // the container's default environment.
     console.log("");
-    console.log("Starting MCAP stream. Open http://localhost:8080 to view.");
+    console.log("Starting MCAP stream. Watch the device in your instance's web app.");
     console.log("Switch profiles mid-stream with: yarn netem-impair --profile <name>");
     console.log("");
     compose(
@@ -200,10 +180,8 @@ function run(opts: Options, positional: string | undefined): void {
       "/data/recording.mcap",
     );
   } catch (err) {
-    // Stop the streamer in case the exec died but left it running. This is
-    // also the Ctrl-C path: the signal reaches the child first, execFileSync
-    // throws, and this catch runs while the wrapper's own copy of the signal
-    // is still latched (see the onSignal comment above).
+    // Also the Ctrl-C path: the signal hits the child first, so execFileSync
+    // throws here while the wrapper's own copy is still latched.
     stopStreamer(upEnv);
     if (wasSignaled(err)) {
       console.log("\nStreamer stopped.");
@@ -211,17 +189,14 @@ function run(opts: Options, positional: string | undefined): void {
       const { status, signal } = err as { status?: number; signal?: string };
       process.exit(signal === "SIGTERM" || status === 143 ? 143 : 130);
     }
-    // A non-signal failure (cargo build error, `up --wait` healthcheck
-    // timeout, streamer panic) already printed its own error to the inherited
-    // stderr. Exit with the child's status so that error stays the last thing
-    // the operator sees, instead of throwing and dumping a node stack trace on
-    // top of it.
+    // A real failure (build error, healthcheck timeout, streamer panic) already
+    // printed to the inherited stderr; exit with the child's status so that
+    // stays the last thing on screen rather than a node stack trace.
     console.error("\n" + DOWN_HINT);
     process.exit((err as { status?: number }).status ?? 1);
   }
 
-  // The streamer normally loops forever; reaching here means it exited on its
-  // own, so make sure nothing lingers before pointing at teardown.
+  // The streamer loops forever, so reaching here means it exited on its own.
   stopStreamer(upEnv);
   console.log("");
   console.log(DOWN_HINT);

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -31,6 +31,13 @@
 //   3. Builds `example_remote_access_stream_mcap` inside the container
 //      (incremental after the first run, ~90s the first time).
 //   4. Execs the streamer with the bind-mounted file.
+//
+// Unlike `yarn start-netem`, this script intentionally LEAVES THE STACK
+// RUNNING when the streamer exits, so `yarn netem-impair` keeps working and
+// re-running `yarn stream-mcap` is fast. Tear the stack down yourself when
+// done:
+//   docker compose -f docker-compose.yaml -f docker-compose.netem.yml \
+//     -f docker-compose.netem-livekit.yml --profile perlink down
 
 import { program } from "commander";
 import { execFileSync } from "node:child_process";
@@ -46,6 +53,10 @@ const COMPOSE_FILES = [
   "docker-compose.netem-livekit.yml",
 ];
 const PROFILE_ARGS = ["--profile", "perlink"];
+const DOWN_HINT =
+  "Tear down the stack when done: docker compose " +
+  COMPOSE_FILES.join(" ") +
+  " --profile perlink down";
 
 interface Options {
   rustLog: string;
@@ -58,6 +69,13 @@ function compose(env: NodeJS.ProcessEnv, ...args: string[]): void {
   });
 }
 
+/** True if the error from `execFileSync` means the child was interrupted (Ctrl-C). */
+function wasSignaled(err: unknown): boolean {
+  const status = (err as { status?: number; signal?: string }).status;
+  const signal = (err as { status?: number; signal?: string }).signal;
+  return status === 130 || signal === "SIGINT" || signal === "SIGTERM";
+}
+
 function resolveMcapPath(positional: string | undefined): string {
   const raw = positional ?? process.env.MCAP_HOST_PATH;
   if (raw == null || raw.length === 0) {
@@ -68,15 +86,16 @@ function resolveMcapPath(positional: string | undefined): string {
     );
     process.exit(1);
   }
+  const abs = path.resolve(raw);
   // Compose splits bind-mount specs on `:` (host:container:options), so a `:`
-  // in the host path silently corrupts the mount. Reject up front.
-  if (raw.includes(":")) {
+  // anywhere in the resolved path silently corrupts the mount. `path.resolve`
+  // can introduce a `:` via the cwd even when `raw` has none, so check `abs`.
+  if (abs.includes(":")) {
     console.error(
-      `Error: MCAP path must not contain ':' (compose treats ':' as a bind-mount separator): ${raw}`,
+      `Error: MCAP path must not contain ':' (compose treats ':' as a bind-mount separator): ${abs}`,
     );
     process.exit(1);
   }
-  const abs = path.resolve(raw);
   try {
     fs.accessSync(abs, fs.constants.R_OK);
   } catch {
@@ -114,34 +133,33 @@ function run(opts: Options, positional: string | undefined): void {
   // the last `up`. That recreation also restarts `gateway-netem`, resetting
   // its qdisc to NETEM_GATEWAY_UPLOAD's value in *this* env.
   const upEnv: NodeJS.ProcessEnv = { ...process.env, MCAP_HOST_PATH: mcapPath };
-  console.log(`Mounting ${mcapPath} -> /workspace/recording.mcap`);
-  compose(upEnv, ...PROFILE_ARGS, "up", "-d", "--wait");
 
-  // Build the streamer inside the container. Inherits stdio so the operator
-  // sees cargo progress in real time.
-  console.log("");
-  console.log("Building example_remote_access_stream_mcap inside gateway-runner...");
-  compose(
-    upEnv,
-    "exec",
-    "gateway-runner",
-    "cargo",
-    "build",
-    "-p",
-    "example_remote_access_stream_mcap",
-    "--release",
-  );
-
-  // Forward only the env vars the streamer needs; everything else stays in
-  // the container's default environment.
-  console.log("");
-  console.log("Starting MCAP stream. Open http://localhost:8080 to view.");
-  console.log("Switch profiles mid-stream with: yarn netem-impair --profile <name>");
-  console.log("");
-  // Operators stop the streamer with Ctrl-C, which makes `docker exec` exit
-  // 130. Treat that as a clean shutdown rather than throwing an unhandled
-  // exception.
+  // The compose calls below inherit stdio, so their own errors print directly.
+  // A single try/catch keeps a Ctrl-C (or container failure) from burying that
+  // output under a node stack trace.
   try {
+    console.log(`Mounting ${mcapPath} -> /workspace/recording.mcap`);
+    compose(upEnv, ...PROFILE_ARGS, "up", "-d", "--wait");
+
+    console.log("");
+    console.log("Building example_remote_access_stream_mcap inside gateway-runner...");
+    compose(
+      upEnv,
+      "exec",
+      "gateway-runner",
+      "cargo",
+      "build",
+      "-p",
+      "example_remote_access_stream_mcap",
+      "--release",
+    );
+
+    // Forward only the env vars the streamer needs; everything else stays in
+    // the container's default environment.
+    console.log("");
+    console.log("Starting MCAP stream. Open http://localhost:8080 to view.");
+    console.log("Switch profiles mid-stream with: yarn netem-impair --profile <name>");
+    console.log("");
     compose(
       upEnv,
       "exec",
@@ -157,20 +175,22 @@ function run(opts: Options, positional: string | undefined): void {
       "/workspace/recording.mcap",
     );
   } catch (err) {
-    const status = (err as { status?: number; signal?: string }).status;
-    const signal = (err as { status?: number; signal?: string }).signal;
-    if (status === 130 || signal === "SIGINT" || signal === "SIGTERM") {
+    if (wasSignaled(err)) {
       console.log("\nStreamer stopped.");
+      console.log(DOWN_HINT);
       return;
     }
     throw err;
   }
+
+  console.log("");
+  console.log(DOWN_HINT);
 }
 
 program
   .description("Stream a host-side MCAP file through the per-link netem stack's gateway-runner.")
   .argument("[mcap-path]", "Absolute path to an MCAP file (overrides MCAP_HOST_PATH)")
-  .option("--rust-log <value>", "RUST_LOG value passed into the container", "foxglove=info,info")
+  .option("--rust-log <value>", "RUST_LOG value passed into the container", "foxglove=debug,info")
   .action((positional: string | undefined, opts: Options) => {
     run(opts, positional);
   })

--- a/scripts/streamMcap.ts
+++ b/scripts/streamMcap.ts
@@ -124,7 +124,7 @@ function run(opts: Options, positional: string | undefined): void {
   // gateway lease. In practice the child dies from its own copy of the signal
   // and the catch below cleans up; this body only runs for a signal landing
   // between compose calls. (SIGKILL skips all of this — the pre-launch
-  // stopStreamer() covers that next run.)
+  // stopStreamer() covers that on the next run.)
   const onSignal = (signal: NodeJS.Signals): void => {
     stopStreamer(upEnv);
     process.exit(signal === "SIGINT" ? 130 : 143);
@@ -177,8 +177,8 @@ function run(opts: Options, positional: string | undefined): void {
     execArgs.push("runner", STREAMER_BIN, "--file", "/data/recording.mcap");
     compose(upEnv, ...execArgs);
   } catch (err) {
-    // Also the Ctrl-C path: the signal hits the child first, so execFileSync
-    // throws here while the wrapper's own copy is still latched.
+    // This is also the Ctrl-C path: the signal hits the child first, so
+    // execFileSync throws here while the wrapper's own copy is still latched.
     stopStreamer(upEnv);
     if (wasSignaled(err)) {
       console.log("\nStreamer stopped.");


### PR DESCRIPTION
### Changelog

None

### Docs

Adds a "Replaying an MCAP under a shaped uplink" section to `rust/remote_access_tests/NETEM.md` covering `yarn stream-mcap`, live retuning with `yarn netem-impair`, and the deployed-instance path.

### Description

FLE-372 asks us to test Foxglove remote access while streaming heavy topics through a congested uplink. The common need (confirmed with the team) is simply to **shape a gateway program's egress to the SFU** — e.g. replaying a recording from the device side under a constrained uplink.

This PR adds a standalone egress overlay and two `yarn` wrappers:

- `docker-compose.netem-egress.yml` — a `runner` container plus a `runner-netem` sidecar that shapes the runner's egress. No per-link network, viewer container, or relay. The runner connects to whatever `FOXGLOVE_API_URL` resolves (a deployed instance, or a local `--dev` LiveKit).
- `yarn stream-mcap [path]` — bind-mounts a host MCAP into the runner, builds and runs `example_remote_access_stream_mcap`, and leaves the stack up so retuning and re-runs stay fast.
- `yarn netem-impair --profile <name>` (or raw netem args after `--`) — live-updates the egress impairment on the running `runner-netem` sidecar without a restart, via named profiles (`starlink`, `4g`, `wifi-walls`, `severe`, `pristine`).

Both wrappers keep output operator-friendly: `stream-mcap` exits with the child's status on failure rather than a node stack trace, and `netem-impair` checks the sidecar is running before suggesting the stack is down.

This also changes the pre-existing `scripts/container/netem_impair.py`: when the requested args carry no `rate` token, it appends an effectively-uncapped `rate 1000gbit`. A bare `tc … change` keeps a previously applied rate cap because `rate` lives in a separate netlink attribute only rewritten when present, so without this every A/B profile comparison after the first rate-bearing profile would silently keep the old cap (e.g. `pristine` after `severe` stayed at 2 Mbit).

**Scope:** this PR deliberately drops the per-link testbed coupling. Per-link development is paused — there are no concrete tests planned on it yet — and the per-link viewer relay (#1317) and live-retune (#1310) work is archived (closed, branches and `archive/*` tags retained, reopenable). The per-link compose stack and its `NETEM.md` sections remain on `main`, untouched.

### Manual testing

The streaming and live-retune behavior, and the `netem_impair.py` rate normalization, were verified live on macOS against the netem sidecar (streaming `data-platform/common/testdata/mcap0/demo.mcap`): `stream-mcap` established the gateway session end-to-end (lease granted, no stray `recording.mcap` stub); Ctrl-C and the pre-launch cleanup leave no orphaned streamer; `netem-impair` profiles confirmed against the live `tc` qdisc (`severe` → `rate 2Mbit`, `starlink` → `rate 15Mbit`, `pristine` clears the cap), profile switching works mid-stream, and error paths are rejected.

The new `docker-compose.netem-egress.yml` is a direct reduction of that verified runner+sidecar pair (same `netem_setup.py`, same `network_mode: service:` egress shaping), moved off the per-link network. An end-to-end `yarn stream-mcap` run against the egress overlay specifically has **not** yet been done and is the remaining verification.

Fixes: [FLE-372](https://linear.app/foxglove/issue/FLE-372)
