### PR TITLE
ci: Update git workflows for lyrical & rolling

### DIFF
--- a/.github/workflows/draft-ros-release.yml
+++ b/.github/workflows/draft-ros-release.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
         # rolling temporarily disabled while upstream changes land; re-enable when stable
-        distro: [humble, jazzy, kilted]
+        distro: [humble, jazzy, kilted, lyrical]
         package: [bridge, msgs]
         include:
           - arch: x86_64

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -3,7 +3,7 @@ name: Publish ROS Bridge Docker image
 on:
   workflow_dispatch: {}
   push:
-    tags: ['ros-v*']
+    tags: ["ros-v*"]
 
 permissions:
   contents: read
@@ -16,7 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distribution: [humble, jazzy, kilted, rolling]
+        # rolling temporarily disabled while upstream changes land; re-enable when stable
+        ros_distribution: [humble, jazzy, kilted, lyrical]
     env:
       DOCKER_REPO: us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
I forgot to update a few other workflows for lyrical, and we never
disabled rolling for publish-ros-bridge.yml.