### PR TITLE
bump uuid from 8.3.2 to 9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "packageManager": "yarn@4.12.0",
   "resolutions": {
     "minimatch": "^10.2.3",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "sockjs/uuid": "^9.0.1"
   },
   "workspaces": [
     "typescript/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10475,12 +10475,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Forcibly bump sockjs/uuid to 9.0.1 to address https://github.com/foxglove/foxglove-sdk/security/dependabot/177.

As suggested by the webpack-dev-server maintainers:
https://github.com/webpack/webpack-dev-server/issues/5662#issuecomment-4448722673

### Testing

Tested playground on this PR, and everything's working fine.

### Links

Fixes: FLE-515