### PR TITLE
netem: Skip the per-link UDP loss test on CI pending FLE-595

### DIFF
--- a/rust/remote_access_tests/tests/netem_perlink_test.rs
+++ b/rust/remote_access_tests/tests/netem_perlink_test.rs
@@ -256,6 +256,16 @@ fn perlink_infra_link_a_has_higher_latency_than_link_b() -> Result<()> {
 #[ignore]
 #[test]
 fn perlink_infra_link_a_has_more_packet_loss_than_link_b() -> Result<()> {
+    // Temporarily skipped on CI: runners intermittently stop forwarding the
+    // UDP echo path (~99% loss on both links regardless of the configured
+    // netem profiles), which makes this measurement meaningless and blocks
+    // unrelated PRs. The test still runs locally. Remove this guard when
+    // FLE-595 is resolved. (`CI=true` is set on all GitHub Actions runners.)
+    if std::env::var_os("CI").is_some() {
+        info!("skipping on CI until FLE-595 is resolved");
+        return Ok(());
+    }
+
     let link_a_args =
         std::env::var("NETEM_LINK_A_ARGS").unwrap_or_else(|_| DEFAULT_LINK_A_ARGS.into());
     let link_b_args =


### PR DESCRIPTION
### Changelog

None (CI test scoping only).

### Docs

None.

### Description

The `netem-perlink-test` CI job intermittently fails when runners stop forwarding the UDP echo path: both links show ~99% loss regardless of the configured netem profiles (5% / 0%), so `perlink_infra_link_a_has_more_packet_loss_than_link_b` panics on an assertion the environment has made meaningless. On June 11 this hit ~60% of runs across unrelated branches, including `main`, and it is blocking open PRs.

This skips that one test on CI (gated on the `CI` env var, which GitHub Actions sets on all runners) with a comment pointing at the investigation. The test still runs locally, where the flake has not been observed. The other five perlink tests — including the TCP latency test against the same targets — keep running on CI unchanged.

The change is deliberately in the test file rather than the workflow so it cannot conflict with #1312, which is instrumenting the same workflow job to diagnose the wedge. Per that investigation, its probe step detects the UDP wedge independently of this test failing, so disabling the test does not blind it.

Verified with `cargo check -p remote_access_tests --tests` and `cargo clippy -p remote_access_tests --tests -- -D warnings`; the guard itself is exercised by this PR's own CI run (the job should now pass even if the wedge reproduces).

Relates to [FLE-595](https://linear.app/foxglove/issue/FLE-595/ci-netem-perlink-test-flake-both-links-show-99percent-udp-loss-spiked) (this disables the test until that issue is fixed; it is not the fix).
