### PR TITLE
netem: Support live retuning of a single per-link class

### DIFF
--- a/rust/remote_access_tests/NETEM.md
+++ b/rust/remote_access_tests/NETEM.md
@@ -153,11 +153,18 @@ $COMPOSE exec gateway-netem python3 /netem_impair.py delay 0ms
 
 # Update ALL download links at once (changes every netem qdisc on the LiveKit sidecar)
 $COMPOSE exec netem python3 /netem_impair.py delay 100ms loss 3%
+
+# Update a single download link's class (per-link mode; the name after `link`
+# is the NETEM_LINK_<NAME>_DST link name the sidecar was set up with)
+$COMPOSE exec netem python3 /netem_impair.py link GATEWAY delay 200ms loss 5%
+$COMPOSE exec netem python3 /netem_impair.py link VIEWER delay 40ms rate 10mbit
+
+# Update only the default (unclassified-traffic) class
+$COMPOSE exec netem python3 /netem_impair.py default delay 10ms
 ```
 
-> **Limitation:** Per-link download impairment cannot be updated independently
-> with `netem_impair.py`. It updates all netem qdiscs at once. To change a
-> single link's download, restart the stack with updated env vars.
+`yarn netem-impair --link gateway-download` / `--link viewer-download` wraps
+the single-link form — see "Switch profiles mid-stream" below.
 
 ## Streaming heavy topics under uplink congestion
 
@@ -231,12 +238,20 @@ yarn netem-impair -- delay 500ms loss 10%
 
 `severe` is tuned to saturate heavy-topic uplinks; adjust from there.
 
-> **Scope:** `yarn netem-impair` hardcodes the `gateway-netem` sidecar, so it
-> only retunes the gateway upload link. The underlying `netem_impair.py` is not
-> limited to uploads — exec'd into the LiveKit-side `netem` sidecar it updates
-> all download links at once (see "Changing impairment live" above). Per-link
-> viewer/download retuning still requires a stack restart with new
-> `NETEM_VIEWER_UPLOAD` / `NETEM_*_DOWNLOAD` env vars.
+By default `yarn netem-impair` retunes the gateway upload link (the
+`gateway-netem` sidecar). Pass `--link` to retune a single download class on
+the LiveKit-side `netem` sidecar instead, without touching the other links:
+
+```sh
+yarn netem-impair --link gateway-download --profile severe
+yarn netem-impair --link viewer-download -- delay 40ms rate 10mbit
+```
+
+> **Scope:** the `--link` download targets exist only when the stack came up
+> in per-link mode (they map to the sidecar's `NETEM_LINK_*` classes); on a
+> flat-mode stack the underlying `netem_impair.py` reports that the sidecar
+> has no links. Viewer-upload retuning (the `viewer-netem` sidecar) is not
+> wrapped yet.
 
 ### Streaming against a deployed Foxglove instance
 

--- a/scripts/container/netem_impair.py
+++ b/scripts/container/netem_impair.py
@@ -4,26 +4,67 @@
 Runs inside a netem sidecar container.
 
 Usage:
-  netem_impair.py <netem-args>           Update all netem qdiscs
-  netem_impair.py default <netem-args>   Update only the default class (ff00:)
+  netem_impair.py <netem-args>               Update all netem qdiscs
+  netem_impair.py default <netem-args>       Update only the default class (ff00:)
+  netem_impair.py link <NAME> <netem-args>   Update only the NETEM_LINK_<NAME>_* class
 """
 
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 
+def discover_link_handles() -> dict[str, str]:
+    """Map link names to their netem qdisc handles.
+
+    Mirrors the assignment in netem_setup.py exactly: links are discovered
+    from NETEM_LINK_<NAME>_DST env vars in sorted-env-key order and get
+    handles 10:, 20:, ... in that order. The sidecar's env is identical to
+    what netem_setup.py saw at startup, so the mapping is deterministic —
+    but keep the two functions in sync.
+    """
+    handles: dict[str, str] = {}
+    class_minor = 0x10
+    for key, value in sorted(os.environ.items()):
+        m = re.match(r"^NETEM_LINK_(.+)_DST$", key)
+        if m and value:
+            handles[m.group(1)] = f"{class_minor:x}:"
+            class_minor += 0x10
+    return handles
+
+
+def usage_error() -> None:
+    print("Usage: netem_impair.py [default | link <NAME>] <netem-args>", file=sys.stderr)
+    sys.exit(1)
+
+
 def main() -> None:
     args = sys.argv[1:]
 
+    # `target` is the qdisc handle to update, or "all" for every netem qdisc.
     target = "all"
     if args and args[0] == "default":
-        target = "default"
+        target = "ff00:"
         args = args[1:]
+    elif args and args[0] == "link":
+        if len(args) < 2:
+            usage_error()
+        handles = discover_link_handles()
+        name = args[1]
+        if name not in handles:
+            known = ", ".join(handles) or "(none — this sidecar runs in flat mode)"
+            print(
+                f"ERROR: unknown link '{name}'. Links on this sidecar: {known}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        target = handles[name]
+        args = args[2:]
 
     if not args:
-        print("Usage: netem_impair.py [default] <netem-args>", file=sys.stderr)
-        sys.exit(1)
+        usage_error()
 
     # Arguments are already a list from sys.argv — no shell parsing needed.
     netem_args = args
@@ -46,6 +87,7 @@ def main() -> None:
         netem_args = [*netem_args, "rate", "1000gbit"]
 
     errors = 0
+    updated = 0
 
     for iface in sorted(p.name for p in Path("/sys/class/net").iterdir()):
         result = subprocess.run(
@@ -65,7 +107,7 @@ def main() -> None:
             else:
                 parent_args = ["parent", parts[4]]
 
-            if target == "default" and handle != "ff00:":
+            if target != "all" and handle != target:
                 continue
 
             change_result = subprocess.run(
@@ -86,12 +128,19 @@ def main() -> None:
             )
             if change_result.returncode == 0:
                 print(f"  {iface} {handle}: netem {' '.join(netem_args)}")
+                updated += 1
             else:
                 print(f"  ERROR: {iface} {handle}", file=sys.stderr)
                 errors += 1
 
     if errors > 0:
         print(f"ERROR: {errors} update(s) failed", file=sys.stderr)
+        sys.exit(1)
+    if updated == 0:
+        # Nothing matched: the hierarchy was never set up, or a targeted
+        # handle has no qdisc (e.g. `default` on a flat-mode sidecar, whose
+        # root netem has a different handle).
+        print("ERROR: no matching netem qdisc found", file=sys.stderr)
         sys.exit(1)
 
 

--- a/scripts/container/netem_impair.py
+++ b/scripts/container/netem_impair.py
@@ -9,30 +9,28 @@ Usage:
   netem_impair.py link <NAME> <netem-args>   Update only the NETEM_LINK_<NAME>_* class
 """
 
-import os
-import re
+import json
 import subprocess
 import sys
 from pathlib import Path
+
+# Written by netem_setup.py at sidecar startup (per-link mode only).
+LINK_MAP_PATH = Path("/run/netem_links.json")
 
 
 def discover_link_handles() -> dict[str, str]:
     """Map link names to their netem qdisc handles.
 
-    Mirrors the assignment in netem_setup.py exactly: links are discovered
-    from NETEM_LINK_<NAME>_DST env vars in sorted-env-key order and get
-    handles 10:, 20:, ... in that order. The sidecar's env is identical to
-    what netem_setup.py saw at startup, so the mapping is deterministic —
-    but keep the two functions in sync.
+    Reads back the map netem_setup.py persisted when it built the hierarchy,
+    so the handle used here is the one setup actually assigned — re-deriving
+    it from env vars could silently retune the wrong class if the two
+    derivations ever drifted. No file means setup ran in flat mode (no link
+    classes exist).
     """
-    handles: dict[str, str] = {}
-    class_minor = 0x10
-    for key, value in sorted(os.environ.items()):
-        m = re.match(r"^NETEM_LINK_(.+)_DST$", key)
-        if m and value:
-            handles[m.group(1)] = f"{class_minor:x}:"
-            class_minor += 0x10
-    return handles
+    try:
+        return json.loads(LINK_MAP_PATH.read_text())
+    except FileNotFoundError:
+        return {}
 
 
 def usage_error() -> None:

--- a/scripts/container/netem_impair.py
+++ b/scripts/container/netem_impair.py
@@ -36,7 +36,9 @@ def discover_link_handles() -> dict[str, str]:
 
 
 def usage_error() -> None:
-    print("Usage: netem_impair.py [default | link <NAME>] <netem-args>", file=sys.stderr)
+    print(
+        "Usage: netem_impair.py [default | link <NAME>] <netem-args>", file=sys.stderr
+    )
     sys.exit(1)
 
 

--- a/scripts/container/netem_impair.py
+++ b/scripts/container/netem_impair.py
@@ -127,7 +127,8 @@ def main() -> None:
                 text=True,
             )
             if change_result.returncode == 0:
-                print(f"  {iface} {handle}: netem {' '.join(netem_args)}")
+                # `handle` already ends with ":" (e.g. "10:"), so no separator.
+                print(f"  {iface} {handle} netem {' '.join(netem_args)}")
                 updated += 1
             else:
                 print(f"  ERROR: {iface} {handle}", file=sys.stderr)

--- a/scripts/container/netem_setup.py
+++ b/scripts/container/netem_setup.py
@@ -53,7 +53,8 @@ def interfaces() -> list[str]:
     """
     skip_lo = os.environ.get("NETEM_SKIP_LOOPBACK", "") == "1"
     return sorted(
-        p.name for p in Path("/sys/class/net").iterdir()
+        p.name
+        for p in Path("/sys/class/net").iterdir()
         if not (skip_lo and p.name == "lo")
     )
 
@@ -82,7 +83,9 @@ def apply_flat(netem_args: list[str]) -> int:
             print(f"netem (flat) applied to {iface}: {' '.join(netem_args)}")
             applied += 1
         else:
-            print(f"  WARNING: failed to apply netem to {iface} (may be expected for lo)")
+            print(
+                f"  WARNING: failed to apply netem to {iface} (may be expected for lo)"
+            )
     return applied
 
 
@@ -97,17 +100,51 @@ def apply_perlink(netem_args: list[str], links: dict[str, str]) -> int:
         print(f"configuring per-link netem on {iface}...")
 
         # HTB root qdisc. Unclassified traffic goes to default class 1:ff00.
-        if not tc("qdisc", "replace", "dev", iface, "root", "handle", "1:", "htb", "default", "ff00"):
+        if not tc(
+            "qdisc",
+            "replace",
+            "dev",
+            iface,
+            "root",
+            "handle",
+            "1:",
+            "htb",
+            "default",
+            "ff00",
+        ):
             print(f"  WARNING: failed to add HTB root qdisc on {iface} (skipping)")
             continue
 
         # Default class (unclassified traffic).
         ok = True
-        if not tc("class", "add", "dev", iface, "parent", "1:", "classid", "1:ff00", "htb", "rate", "10gbit"):
+        if not tc(
+            "class",
+            "add",
+            "dev",
+            iface,
+            "parent",
+            "1:",
+            "classid",
+            "1:ff00",
+            "htb",
+            "rate",
+            "10gbit",
+        ):
             print(f"  ERROR: failed to add default class on {iface}")
             errors += 1
             ok = False
-        if not tc("qdisc", "add", "dev", iface, "parent", "1:ff00", "handle", "ff00:", "netem", *netem_args):
+        if not tc(
+            "qdisc",
+            "add",
+            "dev",
+            iface,
+            "parent",
+            "1:ff00",
+            "handle",
+            "ff00:",
+            "netem",
+            *netem_args,
+        ):
             print(f"  ERROR: failed to add netem qdisc on default class ({iface})")
             errors += 1
             ok = False
@@ -127,21 +164,63 @@ def apply_perlink(netem_args: list[str], links: dict[str, str]) -> int:
             handle = f"{class_minor:x}:"
 
             link_ok = True
-            if not tc("class", "add", "dev", iface, "parent", "1:", "classid", class_id, "htb", "rate", "10gbit"):
+            if not tc(
+                "class",
+                "add",
+                "dev",
+                iface,
+                "parent",
+                "1:",
+                "classid",
+                class_id,
+                "htb",
+                "rate",
+                "10gbit",
+            ):
                 print(f"  ERROR: failed to add class {class_id} on {iface}")
                 errors += 1
                 link_ok = False
-            if not tc("qdisc", "add", "dev", iface, "parent", class_id, "handle", handle, "netem", *link_args):
-                print(f"  ERROR: failed to add netem qdisc on class {class_id} ({iface})")
+            if not tc(
+                "qdisc",
+                "add",
+                "dev",
+                iface,
+                "parent",
+                class_id,
+                "handle",
+                handle,
+                "netem",
+                *link_args,
+            ):
+                print(
+                    f"  ERROR: failed to add netem qdisc on class {class_id} ({iface})"
+                )
                 errors += 1
                 link_ok = False
-            if not tc("filter", "add", "dev", iface, "parent", "1:", "protocol", "ip", "u32",
-                       "match", "ip", "dst", f"{dst}/32", "flowid", class_id):
+            if not tc(
+                "filter",
+                "add",
+                "dev",
+                iface,
+                "parent",
+                "1:",
+                "protocol",
+                "ip",
+                "u32",
+                "match",
+                "ip",
+                "dst",
+                f"{dst}/32",
+                "flowid",
+                class_id,
+            ):
                 print(f"  ERROR: failed to add u32 filter for {dst} on {iface}")
                 errors += 1
                 link_ok = False
             if link_ok:
-                print(f"  link {name}: class {class_id} -> dst {dst} -> netem {' '.join(link_args)}")
+                print(
+                    f"  link {name}: class {class_id} -> dst {dst} -> netem {' '.join(link_args)}"
+                )
 
             class_minor += 0x10
 

--- a/scripts/container/netem_setup.py
+++ b/scripts/container/netem_setup.py
@@ -114,7 +114,10 @@ def apply_perlink(netem_args: list[str], links: dict[str, str]) -> int:
         if ok:
             print(f"  default class 1:ff00 -> netem {' '.join(netem_args)}")
 
-        # Per-link classes. Assign class IDs starting at 1:10, incrementing by 0x10.
+        # Per-link classes. Assign class IDs starting at 1:10, incrementing by
+        # 0x10, in `links` iteration order (sorted env keys — see
+        # discover_links). netem_impair.py's discover_link_handles recomputes
+        # this name -> handle assignment for live retuning; keep them in sync.
         class_minor = 0x10
         for name, dst in links.items():
             link_args_str = os.environ.get(f"NETEM_LINK_{name}_ARGS", "")

--- a/scripts/container/netem_setup.py
+++ b/scripts/container/netem_setup.py
@@ -16,12 +16,19 @@ Per-link env vars follow the pattern:
   NETEM_LINK_<NAME>_ARGS  — netem arguments for this link (defaults to NETEM_ARGS)
 """
 
+import json
 import os
 import re
 import shlex
 import subprocess
 import sys
 from pathlib import Path
+
+# Where the per-link name -> qdisc handle map is persisted for live retuning.
+# netem_impair.py reads this back instead of re-deriving the assignment, so
+# the two scripts cannot drift. Lives in the container's own filesystem (this
+# script runs once at sidecar startup; netem_impair.py is exec'd in later).
+LINK_MAP_PATH = Path("/run/netem_links.json")
 
 
 def tc(*args: str) -> bool:
@@ -89,7 +96,14 @@ def apply_flat(netem_args: list[str]) -> int:
     return applied
 
 
-def apply_perlink(netem_args: list[str], links: dict[str, str]) -> int:
+def assign_link_handles(links: dict[str, str]) -> dict[str, str]:
+    """Assign each link's netem qdisc handle: 10:, 20:, ... in `links` order."""
+    return {name: f"{(i + 1) * 0x10:x}:" for i, name in enumerate(links)}
+
+
+def apply_perlink(
+    netem_args: list[str], links: dict[str, str], handles: dict[str, str]
+) -> int:
     """Per-link mode: HTB root with netem leaf classes per destination IP.
 
     Returns the number of errors encountered.
@@ -151,17 +165,14 @@ def apply_perlink(netem_args: list[str], links: dict[str, str]) -> int:
         if ok:
             print(f"  default class 1:ff00 -> netem {' '.join(netem_args)}")
 
-        # Per-link classes. Assign class IDs starting at 1:10, incrementing by
-        # 0x10, in `links` iteration order (sorted env keys — see
-        # discover_links). netem_impair.py's discover_link_handles recomputes
-        # this name -> handle assignment for live retuning; keep them in sync.
-        class_minor = 0x10
+        # Per-link classes, with handles from `assign_link_handles` (10:, 20:,
+        # ... in `links` iteration order — sorted env keys, see discover_links).
         for name, dst in links.items():
             link_args_str = os.environ.get(f"NETEM_LINK_{name}_ARGS", "")
             link_args = shlex.split(link_args_str) if link_args_str else netem_args
 
-            class_id = f"1:{class_minor:x}"
-            handle = f"{class_minor:x}:"
+            handle = handles[name]
+            class_id = f"1:{handle[:-1]}"
 
             link_ok = True
             if not tc(
@@ -222,8 +233,6 @@ def apply_perlink(netem_args: list[str], links: dict[str, str]) -> int:
                     f"  link {name}: class {class_id} -> dst {dst} -> netem {' '.join(link_args)}"
                 )
 
-            class_minor += 0x10
-
     return errors
 
 
@@ -240,7 +249,11 @@ def main() -> None:
     links = discover_links()
 
     if links:
-        errors = apply_perlink(netem_args, links)
+        handles = assign_link_handles(links)
+        # Persist the assignment so netem_impair.py's `link <NAME>` target can
+        # look up the handle setup actually used.
+        LINK_MAP_PATH.write_text(json.dumps(handles))
+        errors = apply_perlink(netem_args, links, handles)
         if errors > 0:
             dump_state()
             print(f"\nERROR: {errors} tc command(s) failed during per-link setup.")

--- a/scripts/netemImpair.ts
+++ b/scripts/netemImpair.ts
@@ -1,12 +1,16 @@
-// Live-update the gateway-upload netem impairment without restarting the
-// per-link stack. Targets the `gateway-netem` sidecar, which shapes the
+// Live-update netem impairment on one link without restarting the per-link
+// stack. By default targets the `gateway-netem` sidecar, which shapes the
 // gateway-runner's egress to LiveKit (the "uplink" in the FLE-372 scenario).
+// With --link, targets a single download class on the LiveKit-side `netem`
+// sidecar instead.
 //
 // Usage:
 //   yarn netem-impair --profile starlink
 //   yarn netem-impair --profile severe
 //   yarn netem-impair --profile pristine
 //   yarn netem-impair -- delay 500ms loss 10%       # raw netem args
+//   yarn netem-impair --link gateway-download --profile severe
+//   yarn netem-impair --link viewer-download -- delay 40ms rate 10mbit
 //
 // Each invocation REPLACES all netem settings on the qdisc — unmentioned
 // settings reset to their defaults. For example, switching from
@@ -16,12 +20,9 @@
 // means "no rate limit", consistent with the other settings. So `pristine`
 // (`delay 0ms`) really does restore an unshaped link.
 //
-// Scope: this wrapper hardcodes the `gateway-netem` sidecar, so it only
-// retunes the gateway-upload link. The underlying `netem_impair.py` is not so
-// limited — exec'd into the LiveKit-side `netem` sidecar it updates all
-// download links at once (see "Changing impairment live" in
-// rust/remote_access_tests/NETEM.md). Per-link viewer/download retuning still
-// requires a stack restart with new NETEM_* env vars.
+// The --link targets exist only when the stack came up in per-link mode
+// (`yarn start-netem --perlink` / `yarn stream-mcap` with NETEM_LINK_* set);
+// on a flat-mode stack `netem_impair.py` reports the sidecar has no links.
 
 import { program } from "commander";
 import { execFileSync } from "node:child_process";
@@ -48,6 +49,54 @@ const PROFILES: Record<string, string> = {
 
 interface Options {
   profile?: string;
+  link?: string;
+}
+
+/** Which sidecar to exec into and how to scope the update inside it. */
+interface Target {
+  /** Compose service name of the netem sidecar. */
+  service: string;
+  /** Arguments placed before the netem args (netem_impair.py target mode). */
+  targetArgs: string[];
+  /** Human-readable link name for the status line. */
+  label: string;
+}
+
+// --link targets: single download classes on the LiveKit-side `netem`
+// sidecar. The names after `link` are the NETEM_LINK_<NAME>_DST link names
+// the sidecar was set up with (see docker-compose.netem-livekit.yml).
+const LINK_TARGETS: Record<string, Target> = {
+  "gateway-download": {
+    service: "netem",
+    targetArgs: ["link", "GATEWAY"],
+    label: "gateway download",
+  },
+  "viewer-download": {
+    service: "netem",
+    targetArgs: ["link", "VIEWER"],
+    label: "viewer download",
+  },
+};
+
+// Without --link: all qdiscs on the gateway-upload sidecar (it runs flat
+// mode, so this is exactly the gateway-upload link).
+const DEFAULT_TARGET: Target = {
+  service: "gateway-netem",
+  targetArgs: [],
+  label: "gateway upload",
+};
+
+function resolveTarget(opts: Options): Target {
+  if (opts.link == null) {
+    return DEFAULT_TARGET;
+  }
+  const target = LINK_TARGETS[opts.link];
+  if (target == null) {
+    const known = Object.keys(LINK_TARGETS).join(", ");
+    console.error(`Error: unknown link '${opts.link}'. Known: ${known}`);
+    process.exit(1);
+  }
+  return target;
 }
 
 function compose(...args: string[]): void {
@@ -93,6 +142,7 @@ function resolveArgs(opts: Options, trailing: string[]): string[] {
 }
 
 function run(opts: Options, trailing: string[]): void {
+  const target = resolveTarget(opts);
   const netemArgs = resolveArgs(opts, trailing);
 
   // Check the sidecar is up front. `ps -q` prints its container ID when
@@ -102,33 +152,45 @@ function run(opts: Options, trailing: string[]): void {
   // python script with its own error already on stderr).
   let sidecarId = "";
   try {
-    sidecarId = composeCapture("ps", "gateway-netem", "-q").trim();
+    sidecarId = composeCapture("ps", target.service, "-q").trim();
   } catch {
     // docker/compose unavailable or the query failed; treat as "not running".
   }
   if (sidecarId === "") {
     console.error(
-      "Error: the gateway-netem sidecar isn't running.\n" +
+      `Error: the ${target.service} sidecar isn't running.\n` +
         "  Start the per-link stack with `yarn stream-mcap` or\n" +
         "  `yarn start-netem --perlink` first.",
     );
     process.exit(1);
   }
 
