### PR TITLE
example_remote_access: Make video resolution configurable via CLI args (FLE-582)

### DIFF
--- a/rust/examples/remote_access/src/main.rs
+++ b/rust/examples/remote_access/src/main.rs
@@ -136,12 +136,20 @@ const BYTES_PER_PIXEL: usize = 3;
 const FPS: u32 = 30;
 
 /// Read a `usize` from an environment variable, falling back to `default` if the
-/// variable is unset or cannot be parsed.
+/// variable is unset or cannot be parsed. Values below `default` are clamped up
+/// to it: the test-card geometry (checkerboard placement, ticker band) assumes
+/// at least the default 960x540 frame, and smaller frames would panic or render
+/// incorrectly.
 fn env_usize(name: &str, default: usize) -> usize {
-    std::env::var(name)
+    let value = std::env::var(name)
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
+        .unwrap_or(default);
+    if value < default {
+        tracing::warn!("{name}={value} is below the minimum {default}; using {default}");
+        return default;
+    }
+    value
 }
 
 /// 5x7 bitmap font. Each glyph is stored as 7 rows of 5-bit patterns

--- a/rust/examples/remote_access/src/main.rs
+++ b/rust/examples/remote_access/src/main.rs
@@ -3,6 +3,7 @@
 //! (latency, packet loss, low bandwidth) visually obvious, plus a simple
 //! scrolling gradient for a secondary feed.
 
+use clap::{Parser, builder::RangedU64ValueParser};
 use foxglove::{
     ChannelDescriptor,
     bytes::Bytes,
@@ -66,15 +67,39 @@ impl Listener for MessageHandler {
     }
 }
 
