### PR TITLE
python: Suppress import error for remote_access

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -216,6 +216,7 @@ jobs:
               fi
             artifact-suffix: "-2_28"
             test: true
+            remote_access: true
           - runner: ubuntu-22.04
             target: x86_64
             manylinux: auto
@@ -246,6 +247,7 @@ jobs:
               fi
             artifact-suffix: "-2_28"
             test: true
+            remote_access: true
           - runner: ubuntu-22.04-arm
             target: aarch64
             manylinux: auto
@@ -284,6 +286,8 @@ jobs:
       - name: Test wheel
         if: matrix.platform.test
         shell: bash
+        env:
+          FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS: ${{ matrix.platform.remote_access && '1' || '0' }}
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
@@ -341,16 +345,21 @@ jobs:
           path: dist
       - name: Test wheel
         if: matrix.platform.test
+        env:
+          FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS: ${{ matrix.platform.remote_access && '1' || '0' }}
         run: |
-          docker run --rm -v "$PWD:/io" -w /io python:3.10-alpine sh -euxc '
-            pip install dist/*.whl
-            pip install pytest mcap
-            mkdir wheel-test
-            cp -r python/foxglove/tests wheel-test/
-            cp conftest.py wheel-test/
-            cd wheel-test
-            pytest -v tests
-          '
+          docker run --rm \
+            -v "$PWD:/io" -w /io \
+            -e FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS \
+            python:3.10-alpine sh -euxc '
+              pip install dist/*.whl
+              pip install pytest mcap
+              mkdir wheel-test
+              cp -r python/foxglove/tests wheel-test/
+              cp conftest.py wheel-test/
+              cd wheel-test
+              pytest -v tests
+            '
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -362,6 +371,7 @@ jobs:
           - runner: windows-latest
             target: x86_64
             extra-args: --features pyo3/extension-module,remote-access
+            remote_access: true
           - runner: windows-latest
             target: x86
     steps:
@@ -404,6 +414,8 @@ jobs:
           path: dist
       - name: Test wheel
         shell: bash
+        env:
+          FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS: ${{ matrix.platform.remote_access && '1' || '0' }}
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
@@ -425,9 +437,11 @@ jobs:
           - runner: macos-15
             target: aarch64
             extra-args: --features pyo3/extension-module,remote-access
+            remote_access: true
           - runner: macos-15-intel
             target: x86_64
             extra-args: --features pyo3/extension-module,remote-access
+            remote_access: true
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -452,6 +466,8 @@ jobs:
           path: dist
       - name: Test wheel
         shell: bash
+        env:
+          FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS: ${{ matrix.platform.remote_access && '1' || '0' }}
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -215,10 +215,12 @@ jobs:
                 exit 1
               fi
             artifact-suffix: "-2_28"
+            test: true
           - runner: ubuntu-22.04
             target: x86_64
             manylinux: auto
             artifact-suffix: ""
+            test: true
           - runner: ubuntu-22.04-arm
             target: aarch64
             manylinux: "2_28"
@@ -243,14 +245,18 @@ jobs:
                 exit 1
               fi
             artifact-suffix: "-2_28"
+            test: true
           - runner: ubuntu-22.04-arm
             target: aarch64
             manylinux: auto
             artifact-suffix: ""
+            test: true
           - runner: ubuntu-22.04
             target: armv7
             manylinux: auto
             artifact-suffix: ""
+            # No native armv7 runner; qemu emulation is too slow for CI.
+            test: false
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -275,6 +281,21 @@ jobs:
         with:
           name: wheels-linux-${{ matrix.platform.target }}${{ matrix.platform.artifact-suffix }}
           path: dist
+      - name: Test wheel
+        if: matrix.platform.test
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -m pip install pytest mcap
+          # Run pytest from a directory that doesn't contain the local source
+          # tree, so it exercises the installed wheel rather than ./python/foxglove.
+          mkdir wheel-test
+          cp -r python/foxglove/tests wheel-test/
+          cp conftest.py wheel-test/
+          cd wheel-test
+          python -m pytest -v tests
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -285,10 +306,16 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+            # Native x86_64 musl can be tested inside an Alpine container.
+            test: true
           - runner: ubuntu-22.04
             target: aarch64
+            # No native aarch64 musl runner; qemu emulation is too slow for CI.
+            test: false
           - runner: ubuntu-22.04
             target: armv7
+            # No native armv7 musl runner; qemu emulation is too slow for CI.
+            test: false
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -312,6 +339,18 @@ jobs:
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
+      - name: Test wheel
+        if: matrix.platform.test
+        run: |
+          docker run --rm -v "$PWD:/io" -w /io python:3.10-alpine sh -euxc '
+            pip install dist/*.whl
+            pip install pytest mcap
+            mkdir wheel-test
+            cp -r python/foxglove/tests wheel-test/
+            cp conftest.py wheel-test/
+            cd wheel-test
+            pytest -v tests
+          '
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -363,6 +402,18 @@ jobs:
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: dist
+      - name: Test wheel
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -m pip install pytest mcap
+          mkdir wheel-test
+          cp -r python/foxglove/tests wheel-test/
+          cp conftest.py wheel-test/
+          cd wheel-test
+          python -m pytest -v tests
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -399,6 +450,18 @@ jobs:
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
+      - name: Test wheel
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -m pip install pytest mcap
+          mkdir wheel-test
+          cp -r python/foxglove/tests wheel-test/
+          cp conftest.py wheel-test/
+          cd wheel-test
+          python -m pytest -v tests
 
   sdist:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -297,7 +297,6 @@ jobs:
           # tree, so it exercises the installed wheel rather than ./python/foxglove.
           mkdir wheel-test
           cp -r python/foxglove/tests wheel-test/
-          cp conftest.py wheel-test/
           cd wheel-test
           python -m pytest -v tests
 
@@ -356,7 +355,6 @@ jobs:
               pip install pytest mcap
               mkdir wheel-test
               cp -r python/foxglove/tests wheel-test/
-              cp conftest.py wheel-test/
               cd wheel-test
               pytest -v tests
             '
@@ -423,7 +421,6 @@ jobs:
           python -m pip install pytest mcap
           mkdir wheel-test
           cp -r python/foxglove/tests wheel-test/
-          cp conftest.py wheel-test/
           cd wheel-test
           python -m pytest -v tests
 
@@ -475,7 +472,6 @@ jobs:
           python -m pip install pytest mcap
           mkdir wheel-test
           cp -r python/foxglove/tests wheel-test/
-          cp conftest.py wheel-test/
           cd wheel-test
           python -m pytest -v tests
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -351,6 +351,9 @@ jobs:
             -v "$PWD:/io" -w /io \
             -e FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS \
             python:3.10-alpine sh -euxc '
+              # gcc + musl-dev are needed to build the lz4 sdist; lz4 (a
+              # transitive mcap dep) ships no cp310 musllinux wheel.
+              apk add --no-cache gcc musl-dev
               pip install dist/*.whl
               pip install pytest mcap
               mkdir wheel-test

--- a/Container.mk
+++ b/Container.mk
@@ -4,16 +4,19 @@ generate:
 	yarn generate
 
 PYTHON_REMOTE_ACCESS ?= ON
+ifeq ($(PYTHON_REMOTE_ACCESS),ON)
+FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS = 1
+MATURIN_PEP517_ARGS += --features remote-access
+else
+FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS = 0
+endif
+
 # Opts into a build-time check that NVENC hardware acceleration for video
 # encoding will be available (cuda.h is present on supported targets). Only
 # meaningful when remote-access is also enabled. Defaults to OFF because the
 # check fails the build on hosts without the CUDA toolkit; opt in explicitly
 # (e.g. in CI) where you want the loud failure.
 PYTHON_REQUIRE_CUDA ?= OFF
-
-ifeq ($(PYTHON_REMOTE_ACCESS),ON)
-MATURIN_PEP517_ARGS += --features remote-access
-endif
 ifeq ($(PYTHON_REQUIRE_CUDA),ON)
 MATURIN_PEP517_ARGS += --features require-cuda
 endif
@@ -35,7 +38,9 @@ lint-python:
 test-python:
 	uv --directory python/foxglove-sdk lock --check
 	uv --directory python/foxglove-sdk sync --all-extras
-	MATURIN_PEP517_ARGS="$(MATURIN_PEP517_ARGS)" uv --directory python/foxglove-sdk pip install --editable '.[notebook]'
+	MATURIN_PEP517_ARGS="$(MATURIN_PEP517_ARGS)" \
+		FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS="$(FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS)" \
+		uv --directory python/foxglove-sdk pip install --editable '.[notebook]'
 	uv --directory python/foxglove-sdk run mypy .
 	uv --directory python/foxglove-sdk run pytest
 

--- a/Container.mk
+++ b/Container.mk
@@ -38,11 +38,9 @@ lint-python:
 test-python:
 	uv --directory python/foxglove-sdk lock --check
 	uv --directory python/foxglove-sdk sync --all-extras
-	MATURIN_PEP517_ARGS="$(MATURIN_PEP517_ARGS)" \
-		FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS="$(FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS)" \
-		uv --directory python/foxglove-sdk pip install --editable '.[notebook]'
+	MATURIN_PEP517_ARGS="$(MATURIN_PEP517_ARGS)" uv --directory python/foxglove-sdk pip install --editable '.[notebook]'
 	uv --directory python/foxglove-sdk run mypy .
-	uv --directory python/foxglove-sdk run pytest
+	FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS="$(FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS)" uv --directory python/foxglove-sdk run pytest
 
 .PHONY: benchmark-python
 benchmark-python:

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -317,8 +317,8 @@ try:
     __all__ += ["start_gateway"]
 
 except ImportError:
-    if sys.platform != "emscripten":
-        raise
+    # Remote access is only included on supported platforms.
+    pass
 
 
 def set_log_level(level: int | str = "INFO") -> None:

--- a/python/foxglove-sdk/python/foxglove/tests/test_remote_access.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_remote_access.py
@@ -1,4 +1,12 @@
+import os
+
 import pytest
+
+# Set FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS=1 in environments where remote_access
+# is expected to be available (e.g. CI jobs building wheels with the
+# remote-access feature). This converts the soft skip below into a hard failure
+# so a broken or accidentally-disabled remote_access build doesn't slip through.
+_REQUIRE_REMOTE_ACCESS = os.environ.get("FOXGLOVE_TEST_REQUIRE_REMOTE_ACCESS") == "1"
 
 try:
     from foxglove import ConnectionGraph, start_gateway
@@ -10,6 +18,8 @@ try:
 
     HAS_REMOTE_ACCESS = True
 except ImportError:
+    if _REQUIRE_REMOTE_ACCESS:
+        raise
     HAS_REMOTE_ACCESS = False
 
 pytestmark = pytest.mark.skipif(


### PR DESCRIPTION
### Changelog
- python: Fixed an import error on platforms that do not support remote access

### Docs
None

### Description
We have a try/except around the imports from the `remote_access` module, but we're re-raising too aggressively.

This change fixes the bug, and also adds CI coverage to ensure that (a) remote access is exposed on platforms where we expect it to be and (b) tests pass on the wheels we build, regardless of whether remote access is enabled.

Fixes: FLE-559