### PR TITLE
rust: Emit Encode schema definitions in deterministic order

### DIFF
--- a/rust/foxglove_derive/Cargo.toml
+++ b/rust/foxglove_derive/Cargo.toml
@@ -13,8 +13,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-prost-types.workspace = true
+syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 bytes = "1.4"
@@ -22,5 +21,6 @@ chrono = "0.4"
 foxglove = { path = "../foxglove", features = ["chrono"] }
 prost.workspace = true
 prost-reflect = "0.16.3"
+prost-types.workspace = true
 tracing.workspace = true
 tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -494,7 +494,9 @@ fn derive_named_struct_impl(
     let max_field_number = 2047;
 
     // If a struct nests multiple values of the same enum or message type, we
-    // only define them once, based on name.
+    // only define them once, based on name. Use a BTreeMap to collect these
+    // definitions, so that the output will be deterministically ordered by
+    // type name.
     let mut enum_defs: BTreeMap<String, proc_macro2::TokenStream> = BTreeMap::new();
     let mut message_defs: BTreeMap<String, proc_macro2::TokenStream> = BTreeMap::new();
     let mut file_defs: BTreeMap<String, proc_macro2::TokenStream> = BTreeMap::new();
@@ -590,8 +592,6 @@ fn derive_named_struct_impl(
         });
     }
 
-    // Emit definitions in type-token order so macro output is deterministic
-    // across processes.
     let enum_defs = enum_defs.into_values().collect::<Vec<_>>();
     let message_defs = message_defs.into_values().collect::<Vec<_>>();
     let file_defs = file_defs.into_values().collect::<Vec<_>>();