-  console.log(`gateway upload: netem ${netemArgs.join(" ")}`);
+  console.log(`${target.label}: netem ${netemArgs.join(" ")}`);
   try {
-    compose("exec", "gateway-netem", "python3", "/netem_impair.py", ...netemArgs);
+    compose(
+      "exec",
+      target.service,
+      "python3",
+      "/netem_impair.py",
+      ...target.targetArgs,
+      ...netemArgs,
+    );
   } catch (err) {
     // The sidecar is running, so the failure came from netem_impair.py itself
-    // (most likely rejected args). Its stderr is already inherited, so just
-    // exit with its status instead of dumping a node stack trace on top.
+    // (most likely rejected args, or --link on a flat-mode stack). Its stderr
+    // is already inherited, so just exit with its status instead of dumping a
+    // node stack trace on top.
     process.exit((err as { status?: number }).status ?? 1);
   }
 }
 
 program
-  .description("Live-update the gateway-upload netem impairment on the running per-link stack.")
+  .description("Live-update one link's netem impairment on the running per-link stack.")
   .option("-p, --profile <name>", `Named profile (one of: ${Object.keys(PROFILES).join(", ")})`)
+  .option(
+    "-l, --link <name>",
+    `Target link (one of: ${Object.keys(LINK_TARGETS).join(", ")}); default: gateway upload`,
+  )
   .argument("[netem-args...]", "Raw netem args (after `--`)")
   .action((trailing: string[], opts: Options) => {
     run(opts, trailing);


### PR DESCRIPTION
### Changelog

None (internal network-impairment test tooling).

### Docs

NETEM.md updated in this PR ("Changing impairment live" and "Switch profiles mid-stream").

### Description

`netem_impair.py` updates every netem qdisc in its sidecar's network namespace, or — with the `default` keyword — only the default class. There is no way to retune one link class without touching the others, so changing a single download link's impairment on the LiveKit-side `netem` sidecar requires restarting the stack with new env vars (a documented limitation in NETEM.md). It also blocks the planned viewer-upload shaping sidecar for the WireGuard relay (FLE-588 follow-up), which depends on a clean default class that a blanket update would overwrite.

This PR adds a `link <NAME> <netem-args>` target to `netem_impair.py`. `netem_setup.py` persists the name → handle assignment it actually used to `/run/netem_links.json` at startup, and `netem_impair.py` reads that back — so the handle retuned is by construction the one setup created (no re-derivation that could drift). Unknown link names fail with the list of links the sidecar actually has, a missing map file reports the sidecar as flat-mode, and an update that matches no qdisc now exits non-zero instead of silently doing nothing.

The wrapper grows a `--link` flag so no raw `docker compose exec` is needed:

```sh
yarn netem-impair --profile severe                          # unchanged: gateway upload
yarn netem-impair --link gateway-download --profile severe  # one download class
yarn netem-impair --link viewer-download -- delay 40ms rate 10mbit
```

Tradeoffs: the handle handoff uses a file in the container's own filesystem rather than a shared Python module, because the two scripts are bind-mounted into sidecars individually and a shared module would mean another mount in every sidecar definition (this design came out of review feedback — an earlier revision recomputed the assignment in both scripts, which could silently retune the wrong class if the derivations drifted). There is no Python unit-test infrastructure covering `scripts/container/` (CI's pytest runs the SDK package's tests only), so behavior is verified by the manual steps below; the host-side error paths (unknown link, flat-mode sidecar, stack down) were exercised directly.

Manual testing (verified live on macOS / Docker Desktop, 2026-06-11; untouched classes confirmed by their netem seeds staying identical, which the kernel regenerates on any change):

- [x] `yarn start-netem --perlink`, then `yarn netem-impair --link gateway-download --profile severe`; confirmed via `tc qdisc show` in the `netem` sidecar that only the `1:10` class changed and `1:20` + `1:ff00` are untouched.
- [x] Same for `--link viewer-download` (class `1:20`); `1:10` kept the values from the previous step and `1:ff00` stayed at its original defaults.
- [x] `yarn netem-impair --profile pristine` still retunes the gateway-upload sidecar as before (root netem → `delay 0ms rate 1Tbit`, the expected uncapped normalization), with the LiveKit sidecar's classes unmoved.
- [x] `--link gateway-download` against a flat-mode stack (`yarn start-netem`) exits 1 with "unknown link 'GATEWAY'. Links on this sidecar: (none — this sidecar runs in flat mode)" and leaves the flat qdisc untouched.
- [x] After switching to the persisted-map design: re-verified live that setup writes `{"GATEWAY": "10:", "VIEWER": "20:"}` to `/run/netem_links.json`, `--link gateway-download --profile severe` retunes only `1:10` through the map, and the flat-mode error path (no map file) still reports correctly.

Fixes: [FLE-594](https://linear.app/foxglove/issue/FLE-594/support-live-retuning-of-a-single-per-link-netem-class)


