### PR TITLE
ci: Prevent draft-release skip-cascade on ros tag pushes

### DIFF
--- a/.github/workflows/draft-ros-release.yml
+++ b/.github/workflows/draft-ros-release.yml
@@ -93,7 +93,10 @@ jobs:
 
   draft-release:
     needs: [build-deb]
-    if: ${{ github.event_name == 'push' && needs.build-deb.result == 'success' }}
+    # `always()` opts out of the default skip-cascade: build-cpp-dist is skipped
+    # on tag pushes, and without this the cascade would skip draft-release even
+    # though build-deb succeeded.
+    if: ${{ always() && github.event_name == 'push' && needs.build-deb.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

`build-cpp-dist` is skipped on tag pushes (it only runs when
`inputs.use_branch_sdk` is set). GitHub Actions then applies its
default skip-cascade through `build-deb` (which uses `if: always()`)
to `draft-release`, so the draft release never gets created even
though all 16 build-deb matrix jobs succeed. This is what happened
on the ros-v3.4.0 tag push (run 26645699744): all build-deb jobs
were green, but draft-release was skipped.

Add `always()` to draft-release's `if:` so the cascade is broken
while still gating on the push event and a successful build-deb.

Manual testing: will validate by re-tagging or via the next ros
release; no automated coverage of release workflow logic.