### PR TITLE
Fix a leak when disconnecting clients that are still advertising

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /.git/
+/.cargo/
 /.mypy_cache/
 /node_modules/
 /target/

--- a/ros/README.md
+++ b/ros/README.md
@@ -1,3 +1,25 @@
+# ROS packages
+
+The goal of the ROS packages here are to provide a simple way for ROS 2 users to connect their ROS middleware systems into foxglove, either through the foxglove websocket or through the remote access gateway.
+
+# Architecture
+
+The architecture consists of 2 packages:
+
+1. foxglove_msgs - Messages useful for publishing or subscribing from foxglove.  Not directly depended on by any of the other packages.
+2. foxglove_bridge - The ROS 2 bridge.  Standalone; owns its SDK consumption (websocket server + remote access gateway) and implements a whole host of ROS 2-specific things.
+
+There is also a ROS 1 bridge, which lives in its own repository (foxglove_bridge_ros1).
+It is deliberately a parallel implementation sharing no code with the ROS 2 bridge: its transport-facing layer is a copy of the equivalent code here.
+We considered these architectures for supporting both ROS versions:
+
+1.  A shared foxglove_bridge_core layer between ROS 1 and ROS 2.
+2.  Parallel implementations of ROS 1 and ROS 2 bridge, accepting the code duplication.
+3.  Putting both ROS 1 and ROS 2 bridges into the same package, with conditional compilation as necessary.
+4.  Leaving the ROS 2 bridge alone, but splitting the ROS 1 bridge into a common and ROS-1-specific part.
+
+We agreed on architecture 2: a shared layer puts the actively-maintained ROS 2 bridge at risk of regression, for a ROS 1 bridge that is obsolete the day it is shipped (ROS 1 stopped being supported in 2025).
+
 # ROS 2 Packages
 
 ## Building
@@ -63,3 +85,9 @@ make docker-build FOXGLOVE_CPP_SDK_DIR=/sdk/cpp/dist
 
 The volume mount maps the repo root to `/sdk` inside the container, so
 `/sdk/cpp/dist` corresponds to `cpp/dist/` on the host.
+
+# ROS 1
+
+The ROS 1 bridge lives in its own repository (foxglove_bridge_ros1), where it
+is built and tested via its own Docker image; see that repository's README
+for details.

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -82,14 +82,13 @@ if (ENDIAN)
   add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
 endif()
 
-# Fetch the released SDK zip from GitHub. To build against a locally-modified SDK,
-# override FETCHCONTENT_SOURCE_DIR_FOXGLOVE_SDK (cmake's standard FetchContent override)
-# to point at a `cpp/dist`-shaped directory — the ros/Makefile's FOXGLOVE_CPP_SDK_DIR
-# variable does this for you (see ros/README.md). The dist directory needs to contain
-# lib/cmake/foxglove-sdk/foxglove-sdkConfig.cmake; release zips built before the SDK's
-# cmake-glue change don't yet, so the FetchContent download path is broken until a
-# release ships with that glue. For local development, point the override at a
-# `make build-cpp-dist`-produced tree.
+# Fetch the released SDK zip from GitHub. It contains the prebuilt C libraries
+# (with remote access), the C++ wrapper sources, and the CMake package config
+# consumed below. To build against a locally-modified SDK instead, override
+# FETCHCONTENT_SOURCE_DIR_FOXGLOVE_SDK (cmake's standard FetchContent override)
+# to point at a `make build-cpp-dist`-produced `cpp/dist` tree — the
+# ros/Makefile's FOXGLOVE_CPP_SDK_DIR variable does this for you (see
+# ros/README.md).
 set(FOXGLOVE_SDK_VERSION "0.25.1")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")

