### PR TITLE
Bump mcap to 0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8318fda24dc135cdd838f57a2b5ccb6e8f04ff6b6c65528c4bd9b5fcdc5cf6"
 dependencies = [
  "array-init",
- "binrw_derive",
+ "binrw_derive 0.12.0",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
+dependencies = [
+ "array-init",
+ "binrw_derive 0.15.1",
  "bytemuck",
 ]
 
@@ -323,10 +334,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0832bed83248115532dfb25af54fae1c83d67a2e4e3e2f591c13062e372e7e"
 dependencies = [
  "either",
- "owo-colors",
+ "owo-colors 3.5.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
+dependencies = [
+ "either",
+ "owo-colors 4.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1141,7 +1165,7 @@ version = "0.0.0"
 dependencies = [
  "env_logger",
  "foxglove 0.25.1",
- "mcap 0.24.0",
+ "mcap 0.25.0",
  "schemars 1.0.4",
  "serde",
 ]
@@ -1253,7 +1277,7 @@ dependencies = [
  "clap",
  "env_logger",
  "foxglove 0.25.1",
- "mcap 0.24.0",
+ "mcap 0.25.0",
  "tokio",
 ]
 
@@ -1347,7 +1371,7 @@ dependencies = [
  "ctrlc",
  "env_logger",
  "foxglove 0.25.1",
- "mcap 0.24.0",
+ "mcap 0.25.0",
  "tracing",
 ]
 
@@ -1513,7 +1537,7 @@ dependencies = [
  "libwebrtc",
  "livekit",
  "maplit",
- "mcap 0.24.0",
+ "mcap 0.25.0",
  "parking_lot",
  "prost 0.14.3",
  "prost-types 0.14.3",
@@ -1574,7 +1598,7 @@ dependencies = [
  "foxglove 0.25.1",
  "log",
  "maplit",
- "mcap 0.24.0",
+ "mcap 0.25.0",
  "tracing",
 ]
 
@@ -2758,7 +2782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3ca583fed649ed7cd8c976b59422996472c6b08067308443e0b60c56e0a4ca"
 dependencies = [
  "bimap",
- "binrw",
+ "binrw 0.12.0",
  "byteorder",
  "crc32fast",
  "enumset",
@@ -2771,12 +2795,12 @@ dependencies = [
 
 [[package]]
 name = "mcap"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43908ab970f3a880b02834055a1e04221a3056f442a65ae9111f63e550e7daa5"
+checksum = "b215e79631de2a19ed76fda13cd52950c3057b487a2f41d9dc85c4079b969c40"
 dependencies = [
  "bimap",
- "binrw",
+ "binrw 0.15.1",
  "byteorder",
  "crc32fast",
  "enumset",
@@ -2785,7 +2809,7 @@ dependencies = [
  "num_cpus",
  "paste",
  "static_assertions",
- "thiserror 1.0.69",
+ "thiserror 2.0.14",
  "zstd",
 ]
 
@@ -3246,6 +3270,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"
@@ -4004,7 +4034,7 @@ dependencies = [
  "foxglove 0.25.1",
  "jsonschema",
  "libtest-mimic",
- "mcap 0.24.0",
+ "mcap 0.25.0",
  "reqwest 0.13.2",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "MIT"
 bytes = "1.11.1"
 chrono = { version = "0.4.39" }
 log = "0.4.22"
-mcap = { version = "0.25.0", default-features = false }
+mcap = { version = "0.25", default-features = false }
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "MIT"
 bytes = "1.11.1"
 chrono = { version = "0.4.39" }
 log = "0.4.22"
-mcap = { version = "0.24", default-features = false }
+mcap = { version = "0.25.0", default-features = false }
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"

--- a/c/src/channel.rs
+++ b/c/src/channel.rs
@@ -229,7 +229,7 @@ pub extern "C" fn foxglove_mcap_options_default() -> FoxgloveMcapOptions {
         custom_writer: std::ptr::null(),
         compression: FoxgloveMcapCompression::Zstd,
         profile: FoxgloveString::default(),
-        chunk_size: 1024 * 768,
+        chunk_size: 1024 * 1024,
         use_chunks: true,
         disable_seeking: false,
         emit_statistics: true,

--- a/cpp/foxglove/include/foxglove/mcap.hpp
+++ b/cpp/foxglove/include/foxglove/mcap.hpp
@@ -91,7 +91,7 @@ struct McapWriterOptions {
   /// @brief The profile to use for the MCAP file.
   std::string_view profile;
   /// @brief The size of each chunk in the MCAP file.
-  uint64_t chunk_size = static_cast<uint64_t>(1024 * 768);
+  uint64_t chunk_size = static_cast<uint64_t>(1024 * 1024);
   /// @brief The compression algorithm to use for the MCAP file.
   McapCompression compression = McapCompression::Zstd;
   /// @brief Whether to use chunks in the MCAP file.

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/mcap.pyi
@@ -50,7 +50,7 @@ class MCAPWriteOptions:
         *,
         compression: MCAPCompression | None = MCAPCompression.Zstd,
         profile: str | None = None,
-        chunk_size: int | None = 786432,
+        chunk_size: int | None = 1048576,
         use_chunks: bool = True,
         emit_statistics: bool = True,
         emit_summary_offsets: bool = True,

--- a/python/foxglove-sdk/src/mcap.rs
+++ b/python/foxglove-sdk/src/mcap.rs
@@ -163,7 +163,7 @@ impl PyMcapWriteOptions {
         *,
         compression = PyMcapCompression::Zstd,
         profile = None,
-        chunk_size = 786432,
+        chunk_size = 1048576,
         use_chunks = true,
         emit_statistics = true,
         emit_summary_offsets = true,

--- a/rust/examples/mcap/src/main.rs
+++ b/rust/examples/mcap/src/main.rs
@@ -16,7 +16,7 @@ struct Cli {
     #[arg(long)]
     overwrite: bool,
     /// Chunk size.
-    #[arg(long, default_value_t = 1024 * 768)]
+    #[arg(long, default_value_t = 1024 * 1024)]
     chunk_size: u64,
     /// Compression algorithm to use.
     #[arg(long, default_value = "zstd")]

--- a/rust/examples/remote_access_stream_mcap/Cargo.toml
+++ b/rust/examples/remote_access_stream_mcap/Cargo.toml
@@ -12,4 +12,4 @@ tokio = { version = "1.47", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"
 anyhow = "1"
-mcap = "0.24"
+mcap = "0.25.0"

--- a/rust/examples/remote_access_stream_mcap/Cargo.toml
+++ b/rust/examples/remote_access_stream_mcap/Cargo.toml
@@ -12,4 +12,4 @@ tokio = { version = "1.47", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"
 anyhow = "1"
-mcap = "0.25.0"
+mcap = "0.25"

--- a/rust/examples/ws_stream_mcap/Cargo.toml
+++ b/rust/examples/ws_stream_mcap/Cargo.toml
@@ -12,5 +12,5 @@ clap = { version = "4.5", features = ["derive"] }
 ctrlc = "3.4"
 env_logger = "0.11"
 foxglove = { path = "../../foxglove" }
-mcap = "0.24"
+mcap = "0.25.0"
 tracing = { version = "0.1", features = ["log"] }

--- a/rust/examples/ws_stream_mcap/Cargo.toml
+++ b/rust/examples/ws_stream_mcap/Cargo.toml
@@ -12,5 +12,5 @@ clap = { version = "4.5", features = ["derive"] }
 ctrlc = "3.4"
 env_logger = "0.11"
 foxglove = { path = "../../foxglove" }
-mcap = "0.25.0"
+mcap = "0.25"
 tracing = { version = "0.1", features = ["log"] }


### PR DESCRIPTION
### Changelog

Updated the SDK's `mcap` dependency to `0.25.0`; the default MCAP chunk size is now 1 MiB across Rust, Python, C, C++, and examples.

### Docs

None

### Description

Bumps the workspace `mcap` dependency and MCAP streaming examples from `0.24` to `0.25.0`, with the Cargo lockfile refreshed to capture the new transitive versions.

The `mcap` `0.25.0` default chunk size changed to 1 MiB, so this also updates the Rust example plus Python, C, and C++ API default mirrors to keep their existing drift tests passing.