### PR TITLE
write playground url to generated mcap file metadata

### DIFF
--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -306,6 +306,7 @@ export function Playground(): React.JSX.Element {
 
 const DEFAULT_CODE = `\
 import foxglove
+import playground
 from foxglove import Channel
 from foxglove.channels import SceneUpdateChannel
 from foxglove.messages import (
@@ -319,6 +320,7 @@ from foxglove.messages import (
 scene_channel = SceneUpdateChannel("/scene")
 
 with foxglove.open_mcap("playground.mcap") as writer:
+  writer.write_metadata("foxglove.playground", {"url": playground.current_url})
   for i in range(10):
     size = 1 + 0.2 * i
     scene_channel.log(

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -136,7 +136,12 @@ export function Playground(): React.JSX.Element {
       return;
     }
     try {
-      await runner.run(editorRef.current?.getValue() ?? "");
+      const code = editorRef.current?.getValue() ?? "";
+      const layout = await viewerRef.current?.getLayout();
+      setUrlState({ code, layout });
+      // setUrlState() above is synchronous, so location.href includes this exact code/layout
+      // state immediately.
+      await runner.run(code, window.location.href);
 
       try {
         const { name, data } = await runner.readFile();

--- a/playground/src/Runner.ts
+++ b/playground/src/Runner.ts
@@ -30,8 +30,8 @@ export class Runner extends EventEmitter<EventMap> {
     );
   }
 
-  async run(code: string): Promise<void> {
-    this.emit("run-completed", await this.#remote.run(code));
+  async run(code: string, sourceUrl: string): Promise<void> {
+    this.emit("run-completed", await this.#remote.run(code, sourceUrl));
   }
 
   async readFile(): Promise<{ name: string; data: Uint8Array<ArrayBuffer> }> {

--- a/playground/src/Runner.ts
+++ b/playground/src/Runner.ts
@@ -30,8 +30,8 @@ export class Runner extends EventEmitter<EventMap> {
     );
   }
 
-  async run(code: string, sourceUrl: string): Promise<void> {
-    this.emit("run-completed", await this.#remote.run(code, sourceUrl));
+  async run(code: string, currentUrl: string): Promise<void> {
+    this.emit("run-completed", await this.#remote.run(code, currentUrl));
   }
 
   async readFile(): Promise<{ name: string; data: Uint8Array<ArrayBuffer> }> {

--- a/playground/src/RunnerWorker.ts
+++ b/playground/src/RunnerWorker.ts
@@ -279,7 +279,6 @@ mod
         pathlib.Path("/home/pyodide/playground").mkdir(parents=True)
         os.chdir("/home/pyodide/playground")
 
-        import playground
         playground.current_url = current_url
       `,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/playground/src/RunnerWorker.ts
+++ b/playground/src/RunnerWorker.ts
@@ -83,6 +83,7 @@ def set_layout(layout: "foxglove.layouts.Layout", /) -> None:
 mod = ModuleType("playground")
 mod.__doc__ = "Functions available in the SDK playground."
 mod.set_layout = set_layout
+mod.current_url = ""
 mod
     `,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -264,7 +265,7 @@ mod
     return pyodide;
   }
 
-  async run(code: string, sourceUrl: string): Promise<string | undefined> {
+  async run(code: string, currentUrl: string): Promise<string | undefined> {
     const pyodide = await this.#pyodide;
     await pyodide.loadPackagesFromImports(code);
     pyodide.runPython(
@@ -278,21 +279,11 @@ mod
         pathlib.Path("/home/pyodide/playground").mkdir(parents=True)
         os.chdir("/home/pyodide/playground")
 
-        # monkey patch foxglove.open_mcap to write the source URL to the mcap's metadata
-        import foxglove
-
-        if not hasattr(foxglove, "_playground_original_open_mcap"):
-          foxglove._playground_original_open_mcap = foxglove.open_mcap
-
-        def _playground_open_mcap(*args, **kwargs):
-          writer = foxglove._playground_original_open_mcap(*args, **kwargs)
-          writer.write_metadata("foxglove.playground", {"url": source_url})
-          return writer
-
-        foxglove.open_mcap = _playground_open_mcap
+        import playground
+        playground.current_url = current_url
       `,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { globals: pyodide.toPy({ source_url: sourceUrl }) },
+      { globals: pyodide.toPy({ current_url: currentUrl }) },
     );
     pyodide.runPython(code);
     return this.#getFileNames(pyodide)[0];

--- a/playground/src/RunnerWorker.ts
+++ b/playground/src/RunnerWorker.ts
@@ -279,6 +279,7 @@ mod
         pathlib.Path("/home/pyodide/playground").mkdir(parents=True)
         os.chdir("/home/pyodide/playground")
 
+        import playground
         playground.current_url = current_url
       `,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/playground/src/RunnerWorker.ts
+++ b/playground/src/RunnerWorker.ts
@@ -264,7 +264,7 @@ mod
     return pyodide;
   }
 
-  async run(code: string): Promise<string | undefined> {
+  async run(code: string, sourceUrl: string): Promise<string | undefined> {
     const pyodide = await this.#pyodide;
     await pyodide.loadPackagesFromImports(code);
     pyodide.runPython(
@@ -277,9 +277,22 @@ mod
           pass
         pathlib.Path("/home/pyodide/playground").mkdir(parents=True)
         os.chdir("/home/pyodide/playground")
+
+        # monkey patch foxglove.open_mcap to write the source URL to the mcap's metadata
+        import foxglove
+
+        if not hasattr(foxglove, "_playground_original_open_mcap"):
+          foxglove._playground_original_open_mcap = foxglove.open_mcap
+
+        def _playground_open_mcap(*args, **kwargs):
+          writer = foxglove._playground_original_open_mcap(*args, **kwargs)
+          writer.write_metadata("foxglove.playground", {"url": source_url})
+          return writer
+
+        foxglove.open_mcap = _playground_open_mcap
       `,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { globals: pyodide.toPy({}) },
+      { globals: pyodide.toPy({ source_url: sourceUrl }) },
     );
     pyodide.runPython(code);
     return this.#getFileNames(pyodide)[0];


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
The SDK Playground is a great way to generate sample MCAP data for testing. A common follow-up is making small tweaks to that data later, such as adding a topic or adjusting message frequency. To make that easy, this PR stores the originating Playground URL as MCAP metadata, so you can trace and reproduce how a file was generated.

<img width="510" height="242" alt="image" src="https://github.com/user-attachments/assets/dc83b716-2de3-4a2c-b1f9-b9a37ec495b0" />
