### PR TITLE
netem: Replace forking UDP echo servers with a stateless loop (FLE-595)

### DIFF
--- a/docker-compose.netem-perlink.yml
+++ b/docker-compose.netem-perlink.yml
@@ -53,8 +53,15 @@ x-echo-target: &echo-target
   volumes:
     - ./scripts/container/udp_echo.py:/udp_echo.py:ro
   healthcheck:
-    # BusyBox nc doesn't support -z; use socat to probe the TCP port instead.
-    test: ["CMD-SHELL", "echo | socat - TCP:localhost:7000,connect-timeout=2"]
+    # BusyBox nc doesn't support -z; use socat to probe both echo servers.
+    # The UDP probe matters: a dead UDP echo server would otherwise present
+    # as near-total packet loss in the tests while the target reports healthy.
+    # ($$ escapes compose interpolation, producing a literal $ for the shell.)
+    test:
+      [
+        "CMD-SHELL",
+        "echo | socat - TCP:localhost:7000,connect-timeout=2 && [ -n \"$$(echo ping | socat -T2 - UDP-CONNECT:127.0.0.1:7001)\" ]",
+      ]
     interval: 2s
     timeout: 5s
     retries: 10

--- a/docker-compose.netem-perlink.yml
+++ b/docker-compose.netem-perlink.yml
@@ -35,17 +35,14 @@ networks:
       config:
         - subnet: 10.98.0.0/24
 
-# The targets use python:3-alpine (matching the netem sidecar) so the UDP echo
-# can be a stateless single-socket server; see scripts/container/udp_echo.py
-# for why a forking socat server wedges under netem jitter (FLE-595).
+# The targets use python:3-alpine to run the UDP echo server.
 x-echo-target: &echo-target
   image: python:3-alpine
   entrypoint: ["/bin/sh", "-c"]
   command:
     - |
       apk add --no-cache socat > /dev/null 2>&1
-      # TCP echo server on port 7000 for latency measurement. Forking is safe
-      # for TCP: each connection gets its own accepted socket.
+      # TCP echo server on port 7000 for latency measurement.
       socat TCP-LISTEN:7000,fork,reuseaddr EXEC:/bin/cat &
       # UDP echo server on port 7001 for packet loss measurement.
       python3 /udp_echo.py 7001 &
@@ -53,14 +50,12 @@ x-echo-target: &echo-target
   volumes:
     - ./scripts/container/udp_echo.py:/udp_echo.py:ro
   healthcheck:
-    # BusyBox nc doesn't support -z; use socat to probe both echo servers.
-    # The UDP probe matters: a dead UDP echo server would otherwise present
-    # as near-total packet loss in the tests while the target reports healthy.
-    # ($$ escapes compose interpolation, producing a literal $ for the shell.)
+    # BusyBox nc doesn't support -z; use socat to probe the TCP port, and
+    # netstat to confirm the UDP echo server is listening.
     test:
       [
         "CMD-SHELL",
-        "echo | socat - TCP:localhost:7000,connect-timeout=2 && [ -n \"$$(echo ping | socat -T2 - UDP-CONNECT:127.0.0.1:7001)\" ]",
+        "echo | socat - TCP:localhost:7000,connect-timeout=2 && netstat -uln | grep -q ':7001 '",
       ]
     interval: 2s
     timeout: 5s

--- a/docker-compose.netem-perlink.yml
+++ b/docker-compose.netem-perlink.yml
@@ -35,17 +35,23 @@ networks:
       config:
         - subnet: 10.98.0.0/24
 
+# The targets use python:3-alpine (matching the netem sidecar) so the UDP echo
+# can be a stateless single-socket server; see scripts/container/udp_echo.py
+# for why a forking socat server wedges under netem jitter (FLE-595).
 x-echo-target: &echo-target
-  image: alpine:3
+  image: python:3-alpine
   entrypoint: ["/bin/sh", "-c"]
   command:
     - |
       apk add --no-cache socat > /dev/null 2>&1
-      # TCP echo server on port 7000 for latency measurement.
+      # TCP echo server on port 7000 for latency measurement. Forking is safe
+      # for TCP: each connection gets its own accepted socket.
       socat TCP-LISTEN:7000,fork,reuseaddr EXEC:/bin/cat &
       # UDP echo server on port 7001 for packet loss measurement.
