### PR TITLE
ci: Match prior release-notes style in draft-ros-release

### DIFF
--- a/.github/workflows/draft-ros-release.yml
+++ b/.github/workflows/draft-ros-release.yml
@@ -93,7 +93,10 @@ jobs:
 
   draft-release:
     needs: [build-deb]
-    if: ${{ github.event_name == 'push' && needs.build-deb.result == 'success' }}
+    # `always()` opts out of the default skip-cascade: build-cpp-dist is skipped
+    # on tag pushes, and without this the cascade would skip draft-release even
+    # though build-deb succeeded.
+    if: ${{ always() && github.event_name == 'push' && needs.build-deb.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/draft-ros-release.yml
+++ b/.github/workflows/draft-ros-release.yml
@@ -117,22 +117,25 @@ jobs:
         run: |
           set -euo pipefail
           extract() {
-            # Print from the first "X.Y.Z (date)" heading up to (but not including) the second.
+            # Print bullets from the first "X.Y.Z (date)" heading up to (but not
+            # including) the second, skipping the heading line and its dashed
+            # underline so the rendered markdown matches the prior release style.
             awk '
               /^[0-9]+\.[0-9]+\.[0-9]+ \(/ {
                 count++
                 if (count == 2) exit
+                skip_dashes = 1
+                next
               }
+              skip_dashes && /^-+$/ { skip_dashes = 0; next }
               count == 1 { print }
             ' "$1"
           }
           {
             echo "## foxglove_bridge"
-            echo
             extract ros/src/foxglove_bridge/CHANGELOG.rst
             echo
             echo "## foxglove_msgs"
-            echo
             extract ros/src/foxglove_msgs/CHANGELOG.rst
           } > release-notes.md
           cat release-notes.md


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Strip the `X.Y.Z (date)` heading line and its dashed underline from
the extracted CHANGELOG bullets so the rendered release notes match
the manually-published ros-v3.3.0 release (just `## foxglove_bridge` +
bullets, no version line, no RST dashes).