+/// Command-line arguments for the example.
+#[derive(Parser)]
+struct Args {
+    /// Frame width in pixels. The minimum matches the test-card geometry, which
+    /// assumes at least the default 960x540 frame; the maximum bounds the frame
+    /// allocation at 8K.
+    #[arg(long, default_value_t = 960, value_parser = RangedU64ValueParser::<usize>::new().range(960..=7680))]
+    width: usize,
+
+    /// Frame height in pixels. The minimum matches the test-card geometry, which
+    /// assumes at least the default 960x540 frame; the maximum bounds the frame
+    /// allocation at 8K.
+    #[arg(long, default_value_t = 540, value_parser = RangedU64ValueParser::<usize>::new().range(540..=4320))]
+    height: usize,
+}
+
+/// Parsed command-line arguments, accessible from the free rendering functions
+/// below without threading values through every call.
+static ARGS: LazyLock<Args> = LazyLock::new(Args::parse);
+
 #[tokio::main]
 async fn main() {
+    // Force argument parsing up front so `--help` and validation errors are
+    // handled before any other setup runs.
+    LazyLock::force(&ARGS);
+
     let env = env_logger::Env::default().default_filter_or("info");
     env_logger::init_from_env(env);
 
     tracing::info!(
-        "streaming video at {}x{} @ {FPS} fps (override with VIDEO_WIDTH / VIDEO_HEIGHT)",
-        *WIDTH,
-        *HEIGHT
+        "streaming video at {}x{} @ {FPS} fps (override with --width / --height)",
+        ARGS.width,
+        ARGS.height
     );
 
     // Open a gateway for remote visualization and teleop.
@@ -125,32 +150,8 @@ async fn main() {
 // - Scrolling ticker: smooth motion becomes jerky with frame drops.
 // ---------------------------------------------------------------------------
 
-/// Frame width in pixels. Override with the `VIDEO_WIDTH` environment variable
-/// (defaults to 960). Useful for experimenting with higher resolutions such as
-/// 1080p (`VIDEO_WIDTH=1920 VIDEO_HEIGHT=1080`).
-static WIDTH: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_WIDTH", 960));
-/// Frame height in pixels. Override with the `VIDEO_HEIGHT` environment variable
-/// (defaults to 540).
-static HEIGHT: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_HEIGHT", 540));
 const BYTES_PER_PIXEL: usize = 3;
 const FPS: u32 = 30;
-
-/// Read a `usize` from an environment variable, falling back to `default` if the
-/// variable is unset or cannot be parsed. Values below `default` are clamped up
-/// to it: the test-card geometry (checkerboard placement, ticker band) assumes
-/// at least the default 960x540 frame, and smaller frames would panic or render
-/// incorrectly.
-fn env_usize(name: &str, default: usize) -> usize {
-    let value = std::env::var(name)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default);
-    if value < default {
-        tracing::warn!("{name}={value} is below the minimum {default}; using {default}");
-        return default;
-    }
-    value
-}
 
 /// 5x7 bitmap font. Each glyph is stored as 7 rows of 5-bit patterns
 /// (MSB = leftmost pixel). The full alphabet is defined so the font table
@@ -240,8 +241,8 @@ struct Rgb(u8, u8, u8);
 
 /// Set a single pixel in the buffer (bounds-checked).
 fn set_pixel(buf: &mut [u8], x: i32, y: i32, color: Rgb) {
-    if x >= 0 && (x as usize) < *WIDTH && y >= 0 && (y as usize) < *HEIGHT {
-        let off = y as usize * (*WIDTH * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
+    if x >= 0 && (x as usize) < ARGS.width && y >= 0 && (y as usize) < ARGS.height {
+        let off = y as usize * (ARGS.width * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
         buf[off] = color.0;
         buf[off + 1] = color.1;
         buf[off + 2] = color.2;
@@ -257,7 +258,7 @@ fn draw_text(buf: &mut [u8], text: &str, x: i32, y: i32, scale: usize, color: Rg
         if char_x + (GLYPH_W * scale) as i32 <= 0 {
             continue;
         }
-        if char_x >= *WIDTH as i32 {
+        if char_x >= ARGS.width as i32 {
             break;
         }
         let rows = glyph_rows(ch);
@@ -421,7 +422,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let check_w: usize = 260;
     let check_h: usize = 270;
     let cell_size: usize = 10;
-    let stride = *WIDTH * BYTES_PER_PIXEL;
+    let stride = ARGS.width * BYTES_PER_PIXEL;
     for cy_off in 0..check_h {
         let row_start = (check_y + cy_off) * stride + check_x * BYTES_PER_PIXEL;
         let row_cell = cy_off / cell_size;
@@ -438,7 +439,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     }
 
     // --- Scrolling ticker (bottom 80px) ---
-    let ticker_y = *HEIGHT - 80;
+    let ticker_y = ARGS.height - 80;
     let ticker_text = "    FOXGLOVE NETWORK TEST CARD \
         :::  Frame drops appear as jumps in the clock hand  :::  \
         Latency visible by comparing timestamp to wall clock  :::  \
@@ -451,9 +452,9 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let scroll_offset = (frame_number as usize * scroll_speed) % text_pixel_width;
 
     // Draw ticker background.
-    for y in ticker_y..*HEIGHT {
+    for y in ticker_y..ARGS.height {
         let row_start = y * stride;
-        for x in 0..*WIDTH {
+        for x in 0..ARGS.width {
             let off = row_start + x * BYTES_PER_PIXEL;
             buf[off] = 20;
             buf[off + 1] = 20;
@@ -466,7 +467,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let x_start = -(scroll_offset as i32);
     for pass in 0..2i32 {
         let base_x = x_start + pass * text_pixel_width as i32;
-        if base_x < *WIDTH as i32 && base_x + text_pixel_width as i32 > 0 {
+        if base_x < ARGS.width as i32 && base_x + text_pixel_width as i32 > 0 {
             draw_text(
                 buf,
                 ticker_text,
@@ -510,29 +511,29 @@ async fn tf_static_loop() {
 async fn camera_loop() {
     let mut interval = tokio::time::interval(Duration::from_millis(1000 / FPS as u64));
     let mut frame_number: u64 = 0;
-    let mut rgb_buf = vec![0u8; *WIDTH * *HEIGHT * BYTES_PER_PIXEL];
-    let mut mono_buf = vec![0u8; *WIDTH * *HEIGHT];
+    let mut rgb_buf = vec![0u8; ARGS.width * ARGS.height * BYTES_PER_PIXEL];
+    let mut mono_buf = vec![0u8; ARGS.width * ARGS.height];
 
     // Pre-compute a double-width gradient lookup table so we can take a
     // width-sized slice at any offset without per-pixel math each frame.
-    let mono_gradient: Vec<u8> = (0..*WIDTH * 2)
-        .map(|x| ((x % *WIDTH) * 255 / *WIDTH) as u8)
+    let mono_gradient: Vec<u8> = (0..ARGS.width * 2)
+        .map(|x| ((x % ARGS.width) * 255 / ARGS.width) as u8)
         .collect();
 
     let calibration = CameraCalibration {
         timestamp: None,
         frame_id: "camera".into(),
-        width: *WIDTH as u32,
-        height: *HEIGHT as u32,
+        width: ARGS.width as u32,
+        height: ARGS.height as u32,
         distortion_model: String::new(),
         d: vec![],
         k: vec![
             500.0,
             0.0,
-            *WIDTH as f64 / 2.0,
+            ARGS.width as f64 / 2.0,
             0.0,
             500.0,
-            *HEIGHT as f64 / 2.0,
+            ARGS.height as f64 / 2.0,
             0.0,
             0.0,
             1.0,
@@ -541,11 +542,11 @@ async fn camera_loop() {
         p: vec![
             500.0,
             0.0,
-            *WIDTH as f64 / 2.0,
+            ARGS.width as f64 / 2.0,
             0.0,
             0.0,
             500.0,
-            *HEIGHT as f64 / 2.0,
+            ARGS.height as f64 / 2.0,
             0.0,
             0.0,
             0.0,
@@ -562,27 +563,27 @@ async fn camera_loop() {
         let rgb_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: *WIDTH as u32,
-            height: *HEIGHT as u32,
+            width: ARGS.width as u32,
+            height: ARGS.height as u32,
             encoding: "rgb8".into(),
-            step: (*WIDTH * BYTES_PER_PIXEL) as u32,
+            step: (ARGS.width * BYTES_PER_PIXEL) as u32,
             data: Bytes::copy_from_slice(&rgb_buf),
         };
         foxglove::log!("/video/test-card", rgb_img);
 
         // Mono image: scrolling gradient (simple secondary stream).
-        let offset = frame_number as usize % *WIDTH;
-        let mono_row = &mono_gradient[offset..offset + *WIDTH];
-        for row in mono_buf.chunks_exact_mut(*WIDTH) {
+        let offset = frame_number as usize % ARGS.width;
+        let mono_row = &mono_gradient[offset..offset + ARGS.width];
+        for row in mono_buf.chunks_exact_mut(ARGS.width) {
             row.copy_from_slice(mono_row);
         }
         let mono_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: *WIDTH as u32,
-            height: *HEIGHT as u32,
+            width: ARGS.width as u32,
+            height: ARGS.height as u32,
             encoding: "mono8".into(),
-            step: *WIDTH as u32,
+            step: ARGS.width as u32,
             data: Bytes::copy_from_slice(&mono_buf),
         };
         foxglove::log!("/video/gradient", mono_img);

--- a/rust/examples/remote_access/src/main.rs
+++ b/rust/examples/remote_access/src/main.rs
@@ -13,7 +13,7 @@ use foxglove::{
 };
 use serde_json::Value;
 use std::{
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -71,6 +71,12 @@ async fn main() {
     let env = env_logger::Env::default().default_filter_or("info");
     env_logger::init_from_env(env);
 
+    tracing::info!(
+        "streaming video at {}x{} @ {FPS} fps (override with VIDEO_WIDTH / VIDEO_HEIGHT)",
+        *WIDTH,
+        *HEIGHT
+    );
+
     // Open a gateway for remote visualization and teleop.
     let handle = Gateway::new()
         .capabilities([Capability::ClientPublish])
@@ -99,7 +105,8 @@ async fn main() {
 // ---------------------------------------------------------------------------
 // Test card: designed to make network degradation visually obvious.
 //
-// Layout (960x540):
+// Layout (positions are tuned for the default 960x540; at larger configured
+// resolutions the test card renders within the top-left region of the frame):
 //   +---------------------------+------------------+
 //   |                           |  Frame: 00042    |
 //   |    Sweeping clock hand    |  12:34:56.789    |
@@ -118,10 +125,24 @@ async fn main() {
 // - Scrolling ticker: smooth motion becomes jerky with frame drops.
 // ---------------------------------------------------------------------------
 
-const WIDTH: usize = 960;
-const HEIGHT: usize = 540;
+/// Frame width in pixels. Override with the `VIDEO_WIDTH` environment variable
+/// (defaults to 960). Useful for experimenting with higher resolutions such as
+/// 1080p (`VIDEO_WIDTH=1920 VIDEO_HEIGHT=1080`).
+static WIDTH: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_WIDTH", 960));
+/// Frame height in pixels. Override with the `VIDEO_HEIGHT` environment variable
+/// (defaults to 540).
+static HEIGHT: LazyLock<usize> = LazyLock::new(|| env_usize("VIDEO_HEIGHT", 540));
 const BYTES_PER_PIXEL: usize = 3;
 const FPS: u32 = 30;
+
+/// Read a `usize` from an environment variable, falling back to `default` if the
+/// variable is unset or cannot be parsed.
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
 
 /// 5x7 bitmap font. Each glyph is stored as 7 rows of 5-bit patterns
 /// (MSB = leftmost pixel). The full alphabet is defined so the font table
@@ -211,8 +232,8 @@ struct Rgb(u8, u8, u8);
 
 /// Set a single pixel in the buffer (bounds-checked).
 fn set_pixel(buf: &mut [u8], x: i32, y: i32, color: Rgb) {
-    if x >= 0 && (x as usize) < WIDTH && y >= 0 && (y as usize) < HEIGHT {
-        let off = y as usize * (WIDTH * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
+    if x >= 0 && (x as usize) < *WIDTH && y >= 0 && (y as usize) < *HEIGHT {
+        let off = y as usize * (*WIDTH * BYTES_PER_PIXEL) + x as usize * BYTES_PER_PIXEL;
         buf[off] = color.0;
         buf[off + 1] = color.1;
         buf[off + 2] = color.2;
@@ -228,7 +249,7 @@ fn draw_text(buf: &mut [u8], text: &str, x: i32, y: i32, scale: usize, color: Rg
         if char_x + (GLYPH_W * scale) as i32 <= 0 {
             continue;
         }
-        if char_x >= WIDTH as i32 {
+        if char_x >= *WIDTH as i32 {
             break;
         }
         let rows = glyph_rows(ch);
@@ -392,7 +413,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let check_w: usize = 260;
     let check_h: usize = 270;
     let cell_size: usize = 10;
-    let stride = WIDTH * BYTES_PER_PIXEL;
+    let stride = *WIDTH * BYTES_PER_PIXEL;
     for cy_off in 0..check_h {
         let row_start = (check_y + cy_off) * stride + check_x * BYTES_PER_PIXEL;
         let row_cell = cy_off / cell_size;
@@ -409,7 +430,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     }
 
     // --- Scrolling ticker (bottom 80px) ---
-    let ticker_y = HEIGHT - 80;
+    let ticker_y = *HEIGHT - 80;
     let ticker_text = "    FOXGLOVE NETWORK TEST CARD \
         :::  Frame drops appear as jumps in the clock hand  :::  \
         Latency visible by comparing timestamp to wall clock  :::  \
@@ -422,9 +443,9 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let scroll_offset = (frame_number as usize * scroll_speed) % text_pixel_width;
 
     // Draw ticker background.
-    for y in ticker_y..HEIGHT {
+    for y in ticker_y..*HEIGHT {
         let row_start = y * stride;
-        for x in 0..WIDTH {
+        for x in 0..*WIDTH {
             let off = row_start + x * BYTES_PER_PIXEL;
             buf[off] = 20;
             buf[off + 1] = 20;
@@ -437,7 +458,7 @@ fn render_test_card(buf: &mut [u8], frame_number: u64) {
     let x_start = -(scroll_offset as i32);
     for pass in 0..2i32 {
         let base_x = x_start + pass * text_pixel_width as i32;
-        if base_x < WIDTH as i32 && base_x + text_pixel_width as i32 > 0 {
+        if base_x < *WIDTH as i32 && base_x + text_pixel_width as i32 > 0 {
             draw_text(
                 buf,
                 ticker_text,
@@ -481,29 +502,29 @@ async fn tf_static_loop() {
 async fn camera_loop() {
     let mut interval = tokio::time::interval(Duration::from_millis(1000 / FPS as u64));
     let mut frame_number: u64 = 0;
-    let mut rgb_buf = vec![0u8; WIDTH * HEIGHT * BYTES_PER_PIXEL];
-    let mut mono_buf = vec![0u8; WIDTH * HEIGHT];
+    let mut rgb_buf = vec![0u8; *WIDTH * *HEIGHT * BYTES_PER_PIXEL];
+    let mut mono_buf = vec![0u8; *WIDTH * *HEIGHT];
 
     // Pre-compute a double-width gradient lookup table so we can take a
     // width-sized slice at any offset without per-pixel math each frame.
-    let mono_gradient: Vec<u8> = (0..WIDTH * 2)
-        .map(|x| ((x % WIDTH) * 255 / WIDTH) as u8)
+    let mono_gradient: Vec<u8> = (0..*WIDTH * 2)
+        .map(|x| ((x % *WIDTH) * 255 / *WIDTH) as u8)
         .collect();
 
     let calibration = CameraCalibration {
         timestamp: None,
         frame_id: "camera".into(),
-        width: WIDTH as u32,
-        height: HEIGHT as u32,
+        width: *WIDTH as u32,
+        height: *HEIGHT as u32,
         distortion_model: String::new(),
         d: vec![],
         k: vec![
             500.0,
             0.0,
-            WIDTH as f64 / 2.0,
+            *WIDTH as f64 / 2.0,
             0.0,
             500.0,
-            HEIGHT as f64 / 2.0,
+            *HEIGHT as f64 / 2.0,
             0.0,
             0.0,
             1.0,
@@ -512,11 +533,11 @@ async fn camera_loop() {
         p: vec![
             500.0,
             0.0,
-            WIDTH as f64 / 2.0,
+            *WIDTH as f64 / 2.0,
             0.0,
             0.0,
             500.0,
-            HEIGHT as f64 / 2.0,
+            *HEIGHT as f64 / 2.0,
             0.0,
             0.0,
             0.0,
@@ -533,27 +554,27 @@ async fn camera_loop() {
         let rgb_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: WIDTH as u32,
-            height: HEIGHT as u32,
+            width: *WIDTH as u32,
+            height: *HEIGHT as u32,
             encoding: "rgb8".into(),
-            step: (WIDTH * BYTES_PER_PIXEL) as u32,
+            step: (*WIDTH * BYTES_PER_PIXEL) as u32,
             data: Bytes::copy_from_slice(&rgb_buf),
         };
         foxglove::log!("/video/test-card", rgb_img);
 
         // Mono image: scrolling gradient (simple secondary stream).
-        let offset = frame_number as usize % WIDTH;
-        let mono_row = &mono_gradient[offset..offset + WIDTH];
-        for row in mono_buf.chunks_exact_mut(WIDTH) {
+        let offset = frame_number as usize % *WIDTH;
+        let mono_row = &mono_gradient[offset..offset + *WIDTH];
+        for row in mono_buf.chunks_exact_mut(*WIDTH) {
             row.copy_from_slice(mono_row);
         }
         let mono_img = RawImage {
             timestamp: Some(Timestamp::now()),
             frame_id: "camera".into(),
-            width: WIDTH as u32,
-            height: HEIGHT as u32,
+            width: *WIDTH as u32,
+            height: *HEIGHT as u32,
             encoding: "mono8".into(),
-            step: WIDTH as u32,
+            step: *WIDTH as u32,
             data: Bytes::copy_from_slice(&mono_buf),
         };
         foxglove::log!("/video/gradient", mono_img);


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The `example_remote_access` example hardcoded its synthetic video resolution at 960×540, so testing other resolutions meant editing source. This makes it configurable via the `--width` / `--height` CLI flags (defaulting to 960×540, so behavior is unchanged when they're omitted), and logs the configured resolution at startup.

This came out of the FLE-579 investigation, where we needed to drive the example at 1080p:

```
cargo run -p example_remote_access --release -- --width 1920 --height 1080
```

The flags are validated by clap: values below the 960×540 minimum (which the test-card geometry assumes) or above 8K are rejected at parse time with a clear error, and `--help` documents both options.

The test-card layout positions are still tuned for the default 960×540; at larger resolutions the card renders in the top-left region of the frame, which is fine for resolution/throughput testing. This is an example-only, dev-convenience change with no library impact.

Fixes: [FLE-582](https://linear.app/foxglove/issue/FLE-582/make-remote-access-example-video-resolution-configurable-via-env-vars)