--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -2,7 +2,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use syn::{
     Data, DataEnum, DataStruct, DeriveInput, Fields, GenericArgument, GenericParam, Generics,
     PathArguments, Type, parse_macro_input, parse_quote,
@@ -495,9 +495,9 @@ fn derive_named_struct_impl(
 
     // If a struct nests multiple values of the same enum or message type, we
     // only define them once, based on name.
-    let mut enum_defs: HashMap<&syn::Type, proc_macro2::TokenStream> = HashMap::new();
-    let mut message_defs: HashMap<&syn::Type, proc_macro2::TokenStream> = HashMap::new();
-    let mut file_defs: HashMap<&syn::Type, proc_macro2::TokenStream> = HashMap::new();
+    let mut enum_defs: BTreeMap<String, proc_macro2::TokenStream> = BTreeMap::new();
+    let mut message_defs: BTreeMap<String, proc_macro2::TokenStream> = BTreeMap::new();
+    let mut file_defs: BTreeMap<String, proc_macro2::TokenStream> = BTreeMap::new();
 
     for (i, field) in fields.iter().enumerate() {
         let field_name = &field.ident.as_ref().unwrap();
@@ -518,19 +518,21 @@ fn derive_named_struct_impl(
             ::foxglove::protobuf::ProtobufField::encoded_len_tagged(&self.#field_name, #field_number)
         });
 
-        enum_defs.entry(field_type).or_insert_with(|| quote! {
+        let field_type_key = quote!(#field_type).to_string();
+
+        enum_defs.entry(field_type_key.clone()).or_insert_with(|| quote! {
             if let Some(enum_desc) = <#field_type as ::foxglove::protobuf::ProtobufField>::enum_descriptor() {
                 enum_type.push(enum_desc);
             }
         });
 
-        message_defs.entry(field_type).or_insert_with(|| quote! {
+        message_defs.entry(field_type_key.clone()).or_insert_with(|| quote! {
             if let Some(message_descriptor) = <#field_type as ::foxglove::protobuf::ProtobufField>::message_descriptor() {
                 nested_type.push(message_descriptor);
             }
         });
 
-        file_defs.entry(field_type).or_insert_with(|| {
+        file_defs.entry(field_type_key).or_insert_with(|| {
             quote! {
                 for fd in <#field_type as ::foxglove::protobuf::ProtobufField>::file_descriptors() {
                     result.push(fd);
@@ -588,18 +590,11 @@ fn derive_named_struct_impl(
         });
     }
 
-    // Emit definitions in a deterministic order: HashMap iteration order is
-    // randomized per process, so splicing `into_values()` directly makes the
-    // generated tokens (and the consuming crate's SVH) differ build-to-build.
-    let mut enum_defs: Vec<_> = enum_defs.into_iter().collect();
-    enum_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
-    let enum_defs = enum_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
-    let mut message_defs: Vec<_> = message_defs.into_iter().collect();
-    message_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
-    let message_defs = message_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
-    let mut file_defs: Vec<_> = file_defs.into_iter().collect();
-    file_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
-    let file_defs = file_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
+    // Emit definitions in type-token order so macro output is deterministic
+    // across processes.
+    let enum_defs = enum_defs.into_values().collect::<Vec<_>>();
+    let message_defs = message_defs.into_values().collect::<Vec<_>>();
+    let file_defs = file_defs.into_values().collect::<Vec<_>>();
     let has_generics = !input.generics.params.is_empty();
 
     // Extract computation bodies so we can conditionally wrap with OnceLock

--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -50,6 +50,16 @@ fn unwrap_array_type(ty: &Type) -> Option<&Type> {
     }
 }
 
+/// Unwrap a container (`Vec<T>`, `Option<T>`, `[T; N]`) to the element type that
+/// owns its descriptors. One level suffices: nested containers are rejected by
+/// `validate_field_type`.
+fn descriptor_type(ty: &Type) -> &Type {
+    unwrap_generic_type(ty, "Vec")
+        .or_else(|| unwrap_generic_type(ty, "Option"))
+        .or_else(|| unwrap_array_type(ty))
+        .unwrap_or(ty)
+}
+
 /// Check if a type is `Vec<Option<T>>`, which is not supported because protobuf
 /// repeated fields cannot represent null/missing elements.
 fn is_vec_of_option(ty: &Type) -> bool {
@@ -520,23 +530,26 @@ fn derive_named_struct_impl(
             ::foxglove::protobuf::ProtobufField::encoded_len_tagged(&self.#field_name, #field_number)
         });
 
-        let field_type_key = quote!(#field_type).to_string();
+        // Dedup on the element type: containers share their element's
+        // descriptors, so `T` and `Vec<T>` must not emit it twice.
+        let descriptor_type = descriptor_type(field_type);
+        let descriptor_type_key = quote!(#descriptor_type).to_string();
 
-        enum_defs.entry(field_type_key.clone()).or_insert_with(|| quote! {
-            if let Some(enum_desc) = <#field_type as ::foxglove::protobuf::ProtobufField>::enum_descriptor() {
+        enum_defs.entry(descriptor_type_key.clone()).or_insert_with(|| quote! {
+            if let Some(enum_desc) = <#descriptor_type as ::foxglove::protobuf::ProtobufField>::enum_descriptor() {
                 enum_type.push(enum_desc);
             }
         });
 
-        message_defs.entry(field_type_key.clone()).or_insert_with(|| quote! {
-            if let Some(message_descriptor) = <#field_type as ::foxglove::protobuf::ProtobufField>::message_descriptor() {
+        message_defs.entry(descriptor_type_key.clone()).or_insert_with(|| quote! {
+            if let Some(message_descriptor) = <#descriptor_type as ::foxglove::protobuf::ProtobufField>::message_descriptor() {
                 nested_type.push(message_descriptor);
             }
         });
 
-        file_defs.entry(field_type_key).or_insert_with(|| {
+        file_defs.entry(descriptor_type_key).or_insert_with(|| {
             quote! {
-                for fd in <#field_type as ::foxglove::protobuf::ProtobufField>::file_descriptors() {
+                for fd in <#descriptor_type as ::foxglove::protobuf::ProtobufField>::file_descriptors() {
                     result.push(fd);
                 }
             }

--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -50,14 +50,16 @@ fn unwrap_array_type(ty: &Type) -> Option<&Type> {
     }
 }
 
-/// Unwrap a container (`Vec<T>`, `Option<T>`, `[T; N]`) to the element type that
-/// owns its descriptors. One level suffices: nested containers are rejected by
-/// `validate_field_type`.
+/// Unwrap containers (`Vec<T>`, `Option<T>`, `[T; N]`) to the element type that
+/// owns the descriptors.
 fn descriptor_type(ty: &Type) -> &Type {
-    unwrap_generic_type(ty, "Vec")
+    match unwrap_generic_type(ty, "Vec")
         .or_else(|| unwrap_generic_type(ty, "Option"))
         .or_else(|| unwrap_array_type(ty))
-        .unwrap_or(ty)
+    {
+        Some(inner) => descriptor_type(inner),
+        None => ty,
+    }
 }
 
 /// Check if a type is `Vec<Option<T>>`, which is not supported because protobuf

--- a/rust/foxglove_derive/src/lib.rs
+++ b/rust/foxglove_derive/src/lib.rs
@@ -588,9 +588,18 @@ fn derive_named_struct_impl(
         });
     }
 
-    let enum_defs = enum_defs.into_values().collect::<Vec<_>>();
-    let message_defs = message_defs.into_values().collect::<Vec<_>>();
-    let file_defs = file_defs.into_values().collect::<Vec<_>>();
+    // Emit definitions in a deterministic order: HashMap iteration order is
+    // randomized per process, so splicing `into_values()` directly makes the
+    // generated tokens (and the consuming crate's SVH) differ build-to-build.
+    let mut enum_defs: Vec<_> = enum_defs.into_iter().collect();
+    enum_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
+    let enum_defs = enum_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
+    let mut message_defs: Vec<_> = message_defs.into_iter().collect();
+    message_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
+    let message_defs = message_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
+    let mut file_defs: Vec<_> = file_defs.into_iter().collect();
+    file_defs.sort_by_key(|(t, _)| quote::quote!(#t).to_string());
+    let file_defs = file_defs.into_iter().map(|(_, d)| d).collect::<Vec<_>>();
     let has_generics = !input.generics.params.is_empty();
 
     // Extract computation bodies so we can conditionally wrap with OnceLock

--- a/rust/foxglove_derive/tests/container_dedup_test.rs
+++ b/rust/foxglove_derive/tests/container_dedup_test.rs
@@ -1,0 +1,48 @@
+use ::foxglove::Encode;
+use prost::Message;
+
+// Ensure the macro properly references the foxglove crate
+mod foxglove {}
+
+#[derive(Encode)]
+struct Inner {
+    v: u32,
+}
+
+#[derive(Debug, Clone, Copy, Encode)]
+#[allow(dead_code)]
+enum Color {
+    Red = 0,
+}
+
+// The same message and enum types appear both bare and container-wrapped.
+// Containers share their element's descriptors, so each nested definition must
+// be emitted only once regardless of wrapping.
+#[derive(Encode)]
+struct Outer {
+    bare: Inner,
+    optional: Option<Inner>,
+    repeated: Vec<Inner>,
+    array: [Inner; 2],
+    color: Color,
+    colors: Vec<Color>,
+}
+
+#[test]
+fn container_wrapped_definitions_are_deduplicated() {
+    let schema = Outer::get_schema().expect("schema");
+    let fds = prost_types::FileDescriptorSet::decode(schema.data.as_ref()).expect("decode schema");
+
+    let outer = fds
+        .file
+        .iter()
+        .flat_map(|f| f.message_type.iter())
+        .find(|m| m.name() == "Outer")
+        .expect("Outer descriptor");
+
+    let nested: Vec<&str> = outer.nested_type.iter().map(|n| n.name()).collect();
+    assert_eq!(nested, ["Inner"]);
+
+    let enums: Vec<&str> = outer.enum_type.iter().map(|e| e.name()).collect();
+    assert_eq!(enums, ["Color"]);
+}

--- a/rust/foxglove_derive/tests/deterministic_order_test.rs
+++ b/rust/foxglove_derive/tests/deterministic_order_test.rs
@@ -1,0 +1,64 @@
+use ::foxglove::Encode;
+use prost::Message;
+
+// Ensure the macro properly references the foxglove crate
+mod foxglove {}
+
+#[derive(Encode)]
+struct Zulu {
+    v: u32,
+}
+
+#[derive(Encode)]
+struct Alpha {
+    v: u32,
+}
+
+#[derive(Encode)]
+struct Mike {
+    v: u32,
+}
+
+#[derive(Debug, Clone, Copy, Encode)]
+#[allow(dead_code)]
+enum Yankee {
+    A = 0,
+}
+
+#[derive(Debug, Clone, Copy, Encode)]
+#[allow(dead_code)]
+enum Bravo {
+    A = 0,
+}
+
+// Fields are declared in a deliberately non-alphabetical order. The generated
+// schema must emit the nested message and enum definitions sorted by type name,
+// regardless of declaration order, so that the encoded schema bytes are stable
+// across builds.
+#[derive(Encode)]
+struct Container {
+    zulu: Zulu,
+    yankee: Yankee,
+    alpha: Alpha,
+    bravo: Bravo,
+    mike: Mike,
+}
+
+#[test]
+fn nested_definitions_are_deterministically_ordered() {
+    let schema = Container::get_schema().expect("schema");
+    let fds = prost_types::FileDescriptorSet::decode(schema.data.as_ref()).expect("decode schema");
+
+    let container = fds
+        .file
+        .iter()
+        .flat_map(|f| f.message_type.iter())
+        .find(|m| m.name() == "Container")
+        .expect("Container descriptor");
+
+    let nested: Vec<&str> = container.nested_type.iter().map(|n| n.name()).collect();
+    assert_eq!(nested, ["Alpha", "Mike", "Zulu"]);
+
+    let enums: Vec<&str> = container.enum_type.iter().map(|e| e.name()).collect();
+    assert_eq!(enums, ["Bravo", "Yankee"]);
+}


### PR DESCRIPTION
### Changelog
- rust: Emit Encode schema definitions in deterministic order

### Docs
None

### Description
This PR is carried forward from @pchikku's #1298.

The idea is to ensure that the Encode macro output is deterministic, by using a BTreeMap instead of a hashmap to collect the various definitions that it emits.

This change also fixes a pre-existing issue in which fields with container types (`Vec<T>`, `Option<T>`, `[T;N]`) were not being deduplicated properly. We now unwrap the container and dedupe based on element type.

### Links
Carried forward from: #1298 
Fixes: #1297