-      socat UDP-RECVFROM:7001,fork EXEC:/bin/cat &
+      python3 /udp_echo.py 7001 &
       exec sleep infinity
+  volumes:
+    - ./scripts/container/udp_echo.py:/udp_echo.py:ro
   healthcheck:
     # BusyBox nc doesn't support -z; use socat to probe the TCP port instead.
     test: ["CMD-SHELL", "echo | socat - TCP:localhost:7000,connect-timeout=2"]

--- a/docker-compose.netem-perlink.yml
+++ b/docker-compose.netem-perlink.yml
@@ -35,7 +35,6 @@ networks:
       config:
         - subnet: 10.98.0.0/24
 
-# The targets use python:3-alpine to run the UDP echo server.
 x-echo-target: &echo-target
   image: python:3-alpine
   entrypoint: ["/bin/sh", "-c"]

--- a/docker-compose.netem.yml
+++ b/docker-compose.netem.yml
@@ -76,7 +76,15 @@ services:
         # Keep the container alive so the qdisc rules persist.
         exec sleep infinity
     healthcheck:
-      test: ["CMD-SHELL", "tc qdisc show | grep -q netem"]
+      # Verify both the tc hierarchy and the UDP echo server: a dead echo
+      # server would otherwise present as near-total packet loss in the tests
+      # while the sidecar reports healthy.
+      # ($$ escapes compose interpolation, producing a literal $ for the shell.)
+      test:
+        [
+          "CMD-SHELL",
+          "tc qdisc show | grep -q netem && [ -n \"$$(echo ping | socat -T2 - UDP-CONNECT:127.0.0.1:9999)\" ]",
+        ]
       interval: 2s
       timeout: 5s
       retries: 10

--- a/docker-compose.netem.yml
+++ b/docker-compose.netem.yml
@@ -67,8 +67,6 @@ services:
         apk add --no-cache iproute2 socat > /dev/null 2>&1
         # Start a UDP echo server for packet loss testing. Each received
         # datagram is echoed back through the netem-shaped egress path.
-        # A stateless single-socket server is required here; see
-        # scripts/container/udp_echo.py for why a forking server wedges.
         python3 /udp_echo.py 9999 &
         # Apply netem rules (flat or per-link depending on env vars).
         # Exit on failure so a broken tc hierarchy doesn't silently persist.
@@ -76,18 +74,11 @@ services:
         # Keep the container alive so the qdisc rules persist.
         exec sleep infinity
     healthcheck:
-      # Verify both the tc hierarchy and the UDP echo server: a dead echo
-      # server would otherwise present as near-total packet loss in the tests
-      # while the sidecar reports healthy.
-      # The UDP probe rides the shaped loopback (netem applies to all
-      # interfaces in this namespace), so `retries` absorbs the default 2%
-      # simulated loss; an aggressive NETEM_ARGS loss override could make
-      # startup flaky.
-      # ($$ escapes compose interpolation, producing a literal $ for the shell.)
+      # Verify the tc hierarchy is applied and the UDP echo server is listening.
       test:
         [
           "CMD-SHELL",
-          "tc qdisc show | grep -q netem && [ -n \"$$(echo ping | socat -T2 - UDP-CONNECT:127.0.0.1:9999)\" ]",
+          "tc qdisc show | grep -q netem && netstat -uln | grep -q ':9999 '",
         ]
       interval: 2s
       timeout: 5s

--- a/docker-compose.netem.yml
+++ b/docker-compose.netem.yml
@@ -79,6 +79,10 @@ services:
       # Verify both the tc hierarchy and the UDP echo server: a dead echo
       # server would otherwise present as near-total packet loss in the tests
       # while the sidecar reports healthy.
