### PR TITLE
Bump @foxglove/schemas to 2.1.0

### DIFF
--- a/typescript/schemas/package.json
+++ b/typescript/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/schemas",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Foxglove-defined message schemas for ROS, Protobuf, FlatBuffers, OMG IDL, and JSON",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
### Changelog

Bump `@foxglove/schemas` to 2.1.0.

### Docs

None.

### Description

Updates the `@foxglove/schemas` package version from 2.0.0 to 2.1.0 so the next TypeScript schemas npm release can be published with the `typescript/schemas/v2.1.0` release tag.

Reviewer manual steps:

- After merge, create and publish a GitHub release tagged `typescript/schemas/v2.1.0`.
- Confirm the TypeScript GitHub Actions job publishes `@foxglove/schemas@2.1.0` to npm.

### Validation

- `yarn workspace @foxglove/schemas pack`
