### PR TITLE
remote_access: Publish VP8 instead of H.264 on macOS (FLE-579)

### DIFF
--- a/rust/examples/remote_access/src/main.rs
+++ b/rust/examples/remote_access/src/main.rs
@@ -13,7 +13,7 @@ use foxglove::{
 };
 use serde_json::Value;
 use std::{
-    sync::{Arc, LazyLock},
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -71,12 +71,6 @@ async fn main() {
     let env = env_logger::Env::default().default_filter_or("info");
     env_logger::init_from_env(env);
 
-    tracing::info!(
-        "streaming video at {}x{} @ {FPS} fps (override with VIDEO_WIDTH / VIDEO_HEIGHT)",
-        *WIDTH,
-        *HEIGHT
-    );
-
     // Open a gateway for remote visualization and teleop.
     let handle = Gateway::new()
         .capabilities([Capability::ClientPublish])
@@ -105,8 +99,7 @@ async fn main() {
 // ---------------------------------------------------------------------------
 // Test card: designed to make network degradation visually obvious.
 //
-// Layout (positions are tuned for the default 960x540; at larger configured
-// resolutions the test card renders within the top-left region of the frame):
+// Layout (960x540):
 //   +---------------------------+------------------+
 //   |                           |  Frame: 00042    |
 //   |    Sweeping clock hand    |  12:34:56.789    |
@@ -125,24 +118,10 @@ async fn main() {
 // - Scrolling ticker: smooth motion becomes jerky with frame drops.
 // ---------------------------------------------------------------------------
 
-/// Frame width in pixels. Override with the `VIDEO_WIDTH` environment variable
-/// (defaults to 960). Useful for experimenting with higher resolutions such as
-/// 1080p (`VIDEO_WIDTH=1920 VIDEO_HEIGHT=1080`).
-static WIDTH: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_WIDTH", 960));
-/// Frame height in pixels. Override with the `VIDEO_HEIGHT` environment variable
-/// (defaults to 540).
-static HEIGHT: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_HEIGHT", 540));
+const WIDTH: usize = 960;
+const HEIGHT: usize = 540;
 const BYTES_PER_PIXEL: usize = 3;
 const FPS: u32 = 30;
-
-/// Read a `usize` from an environment variable, falling back to `default` if the
-/// variable is unset or cannot be parsed.
-fn env_usize(name: &str, default: usize) -> usize {
-    std::env::var(name)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
-}
 
 /// 5x7 bitmap font. Each glyph is stored as 7 rows of 5-bit patterns
 /// (MSB = leftmost pixel). The full alphabet is defined so the font table
@@ -232,8 +211,8 @@ struct Rgb(u8, u8, u8);
 
 /// Set a single pixel in the buffer (bounds-checked).
 fn set_pixel(buf: &mut [u8], x: i32, y: i32, color: Rgb) {
-    if x >= 0 && (x as usize) < *WIDTH && y >= 0 && (y as usize) < *HEIGHT {
-        let off = y as usize * (*WIDTH * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
+    if x >= 0 && (x as usize) < WIDTH && y >= 0 && (y as usize) < HEIGHT {
+        let off = y as usize * (WIDTH * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
         buf[off] = color.0;
         buf[off + 1] = color.1;
         buf[off + 2] = color.2;
@@ -249,7 +228,7 @@ fn draw_text(buf: &mut [u8], text: &str, x: i32, y: i32, scale: usize, color: Rg
         if char_x + (GLYPH_W * scale) as i32 <= 0 {
             continue;
         }
-        if char_x >= *WIDTH as i32 {
+        if char_x >= WIDTH as i32 {
             break;
         }
         let rows = glyph_rows(ch);
@@ -413,7 +392,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let check_w: usize = 260;
     let check_h: usize = 270;
     let cell_size: usize = 10;
-    let stride = *WIDTH * BYTES_PER_PIXEL;
+    let stride = WIDTH * BYTES_PER_PIXEL;
     for cy_off in 0..check_h {
         let row_start = (check_y + cy_off) * stride + check_x * BYTES_PER_PIXEL;
         let row_cell = cy_off / cell_size;
@@ -430,7 +409,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     }
 
     // --- Scrolling ticker (bottom 80px) ---
-    let ticker_y = *HEIGHT - 80;
+    let ticker_y = HEIGHT - 80;
     let ticker_text = "    FOXGLOVE NETWORK TEST CARD \
         :::  Frame drops appear as jumps in the clock hand  :::  \
         Latency visible by comparing timestamp to wall clock  :::  \
@@ -443,9 +422,9 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let scroll_offset = (frame_number as usize * scroll_speed) % text_pixel_width;
 
     // Draw ticker background.
-    for y in ticker_y..*HEIGHT {
+    for y in ticker_y..HEIGHT {
         let row_start = y * stride;
-        for x in 0..*WIDTH {
+        for x in 0..WIDTH {
             let off = row_start + x * BYTES_PER_PIXEL;
             buf[off] = 20;
             buf[off + 1] = 20;
@@ -458,7 +437,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let x_start = -(scroll_offset as i32);
     for pass in 0..2i32 {
         let base_x = x_start + pass * text_pixel_width as i32;
-        if base_x < *WIDTH as i32 && base_x + text_pixel_width as i32 > 0 {
+        if base_x < WIDTH as i32 && base_x + text_pixel_width as i32 > 0 {
             draw_text(
                 buf,
                 ticker_text,
@@ -502,29 +481,29 @@ async fn tf_static_loop() {
 async fn camera_loop() {
     let mut interval = tokio::time::interval(Duration::from_millis(1000 / FPS as u64));
     let mut frame_number: u64 = 0;
-    let mut rgb_buf = vec![0u8; *WIDTH * *HEIGHT * BYTES_PER_PIXEL];
-    let mut mono_buf = vec![0u8; *WIDTH * *HEIGHT];
+    let mut rgb_buf = vec![0u8; WIDTH * HEIGHT * BYTES_PER_PIXEL];
+    let mut mono_buf = vec![0u8; WIDTH * HEIGHT];
 
     // Pre-compute a double-width gradient lookup table so we can take a
     // width-sized slice at any offset without per-pixel math each frame.
-    let mono_gradient: Vec<u8> = (0..*WIDTH * 2)
-        .map(|x| ((x % *WIDTH) * 255 / *WIDTH) as u8)
+    let mono_gradient: Vec<u8> = (0..WIDTH * 2)
+        .map(|x| ((x % WIDTH) * 255 / WIDTH) as u8)
         .collect();
 
     let calibration = CameraCalibration {
         timestamp: None,
         frame_id: "camera".into(),
-        width: *WIDTH as u32,
-        height: *HEIGHT as u32,
+        width: WIDTH as u32,
+        height: HEIGHT as u32,
         distortion_model: String::new(),
         d: vec![],
         k: vec![
             500.0,
             0.0,
-            *WIDTH as f64 / 2.0,
+            WIDTH as f64 / 2.0,
             0.0,
             500.0,
-            *HEIGHT as f64 / 2.0,
+            HEIGHT as f64 / 2.0,
             0.0,
             0.0,
             1.0,
@@ -533,11 +512,11 @@ async fn camera_loop() {
         p: vec![
             500.0,
             0.0,
-            *WIDTH as f64 / 2.0,
+            WIDTH as f64 / 2.0,
             0.0,
             0.0,
             500.0,
-            *HEIGHT as f64 / 2.0,
+            HEIGHT as f64 / 2.0,
             0.0,
             0.0,
             0.0,
@@ -554,27 +533,27 @@ async fn camera_loop() {
         let rgb_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: *WIDTH as u32,
-            height: *HEIGHT as u32,
+            width: WIDTH as u32,
+            height: HEIGHT as u32,
             encoding: "rgb8".into(),
-            step: (*WIDTH * BYTES_PER_PIXEL) as u32,
+            step: (WIDTH * BYTES_PER_PIXEL) as u32,
             data: Bytes::copy_from_slice(&rgb_buf),
         };
         foxglove::log!("/video/test-card", rgb_img);
 
         // Mono image: scrolling gradient (simple secondary stream).
-        let offset = frame_number as usize % *WIDTH;
-        let mono_row = &mono_gradient[offset..offset + *WIDTH];
-        for row in mono_buf.chunks_exact_mut(*WIDTH) {
+        let offset = frame_number as usize % WIDTH;
+        let mono_row = &mono_gradient[offset..offset + WIDTH];
+        for row in mono_buf.chunks_exact_mut(WIDTH) {
             row.copy_from_slice(mono_row);
         }
         let mono_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: *WIDTH as u32,
-            height: *HEIGHT as u32,
+            width: WIDTH as u32,
+            height: HEIGHT as u32,
             encoding: "mono8".into(),
-            step: *WIDTH as u32,
+            step: WIDTH as u32,
             data: Bytes::copy_from_slice(&mono_buf),
         };
         foxglove::log!("/video/gradient", mono_img);

--- a/rust/examples/remote_access/src/main.rs
+++ b/rust/examples/remote_access/src/main.rs
@@ -13,7 +13,7 @@ use foxglove::{
 };
 use serde_json::Value;
 use std::{
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -71,6 +71,12 @@ async fn main() {
     let env = env_logger::Env::default().default_filter_or("info");
     env_logger::init_from_env(env);
 
+    tracing::info!(
+        "streaming video at {}x{} @ {FPS} fps (override with VIDEO_WIDTH / VIDEO_HEIGHT)",
+        *WIDTH,
+        *HEIGHT
+    );
+
     // Open a gateway for remote visualization and teleop.
     let handle = Gateway::new()
         .capabilities([Capability::ClientPublish])
@@ -99,7 +105,8 @@ async fn main() {
 // ---------------------------------------------------------------------------
 // Test card: designed to make network degradation visually obvious.
 //
-// Layout (960x540):
+// Layout (positions are tuned for the default 960x540; at larger configured
+// resolutions the test card renders within the top-left region of the frame):
 //   +---------------------------+------------------+
 //   |                           |  Frame: 00042    |
 //   |    Sweeping clock hand    |  12:34:56.789    |
@@ -118,10 +125,24 @@ async fn main() {
 // - Scrolling ticker: smooth motion becomes jerky with frame drops.
 // ---------------------------------------------------------------------------
 
-const WIDTH: usize = 960;
-const HEIGHT: usize = 540;
+/// Frame width in pixels. Override with the `VIDEO_WIDTH` environment variable
+/// (defaults to 960). Useful for experimenting with higher resolutions such as
+/// 1080p (`VIDEO_WIDTH=1920 VIDEO_HEIGHT=1080`).
+static WIDTH: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_WIDTH", 960));
+/// Frame height in pixels. Override with the `VIDEO_HEIGHT` environment variable
+/// (defaults to 540).
+static HEIGHT: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_HEIGHT", 540));
 const BYTES_PER_PIXEL: usize = 3;
 const FPS: u32 = 30;
+
+/// Read a `usize` from an environment variable, falling back to `default` if the
+/// variable is unset or cannot be parsed.
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
 
 /// 5x7 bitmap font. Each glyph is stored as 7 rows of 5-bit patterns
 /// (MSB = leftmost pixel). The full alphabet is defined so the font table
@@ -211,8 +232,8 @@ struct Rgb(u8, u8, u8);
 
 /// Set a single pixel in the buffer (bounds-checked).
 fn set_pixel(buf: &mut [u8], x: i32, y: i32, color: Rgb) {
-    if x >= 0 && (x as usize) < WIDTH && y >= 0 && (y as usize) < HEIGHT {
-        let off = y as usize * (WIDTH * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
+    if x >= 0 && (x as usize) < *WIDTH && y >= 0 && (y as usize) < *HEIGHT {
+        let off = y as usize * (*WIDTH * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
         buf[off] = color.0;
         buf[off + 1] = color.1;
         buf[off + 2] = color.2;
@@ -228,7 +249,7 @@ fn draw_text(buf: &mut [u8], text: &str, x: i32, y: i32, scale: usize, color: Rg
         if char_x + (GLYPH_W * scale) as i32 <= 0 {
             continue;
         }
-        if char_x >= WIDTH as i32 {
+        if char_x >= *WIDTH as i32 {
             break;
         }
         let rows = glyph_rows(ch);
@@ -392,7 +413,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let check_w: usize = 260;
     let check_h: usize = 270;
     let cell_size: usize = 10;
-    let stride = WIDTH * BYTES_PER_PIXEL;
+    let stride = *WIDTH * BYTES_PER_PIXEL;
     for cy_off in 0..check_h {
         let row_start = (check_y + cy_off) * stride + check_x * BYTES_PER_PIXEL;
         let row_cell = cy_off / cell_size;
@@ -409,7 +430,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     }
 
     // --- Scrolling ticker (bottom 80px) ---
-    let ticker_y = HEIGHT - 80;
+    let ticker_y = *HEIGHT - 80;
     let ticker_text = "    FOXGLOVE NETWORK TEST CARD \
         :::  Frame drops appear as jumps in the clock hand  :::  \
         Latency visible by comparing timestamp to wall clock  :::  \
@@ -422,9 +443,9 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let scroll_offset = (frame_number as usize * scroll_speed) % text_pixel_width;
 
     // Draw ticker background.
-    for y in ticker_y..HEIGHT {
+    for y in ticker_y..*HEIGHT {
         let row_start = y * stride;
-        for x in 0..WIDTH {
+        for x in 0..*WIDTH {
             let off = row_start + x * BYTES_PER_PIXEL;
             buf[off] = 20;
             buf[off + 1] = 20;
@@ -437,7 +458,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let x_start = -(scroll_offset as i32);
     for pass in 0..2i32 {
         let base_x = x_start + pass * text_pixel_width as i32;
-        if base_x < WIDTH as i32 && base_x + text_pixel_width as i32 > 0 {
+        if base_x < *WIDTH as i32 && base_x + text_pixel_width as i32 > 0 {
             draw_text(
                 buf,
                 ticker_text,
@@ -481,29 +502,29 @@ async fn tf_static_loop() {
 async fn camera_loop() {
     let mut interval = tokio::time::interval(Duration::from_millis(1000 / FPS as u64));
     let mut frame_number: u64 = 0;
-    let mut rgb_buf = vec![0u8; WIDTH * HEIGHT * BYTES_PER_PIXEL];
-    let mut mono_buf = vec![0u8; WIDTH * HEIGHT];
+    let mut rgb_buf = vec![0u8; *WIDTH * *HEIGHT * BYTES_PER_PIXEL];
+    let mut mono_buf = vec![0u8; *WIDTH * *HEIGHT];
 
     // Pre-compute a double-width gradient lookup table so we can take a
     // width-sized slice at any offset without per-pixel math each frame.
-    let mono_gradient: Vec<u8> = (0..WIDTH * 2)
-        .map(|x| ((x % WIDTH) * 255 / WIDTH) as u8)
+    let mono_gradient: Vec<u8> = (0..*WIDTH * 2)
+        .map(|x| ((x % *WIDTH) * 255 / *WIDTH) as u8)
         .collect();
 
     let calibration = CameraCalibration {
         timestamp: None,
         frame_id: "camera".into(),
-        width: WIDTH as u32,
-        height: HEIGHT as u32,
+        width: *WIDTH as u32,
+        height: *HEIGHT as u32,
         distortion_model: String::new(),
         d: vec![],
         k: vec![
             500.0,
             0.0,
-            WIDTH as f64 / 2.0,
+            *WIDTH as f64 / 2.0,
             0.0,
             500.0,
-            HEIGHT as f64 / 2.0,
+            *HEIGHT as f64 / 2.0,
             0.0,
             0.0,
             1.0,
@@ -512,11 +533,11 @@ async fn camera_loop() {
         p: vec![
             500.0,
             0.0,
-            WIDTH as f64 / 2.0,
+            *WIDTH as f64 / 2.0,
             0.0,
             0.0,
             500.0,
-            HEIGHT as f64 / 2.0,
+            *HEIGHT as f64 / 2.0,
             0.0,
             0.0,
             0.0,
@@ -533,27 +554,27 @@ async fn camera_loop() {
         let rgb_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: WIDTH as u32,
-            height: HEIGHT as u32,
+            width: *WIDTH as u32,
+            height: *HEIGHT as u32,
             encoding: "rgb8".into(),
-            step: (WIDTH * BYTES_PER_PIXEL) as u32,
+            step: (*WIDTH * BYTES_PER_PIXEL) as u32,
             data: Bytes::copy_from_slice(&rgb_buf),
         };
         foxglove::log!("/video/test-card", rgb_img);
 
         // Mono image: scrolling gradient (simple secondary stream).
-        let offset = frame_number as usize % WIDTH;
-        let mono_row = &mono_gradient[offset..offset + WIDTH];
-        for row in mono_buf.chunks_exact_mut(WIDTH) {
+        let offset = frame_number as usize % *WIDTH;
+        let mono_row = &mono_gradient[offset..offset + *WIDTH];
+        for row in mono_buf.chunks_exact_mut(*WIDTH) {
             row.copy_from_slice(mono_row);
         }
         let mono_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: WIDTH as u32,
-            height: HEIGHT as u32,
+            width: *WIDTH as u32,
+            height: *HEIGHT as u32,
             encoding: "mono8".into(),
-            step: WIDTH as u32,
+            step: *WIDTH as u32,
             data: Bytes::copy_from_slice(&mono_buf),
         };
         foxglove::log!("/video/gradient", mono_img);

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2182,12 +2182,12 @@ impl RemoteAccessSession {
                 // on Linux hosts that have nvenc available. VP8/VP9/AV1 paths
                 // are software-only in our builds, so H.264 is at worst parity elsewhere.
                 //
-                // Exception: on macOS the H.264 path uses Apple's VideoToolbox hardware
-                // encoder, which negotiates H.264 level 3.1 (capping resolution at 720p) and
-                // periodically freezes for several seconds while reconfiguring on WebRTC
-                // bitrate probes (FLE-579). macOS is only a dev machine here (real devices are
-                // Linux) with no nvenc to benefit from, so prefer software VP8 there — it has
-                // no level cap and no reconfigure freeze.
+                // Exception: on macOS we publish VP8 instead. On the macOS VideoToolbox
+                // H.264 path we observed (FLE-579) that the default negotiated H.264 level
+                // (Constrained Baseline 3.1) limits the stream to 720p, and that encoded
+                // output paused for several seconds at a time while the encoder adapted to
+                // bitrate changes; VP8 reached full 1080p without those pauses. The H.264
+                // level default is not macOS-specific and is tracked separately in FLE-584.
                 //
                 // Disable simulcast. We expect viewers will be mostly homogenous, and
                 // simulcast is a lot of work for the robot without much to gain.

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -2181,12 +2181,25 @@ impl RemoteAccessSession {
                 // Prefer H.264 so that the libwebrtc nvenc encoder (H.264-only) can be used
                 // on Linux hosts that have nvenc available. VP8/VP9/AV1 paths
                 // are software-only in our builds, so H.264 is at worst parity elsewhere.
+                //
+                // Exception: on macOS the H.264 path uses Apple's VideoToolbox hardware
+                // encoder, which negotiates H.264 level 3.1 (capping resolution at 720p) and
+                // periodically freezes for several seconds while reconfiguring on WebRTC
+                // bitrate probes (FLE-579). macOS is only a dev machine here (real devices are
+                // Linux) with no nvenc to benefit from, so prefer software VP8 there — it has
+                // no level cap and no reconfigure freeze.
+                //
                 // Disable simulcast. We expect viewers will be mostly homogenous, and
                 // simulcast is a lot of work for the robot without much to gain.
                 // We observed that nvenc aggressively enforces the target bitrate,
                 // and combined with simulcast results in very low quality video with compression artifacts.
+                let video_codec = if cfg!(target_os = "macos") {
+                    VideoCodec::VP8
+                } else {
+                    VideoCodec::H264
+                };
                 let publish_options = TrackPublishOptions {
-                    video_codec: VideoCodec::H264,
+                    video_codec,
                     simulcast: false,
                     ..Default::default()
                 };

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -602,6 +602,33 @@ impl ViewerConnection {
         }
     }
 
+    /// Waits for a `TrackSubscribed` room event for a video track and returns the
+    /// subscribed [`RemoteVideoTrack`], so callers can read receiver-side WebRTC stats
+    /// (e.g. the actually-received frame dimensions and frame rate).
+    ///
+    /// Non-matching `DataTrackPublished` events are buffered for later consumption.
+    pub async fn expect_video_track_subscribed(
+        &mut self,
+    ) -> Result<livekit::track::RemoteVideoTrack> {
+        let deadline = tokio::time::Instant::now() + EVENT_TIMEOUT;
+        loop {
+            let event = tokio::time::timeout_at(deadline, self.events.recv())
+                .await
+                .context("timeout waiting for TrackSubscribed event")?
+                .context("room events channel closed")?;
+            match event {
+                RoomEvent::TrackSubscribed {
+                    track: livekit::track::RemoteTrack::Video(track),
+                    ..
+                } => return Ok(track),
+                RoomEvent::DataTrackPublished(track) => {
+                    self.pending_data_tracks.push(track);
+                }
+                _ => continue,
+            }
+        }
+    }
+
     /// Waits for a `TrackUnsubscribed` room event and returns the track name.
     pub async fn expect_track_unsubscribed(&mut self) -> Result<String> {
         let deadline = tokio::time::Instant::now() + EVENT_TIMEOUT;

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -582,34 +582,16 @@ impl ViewerConnection {
         self.send_framed_message(&framed).await
     }
 
-    /// Waits for a `TrackSubscribed` room event and returns the track name.
-    pub async fn expect_track_subscribed(&mut self) -> Result<String> {
-        let deadline = tokio::time::Instant::now() + EVENT_TIMEOUT;
-        loop {
-            let event = tokio::time::timeout_at(deadline, self.events.recv())
-                .await
-                .context("timeout waiting for TrackSubscribed event")?
-                .context("room events channel closed")?;
-            match event {
-                RoomEvent::TrackSubscribed { publication, .. } => {
-                    return Ok(publication.name());
-                }
-                RoomEvent::DataTrackPublished(track) => {
-                    self.pending_data_tracks.push(track);
-                }
-                _ => continue,
-            }
-        }
-    }
-
-    /// Waits for a `TrackSubscribed` room event for a video track and returns the
-    /// subscribed [`RemoteVideoTrack`], so callers can read receiver-side WebRTC stats
-    /// (e.g. the actually-received frame dimensions and frame rate).
+    /// Waits for a `TrackSubscribed` room event and returns the publication name
+    /// together with the subscribed [`RemoteTrack`].
+    ///
+    /// The returned track lets callers read receiver-side WebRTC stats (e.g. the
+    /// actually-received frame dimensions and frame rate for video tracks).
     ///
     /// Non-matching `DataTrackPublished` events are buffered for later consumption.
-    pub async fn expect_video_track_subscribed(
+    pub async fn expect_track_subscribed(
         &mut self,
-    ) -> Result<livekit::track::RemoteVideoTrack> {
+    ) -> Result<(String, livekit::track::RemoteTrack)> {
         let deadline = tokio::time::Instant::now() + EVENT_TIMEOUT;
         loop {
             let event = tokio::time::timeout_at(deadline, self.events.recv())
@@ -618,9 +600,10 @@ impl ViewerConnection {
                 .context("room events channel closed")?;
             match event {
                 RoomEvent::TrackSubscribed {
-                    track: livekit::track::RemoteTrack::Video(track),
-                    ..
-                } => return Ok(track),
+                    track, publication, ..
+                } => {
+                    return Ok((publication.name(), track));
+                }
                 RoomEvent::DataTrackPublished(track) => {
                     self.pending_data_tracks.push(track);
                 }

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -956,23 +956,17 @@ fn encode_raw_image_sized(frame_id: &str, width: u32, height: u32) -> Vec<u8> {
     buf
 }
 
-/// FLE-579 reproduction: stream 1080p frames and measure the resolution the
-/// receiver actually decodes.
+/// FLE-579 regression: stream 1080p frames and verify the receiver decodes the full
+/// 1920x1080.
 ///
-/// The gateway initializes its `NativeVideoSource` with `VideoResolution::default()`
-/// (1280x720), so even though we capture 1920x1080 frames the encoder is configured
-/// for 720p. This test feeds 1080p frames, subscribes a viewer, and reads the
-/// receiver-side inbound-RTP stats (`frame_width`/`frame_height`/`frames_per_second`).
+/// Background: on the H.264/VideoToolbox path (macOS) the encoder negotiated H.264
+/// level 3.1, which caps resolution at 720p regardless of bitrate (and periodically
+/// froze while reconfiguring on WebRTC bitrate probes). The fix publishes VP8 on macOS
+/// (`start_video_tracks`), which has no level cap, so 1080p is delivered.
 ///
-/// The gateway publishes with `video_codec: VideoCodec::H264` (see
-/// `start_video_tracks`), so on macOS this exercises the real H.264/VideoToolbox
-/// encoder path rather than a software VP8 loopback — i.e. the same path that
-/// exhibits the production cap.
-///
-/// It asserts the receiver decodes the full 1920x1080. On current code the bug
-/// reproduces and the assertion fails showing the capped dimensions (observed
-/// 320x180 @ ~15 fps, never recovering); after the fix (initializing the source
-/// at the real frame size) it should pass.
+/// This feeds 1080p frames, subscribes a viewer, and polls the receiver-side inbound-RTP
+/// resolution until it ramps up to the full 1920x1080 (WebRTC starts low and climbs, so
+/// we wait for the target rather than sampling a single early frame).
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -1018,9 +1012,9 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
         })
     };
 
-    // Poll receiver stats until we've decoded a healthy number of frames, then
-    // record the steady-state resolution and frame rate.
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    // Poll receiver stats until the resolution ramps up to the full frame size
+    // (or we time out). WebRTC starts at a downscaled resolution and climbs.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     let mut last: Option<(u32, u32, f64, u64)> = None;
     loop {
         if tokio::time::Instant::now() >= deadline {
@@ -1048,9 +1042,9 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
                 last = Some((w, h, fps, received));
             }
         }
-        // Once we've decoded a good number of frames at a stable resolution, stop early.
-        if let Some((_, _, _, received)) = last {
-            if received >= 60 {
+        // Stop as soon as the receiver has ramped up to the full resolution.
+        if let Some((w, h, _, _)) = last {
+            if (w, h) == (WIDTH, HEIGHT) {
                 break;
             }
         }
@@ -1069,8 +1063,8 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
     assert_eq!(
         (w, h),
         (WIDTH, HEIGHT),
-        "receiver decoded {w}x{h} but expected {WIDTH}x{HEIGHT}; \
-         the encoder source was likely capped to its 720p default (FLE-579)"
+        "receiver decoded {w}x{h} but expected {WIDTH}x{HEIGHT} within the timeout; \
+         the H.264/VideoToolbox level-3.1 cap should be avoided by publishing VP8 on macOS (FLE-579)"
     );
 
     viewer.close().await?;

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -956,17 +956,15 @@ fn encode_raw_image_sized(frame_id: &str, width: u32, height: u32) -> Vec<u8> {
     buf
 }
 
-/// FLE-579 regression: stream 1080p frames and verify the receiver decodes the full
-/// 1920x1080.
+/// FLE-579 regression: verify the per-platform video codec selection, and that the
+/// macOS path is no longer resolution-capped.
 ///
-/// Background: on the H.264/VideoToolbox path (macOS) the encoder negotiated H.264
-/// level 3.1, which caps resolution at 720p regardless of bitrate (and periodically
-/// froze while reconfiguring on WebRTC bitrate probes). The fix publishes VP8 on macOS
-/// (`start_video_tracks`), which has no level cap, so 1080p is delivered.
-///
-/// This feeds 1080p frames, subscribes a viewer, and polls the receiver-side inbound-RTP
-/// resolution until it ramps up to the full 1920x1080 (WebRTC starts low and climbs, so
-/// we wait for the target rather than sampling a single early frame).
+/// On macOS the gateway publishes VP8 (`start_video_tracks`) to avoid the H.264 /
+/// VideoToolbox level-3.1 720p cap; VP8 has no level cap, so 1080p is delivered. On
+/// other platforms (e.g. Linux/nvenc) it keeps H.264, which is still level-capped until
+/// FLE-584. So this asserts the codec on every platform, and the full-resolution payoff
+/// only on the VP8 (macOS) path. WebRTC starts downscaled and climbs, so on the VP8 path
+/// we wait for the resolution to reach the target rather than sampling an early frame.
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -1012,10 +1010,15 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
         })
     };
 
-    // Poll receiver stats until the resolution ramps up to the full frame size
-    // (or we time out). WebRTC starts at a downscaled resolution and climbs.
+    // macOS publishes VP8 (no level cap → reaches full resolution); other platforms keep
+    // H.264, which is still level-capped until FLE-584.
+    let expect_vp8 = cfg!(target_os = "macos");
+
+    // Poll receiver stats. On the VP8 path, wait for the resolution to climb to the full
+    // frame size; otherwise just wait for steady flow (H.264 stays capped).
     let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     let mut last: Option<(u32, u32, f64, u64)> = None;
+    let mut last_codec = String::new();
     loop {
         if tokio::time::Instant::now() >= deadline {
             break;
@@ -1042,9 +1045,17 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
                 last = Some((w, h, fps, received));
             }
         }
-        // Stop as soon as the receiver has ramped up to the full resolution.
-        if let Some((w, h, _, _)) = last {
-            if (w, h) == (WIDTH, HEIGHT) {
+        if !codec.is_empty() {
+            last_codec = codec;
+        }
+        // Stop once we have a codec reading and the platform-appropriate target is met.
+        if let (false, Some((w, h, _, received))) = (last_codec.is_empty(), last) {
+            let ready = if expect_vp8 {
+                (w, h) == (WIDTH, HEIGHT)
+            } else {
+                received >= 60
+            };
+            if ready {
                 break;
             }
         }
@@ -1054,18 +1065,33 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
     let _ = pump.await;
 
     let (w, h, fps, received) = last.context("never received any inbound video stats")?;
-    info!("final inbound video stats: {w}x{h} @ {fps:.1} fps, frames_received={received}");
+    info!(
+        "final inbound video stats: {w}x{h} @ {fps:.1} fps, frames_received={received}, codec={last_codec}"
+    );
 
     assert!(
         received > 0,
         "viewer should have decoded at least one frame"
     );
-    assert_eq!(
-        (w, h),
-        (WIDTH, HEIGHT),
-        "receiver decoded {w}x{h} but expected {WIDTH}x{HEIGHT} within the timeout; \
-         the H.264/VideoToolbox level-3.1 cap should be avoided by publishing VP8 on macOS (FLE-579)"
-    );
+
+    if expect_vp8 {
+        assert!(
+            last_codec.eq_ignore_ascii_case("video/VP8"),
+            "macOS should publish VP8, got {last_codec}"
+        );
+        assert_eq!(
+            (w, h),
+            (WIDTH, HEIGHT),
+            "VP8 on macOS should deliver the full {WIDTH}x{HEIGHT} (FLE-579); got {w}x{h}"
+        );
+    } else {
+        // Non-macOS keeps H.264 for nvenc; it is still level-3.1 capped (FLE-584), so we
+        // only assert the codec selection here, not the resolution.
+        assert!(
+            last_codec.eq_ignore_ascii_case("video/H264"),
+            "non-macOS should publish H.264, got {last_codec}"
+        );
+    }
 
     viewer.close().await?;
     gw.stop().await?;

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -925,6 +925,154 @@ async fn livekit_video_metadata_advertised_after_image_logged() -> Result<()> {
     Ok(())
 }
 
+/// Encode an `width`x`height` rgb8 `foxglove.RawImage` as protobuf bytes.
+///
+/// Fills the buffer with a simple vertical gradient so the encoder sees real
+/// (non-uniform) content rather than a flat color.
+fn encode_raw_image_sized(frame_id: &str, width: u32, height: u32) -> Vec<u8> {
+    let step = width * 3; // rgb8: 3 bytes per pixel
+    let mut data = vec![0u8; (step * height) as usize];
+    for y in 0..height {
+        let row = (y * step) as usize;
+        let v = (y % 256) as u8;
+        for x in 0..width {
+            let px = row + (x * 3) as usize;
+            data[px] = v;
+            data[px + 1] = (x % 256) as u8;
+            data[px + 2] = 128;
+        }
+    }
+    let msg = RawImage {
+        timestamp: Some(Timestamp::new(1, 0)),
+        frame_id: frame_id.to_string(),
+        width,
+        height,
+        encoding: "rgb8".to_string(),
+        step,
+        data: data.into(),
+    };
+    let mut buf = Vec::new();
+    Encode::encode(&msg, &mut buf).expect("encode RawImage");
+    buf
+}
+
+/// FLE-579 reproduction: stream 1080p frames and measure the resolution the
+/// receiver actually decodes.
+///
+/// The gateway initializes its `NativeVideoSource` with `VideoResolution::default()`
+/// (1280x720), so even though we capture 1920x1080 frames the encoder is configured
+/// for 720p. This test feeds 1080p frames, subscribes a viewer, and reads the
+/// receiver-side inbound-RTP stats (`frame_width`/`frame_height`/`frames_per_second`).
+///
+/// It asserts the receiver decodes the full 1920x1080. If the bug reproduces in this
+/// local (software-encoder) loopback, the assertion fails showing the capped
+/// dimensions; after the fix (initializing the source at the real frame size) it
+/// should pass.
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
+    const WIDTH: u32 = 1920;
+    const HEIGHT: u32 = 1080;
+
+    let ctx = foxglove::Context::new();
+
+    let video_channel = ctx
+        .channel_builder("/camera")
+        .message_encoding("protobuf")
+        .schema(Schema::new("foxglove.RawImage", "protobuf", &b""[..]))
+        .build_raw()
+        .context("create video channel")?;
+
+    let gw = TestGateway::start(&ctx).await?;
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+
+    let _server_info = viewer.expect_server_info().await?;
+    let advertise = viewer.expect_advertise().await?;
+    let channel_id = advertise.channels[0].id;
+
+    viewer
+        .subscribe_video_and_wait(&[channel_id], &video_channel)
+        .await?;
+    let track = viewer.expect_video_track_subscribed().await?;
+    info!("subscribed to video track {}", track.name());
+
+    // Pump 1080p frames at ~30fps from a background task until told to stop.
+    let frame = encode_raw_image_sized("camera_optical_frame", WIDTH, HEIGHT);
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let pump = {
+        let video_channel = video_channel.clone();
+        let stop = stop.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(33));
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                interval.tick().await;
+                video_channel.log(&frame);
+            }
+        })
+    };
+
+    // Poll receiver stats until we've decoded a healthy number of frames, then
+    // record the steady-state resolution and frame rate.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    let mut last: Option<(u32, u32, f64, u64)> = None;
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let stats = track.get_stats().await.context("get_stats")?;
+        let mut codec = String::new();
+        for s in &stats {
+            if let livekit::webrtc::stats::RtcStats::Codec(c) = s {
+                codec = c.codec.mime_type.clone();
+            }
+        }
+        for s in &stats {
+            if let livekit::webrtc::stats::RtcStats::InboundRtp(rtp) = s {
+                let w = rtp.inbound.frame_width;
+                let h = rtp.inbound.frame_height;
+                let fps = rtp.inbound.frames_per_second;
+                let received = rtp.inbound.frames_received;
+                let decoder = &rtp.inbound.decoder_implementation;
+                info!(
+                    "inbound video stats: {w}x{h} @ {fps:.1} fps, frames_received={received}, \
+                     codec={codec}, decoder={decoder}"
+                );
+                last = Some((w, h, fps, received));
+            }
+        }
+        // Once we've decoded a good number of frames at a stable resolution, stop early.
+        if let Some((_, _, _, received)) = last {
+            if received >= 60 {
+                break;
+            }
+        }
+    }
+
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _ = pump.await;
+
+    let (w, h, fps, received) = last.context("never received any inbound video stats")?;
+    info!("final inbound video stats: {w}x{h} @ {fps:.1} fps, frames_received={received}");
+
+    assert!(
+        received > 0,
+        "viewer should have decoded at least one frame"
+    );
+    assert_eq!(
+        (w, h),
+        (WIDTH, HEIGHT),
+        "receiver decoded {w}x{h} but expected {WIDTH}x{HEIGHT}; \
+         the encoder source was likely capped to its 720p default (FLE-579)"
+    );
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
 /// Test that when a viewer sends a client Advertise message the gateway fires
 /// `on_client_advertise` on the listener with the correct client identity and topic.
 #[traced_test]

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -7,7 +7,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::{bail, Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use foxglove::messages::{RawImage, Timestamp};
 use foxglove::protocol::v2::client::SubscribeChannel;
 use foxglove::protocol::v2::server::ServerMessage;
@@ -928,17 +928,18 @@ async fn livekit_video_metadata_advertised_after_image_logged() -> Result<()> {
 /// Encode an `width`x`height` rgb8 `foxglove.RawImage` as protobuf bytes.
 ///
 /// Fills the buffer with a 2D gradient (red varies by row, green by column, blue
-/// constant) so the encoder sees real (non-uniform) content rather than a flat color.
-fn encode_raw_image_sized(frame_id: &str, width: u32, height: u32) -> Vec<u8> {
+/// constant), shifted by `seq` so successive frames differ — identical frames would
+/// compress to almost nothing and wouldn't exercise the encoder realistically.
+fn encode_raw_image_sized(frame_id: &str, width: u32, height: u32, seq: u32) -> Vec<u8> {
     let step = width * 3; // rgb8: 3 bytes per pixel
     let mut data = vec![0u8; (step * height) as usize];
     for y in 0..height {
         let row = (y * step) as usize;
-        let v = (y % 256) as u8;
+        let v = ((y + seq) % 256) as u8;
         for x in 0..width {
             let px = row + (x * 3) as usize;
             data[px] = v;
-            data[px + 1] = (x % 256) as u8;
+            data[px + 1] = ((x + seq) % 256) as u8;
             data[px + 2] = 128;
         }
     }
@@ -998,17 +999,24 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
     };
     info!("subscribed to video track {track_name}");
 
-    // Pump 1080p frames at ~30fps from a background task until told to stop.
-    let frame = encode_raw_image_sized("camera_optical_frame", WIDTH, HEIGHT);
+    // Pump 1080p frames at ~30fps from a background task until told to stop. Cycle through
+    // a handful of distinct frames (shifted gradients) so the encoder sees real motion
+    // rather than a static image. Pre-encode them up front: encoding a frame is blocking
+    // CPU work, so doing it in the hot loop would stall the runtime.
+    let frames: Vec<Vec<u8>> = (0u32..8)
+        .map(|seq| encode_raw_image_sized("camera_optical_frame", WIDTH, HEIGHT, seq))
+        .collect();
     let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let pump = {
         let video_channel = video_channel.clone();
         let stop = stop.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_millis(33));
+            let mut i = 0usize;
             while !stop.load(std::sync::atomic::Ordering::Relaxed) {
                 interval.tick().await;
-                video_channel.log(&frame);
+                video_channel.log(&frames[i % frames.len()]);
+                i += 1;
             }
         })
     };

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -927,8 +927,8 @@ async fn livekit_video_metadata_advertised_after_image_logged() -> Result<()> {
 
 /// Encode an `width`x`height` rgb8 `foxglove.RawImage` as protobuf bytes.
 ///
-/// Fills the buffer with a simple vertical gradient so the encoder sees real
-/// (non-uniform) content rather than a flat color.
+/// Fills the buffer with a 2D gradient (red varies by row, green by column, blue
+/// constant) so the encoder sees real (non-uniform) content rather than a flat color.
 fn encode_raw_image_sized(frame_id: &str, width: u32, height: u32) -> Vec<u8> {
     let step = width * 3; // rgb8: 3 bytes per pixel
     let mut data = vec![0u8; (step * height) as usize];
@@ -1062,7 +1062,7 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
     }
 
     stop.store(true, std::sync::atomic::Ordering::Relaxed);
-    let _ = pump.await;
+    pump.await.expect("stopping frame pump");
 
     let (w, h, fps, received) = last.context("never received any inbound video stats")?;
     info!(

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -964,10 +964,15 @@ fn encode_raw_image_sized(frame_id: &str, width: u32, height: u32) -> Vec<u8> {
 /// for 720p. This test feeds 1080p frames, subscribes a viewer, and reads the
 /// receiver-side inbound-RTP stats (`frame_width`/`frame_height`/`frames_per_second`).
 ///
-/// It asserts the receiver decodes the full 1920x1080. If the bug reproduces in this
-/// local (software-encoder) loopback, the assertion fails showing the capped
-/// dimensions; after the fix (initializing the source at the real frame size) it
-/// should pass.
+/// The gateway publishes with `video_codec: VideoCodec::H264` (see
+/// `start_video_tracks`), so on macOS this exercises the real H.264/VideoToolbox
+/// encoder path rather than a software VP8 loopback — i.e. the same path that
+/// exhibits the production cap.
+///
+/// It asserts the receiver decodes the full 1920x1080. On current code the bug
+/// reproduces and the assertion fails showing the capped dimensions (observed
+/// 320x180 @ ~15 fps, never recovering); after the fix (initializing the source
+/// at the real frame size) it should pass.
 #[traced_test]
 #[ignore]
 #[tokio::test]

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -1025,38 +1025,37 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
         let stats = track.get_stats().await.context("get_stats")?;
-        let mut codec = String::new();
         for s in &stats {
-            if let livekit::webrtc::stats::RtcStats::Codec(c) = s {
-                codec = c.codec.mime_type.clone();
+            match s {
+                livekit::webrtc::stats::RtcStats::Codec(c) => {
+                    last_codec = c.codec.mime_type.clone();
+                }
+                livekit::webrtc::stats::RtcStats::InboundRtp(rtp) => {
+                    let w = rtp.inbound.frame_width;
+                    let h = rtp.inbound.frame_height;
+                    let fps = rtp.inbound.frames_per_second;
+                    let received = rtp.inbound.frames_received;
+                    let decoder = &rtp.inbound.decoder_implementation;
+                    info!(
+                        "inbound video stats: {w}x{h} @ {fps:.1} fps, frames_received={received}, \
+                         codec={last_codec}, decoder={decoder}"
+                    );
+                    last = Some((w, h, fps, received));
+                }
+                _ => {}
             }
-        }
-        for s in &stats {
-            if let livekit::webrtc::stats::RtcStats::InboundRtp(rtp) = s {
-                let w = rtp.inbound.frame_width;
-                let h = rtp.inbound.frame_height;
-                let fps = rtp.inbound.frames_per_second;
-                let received = rtp.inbound.frames_received;
-                let decoder = &rtp.inbound.decoder_implementation;
-                info!(
-                    "inbound video stats: {w}x{h} @ {fps:.1} fps, frames_received={received}, \
-                     codec={codec}, decoder={decoder}"
-                );
-                last = Some((w, h, fps, received));
-            }
-        }
-        if !codec.is_empty() {
-            last_codec = codec;
         }
         // Stop once we have a codec reading and the platform-appropriate target is met.
-        if let (false, Some((w, h, _, received))) = (last_codec.is_empty(), last) {
-            let ready = if expect_vp8 {
-                (w, h) == (WIDTH, HEIGHT)
-            } else {
-                received >= 60
-            };
-            if ready {
-                break;
+        if !last_codec.is_empty() {
+            if let Some((w, h, _, received)) = last {
+                let ready = if expect_vp8 {
+                    (w, h) == (WIDTH, HEIGHT)
+                } else {
+                    received >= 60
+                };
+                if ready {
+                    break;
+                }
             }
         }
     }

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -7,7 +7,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::{Context as _, Result};
+use anyhow::{bail, Context as _, Result};
 use foxglove::messages::{RawImage, Timestamp};
 use foxglove::protocol::v2::client::SubscribeChannel;
 use foxglove::protocol::v2::server::ServerMessage;
@@ -526,7 +526,7 @@ async fn livekit_video_track_lifecycle() -> Result<()> {
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
     let expected_track_name = format!("video-ch-{channel_id}");
-    let track_name = viewer.expect_track_subscribed().await?;
+    let (track_name, _track) = viewer.expect_track_subscribed().await?;
     assert_eq!(
         track_name, expected_track_name,
         "video track name should match video-ch-{{channelId}}"
@@ -573,7 +573,7 @@ async fn livekit_video_track_resubscribe() -> Result<()> {
     viewer
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
-    let track_name = viewer.expect_track_subscribed().await?;
+    let (track_name, _track) = viewer.expect_track_subscribed().await?;
     assert_eq!(track_name, expected_track_name);
     info!("first subscribe: video track published");
 
@@ -596,7 +596,7 @@ async fn livekit_video_track_resubscribe() -> Result<()> {
             request_video_track: true,
         }])
         .await?;
-    let track_name = viewer.expect_track_subscribed().await?;
+    let (track_name, _track) = viewer.expect_track_subscribed().await?;
     assert_eq!(track_name, expected_track_name);
     info!("resubscribe: video track re-established");
 
@@ -731,7 +731,7 @@ async fn livekit_video_resubscribe_switches_to_data_plane() -> Result<()> {
     viewer
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
-    let track_name = viewer.expect_track_subscribed().await?;
+    let (track_name, _track) = viewer.expect_track_subscribed().await?;
     assert_eq!(track_name, expected_track_name);
     info!("video track published");
 
@@ -876,7 +876,7 @@ async fn livekit_video_metadata_advertised_after_image_logged() -> Result<()> {
     viewer
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
-    let _track_name = viewer.expect_track_subscribed().await?;
+    let (_track_name, _track) = viewer.expect_track_subscribed().await?;
 
     // Log a valid protobuf-encoded RawImage.
     let image_bytes = encode_raw_image("camera_optical_frame");
@@ -992,8 +992,11 @@ async fn livekit_video_1080p_resolution_not_capped() -> Result<()> {
     viewer
         .subscribe_video_and_wait(&[channel_id], &video_channel)
         .await?;
-    let track = viewer.expect_video_track_subscribed().await?;
-    info!("subscribed to video track {}", track.name());
+    let (track_name, track) = viewer.expect_track_subscribed().await?;
+    let livekit::track::RemoteTrack::Video(track) = track else {
+        bail!("expected a video track, got {track_name}");
+    };
+    info!("subscribed to video track {track_name}");
 
     // Pump 1080p frames at ~30fps from a background task until told to stop.
     let frame = encode_raw_image_sized("camera_optical_frame", WIDTH, HEIGHT);


### PR DESCRIPTION
### Changelog

Remote access video on macOS now publishes VP8 instead of H.264, so 1080p capture is delivered at full resolution and without the intermittent pauses seen on that path.

### Docs

None.

### Description

When a Mac runs the remote access gateway, video is published over H.264 via Apple's VideoToolbox encoder. While investigating FLE-579 we observed two things on that path, both from on-the-wire stats:

- **Resolution limited to 720p.** The negotiated H.264 parameters are `profile-level-id=42e01f` (Constrained Baseline, Level 3.1), and Level 3.1 allows up to 720p30. The stream stayed at 1280×720 even with ample headroom (held 720p at a ~6 Mbps estimate on a ~900 Mbps link).
- **Intermittent pauses.** Roughly every ~16 s, encoded output paused for a few seconds while the encoder adapted to a bitrate change (frames were still handed to `capture_frame`, but `frames_encoded` stopped advancing for the duration).

Publishing the same 1080p source over VP8 reached full **1920×1080 @ 30 fps without those pauses** at ~4.3 Mbps, so this PR selects VP8 on macOS.

Elsewhere (e.g. Linux devices) it keeps H.264 so the nvenc hardware encoder can be used; macOS has no nvenc to gain from H.264, and the software VP8 encode cost is acceptable there. Linux behavior is unchanged by this PR (H.264 was already the codec there). The codec choice is per-OS at compile time today; exposing a builder override is tracked in FLE-585.

This does not change 1080p on Linux/nvenc devices, which also negotiate Level 3.1 — raising the negotiated level there is tracked separately in FLE-584.

### Tested

- **Integration regression test** `livekit_video_1080p_resolution_not_capped` (committed code): on macOS the viewer decodes the full **1920×1080 over VP8**; in CI on Linux it asserts **H.264** is selected and video flows.
- **End-to-end on party** (macOS gateway → Foxglove app in Chrome): `chrome://webrtc-internals` inbound-rtp video showed `[codec]` VP8, `[framesDecoded/s]` ≈ 30, and `freezeCount` = 1 / `totalFreezesDuration` ≈ 0.28 s (one brief startup blip, stable — no recurring pauses).

Reviewers can reproduce: run `example_remote_access` at 1080p, connect a viewer, and in `chrome://webrtc-internals` (inbound-rtp video) check `[codec]` is VP8, `frameWidth`/`frameHeight` reach 1920×1080, `[framesDecoded/s]` ≈ 30, and `totalFreezesDuration` stays near 0.

Refs: [FLE-579](https://linear.app/foxglove/issue/FLE-579/investigate-1080p-encoder-initialization-and-frame-rate-cap)