+      # The UDP probe rides the shaped loopback (netem applies to all
+      # interfaces in this namespace), so `retries` absorbs the default 2%
+      # simulated loss; an aggressive NETEM_ARGS loss override could make
+      # startup flaky.
       # ($$ escapes compose interpolation, producing a literal $ for the shell.)
       test:
         [

--- a/docker-compose.netem.yml
+++ b/docker-compose.netem.yml
@@ -60,13 +60,16 @@ services:
     volumes:
       - ./scripts/container/netem_setup.py:/netem_setup.py:ro
       - ./scripts/container/netem_impair.py:/netem_impair.py:ro
+      - ./scripts/container/udp_echo.py:/udp_echo.py:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
         apk add --no-cache iproute2 socat > /dev/null 2>&1
         # Start a UDP echo server for packet loss testing. Each received
         # datagram is echoed back through the netem-shaped egress path.
-        socat UDP-RECVFROM:9999,fork EXEC:/bin/cat &
+        # A stateless single-socket server is required here; see
+        # scripts/container/udp_echo.py for why a forking server wedges.
+        python3 /udp_echo.py 9999 &
         # Apply netem rules (flat or per-link depending on env vars).
         # Exit on failure so a broken tc hierarchy doesn't silently persist.
         python3 /netem_setup.py || exit 1

--- a/rust/remote_access_tests/tests/netem_perlink_test.rs
+++ b/rust/remote_access_tests/tests/netem_perlink_test.rs
@@ -256,16 +256,6 @@ fn perlink_infra_link_a_has_higher_latency_than_link_b() -> Result<()> {
 #[ignore]
 #[test]
 fn perlink_infra_link_a_has_more_packet_loss_than_link_b() -> Result<()> {
-    // Temporarily skipped on CI: runners intermittently stop forwarding the
-    // UDP echo path (~99% loss on both links regardless of the configured
-    // netem profiles), which makes this measurement meaningless and blocks
-    // unrelated PRs. The test still runs locally. Remove this guard when
-    // FLE-595 is resolved. (`CI=true` is set on all GitHub Actions runners.)
-    if std::env::var_os("CI").is_some() {
-        info!("skipping on CI until FLE-595 is resolved");
-        return Ok(());
-    }
-
     let link_a_args =
         std::env::var("NETEM_LINK_A_ARGS").unwrap_or_else(|_| DEFAULT_LINK_A_ARGS.into());
     let link_b_args =

--- a/scripts/container/udp_echo.py
+++ b/scripts/container/udp_echo.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Stateless UDP echo server for netem packet loss measurement.
+
+Echoes every received datagram back to its sender from a single unconnected
+socket. Used by the netem test stacks (`docker-compose.netem.yml` port 9999,
+`docker-compose.netem-perlink.yml` port 7001 on the targets).
+
+A single-socket loop is used deliberately instead of a forking server such as
+`socat UDP-RECVFROM:<port>,fork`: forked children share the bound socket with
+the parent, and a child that lingers (e.g. after receiving the 0-length
+datagram a socat client emits at EOF, which netem jitter can reorder ahead of
+the payload) steals datagrams from new clients and never replies. That race
+intermittently blackholed the per-link loss measurements in CI (FLE-595).
+
+Usage: udp_echo.py <port>
+"""
+
+import socket
+import sys
+
+
+def main() -> None:
+    port = int(sys.argv[1])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("0.0.0.0", port))
+    print(f"udp_echo: listening on {port}", flush=True)
+    while True:
+        data, addr = sock.recvfrom(65535)
+        # Skip empty datagrams: socat clients send one at EOF as an
+        # end-of-stream marker, and echoing it back would only trigger ICMP
+        # errors once the client's ephemeral port is closed.
+        if not data:
+            continue
+        try:
+            sock.sendto(data, addr)
+        except OSError:
+            # A reply can fail (e.g. ICMP error queued by a previous send);
+            # the server must keep serving other clients regardless.
+            continue
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/container/udp_echo.py
+++ b/scripts/container/udp_echo.py
@@ -2,15 +2,8 @@
 """Stateless UDP echo server for netem packet loss measurement.
 
 Echoes every received datagram back to its sender from a single unconnected
-socket. Used by the netem test stacks (`docker-compose.netem.yml` port 9999,
-`docker-compose.netem-perlink.yml` port 7001 on the targets).
-
-A single-socket loop is used deliberately instead of a forking server such as
-`socat UDP-RECVFROM:<port>,fork`: forked children share the bound socket with
-the parent, and a child that lingers (e.g. after receiving the 0-length
-datagram a socat client emits at EOF, which netem jitter can reorder ahead of
-the payload) steals datagrams from new clients and never replies. That race
-intermittently blackholed the per-link loss measurements in CI (FLE-595).
+socket. The single-socket loop is deliberate: forking servers share the bound
+socket with their children and can swallow datagrams from new clients (FLE-595).
 
 Usage: udp_echo.py <port>
 """
@@ -26,16 +19,13 @@ def main() -> None:
     print(f"udp_echo: listening on {port}", flush=True)
     while True:
         data, addr = sock.recvfrom(65535)
-        # Skip empty datagrams: socat clients send one at EOF as an
-        # end-of-stream marker, and echoing it back would only trigger ICMP
-        # errors once the client's ephemeral port is closed.
+        # Ignore empty datagrams: socat clients send one at EOF.
         if not data:
             continue
         try:
             sock.sendto(data, addr)
         except OSError:
-            # A reply can fail (e.g. ICMP error queued by a previous send);
-            # the server must keep serving other clients regardless.
+            # Keep serving if a reply fails (e.g. a queued ICMP error).
             continue
 
 


### PR DESCRIPTION
### Changelog

None (CI test infrastructure only).

### Docs

None.

### Description

Fixes the `netem-perlink-test` flake that has been failing ~60% of Remote Access Tests runs since June 11 (all branches, including `main`).

**Root cause** (confirmed by instrumenting a failing run via #1312): the tc/netem hierarchy under test was healthy — counters showed correct per-link classification and exactly the configured 5%/0% drops. The wedge was in the test's own UDP echo servers. The forking socat UDP echo shares its bound socket between the parent and forked children; the socat *client* sends a 0-length datagram at stdin EOF, and netem jitter can reorder it ahead of the payload. Under the right ordering a child lingers, steals datagrams sent by subsequent clients, and never replies — from then on nearly every echo times out. tcpdump on a failing run showed all 58 request datagrams arriving at the target while the target emitted only 3 replies, with a stale echo-server child visible in the process list. This also explains why both links always degraded together (same server design on both targets) and why TCP echoes kept working (per-connection sockets).

**Fix:** replace the forking UDP echo with `scripts/container/udp_echo.py`, a stateless single-socket recvfrom/sendto loop — no forking, no shared-socket state, 0-length datagrams ignored. Applied to both the per-link targets (port 7001) and the netem sidecar echo (port 9999), which used the same fragile construct. The targets switch from `alpine:3` to `python:3-alpine`, matching the sidecar. The TCP echo stays on socat, which is safe for TCP. The temporary CI skip from #1313 is reverted since the cause is fixed.

**Hardening (from review):** both containers' healthchecks now also verify the UDP echo server is listening (`netstat -uln | grep`), so a dead echo server fails `up --wait` loudly instead of presenting as ~100% packet loss. BusyBox `netstat` is built into `python:3-alpine`, so no extra packages are needed.

**Testing:**
- Unit-level: 40 fresh-source-port probes against `udp_echo.py` with empty datagrams interleaved before/after each payload (the exact poison sequence) — 40/40 echoed.
- Stack-level (local, Docker Desktop): 60-packet probe per link through the netem sidecar shows scattered ~5% loss on link A and 0% on link B — previously a hard cutoff after the first 3-4 packets.
- `cargo test -p remote_access_tests -- --ignored perlink_` (6/6) and `-- --ignored netem_` (6/6) against the rebuilt stacks.
- Healthchecks (final `netstat` form): stack reaches healthy under `up -d --wait`; killing `udp_echo.py` in a target flips it to unhealthy within ~25s, confirming busybox `netstat -uln` lists the bound UDP socket while the server is alive and stops listing it once dead.
- `cargo check`, `cargo clippy -D warnings`, `cargo fmt --check` all clean.

Open question tracked in FLE-595: why the race odds jumped on June 11 (0/11 on June 10 vs 14/23 on June 11 with identical images and package versions). The fix removes the race class entirely, so it holds regardless.

Fixes: [FLE-595](https://linear.app/foxglove/issue/FLE-595/ci-netem-perlink-test-flake-both-links-show-99percent-udp-loss-spiked)