--- a/rust/foxglove/src/websocket/connected_client.rs
+++ b/rust/foxglove/src/websocket/connected_client.rs
@@ -312,6 +312,26 @@ impl ConnectedClient {
     pub fn on_disconnect(&self) {
         let channel_ids = self.subscriptions.lock().left_values().copied().collect();
         self.unsubscribe_channel_ids(channel_ids);
+
+        // Unadvertise any client channels the client was still advertising,
+        // mirroring the unsubscribe replay above (and the remote-access
+        // gateway's behavior on participant removal), so that ServerListener
+        // implementations can release per-channel state. Drained under the
+        // lock; the handler is called after releasing it.
+        let client_channels: Vec<_> = {
+            let mut advertised_channels = self.advertised_channels.lock();
+            advertised_channels.drain().map(|(_, c)| c).collect()
+        };
+        if client_channels.is_empty() {
+            return;
+        }
+        let server = self.server.upgrade();
+        let Some(handler) = server.as_ref().and_then(|s| s.listener()) else {
+            return;
+        };
+        for client_channel in client_channels {
+            handler.on_client_unadvertise(Client::new(self), &client_channel);
+        }
     }
 
     fn on_message_data(&self, server: Arc<Server>, message: ws_protocol::client::MessageData) {

--- a/rust/foxglove/src/websocket/server_listener.rs
+++ b/rust/foxglove/src/websocket/server_listener.rs
@@ -25,8 +25,10 @@ pub trait ServerListener: Send + Sync {
     /// Callback invoked when a client advertises a client channel. Requires
     /// [`Capability::ClientPublish`][super::Capability::ClientPublish].
     fn on_client_advertise(&self, _client: Client, _channel: &ClientChannel) {}
-    /// Callback invoked when a client unadvertises a client channel. Requires
-    /// [`Capability::ClientPublish`][super::Capability::ClientPublish].
+    /// Callback invoked when a client unadvertises a client channel, or
+    /// disconnects with client channels still advertised (once per such
+    /// channel, before [`on_client_disconnect`][Self::on_client_disconnect]).
+    /// Requires [`Capability::ClientPublish`][super::Capability::ClientPublish].
     fn on_client_unadvertise(&self, _client: Client, _channel: &ClientChannel) {}
     /// Callback invoked when a client requests parameters. Requires
     /// [`Capability::Parameters`][super::Capability::Parameters]. Should return the named

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -682,11 +682,10 @@ async fn test_on_client_unadvertise_called_after_disconnect() {
         .expect("Failed to connect");
     expect_recv!(client, ServerMessage::ServerInfo);
 
-    let advertise = client::Advertise::new([client::advertise::Channel::builder(
-        1, "/test", "json",
-    )
-    .build()
-    .unwrap()]);
+    let advertise =
+        client::Advertise::new([client::advertise::Channel::builder(1, "/test", "json")
+            .build()
+            .unwrap()]);
     client.send(&advertise).await.expect("Failed to send");
 
     // Allow the server to process the advertisement

--- a/rust/foxglove/src/websocket/tests.rs
+++ b/rust/foxglove/src/websocket/tests.rs
@@ -658,6 +658,54 @@ async fn test_on_unsubscribe_called_after_disconnect() {
 }
 
 #[tokio::test]
+async fn test_on_client_unadvertise_called_after_disconnect() {
+    let recording_listener = Arc::new(RecordingServerListener::new());
+
+    let ctx = Context::new();
+    let server = create_server(
+        &ctx,
+        ServerOptions {
+            capabilities: Some(IndexSet::from([Capability::ClientPublish])),
+            supported_encodings: Some(IndexSet::from(["json".to_string()])),
+            listener: Some(recording_listener.clone()),
+            ..Default::default()
+        },
+    );
+
+    let addr = server
+        .start("127.0.0.1", 0)
+        .await
+        .expect("Failed to start server");
+
+    let mut client = WebSocketClient::connect(format!("{addr}"))
+        .await
+        .expect("Failed to connect");
+    expect_recv!(client, ServerMessage::ServerInfo);
+
+    let advertise = client::Advertise::new([client::advertise::Channel::builder(
+        1, "/test", "json",
+    )
+    .build()
+    .unwrap()]);
+    client.send(&advertise).await.expect("Failed to send");
+
+    // Allow the server to process the advertisement
+    assert_eventually(|| recording_listener.client_advertise_len() == 1).await;
+    assert_eq!(recording_listener.client_unadvertise_len(), 0);
+
+    // Disconnect the client without unadvertising explicitly
+    client.close().await.expect("Failed to close");
+
+    // The unadvertisement is replayed to the listener on disconnect
+    assert_eventually(|| recording_listener.client_unadvertise_len() == 1).await;
+    let unadvertises = recording_listener.take_client_unadvertise();
+    assert_eq!(unadvertises.len(), 1);
+    assert_eq!(unadvertises[0].1.topic, "/test");
+
+    let _ = server.stop();
+}
+
+#[tokio::test]
 async fn test_on_unsubscribe_called_after_channel_removal() {
     let recording_listener = Arc::new(RecordingServerListener::new());
 


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description
    
When a websocket client disconnected without unadvertising its client channels, the server replayed `on_unsubscribe` for the client's subscriptions but silently dropped its advertised channels, never firing `on_client_unadvertise`. `ServerListener` implementations that allocate per-channel state on `on_client_advertise` (both ROS bridges create a ROS publisher there) leaked that state for every client that disconnected mid-advertisement.
    
Drain the client's advertised channels in `on_disconnect` and invoke `on_client_unadvertise` for each, mirroring the unsubscribe replay directly above and the remote-access gateway's existing behavior on participant removal. The handler runs after the advertised_channels lock is released, and before the server's `on_client_disconnect` notification, so listeners never observe events from a client they were already told is gone.

Tested as part of the ongoing work for the ROS 1 bridge, where it fixed a leak in subscribers.

Part of FLE-601