### PR TITLE
ros: Release version 3.4.0

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -65,6 +65,7 @@ jobs:
           - humble
           - jazzy
           - kilted
+          - lyrical
           - rolling
     name: "ros (${{ matrix.ros_distribution }})"
     steps:

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -66,7 +66,7 @@ jobs:
           - jazzy
           - kilted
           - lyrical
-          - rolling
+          # rolling temporarily disabled while upstream changes land; re-enable when stable
     name: "ros (${{ matrix.ros_distribution }})"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -65,7 +65,7 @@ jobs:
           - humble
           - jazzy
           - kilted
-          # rolling temporarily disabled while upstream changes land; re-enable when stable
+          - rolling
     name: "ros (${{ matrix.ros_distribution }})"
     steps:
       - uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,4 +73,5 @@ Packages will be available via apt after the [next sync](https://discourse.ros.o
 [humble](http://repo.ros2.org/status_page/ros_humble_default.html?q=foxglove),
 [jazzy](http://repo.ros2.org/status_page/ros_jazzy_default.html?q=foxglove),
 [kilted](http://repo.ros2.org/status_page/ros_kilted_default.html?q=foxglove),
+[lyrical](http://repo.ros2.org/status_page/ros_lyrical_default.html?q=foxglove),
 [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html?q=foxglove)

--- a/ros/Makefile
+++ b/ros/Makefile
@@ -1,4 +1,4 @@
-ROS_DISTRIBUTIONS := humble jazzy kilted rolling
+ROS_DISTRIBUTIONS := humble jazzy kilted lyrical rolling
 FOXGLOVE_BRIDGE_REMOTE_ACCESS := ON
 FOXGLOVE_CPP_SDK_DIR :=
 EXTRA_DOCKER_ARGS :=

--- a/ros/src/foxglove_bridge/CHANGELOG.rst
+++ b/ros/src/foxglove_bridge/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package foxglove_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.4.0 (2026-05-28)
+------------------
+* Fix an issue where the ``parameters`` implementation would occasionally stall message forwarding for several seconds
+* Fix an issue where the bridge was not refcounting parameter subscriptions properly when a WebSocket server and Remote Access gateway were simultaneously in use
+* Fix an issue where the parameter whitelist would randomly prevent subscribing to or setting unrelated parameters
+* Add ``message_backlog_size`` option to configure the outgoing message buffer
+* Update Foxglove SDK version to 0.25.0
+
 3.3.0 (2026-04-30)
 ------------------
 * Fix an issue where the bridge would stay subscribed to the graph even after clients disconnect

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -9,7 +9,7 @@ if(POLICY CMP0024)
   set(CMAKE_POLICY_DEFAULT_CMP0024 NEW)
 endif()
 
-project(foxglove_bridge LANGUAGES CXX VERSION 3.3.0)
+project(foxglove_bridge LANGUAGES CXX VERSION 3.4.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -90,14 +90,14 @@ endif()
 # cmake-glue change don't yet, so the FetchContent download path is broken until a
 # release ships with that glue. For local development, point the override at a
 # `make build-cpp-dist`-produced tree.
-set(FOXGLOVE_SDK_VERSION "0.24.0")
+set(FOXGLOVE_SDK_VERSION "0.25.0")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   set(FOXGLOVE_SDK_PLATFORM "aarch64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "27f689210f277bbf05cddc96df14e1149ac34c9b68a6f05ba14f2c7baa7ee6ae")
+  set(FOXGLOVE_SDK_SHA "d0c862d6923a0964ac112f0b918befcd60152093f8aeb806b4f440fca0448a66")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(FOXGLOVE_SDK_PLATFORM "x86_64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "4381e1759f08b76f3bb2bf27ac4ab480caeb5cd71b8119221866c469534490c4")
+  set(FOXGLOVE_SDK_SHA "16ff2f7eafbcf673ebb5560f5a84bae07694c7f106973efb6b16253280e4766b")
 else()
   message(FATAL_ERROR "Unsupported platform/architecture combination: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
 endif()

--- a/ros/src/foxglove_bridge/README.md
+++ b/ros/src/foxglove_bridge/README.md
@@ -134,6 +134,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
 - **sysinfo**: Publish process and system statistics (CPU, memory, etc.) on a channel. Defaults to `true`.
 - **sysinfo_topic**: Topic name for system info messages. Defaults to `/foxglove_bridge/sysinfo`.
 - **sysinfo_refresh_interval**: Refresh interval for system info messages in milliseconds. Minimum 200ms. Defaults to `500`.
+- **message_backlog_size**: Maximum number of outgoing messages to buffer per connected WebSocket client or remote access gateway participant. The WebSocket server drops the oldest data-plane message on overflow and disconnects clients whose control-plane queue fills. The remote access gateway disconnects participants whose queue fills. Defaults to `1024`.
 - **remote_access**: Enable the remote access gateway, allowing the bridge to be reached through Foxglove's platform without exposing a port on the device. Requires the bridge to be built with `FOXGLOVE_BRIDGE_REMOTE_ACCESS=ON` (the default for our published Docker images). Defaults to `false`.
 - **device_token**: Foxglove device token used to authenticate with the Foxglove platform when `remote_access` is enabled. If empty, the bridge falls back to the `FOXGLOVE_DEVICE_TOKEN` environment variable.
 

--- a/ros/src/foxglove_bridge/package.xml
+++ b/ros/src/foxglove_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>foxglove_bridge</name>
-    <version>3.3.0</version>
+    <version>3.4.0</version>
     <description>ROS Foxglove Bridge</description>
     <license>MIT</license>
     <url type="website">https://github.com/foxglove/foxglove-sdk</url>

--- a/ros/src/foxglove_msgs/CHANGELOG.rst
+++ b/ros/src/foxglove_msgs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package foxglove_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.4.0 (2026-05-28)
+------------------
+* Version bump for foxglove_bridge 3.4.0 release
+
 3.3.0 (2026-04-30)
 ------------------
 * Breaking: Remove Velocity3 schema; LocationFix.velocity now uses Vector3

--- a/ros/src/foxglove_msgs/package.xml
+++ b/ros/src/foxglove_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>foxglove_msgs</name>
-  <version>3.3.0</version>
+  <version>3.4.0</version>
   <description>
     foxglove_msgs provides visualization messages that are supported by Foxglove.
   </description>


### PR DESCRIPTION
### Changelog
foxglove_bridge:
* Fix an issue where the `parameters` implementation would occasionally stall message forwarding for several seconds
* Fix an issue where the bridge was not refcounting parameter subscriptions properly when a WebSocket server and Remote Access gateway were simultaneously in use
* Fix an issue where the parameter whitelist would randomly prevent subscribing to or setting unrelated parameters
* Add `message_backlog_size` option to configure the outgoing message buffer
* Update Foxglove SDK version to 0.25.0

### Docs
Updated readme for `message_backlog_size`

### Description
Update foxglove_bridge and foxglove_msgs to 3.4.0, and bump the bundled
Foxglove SDK to v0.25.0.

This change also adds lyrical to CI.