### PR TITLE
schemas: update description for SceneEntity frame_locked

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -1750,7 +1750,7 @@ typedef struct foxglove_scene_entity {
    */
   const struct foxglove_duration *lifetime;
   /**
-   * Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+   * False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
    */
   bool frame_locked;
   /**

--- a/c/src/generated_types.rs
+++ b/c/src/generated_types.rs
@@ -4594,7 +4594,7 @@ pub struct SceneEntity {
     /// Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
     pub lifetime: *const FoxgloveDuration,
 
-    /// Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+    /// False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
     pub frame_locked: bool,
 
     /// Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/cpp/foxglove/include/foxglove/messages.hpp
+++ b/cpp/foxglove/include/foxglove/messages.hpp
@@ -1706,8 +1706,9 @@ struct SceneEntity {
   /// deleted.
   std::optional<Duration> lifetime;
 
-  /// @brief Whether the entity should keep its location in the fixed frame (false) or follow the
-  /// frame specified in `frame_id` as it moves relative to the fixed frame (true)
+  /// @brief False indicates the entity should keep its location in the fixed frame until a new
+  /// entity is published. True indicates the entity should follow the frame specified in `frame_id`
+  /// as it moves relative to the fixed frame when new transform messages are received.
   bool frame_locked = false;
 
   /// @brief Additional user-provided metadata associated with the entity. Keys must be unique.
@@ -2589,8 +2590,8 @@ public:
   }
 
   CompressedPointCloudChannel(const CompressedPointCloudChannel& other) noexcept = delete;
-  CompressedPointCloudChannel& operator=(const CompressedPointCloudChannel& other
-  ) noexcept = delete;
+  CompressedPointCloudChannel& operator=(const CompressedPointCloudChannel& other) noexcept =
+    delete;
   /// @brief Default move constructor.
   CompressedPointCloudChannel(CompressedPointCloudChannel&& other) noexcept = default;
   /// @brief Default move assignment.
@@ -5136,8 +5137,8 @@ public:
   }
 
   TriangleListPrimitiveChannel(const TriangleListPrimitiveChannel& other) noexcept = delete;
-  TriangleListPrimitiveChannel& operator=(const TriangleListPrimitiveChannel& other
-  ) noexcept = delete;
+  TriangleListPrimitiveChannel& operator=(const TriangleListPrimitiveChannel& other) noexcept =
+    delete;
   /// @brief Default move constructor.
   TriangleListPrimitiveChannel(TriangleListPrimitiveChannel&& other) noexcept = default;
   /// @brief Default move assignment.

--- a/cpp/foxglove/include/foxglove/messages.hpp
+++ b/cpp/foxglove/include/foxglove/messages.hpp
@@ -2590,8 +2590,8 @@ public:
   }
 
   CompressedPointCloudChannel(const CompressedPointCloudChannel& other) noexcept = delete;
-  CompressedPointCloudChannel& operator=(const CompressedPointCloudChannel& other) noexcept =
-    delete;
+  CompressedPointCloudChannel& operator=(const CompressedPointCloudChannel& other
+  ) noexcept = delete;
   /// @brief Default move constructor.
   CompressedPointCloudChannel(CompressedPointCloudChannel&& other) noexcept = default;
   /// @brief Default move assignment.
@@ -5137,8 +5137,8 @@ public:
   }
 
   TriangleListPrimitiveChannel(const TriangleListPrimitiveChannel& other) noexcept = delete;
-  TriangleListPrimitiveChannel& operator=(const TriangleListPrimitiveChannel& other) noexcept =
-    delete;
+  TriangleListPrimitiveChannel& operator=(const TriangleListPrimitiveChannel& other
+  ) noexcept = delete;
   /// @brief Default move constructor.
   TriangleListPrimitiveChannel(TriangleListPrimitiveChannel&& other) noexcept = default;
   /// @brief Default move assignment.

--- a/python/foxglove-sdk/src/generated/messages.rs
+++ b/python/foxglove-sdk/src/generated/messages.rs
@@ -2093,7 +2093,7 @@ impl From<SceneEntityDeletion> for foxglove::messages::SceneEntityDeletion {
 /// :param frame_id: Frame of reference
 /// :param id: Identifier for the entity. A entity will replace any prior entity on the same topic with the same `id`.
 /// :param lifetime: Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
-/// :param frame_locked: Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+/// :param frame_locked: False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
 /// :param metadata: Additional user-provided metadata associated with the entity. Keys must be unique.
 /// :param arrows: Arrow primitives
 /// :param cubes: Cube primitives

--- a/ros/src/foxglove_msgs/ros1/SceneEntity.msg
+++ b/ros/src/foxglove_msgs/ros1/SceneEntity.msg
@@ -15,7 +15,7 @@ string id
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 duration lifetime
 
-# Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+# False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
 bool frame_locked
 
 # Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/ros/src/foxglove_msgs/ros2/SceneEntity.msg
+++ b/ros/src/foxglove_msgs/ros2/SceneEntity.msg
@@ -15,7 +15,7 @@ string id
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 builtin_interfaces/Duration lifetime
 
-# Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+# False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
 bool frame_locked
 
 # Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/rust/foxglove/src/messages/foxglove.rs
+++ b/rust/foxglove/src/messages/foxglove.rs
@@ -1312,7 +1312,7 @@ pub struct SceneEntity {
     /// Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
     #[prost(message, optional, tag = "4")]
     pub lifetime: ::core::option::Option<crate::messages::Duration>,
-    /// Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+    /// False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
     #[prost(bool, tag = "5")]
     pub frame_locked: bool,
     /// Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3215,7 +3215,7 @@ boolean
 </td>
 <td>
 
-Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
 
 </td>
 </tr>

--- a/schemas/flatbuffer/SceneEntity.fbs
+++ b/schemas/flatbuffer/SceneEntity.fbs
@@ -28,7 +28,7 @@ table SceneEntity {
   /// Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
   lifetime:Duration (id: 3);
 
-  /// Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+  /// False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
   frame_locked:bool (id: 4);
 
   /// Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/schemas/jsonschema/SceneEntity.json
+++ b/schemas/jsonschema/SceneEntity.json
@@ -45,7 +45,7 @@
     },
     "frame_locked": {
       "type": "boolean",
-      "description": "Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)"
+      "description": "False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received."
     },
     "metadata": {
       "type": "array",

--- a/schemas/jsonschema/SceneUpdate.json
+++ b/schemas/jsonschema/SceneUpdate.json
@@ -104,7 +104,7 @@
           },
           "frame_locked": {
             "type": "boolean",
-            "description": "Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)"
+            "description": "False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received."
           },
           "metadata": {
             "type": "array",

--- a/schemas/jsonschema/index.ts
+++ b/schemas/jsonschema/index.ts
@@ -3111,7 +3111,7 @@ export const SceneEntity = {
     },
     "frame_locked": {
       "type": "boolean",
-      "description": "Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)"
+      "description": "False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received."
     },
     "metadata": {
       "type": "array",
@@ -4472,7 +4472,7 @@ export const SceneUpdate = {
           },
           "frame_locked": {
             "type": "boolean",
-            "description": "Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)"
+            "description": "False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received."
           },
           "metadata": {
             "type": "array",

--- a/schemas/omgidl/foxglove/SceneEntity.idl
+++ b/schemas/omgidl/foxglove/SceneEntity.idl
@@ -28,7 +28,7 @@ struct SceneEntity {
   // Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
   Duration lifetime;
 
-  // Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+  // False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
   boolean frame_locked;
 
   // Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/schemas/proto/foxglove/SceneEntity.proto
+++ b/schemas/proto/foxglove/SceneEntity.proto
@@ -30,7 +30,7 @@ message SceneEntity {
   // Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
   google.protobuf.Duration lifetime = 4;
 
-  // Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+  // False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
   bool frame_locked = 5;
 
   // Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/schemas/ros1/SceneEntity.msg
+++ b/schemas/ros1/SceneEntity.msg
@@ -15,7 +15,7 @@ string id
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 duration lifetime
 
-# Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+# False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
 bool frame_locked
 
 # Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/schemas/ros2/SceneEntity.msg
+++ b/schemas/ros2/SceneEntity.msg
@@ -15,7 +15,7 @@ string id
 # Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted.
 builtin_interfaces/Duration lifetime
 
-# Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)
+# False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.
 bool frame_locked
 
 # Additional user-provided metadata associated with the entity. Keys must be unique.

--- a/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
+++ b/typescript/schemas/src/internal/__snapshots__/exportTypeScriptSchemas.test.ts.snap
@@ -815,7 +815,7 @@ export type SceneEntity = {
   /** Length of time (relative to \`timestamp\`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted. */
   lifetime: Duration;
 
-  /** Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in \`frame_id\` as it moves relative to the fixed frame (true) */
+  /** False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in \`frame_id\` as it moves relative to the fixed frame when new transform messages are received. */
   frame_locked: boolean;
 
   /** Additional user-provided metadata associated with the entity. Keys must be unique. */

--- a/typescript/schemas/src/internal/schemas.ts
+++ b/typescript/schemas/src/internal/schemas.ts
@@ -714,7 +714,7 @@ const SceneEntity: FoxgloveMessageSchema = {
       name: "frame_locked",
       type: { type: "primitive", name: "boolean" },
       description:
-        "Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)",
+        "False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.",
     },
     {
       name: "metadata",

--- a/typescript/schemas/src/types/SceneEntity.ts
+++ b/typescript/schemas/src/types/SceneEntity.ts
@@ -27,7 +27,7 @@ export type SceneEntity = {
   /** Length of time (relative to `timestamp`) after which the entity should be automatically removed. Zero value indicates the entity should remain visible until it is replaced or deleted. */
   lifetime: Duration;
 
-  /** Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true) */
+  /** False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received. */
   frame_locked: boolean;
 
   /** Additional user-provided metadata associated with the entity. Keys must be unique. */


### PR DESCRIPTION
### Changelog

Updated the description for SceneEntity's `frame_locked` field.

### Docs

None

### Description

Updating the wording for clarity based on customer feedback:

<table><tr><th>Before</th><th>After</th></tr><tr><td>

Whether the entity should keep its location in the fixed frame (false) or follow the frame specified in `frame_id` as it moves relative to the fixed frame (true)

</td><td>

False indicates the entity should keep its location in the fixed frame until a new entity is published. True indicates the entity should follow the frame specified in `frame_id` as it moves relative to the fixed frame when new transform messages are received.

</td></tr></table>

Review note: I don't believe this actually breaks ROS msg compatibility, but CI is forcing me to add the `breaking:msg-schema` label.