### PR TITLE
Emit Encode schema definitions in deterministic order (fixes #1297)

### DIFF
--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -588,9 +588,18 @@ fn derive_named_struct_impl(
         });
     }
 
-    let enum_defs = enum_defs.into_values().collect::<Vec<_>>();
-    let message_defs = message_defs.into_values().collect::<Vec<_>>();
-    let file_defs = file_defs.into_values().collect::<Vec<_>>();
+    // Emit definitions in a deterministic order: HashMap iteration order is
+    // randomized per process, so splicing `into_values()` directly makes the
+    // generated tokens (and the consuming crate's SVH) differ build-to-build.
+    let mut enum_defs: Vec<_> = enum_defs.into_iter().collect();
+    enum_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
+    let enum_defs = enum_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
+    let mut message_defs: Vec<_> = message_defs.into_iter().collect();
+    message_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
+    let message_defs = message_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
+    let mut file_defs: Vec<_> = file_defs.into_iter().collect();
+    file_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
+    let file_defs = file_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
     let has_generics = !input.generics.params.is_empty();
 
     // Extract computation bodies so we can conditionally wrap with OnceLock


### PR DESCRIPTION
Fixes #1297.

`#[derive(Encode)]` (`derive_named_struct_impl`) collects per-field-type schema definitions into three `HashMap<&syn::Type, TokenStream>` (`enum_defs`/`message_defs`/`file_defs`) and then splices them via `into_values()`:

```rust
let enum_defs = enum_defs.into_values().collect::<Vec<_>>();   // HashMap order = per-process random
// … #(#enum_defs)*  #(#message_defs)*  #(#file_defs)*
```

`HashMap` iteration order is randomized per process, so the generated descriptor statements come out in a different order on every compile, which changes the **consuming crate's metadata hash (SVH)**. Under content-addressed build systems with a shared cache that yields different artifacts for the same input, and mixing a fresh build with a cached dependency fails with `error[E0463]: can't find crate` (the proc-macro variant of rust-lang/rust#89904).

This PR sorts the collected definitions by their field-type tokens before splicing, making the order deterministic. (An insertion-ordered map such as `IndexMap` would also work.)

**Verified:** a struct with several distinct primitive field types, built three times with a clean rebuild each, produced three different `.rmeta` hashes before this change and three identical hashes after.

