### PR TITLE
bump pyo3 from 0.25.1 to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2c5f3bf25ec225351aa1c8e230d04d880d3bd89dea133537dafad4ae291e5c"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -2324,12 +2324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
 name = "insta"
 version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,15 +2812,6 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -3704,36 +3689,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3741,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45192e5e4a4d2505587e27806c7b710c231c40c56f3bfc19535d0bb25df52264"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -3752,9 +3733,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3764,13 +3745,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.104",
 ]
@@ -4874,9 +4854,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -5398,12 +5378,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -35,8 +35,8 @@ base64 = "0.22.1"
 bytes.workspace = true
 log.workspace = true
 prost-types = "0.13"
-pyo3 = { version = "0.25.1", features = ["abi3-py310"] }
-pyo3-log = "0.12.3"
+pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
+pyo3-log = "0.13.4"
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -158,7 +158,7 @@ def test_channel_metadata(new_topic: str) -> None:
 
 
 def test_channel_metadata_mistyped(new_topic: str) -> None:
-    with pytest.raises(TypeError, match="argument 'metadata'"):
+    with pytest.raises(TypeError, match="is not an instance of 'str'"):
         Channel(new_topic, metadata={"1": 1})  # type: ignore
 
 
@@ -170,7 +170,7 @@ def test_typed_channel_metadata(new_topic: str) -> None:
 
 
 def test_typed_channel_metadata_mistyped(new_topic: str) -> None:
-    with pytest.raises(TypeError, match="argument 'metadata'"):
+    with pytest.raises(TypeError, match="is not an instance of 'str'"):
         LogChannel(new_topic, metadata={"1": 1})  # type: ignore
 
 

--- a/python/foxglove-sdk/src/generated/channels.rs
+++ b/python/foxglove-sdk/src/generated/channels.rs
@@ -94,7 +94,7 @@ impl ArrowPrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -126,7 +126,7 @@ impl ArrowPrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -211,7 +211,7 @@ impl CameraCalibrationChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -243,7 +243,7 @@ impl CameraCalibrationChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -328,7 +328,7 @@ impl CircleAnnotationChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -360,7 +360,7 @@ impl CircleAnnotationChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -445,7 +445,7 @@ impl ColorChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -477,7 +477,7 @@ impl ColorChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -557,7 +557,7 @@ impl CompressedAudioChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -589,7 +589,7 @@ impl CompressedAudioChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -674,7 +674,7 @@ impl CompressedImageChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -706,7 +706,7 @@ impl CompressedImageChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -791,7 +791,7 @@ impl CompressedPointCloudChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -823,7 +823,7 @@ impl CompressedPointCloudChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -913,7 +913,7 @@ impl CompressedVideoChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -945,7 +945,7 @@ impl CompressedVideoChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1030,7 +1030,7 @@ impl CylinderPrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1062,7 +1062,7 @@ impl CylinderPrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1147,7 +1147,7 @@ impl CubePrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1179,7 +1179,7 @@ impl CubePrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1264,7 +1264,7 @@ impl FrameTransformChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1296,7 +1296,7 @@ impl FrameTransformChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1381,7 +1381,7 @@ impl FrameTransformsChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1413,7 +1413,7 @@ impl FrameTransformsChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1498,7 +1498,7 @@ impl GeoJsonChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1530,7 +1530,7 @@ impl GeoJsonChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1610,7 +1610,7 @@ impl GridChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1642,7 +1642,7 @@ impl GridChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1722,7 +1722,7 @@ impl VoxelGridChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1754,7 +1754,7 @@ impl VoxelGridChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1839,7 +1839,7 @@ impl ImageAnnotationsChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1871,7 +1871,7 @@ impl ImageAnnotationsChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -1956,7 +1956,7 @@ impl JointStateChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -1988,7 +1988,7 @@ impl JointStateChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2073,7 +2073,7 @@ impl JointStatesChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2105,7 +2105,7 @@ impl JointStatesChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2190,7 +2190,7 @@ impl KeyValuePairChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2222,7 +2222,7 @@ impl KeyValuePairChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2307,7 +2307,7 @@ impl LaserScanChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2339,7 +2339,7 @@ impl LaserScanChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2424,7 +2424,7 @@ impl LinePrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2456,7 +2456,7 @@ impl LinePrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2541,7 +2541,7 @@ impl LocationFixChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2573,7 +2573,7 @@ impl LocationFixChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2658,7 +2658,7 @@ impl LocationFixesChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2690,7 +2690,7 @@ impl LocationFixesChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2775,7 +2775,7 @@ impl LogChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2807,7 +2807,7 @@ impl LogChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -2887,7 +2887,7 @@ impl SceneEntityDeletionChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -2919,7 +2919,7 @@ impl SceneEntityDeletionChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3009,7 +3009,7 @@ impl SceneEntityChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3041,7 +3041,7 @@ impl SceneEntityChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3126,7 +3126,7 @@ impl SceneUpdateChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3158,7 +3158,7 @@ impl SceneUpdateChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3243,7 +3243,7 @@ impl ModelPrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3275,7 +3275,7 @@ impl ModelPrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3360,7 +3360,7 @@ impl OdometryChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3392,7 +3392,7 @@ impl OdometryChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3477,7 +3477,7 @@ impl PackedElementFieldChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3509,7 +3509,7 @@ impl PackedElementFieldChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3594,7 +3594,7 @@ impl Point2Channel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3626,7 +3626,7 @@ impl Point2Channel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3706,7 +3706,7 @@ impl Point3Channel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3738,7 +3738,7 @@ impl Point3Channel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3818,7 +3818,7 @@ impl Point3InFrameChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3850,7 +3850,7 @@ impl Point3InFrameChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -3935,7 +3935,7 @@ impl PointCloudChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -3967,7 +3967,7 @@ impl PointCloudChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4052,7 +4052,7 @@ impl PointsAnnotationChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4084,7 +4084,7 @@ impl PointsAnnotationChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4169,7 +4169,7 @@ impl PoseChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4201,7 +4201,7 @@ impl PoseChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4281,7 +4281,7 @@ impl PoseInFrameChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4313,7 +4313,7 @@ impl PoseInFrameChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4398,7 +4398,7 @@ impl PosesInFrameChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4430,7 +4430,7 @@ impl PosesInFrameChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4515,7 +4515,7 @@ impl QuaternionChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4547,7 +4547,7 @@ impl QuaternionChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4632,7 +4632,7 @@ impl RawAudioChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4664,7 +4664,7 @@ impl RawAudioChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4749,7 +4749,7 @@ impl RawImageChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4781,7 +4781,7 @@ impl RawImageChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4866,7 +4866,7 @@ impl SpherePrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -4898,7 +4898,7 @@ impl SpherePrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -4983,7 +4983,7 @@ impl TextAnnotationChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -5015,7 +5015,7 @@ impl TextAnnotationChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -5100,7 +5100,7 @@ impl TextPrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -5132,7 +5132,7 @@ impl TextPrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -5217,7 +5217,7 @@ impl TriangleListPrimitiveChannel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -5249,7 +5249,7 @@ impl TriangleListPrimitiveChannel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -5339,7 +5339,7 @@ impl Vector2Channel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -5371,7 +5371,7 @@ impl Vector2Channel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -5451,7 +5451,7 @@ impl Vector3Channel {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -5483,7 +5483,7 @@ impl Vector3Channel {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;

--- a/python/foxglove-sdk/src/generated/messages.rs
+++ b/python/foxglove-sdk/src/generated/messages.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
 /// An enumeration indicating how input points should be interpreted to create lines
-#[pyclass(eq, eq_int, module = "foxglove.messages")]
+#[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
 pub(crate) enum LinePrimitiveLineType {
     LineStrip = 0,
@@ -41,7 +41,7 @@ impl LinePrimitiveLineType {
 }
 
 /// Log level
-#[pyclass(eq, eq_int, module = "foxglove.messages")]
+#[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
 pub(crate) enum LogLevel {
     Unknown = 0,
@@ -80,7 +80,7 @@ impl LogLevel {
 }
 
 /// An enumeration indicating which entities should match a SceneEntityDeletion command
-#[pyclass(eq, eq_int, module = "foxglove.messages")]
+#[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
 pub(crate) enum SceneEntityDeletionType {
     MatchingId = 0,
@@ -107,7 +107,7 @@ impl SceneEntityDeletionType {
 }
 
 /// Numeric type
-#[pyclass(eq, eq_int, module = "foxglove.messages")]
+#[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
 pub(crate) enum PackedElementFieldNumericType {
     Unknown = 0,
@@ -155,7 +155,7 @@ impl PackedElementFieldNumericType {
 }
 
 /// Type of points annotation
-#[pyclass(eq, eq_int, module = "foxglove.messages")]
+#[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
 pub(crate) enum PointsAnnotationType {
     Unknown = 0,
@@ -191,7 +191,7 @@ impl PointsAnnotationType {
 }
 
 /// Type of position covariance
-#[pyclass(eq, eq_int, module = "foxglove.messages")]
+#[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]
 #[derive(PartialEq, Clone)]
 pub(crate) enum LocationFixPositionCovarianceType {
     Unknown = 0,
@@ -233,7 +233,7 @@ impl LocationFixPositionCovarianceType {
 /// :param color: Color of the arrow
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/arrow-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct ArrowPrimitive(pub(crate) foxglove::messages::ArrowPrimitive);
 #[pymethods]
@@ -352,7 +352,7 @@ impl From<ArrowPrimitive> for foxglove::messages::ArrowPrimitive {
 ///     
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/camera-calibration
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CameraCalibration(pub(crate) foxglove::messages::CameraCalibration);
 #[pymethods]
@@ -437,7 +437,7 @@ impl From<CameraCalibration> for foxglove::messages::CameraCalibration {
 /// :param metadata: Additional user-provided metadata associated with this annotation. Keys must be unique.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/circle-annotation
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CircleAnnotation(pub(crate) foxglove::messages::CircleAnnotation);
 #[pymethods]
@@ -516,7 +516,7 @@ impl From<CircleAnnotation> for foxglove::messages::CircleAnnotation {
 /// :param a: Alpha value between 0 and 1
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/color
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Color(pub(crate) foxglove::messages::Color);
 #[pymethods]
@@ -574,7 +574,7 @@ impl From<Color> for foxglove::messages::Color {
 /// :param format: Audio format. Values supported by Foxglove are `opus` for raw Opus packets and `mp4a.40.2` for AAC-LC ADTS frames.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/compressed-audio
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CompressedAudio(pub(crate) foxglove::messages::CompressedAudio);
 #[pymethods]
@@ -635,7 +635,7 @@ impl From<CompressedAudio> for foxglove::messages::CompressedAudio {
 ///     Supported values: `jpeg`, `png`, `webp`, `avif`
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/compressed-image
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CompressedImage(pub(crate) foxglove::messages::CompressedImage);
 #[pymethods]
@@ -703,7 +703,7 @@ impl From<CompressedImage> for foxglove::messages::CompressedImage {
 ///     Supported values: `draco` (`Google Draco <https://google.github.io/draco/>`__).
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/compressed-point-cloud
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CompressedPointCloud(pub(crate) foxglove::messages::CompressedPointCloud);
 #[pymethods]
@@ -798,7 +798,7 @@ impl From<CompressedPointCloud> for foxglove::messages::CompressedPointCloud {
 ///     Note: compressed video support is subject to hardware limitations and patent licensing, so not all encodings may be supported on all platforms. See more about `H.265 support <https://caniuse.com/hevc>`__, `VP9 support <https://caniuse.com/webm>`__, and `AV1 support <https://caniuse.com/av1>`__.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/compressed-video
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CompressedVideo(pub(crate) foxglove::messages::CompressedVideo);
 #[pymethods]
@@ -864,7 +864,7 @@ impl From<CompressedVideo> for foxglove::messages::CompressedVideo {
 /// :param color: Color of the cylinder
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/cylinder-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CylinderPrimitive(pub(crate) foxglove::messages::CylinderPrimitive);
 #[pymethods]
@@ -928,7 +928,7 @@ impl From<CylinderPrimitive> for foxglove::messages::CylinderPrimitive {
 /// :param color: Color of the cube
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/cube-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct CubePrimitive(pub(crate) foxglove::messages::CubePrimitive);
 #[pymethods]
@@ -992,7 +992,7 @@ impl From<CubePrimitive> for foxglove::messages::CubePrimitive {
 /// :param rotation: Rotation component of the transform, representing the orientation of the child frame in the parent frame
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/frame-transform
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct FrameTransform(pub(crate) foxglove::messages::FrameTransform);
 #[pymethods]
@@ -1058,7 +1058,7 @@ impl From<FrameTransform> for foxglove::messages::FrameTransform {
 /// :param transforms: Array of transforms
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/frame-transforms
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct FrameTransforms(pub(crate) foxglove::messages::FrameTransforms);
 #[pymethods]
@@ -1111,7 +1111,7 @@ impl From<FrameTransforms> for foxglove::messages::FrameTransforms {
 /// :param geojson: GeoJSON data encoded as a UTF-8 string
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/geo-json
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct GeoJson(pub(crate) foxglove::messages::GeoJson);
 #[pymethods]
@@ -1207,7 +1207,7 @@ impl From<GeoJson> for foxglove::messages::GeoJson {
 ///     - x = (i % row_stride) / cell_stride * cell_size.x
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/grid
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Grid(pub(crate) foxglove::messages::Grid);
 #[pymethods]
@@ -1304,7 +1304,7 @@ impl From<Grid> for foxglove::messages::Grid {
 ///     - x = (i % row_stride) / cell_stride * cell_size.x
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/voxel-grid
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct VoxelGrid(pub(crate) foxglove::messages::VoxelGrid);
 #[pymethods]
@@ -1396,7 +1396,7 @@ impl From<VoxelGrid> for foxglove::messages::VoxelGrid {
 /// :param metadata: Additional user-provided metadata associated with the image annotations. Keys must be unique within this object. Per-annotation metadata takes precedence over these values.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/image-annotations
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct ImageAnnotations(pub(crate) foxglove::messages::ImageAnnotations);
 #[pymethods]
@@ -1478,7 +1478,7 @@ impl From<ImageAnnotations> for foxglove::messages::ImageAnnotations {
 /// :param effort: Joint effort (force or torque). Nm for revolute joints, N for prismatic joints.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/joint-state
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct JointState(pub(crate) foxglove::messages::JointState);
 #[pymethods]
@@ -1539,7 +1539,7 @@ impl From<JointState> for foxglove::messages::JointState {
 /// :param joints: Joint states
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/joint-states
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct JointStates(pub(crate) foxglove::messages::JointStates);
 #[pymethods]
@@ -1597,7 +1597,7 @@ impl From<JointStates> for foxglove::messages::JointStates {
 /// :param value: Value
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/key-value-pair
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct KeyValuePair(pub(crate) foxglove::messages::KeyValuePair);
 #[pymethods]
@@ -1656,7 +1656,7 @@ impl From<KeyValuePair> for foxglove::messages::KeyValuePair {
 /// :param intensities: Intensity of detections
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/laser-scan
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct LaserScan(pub(crate) foxglove::messages::LaserScan);
 #[pymethods]
@@ -1735,7 +1735,7 @@ impl From<LaserScan> for foxglove::messages::LaserScan {
 ///     If omitted or empty, indexing will not be used. This default behavior is equivalent to specifying [0, 1, ..., N-1] for the indices (where N is the number of `points` provided).
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/line-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct LinePrimitive(pub(crate) foxglove::messages::LinePrimitive);
 #[pymethods]
@@ -1828,7 +1828,7 @@ impl From<LinePrimitive> for foxglove::messages::LinePrimitive {
 /// :param metadata: Additional user-provided metadata associated with the location fix. Keys must be unique.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/location-fix
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct LocationFix(pub(crate) foxglove::messages::LocationFix);
 #[pymethods]
@@ -1916,7 +1916,7 @@ impl From<LocationFix> for foxglove::messages::LocationFix {
 /// :param fixes: An array of location fixes
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/location-fixes
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct LocationFixes(pub(crate) foxglove::messages::LocationFixes);
 #[pymethods]
@@ -1974,7 +1974,7 @@ impl From<LocationFixes> for foxglove::messages::LocationFixes {
 /// :param line: Line number in the file
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/log
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Log(pub(crate) foxglove::messages::Log);
 #[pymethods]
@@ -2038,7 +2038,7 @@ impl From<Log> for foxglove::messages::Log {
 /// :param id: Identifier which must match if `type` is `MATCHING_ID`.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/scene-entity-deletion
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct SceneEntityDeletion(pub(crate) foxglove::messages::SceneEntityDeletion);
 #[pymethods]
@@ -2105,7 +2105,7 @@ impl From<SceneEntityDeletion> for foxglove::messages::SceneEntityDeletion {
 /// :param models: Model primitives
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/scene-entity
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct SceneEntity(pub(crate) foxglove::messages::SceneEntity);
 #[pymethods]
@@ -2235,7 +2235,7 @@ impl From<SceneEntity> for foxglove::messages::SceneEntity {
 /// :param entities: Scene entities to add or replace
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/scene-update
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct SceneUpdate(pub(crate) foxglove::messages::SceneUpdate);
 #[pymethods]
@@ -2305,7 +2305,7 @@ impl From<SceneUpdate> for foxglove::messages::SceneUpdate {
 /// :param data: Embedded model. One of `url` or `data` should be non-empty. If `data` is non-empty, `media_type` must be set to indicate the type of the data.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/model-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct ModelPrimitive(pub(crate) foxglove::messages::ModelPrimitive);
 #[pymethods]
@@ -2387,7 +2387,7 @@ impl From<ModelPrimitive> for foxglove::messages::ModelPrimitive {
 /// :param metadata: Additional user-provided metadata associated with the odometry message. Keys must be unique.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/odometry
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Odometry(pub(crate) foxglove::messages::Odometry);
 #[pymethods]
@@ -2469,7 +2469,7 @@ impl From<Odometry> for foxglove::messages::Odometry {
 /// :param type: Type of data in the field. Integers are stored using little-endian byte order.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/packed-element-field
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct PackedElementField(pub(crate) foxglove::messages::PackedElementField);
 #[pymethods]
@@ -2524,7 +2524,7 @@ impl From<PackedElementField> for foxglove::messages::PackedElementField {
 /// :param y: y coordinate position
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/point2
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Point2(pub(crate) foxglove::messages::Point2);
 #[pymethods]
@@ -2571,7 +2571,7 @@ impl From<Point2> for foxglove::messages::Point2 {
 /// :param z: z coordinate position
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/point3
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Point3(pub(crate) foxglove::messages::Point3);
 #[pymethods]
@@ -2621,7 +2621,7 @@ impl From<Point3> for foxglove::messages::Point3 {
 /// :param point: Point in 3D space
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/point3-in-frame
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Point3InFrame(pub(crate) foxglove::messages::Point3InFrame);
 #[pymethods]
@@ -2680,7 +2680,7 @@ impl From<Point3InFrame> for foxglove::messages::Point3InFrame {
 /// :param data: Point data, interpreted using `fields`
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/point-cloud
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct PointCloud(pub(crate) foxglove::messages::PointCloud);
 #[pymethods]
@@ -2761,7 +2761,7 @@ impl From<PointCloud> for foxglove::messages::PointCloud {
 /// :param metadata: Additional user-provided metadata associated with this annotation. Keys must be unique.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/points-annotation
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct PointsAnnotation(pub(crate) foxglove::messages::PointsAnnotation);
 #[pymethods]
@@ -2849,7 +2849,7 @@ impl From<PointsAnnotation> for foxglove::messages::PointsAnnotation {
 /// :param orientation: Quaternion denoting orientation in 3D space
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/pose
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Pose(pub(crate) foxglove::messages::Pose);
 #[pymethods]
@@ -2902,7 +2902,7 @@ impl From<Pose> for foxglove::messages::Pose {
 /// :param pose: Pose in 3D space
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/pose-in-frame
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct PoseInFrame(pub(crate) foxglove::messages::PoseInFrame);
 #[pymethods]
@@ -2958,7 +2958,7 @@ impl From<PoseInFrame> for foxglove::messages::PoseInFrame {
 /// :param poses: Poses in 3D space
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/poses-in-frame
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct PosesInFrame(pub(crate) foxglove::messages::PosesInFrame);
 #[pymethods]
@@ -3019,7 +3019,7 @@ impl From<PosesInFrame> for foxglove::messages::PosesInFrame {
 /// :param w: w value
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/quaternion
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Quaternion(pub(crate) foxglove::messages::Quaternion);
 #[pymethods]
@@ -3071,7 +3071,7 @@ impl From<Quaternion> for foxglove::messages::Quaternion {
 /// :param number_of_channels: Number of channels in the audio block
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/raw-audio
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct RawAudio(pub(crate) foxglove::messages::RawAudio);
 #[pymethods]
@@ -3205,7 +3205,7 @@ impl From<RawAudio> for foxglove::messages::RawAudio {
 ///     
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/raw-image
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct RawImage(pub(crate) foxglove::messages::RawImage);
 #[pymethods]
@@ -3279,7 +3279,7 @@ impl From<RawImage> for foxglove::messages::RawImage {
 /// :param color: Color of the sphere
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/sphere-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct SpherePrimitive(pub(crate) foxglove::messages::SpherePrimitive);
 #[pymethods]
@@ -3340,7 +3340,7 @@ impl From<SpherePrimitive> for foxglove::messages::SpherePrimitive {
 /// :param metadata: Additional user-provided metadata associated with this annotation. Keys must be unique.
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/text-annotation
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct TextAnnotation(pub(crate) foxglove::messages::TextAnnotation);
 #[pymethods]
@@ -3421,7 +3421,7 @@ impl From<TextAnnotation> for foxglove::messages::TextAnnotation {
 /// :param text: Text
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/text-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct TextPrimitive(pub(crate) foxglove::messages::TextPrimitive);
 #[pymethods]
@@ -3496,7 +3496,7 @@ impl From<TextPrimitive> for foxglove::messages::TextPrimitive {
 ///     If omitted or empty, indexing will not be used. This default behavior is equivalent to specifying [0, 1, ..., N-1] for the indices (where N is the number of `points` provided).
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/triangle-list-primitive
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct TriangleListPrimitive(pub(crate) foxglove::messages::TriangleListPrimitive);
 #[pymethods]
@@ -3567,7 +3567,7 @@ impl From<TriangleListPrimitive> for foxglove::messages::TriangleListPrimitive {
 /// :param y: y component
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/vector2
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Vector2(pub(crate) foxglove::messages::Vector2);
 #[pymethods]
@@ -3614,7 +3614,7 @@ impl From<Vector2> for foxglove::messages::Vector2 {
 /// :param z: z component
 ///
 /// See https://docs.foxglove.dev/docs/visualization/message-schemas/vector3
-#[pyclass(module = "foxglove.messages")]
+#[pyclass(from_py_object, module = "foxglove.messages")]
 #[derive(Clone)]
 pub(crate) struct Vector3(pub(crate) foxglove::messages::Vector3);
 #[pymethods]

--- a/python/foxglove-sdk/src/lib.rs
+++ b/python/foxglove-sdk/src/lib.rs
@@ -46,7 +46,14 @@ mod websocket;
 /// :type encoding: str
 /// :param data: Schema data.
 /// :type data: bytes
-#[pyclass(name = "Schema", module = "foxglove", get_all, set_all, eq)]
+#[pyclass(
+    from_py_object,
+    name = "Schema",
+    module = "foxglove",
+    get_all,
+    set_all,
+    eq
+)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct PySchema {
     /// The name of the schema.
@@ -100,13 +107,13 @@ impl BaseChannel {
     ) -> PyResult<Self> {
         // Release the GIL before calling build_raw(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks. That callback needs to
-        // re-acquire the GIL via Python::with_gil(); if we still hold it here, we deadlock.
+        // re-acquire the GIL via Python::attach(); if we still hold it here, we deadlock.
         let topic = topic.to_owned();
         let message_encoding = message_encoding.to_owned();
         let schema = schema.map(Schema::from);
         let metadata = metadata.unwrap_or_default();
         let channel = py
-            .allow_threads(move || {
+            .detach(move || {
                 ChannelBuilder::new(&topic)
                     .message_encoding(&message_encoding)
                     .schema(schema)
@@ -139,7 +146,7 @@ impl BaseChannel {
         self.0.message_encoding()
     }
 
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;
@@ -207,14 +214,14 @@ impl PyContext {
     ) -> PyResult<BaseChannel> {
         // Release the GIL before calling build_raw(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks. That callback needs to
-        // re-acquire the GIL via Python::with_gil(); if we still hold it here, we deadlock.
+        // re-acquire the GIL via Python::attach(); if we still hold it here, we deadlock.
         let context = self.0.clone();
         let topic = topic.to_owned();
         let message_encoding = message_encoding.to_owned();
         let schema = schema.map(Schema::from);
         let metadata = metadata.unwrap_or_default();
         let channel = py
-            .allow_threads(move || {
+            .detach(move || {
                 context
                     .channel_builder(&topic)
                     .message_encoding(&message_encoding)
@@ -288,9 +295,9 @@ fn open_mcap(
 
     // Release the GIL before calling create(), which calls context.add_sink() and may invoke
     // PySinkChannelFilter::should_subscribe() on existing channels. That callback needs to
-    // re-acquire the GIL via Python::with_gil(); if we still hold it here, we deadlock.
+    // re-acquire the GIL via Python::attach(); if we still hold it here, we deadlock.
     let handle = py
-        .allow_threads(move || handle.create(writer))
+        .detach(move || handle.create(writer))
         .map_err(PyFoxgloveError::from)?;
     Ok(PyMcapWriter(Some(handle)))
 }
@@ -329,7 +336,7 @@ fn disable_logging() -> PyResult<()> {
 #[pyfunction]
 fn shutdown(#[allow(unused_variables)] py: Python<'_>) {
     #[cfg(not(target_family = "wasm"))]
-    py.allow_threads(foxglove::shutdown_runtime);
+    py.detach(foxglove::shutdown_runtime);
 }
 
 /// Our public API is in the `python` directory.

--- a/python/foxglove-sdk/src/mcap.rs
+++ b/python/foxglove-sdk/src/mcap.rs
@@ -12,7 +12,7 @@ pub(crate) struct PyFileLikeWriter(pub(crate) Py<PyAny>);
 
 impl Write for PyFileLikeWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes = PyBytes::new(py, buf);
             self.0
                 .call_method1(py, "write", (bytes,))
@@ -22,7 +22,7 @@ impl Write for PyFileLikeWriter {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.0
                 .call_method0(py, "flush")
                 .map(|_| ())
@@ -33,7 +33,7 @@ impl Write for PyFileLikeWriter {
 
 impl std::io::Seek for PyFileLikeWriter {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let (offset, whence): (i64, i32) = match pos {
                 SeekFrom::Start(n) => (n as i64, 0),
                 SeekFrom::Current(n) => (n, 1),
@@ -79,7 +79,13 @@ impl std::io::Seek for WriterInner {
 }
 
 /// Compression algorithm to use for MCAP writing.
-#[pyclass(eq, eq_int, name = "MCAPCompression", module = "foxglove.mcap")]
+#[pyclass(
+    from_py_object,
+    eq,
+    eq_int,
+    name = "MCAPCompression",
+    module = "foxglove.mcap"
+)]
 #[derive(PartialEq, Clone)]
 pub enum PyMcapCompression {
     Zstd = 0,
@@ -153,7 +159,7 @@ impl From<PyMcapCompression> for McapCompression {
 /// :param compression_threads: Specifies how many threads to use for zstd compression. None uses the number of physical CPUs. 0 disables multithreaded compression.
 /// :type compression_threads: int | None
 #[derive(Clone)]
-#[pyclass(name = "MCAPWriteOptions", module = "foxglove.mcap")]
+#[pyclass(from_py_object, name = "MCAPWriteOptions", module = "foxglove.mcap")]
 pub(crate) struct PyMcapWriteOptions(McapWriteOptions);
 
 #[pymethods]
@@ -387,11 +393,11 @@ mod tests {
     /// the new Rust defaults.
     #[test]
     fn python_defaults_match_rust_defaults() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let ty = py.get_type::<PyMcapWriteOptions>();
             let obj = ty.call0().unwrap();
-            let cell = obj.downcast::<PyMcapWriteOptions>().unwrap();
+            let cell = obj.cast::<PyMcapWriteOptions>().unwrap();
             let py_debug = format!("{:?}", cell.borrow().0);
 
             let rust_default = McapWriteOptions::default();

--- a/python/foxglove-sdk/src/remote_access.rs
+++ b/python/foxglove-sdk/src/remote_access.rs
@@ -39,6 +39,7 @@ impl From<&remote_access::Client> for PyRemoteAccessClient {
 
 /// The status of the remote access gateway connection.
 #[pyclass(
+    skip_from_py_object,
     name = "RemoteAccessConnectionStatus",
     module = "foxglove.remote_access",
     eq,
@@ -92,7 +93,13 @@ impl From<ConnectionStatus> for PyConnectionStatus {
 }
 
 /// A capability that can be advertised by a remote access gateway.
-#[pyclass(name = "Capability", module = "foxglove.remote_access", eq, eq_int)]
+#[pyclass(
+    from_py_object,
+    name = "Capability",
+    module = "foxglove.remote_access",
+    eq,
+    eq_int
+)]
 #[derive(Clone, PartialEq)]
 pub enum PyRemoteAccessCapability {
     /// Allow clients to advertise channels to send data messages to the server.
@@ -148,7 +155,7 @@ pub struct PyRemoteAccessListener {
 
 impl Listener for PyRemoteAccessListener {
     fn on_connection_status_changed(&self, status: ConnectionStatus) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             let py_status = PyConnectionStatus::from(status);
             self.listener.bind(py).call_method(
                 "on_connection_status_changed",
@@ -185,7 +192,7 @@ impl Listener for PyRemoteAccessListener {
         payload: &[u8],
     ) {
         let py_client = PyRemoteAccessClient::from(client);
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             let py_channel = PyChannelDescriptor(channel.clone());
             let py_payload = PyBytes::new(py, payload);
             self.listener.bind(py).call_method(
@@ -207,7 +214,7 @@ impl Listener for PyRemoteAccessListener {
         request_id: Option<&str>,
     ) -> Vec<foxglove::remote_access::Parameter> {
         let py_client = PyRemoteAccessClient::from(client);
-        let result: PyResult<Vec<foxglove::remote_access::Parameter>> = Python::with_gil(|py| {
+        let result: PyResult<Vec<foxglove::remote_access::Parameter>> = Python::attach(|py| {
             let args = (py_client, param_names, request_id);
             let result = self
                 .listener
@@ -232,7 +239,7 @@ impl Listener for PyRemoteAccessListener {
         request_id: Option<&str>,
     ) -> Vec<foxglove::remote_access::Parameter> {
         let py_client = PyRemoteAccessClient::from(client);
-        let result: PyResult<Vec<foxglove::remote_access::Parameter>> = Python::with_gil(|py| {
+        let result: PyResult<Vec<foxglove::remote_access::Parameter>> = Python::attach(|py| {
             let parameters: Vec<PyParameter> = parameters.into_iter().map(Into::into).collect();
             let args = (py_client, parameters, request_id);
             let result = self
@@ -252,7 +259,7 @@ impl Listener for PyRemoteAccessListener {
     }
 
     fn on_parameters_subscribe(&self, param_names: Vec<String>) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             self.listener
                 .bind(py)
                 .call_method("on_parameters_subscribe", (param_names,), None)?;
@@ -264,7 +271,7 @@ impl Listener for PyRemoteAccessListener {
     }
 
     fn on_parameters_unsubscribe(&self, param_names: Vec<String>) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             self.listener.bind(py).call_method(
                 "on_parameters_unsubscribe",
                 (param_names,),
@@ -278,7 +285,7 @@ impl Listener for PyRemoteAccessListener {
     }
 
     fn on_connection_graph_subscribe(&self) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             self.listener
                 .bind(py)
                 .call_method("on_connection_graph_subscribe", (), None)?;
@@ -290,7 +297,7 @@ impl Listener for PyRemoteAccessListener {
     }
 
     fn on_connection_graph_unsubscribe(&self) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             self.listener
                 .bind(py)
                 .call_method("on_connection_graph_unsubscribe", (), None)?;
@@ -310,7 +317,7 @@ impl PyRemoteAccessListener {
         channel: &ChannelDescriptor,
     ) {
         let py_client = PyRemoteAccessClient::from(client);
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             let py_channel = PyChannelDescriptor(channel.clone());
             self.listener
                 .bind(py)
@@ -352,7 +359,7 @@ impl PyRemoteAccessGateway {
     /// :type services: list[Service]
     pub fn add_services(&self, py: Python<'_>, services: Vec<PyService>) -> PyResult<()> {
         if let Some(handle) = &self.0 {
-            py.allow_threads(move || {
+            py.detach(move || {
                 handle
                     .add_services(services.into_iter().map(Into::into))
                     .map_err(PyFoxgloveError::from)
@@ -367,7 +374,7 @@ impl PyRemoteAccessGateway {
     /// :type names: list[str]
     pub fn remove_services(&self, py: Python<'_>, names: Vec<String>) {
         if let Some(handle) = &self.0 {
-            py.allow_threads(move || handle.remove_services(names));
+            py.detach(move || handle.remove_services(names));
         }
     }
 
@@ -418,14 +425,13 @@ impl PyRemoteAccessGateway {
     ///
     /// :param graph: The connection graph to publish.
     /// :type graph: ConnectionGraph
-    pub fn publish_connection_graph(&self, graph: Bound<'_, PyConnectionGraph>) -> PyResult<()> {
+    pub fn publish_connection_graph(&self, graph: PyRef<'_, PyConnectionGraph>) -> PyResult<()> {
         let Some(handle) = &self.0 else {
             tracing::debug!("publish_connection_graph called after gateway stopped; ignoring");
             return Ok(());
         };
-        let graph = graph.extract::<PyConnectionGraph>()?;
         handle
-            .publish_connection_graph(graph.into())
+            .publish_connection_graph(graph.0.clone())
             .map_err(PyFoxgloveError::from)
             .map_err(PyErr::from)
     }
@@ -433,13 +439,19 @@ impl PyRemoteAccessGateway {
     /// Gracefully disconnect from the remote access gateway.
     pub fn stop(&mut self, py: Python<'_>) {
         if let Some(handle) = self.0.take() {
-            py.allow_threads(|| handle.stop_blocking())
+            py.detach(|| handle.stop_blocking())
         }
     }
 }
 
 /// The reliability policy for a channel's data delivery.
-#[pyclass(name = "Reliability", module = "foxglove.remote_access", eq, eq_int)]
+#[pyclass(
+    from_py_object,
+    name = "Reliability",
+    module = "foxglove.remote_access",
+    eq,
+    eq_int
+)]
 #[derive(Clone, PartialEq)]
 pub enum PyReliability {
     /// Data is sent over unreliable data tracks. This is the default.
@@ -477,7 +489,7 @@ impl From<PyReliability> for Reliability {
 }
 
 /// Quality-of-service profile for a channel.
-#[pyclass(name = "QosProfile", module = "foxglove.remote_access")]
+#[pyclass(from_py_object, name = "QosProfile", module = "foxglove.remote_access")]
 #[derive(Clone)]
 pub struct PyQosProfile {
     #[pyo3(get, set)]
@@ -508,13 +520,13 @@ pub struct PyQosClassifier(pub Py<PyAny>);
 
 impl foxglove::remote_access::QosClassifier for PyQosClassifier {
     fn classify(&self, channel: &foxglove::ChannelDescriptor) -> QosProfile {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let handler = self.0.clone_ref(py);
             let descriptor = PyChannelDescriptor(channel.clone());
             let result = handler
                 .bind(py)
                 .call((descriptor,), None)
-                .and_then(|f| f.extract::<PyQosProfile>());
+                .and_then(|f| f.extract::<PyQosProfile>().map_err(Into::into));
 
             match result {
                 Ok(profile) => profile.into(),
@@ -605,7 +617,7 @@ pub fn start_gateway(
     }
 
     let handle = py
-        .allow_threads(|| gateway.start())
+        .detach(|| gateway.start())
         .map_err(PyFoxgloveError::from)?;
 
     Ok(PyRemoteAccessGateway(Some(handle)))

--- a/python/foxglove-sdk/src/remote_common.rs
+++ b/python/foxglove-sdk/src/remote_common.rs
@@ -23,7 +23,7 @@ impl foxglove::websocket::service::Handler for ServiceHandler {
         let request = PyServiceRequest(request);
         // Punt the callback to a blocking thread.
         tokio::task::spawn_blocking(move || {
-            let result = Python::with_gil(|py| {
+            let result = Python::attach(|py| {
                 handler
                     .bind(py)
                     .call((request,), None)
@@ -116,7 +116,13 @@ impl PyServiceRequest {
 /// :type request: :py:class:`foxglove.MessageSchema` | `None`
 /// :param response: The response schema.
 /// :type response: :py:class:`foxglove.MessageSchema` | `None`
-#[pyclass(name = "ServiceSchema", module = "foxglove", get_all, set_all)]
+#[pyclass(
+    from_py_object,
+    name = "ServiceSchema",
+    module = "foxglove",
+    get_all,
+    set_all
+)]
 #[derive(Clone)]
 pub struct PyServiceSchema {
     /// The name of the service.
@@ -163,7 +169,13 @@ impl From<PyServiceSchema> for foxglove::websocket::service::ServiceSchema {
 /// :type encoding: str
 /// :param schema: The message schema.
 /// :type schema: :py:class:`foxglove.Schema`
-#[pyclass(name = "MessageSchema", module = "foxglove", get_all, set_all)]
+#[pyclass(
+    from_py_object,
+    name = "MessageSchema",
+    module = "foxglove",
+    get_all,
+    set_all
+)]
 #[derive(Clone)]
 pub struct PyMessageSchema {
     /// The encoding of the message.
@@ -200,7 +212,13 @@ impl PyMessageSchema {
 ///
 /// Parameters of other types (integer, bool, string, dict, arrays of these) leave
 /// :py:attr:`Parameter.type` set to ``None``.
-#[pyclass(name = "ParameterType", module = "foxglove", eq, eq_int)]
+#[pyclass(
+    from_py_object,
+    name = "ParameterType",
+    module = "foxglove",
+    eq,
+    eq_int
+)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyParameterType {
     /// A byte array, transmitted on the wire as a base64-encoded string. The type hint
@@ -256,7 +274,7 @@ impl From<foxglove::websocket::ParameterType> for PyParameterType {
 }
 
 /// A parameter value.
-#[pyclass(name = "ParameterValue", module = "foxglove", eq)]
+#[pyclass(from_py_object, name = "ParameterValue", module = "foxglove", eq)]
 #[derive(Clone, PartialEq)]
 pub enum PyParameterValue {
     /// An integer value.
@@ -320,7 +338,7 @@ impl From<foxglove::websocket::ParameterValue> for PyParameterValue {
 /// :param type: Optional parameter type. This is automatically derived when passing a native
 ///              python object as the value.
 /// :type type: ParameterType|None
-#[pyclass(name = "Parameter", module = "foxglove")]
+#[pyclass(from_py_object, name = "Parameter", module = "foxglove")]
 #[derive(Clone)]
 pub struct PyParameter {
     /// The name of the parameter.
@@ -423,8 +441,10 @@ impl<'py> IntoPyObject<'py> for ParameterValueConverter {
     }
 }
 
-impl<'py> FromPyObject<'py> for ParameterValueConverter {
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for ParameterValueConverter {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         if let Ok(val) = obj.extract::<PyParameterValue>() {
             Ok(Self(val))
         } else if let Ok(val) = obj.extract::<bool>() {
@@ -435,16 +455,16 @@ impl<'py> FromPyObject<'py> for ParameterValueConverter {
             Ok(Self(PyParameterValue::Float64(val)))
         } else if let Ok(val) = obj.extract::<String>() {
             Ok(Self(PyParameterValue::String(val)))
-        } else if let Ok(list) = obj.downcast::<PyList>() {
+        } else if let Ok(list) = obj.cast::<PyList>() {
             let mut values = Vec::with_capacity(list.len());
             for item in list.iter() {
                 let value: ParameterValueConverter = item.extract()?;
                 values.push(value.0);
             }
             Ok(Self(PyParameterValue::Array(values)))
-        } else if let Ok(dict) = obj.downcast::<PyDict>() {
+        } else if let Ok(dict) = obj.cast::<PyDict>() {
             let mut values = HashMap::new();
-            for (key, value) in dict {
+            for (key, value) in dict.iter() {
                 let key: String = key.extract()?;
                 let value: ParameterValueConverter = value.extract()?;
                 values.insert(key, value.0);
@@ -480,8 +500,10 @@ impl<'py> IntoPyObject<'py> for ParameterTypeValueConverter {
     }
 }
 
-impl<'py> FromPyObject<'py> for ParameterTypeValueConverter {
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for ParameterTypeValueConverter {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         if let Ok(val) = obj.extract::<ParameterValueConverter>() {
             let val = val.0;
             let (typ, val) = match val {
@@ -514,9 +536,9 @@ impl<'py> FromPyObject<'py> for ParameterTypeValueConverter {
 }
 
 /// A connection graph.
-#[pyclass(name = "ConnectionGraph", module = "foxglove")]
+#[pyclass(skip_from_py_object, name = "ConnectionGraph", module = "foxglove")]
 #[derive(Clone)]
-pub struct PyConnectionGraph(foxglove::websocket::ConnectionGraph);
+pub struct PyConnectionGraph(pub(crate) foxglove::websocket::ConnectionGraph);
 
 #[pymethods]
 impl PyConnectionGraph {
@@ -574,7 +596,7 @@ impl AssetHandler for CallbackAssetHandler {
         let handler = self.handler.clone();
 
         tokio::task::spawn_blocking(move || {
-            let result = Python::with_gil(|py| {
+            let result = Python::attach(|py| {
                 handler.bind(py).call((uri,), None).and_then(|data| {
                     if data.is_none() {
                         Err(PyIOError::new_err("not found"))
@@ -589,7 +611,13 @@ impl AssetHandler for CallbackAssetHandler {
 }
 
 /// A status message severity level.
-#[pyclass(name = "StatusLevel", module = "foxglove", eq, eq_int)]
+#[pyclass(
+    skip_from_py_object,
+    name = "StatusLevel",
+    module = "foxglove",
+    eq,
+    eq_int
+)]
 #[derive(Clone, PartialEq)]
 pub enum PyStatusLevel {
     Info,

--- a/python/foxglove-sdk/src/schemas_wkt.rs
+++ b/python/foxglove-sdk/src/schemas_wkt.rs
@@ -8,7 +8,7 @@ use pyo3::types::{PyDateTime, PyTzInfo};
 ///
 /// :param sec: The number of seconds since a user-defined epoch.
 /// :param nsec: The number of nanoseconds since the sec value.
-#[pyclass(module = "foxglove.messages", eq)]
+#[pyclass(from_py_object, module = "foxglove.messages", eq)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct Timestamp(foxglove::messages::Timestamp);
 
@@ -123,7 +123,7 @@ impl From<Timestamp> for foxglove::messages::Timestamp {
 ///
 /// :param sec: The number of seconds in the duration.
 /// :param nsec: The number of nanoseconds in the positive direction.
-#[pyclass(module = "foxglove.messages", eq)]
+#[pyclass(from_py_object, module = "foxglove.messages", eq)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct Duration(foxglove::messages::Duration);
 

--- a/python/foxglove-sdk/src/sink_channel_filter.rs
+++ b/python/foxglove-sdk/src/sink_channel_filter.rs
@@ -66,7 +66,7 @@ pub struct PySinkChannelFilter(pub Py<PyAny>);
 
 impl foxglove::SinkChannelFilter for PySinkChannelFilter {
     fn should_subscribe(&self, channel: &ChannelDescriptor) -> bool {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let handler = self.0.clone_ref(py);
             let descriptor = PyChannelDescriptor(channel.clone());
             let result = handler

--- a/python/foxglove-sdk/src/websocket.rs
+++ b/python/foxglove-sdk/src/websocket.rs
@@ -57,7 +57,13 @@ impl From<Client> for PyClient {
     }
 }
 
-#[pyclass(name = "PlaybackStatus", module = "foxglove.websocket", eq, eq_int)]
+#[pyclass(
+    from_py_object,
+    name = "PlaybackStatus",
+    module = "foxglove.websocket",
+    eq,
+    eq_int
+)]
 #[derive(Clone, PartialEq)]
 #[repr(u8)]
 pub enum PyPlaybackStatus {
@@ -101,7 +107,13 @@ impl From<PyPlaybackStatus> for PlaybackStatus {
     }
 }
 
-#[pyclass(name = "PlaybackState", module = "foxglove.websocket", eq, get_all)]
+#[pyclass(
+    from_py_object,
+    name = "PlaybackState",
+    module = "foxglove.websocket",
+    eq,
+    get_all
+)]
 #[derive(Clone, PartialEq)]
 /// The status playback of data that the server is providing
 pub struct PyPlaybackState {
@@ -151,7 +163,13 @@ impl From<PyPlaybackState> for PlaybackState {
     }
 }
 
-#[pyclass(name = "PlaybackCommand", module = "foxglove.websocket", eq, eq_int)]
+#[pyclass(
+    skip_from_py_object,
+    name = "PlaybackCommand",
+    module = "foxglove.websocket",
+    eq,
+    eq_int
+)]
 #[derive(Clone, PartialEq)]
 #[repr(u8)]
 pub enum PyPlaybackCommand {
@@ -244,7 +262,7 @@ impl ServerListener for PyServerListener {
             id: client.id().into(),
         };
 
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             let py_channel = PyClientChannel {
                 id: channel.id.into(),
                 topic: PyString::new(py, channel.topic.as_str()).into(),
@@ -280,7 +298,7 @@ impl ServerListener for PyServerListener {
             id: client.id().into(),
         };
 
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             // client, client_channel_id
             let args = (client_info, u32::from(channel.id));
             self.listener
@@ -301,7 +319,7 @@ impl ServerListener for PyServerListener {
             id: client.id().into(),
         };
 
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             // client, client_channel_id, data
             let args = (
                 client_info,
@@ -330,7 +348,7 @@ impl ServerListener for PyServerListener {
             id: client.id().into(),
         };
 
-        let result: PyResult<Vec<foxglove::websocket::Parameter>> = Python::with_gil(|py| {
+        let result: PyResult<Vec<foxglove::websocket::Parameter>> = Python::attach(|py| {
             let args = (client_info, param_names, request_id);
 
             let result = self
@@ -362,7 +380,7 @@ impl ServerListener for PyServerListener {
             id: client.id().into(),
         };
 
-        let result: PyResult<Vec<foxglove::websocket::Parameter>> = Python::with_gil(|py| {
+        let result: PyResult<Vec<foxglove::websocket::Parameter>> = Python::attach(|py| {
             let parameters: Vec<PyParameter> = parameters.into_iter().map(Into::into).collect();
             let args = (client_info, parameters, request_id);
 
@@ -386,7 +404,7 @@ impl ServerListener for PyServerListener {
     }
 
     fn on_parameters_subscribe(&self, param_names: Vec<String>) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             let args = (param_names,);
             self.listener
                 .bind(py)
@@ -401,7 +419,7 @@ impl ServerListener for PyServerListener {
     }
 
     fn on_parameters_unsubscribe(&self, param_names: Vec<String>) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             let args = (param_names,);
             self.listener
                 .bind(py)
@@ -416,7 +434,7 @@ impl ServerListener for PyServerListener {
     }
 
     fn on_connection_graph_subscribe(&self) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             self.listener
                 .bind(py)
                 .call_method("on_connection_graph_subscribe", (), None)?;
@@ -430,7 +448,7 @@ impl ServerListener for PyServerListener {
     }
 
     fn on_connection_graph_unsubscribe(&self) {
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             self.listener
                 .bind(py)
                 .call_method("on_connection_graph_unsubscribe", (), None)?;
@@ -448,14 +466,16 @@ impl ServerListener for PyServerListener {
         playback_control_request: PlaybackControlRequest,
     ) -> Option<PlaybackState> {
         let py_playback_control_request: PyPlaybackControlRequest = playback_control_request.into();
-        let result: PyResult<Option<PyPlaybackState>> = Python::with_gil(|py| {
+        let result: PyResult<Option<PyPlaybackState>> = Python::attach(|py| {
             let result = self.listener.bind(py).call_method(
                 "on_playback_control_request",
                 (py_playback_control_request,),
                 None,
             )?;
 
-            result.extract::<Option<PyPlaybackState>>()
+            result
+                .extract::<Option<PyPlaybackState>>()
+                .map_err(Into::into)
         });
 
         match result {
@@ -483,7 +503,7 @@ impl PyServerListener {
             id: client.id().into(),
         };
 
-        let result: PyResult<()> = Python::with_gil(|py| {
+        let result: PyResult<()> = Python::attach(|py| {
             let channel_view = PyChannelView {
                 id: channel_id,
                 topic: PyString::new(py, topic).into(),
@@ -583,7 +603,7 @@ pub fn start_server(
     }
 
     let handle = py
-        .allow_threads(|| server.start_blocking())
+        .detach(|| server.start_blocking())
         .map_err(PyFoxgloveError::from)?;
 
     Ok(PyWebSocketServer(Some(handle)))
@@ -598,7 +618,7 @@ impl PyWebSocketServer {
     /// Explicitly stop the server.
     pub fn stop(&mut self, py: Python<'_>) {
         if let Some(server) = self.0.take() {
-            py.allow_threads(|| server.stop().wait_blocking())
+            py.detach(|| server.stop().wait_blocking())
         }
     }
 
@@ -722,7 +742,7 @@ impl PyWebSocketServer {
     /// :type services: list[Service]
     pub fn add_services(&self, py: Python<'_>, services: Vec<PyService>) -> PyResult<()> {
         if let Some(server) = &self.0 {
-            py.allow_threads(move || {
+            py.detach(move || {
                 server
                     .add_services(services.into_iter().map(|s| s.into()))
                     .map_err(PyFoxgloveError::from)
@@ -737,7 +757,7 @@ impl PyWebSocketServer {
     /// :type names: list[str]
     pub fn remove_services(&self, py: Python<'_>, names: Vec<String>) {
         if let Some(server) = &self.0 {
-            py.allow_threads(move || server.remove_services(names));
+            py.detach(move || server.remove_services(names));
         }
     }
 
@@ -749,13 +769,12 @@ impl PyWebSocketServer {
     ///
     /// :param graph: The connection graph to publish.
     /// :type graph: ConnectionGraph
-    pub fn publish_connection_graph(&self, graph: Bound<'_, PyConnectionGraph>) -> PyResult<()> {
+    pub fn publish_connection_graph(&self, graph: PyRef<'_, PyConnectionGraph>) -> PyResult<()> {
         let Some(server) = &self.0 else {
             return Ok(());
         };
-        let graph = graph.extract::<PyConnectionGraph>()?;
         server
-            .publish_connection_graph(graph.into())
+            .publish_connection_graph(graph.0.clone())
             .map_err(PyFoxgloveError::from)
             .map_err(PyErr::from)
     }
@@ -765,7 +784,13 @@ impl PyWebSocketServer {
 ///
 /// Specify the capabilities you support when calling :py:func:`start_server`. These will be
 /// advertised to the Foxglove app when connected as a WebSocket client.
-#[pyclass(name = "Capability", module = "foxglove.websocket", eq, eq_int)]
+#[pyclass(
+    from_py_object,
+    name = "Capability",
+    module = "foxglove.websocket",
+    eq,
+    eq_int
+)]
 #[derive(Clone, PartialEq)]
 pub enum PyCapability {
     /// Allow clients to advertise channels to send data messages to the server.

--- a/typescript/schemas/src/internal/generatePyclass.test.ts
+++ b/typescript/schemas/src/internal/generatePyclass.test.ts
@@ -23,7 +23,7 @@ describe("generatePyclass", () => {
   it("generates an enum", () => {
     expect(generatePyclass(exampleEnum)).toMatchInlineSnapshot(`
      "/// An example enum
-     #[pyclass(eq, eq_int, module = "foxglove.messages")]
+     #[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]
      #[derive(PartialEq, Clone)]
      pub(crate) enum ExampleMessageExampleEnum {
          A = 0,
@@ -92,7 +92,7 @@ describe("generatePyclass", () => {
      /// :param field_optional_float64: An optional float64 field
      ///
      /// See https://docs.foxglove.dev/docs/visualization/message-schemas/example-message
-     #[pyclass(module = "foxglove.messages")]
+     #[pyclass(from_py_object, module = "foxglove.messages")]
      #[derive(Clone)]
      pub(crate) struct ExampleMessage(pub(crate) foxglove::messages::ExampleMessage);
      #[pymethods]

--- a/typescript/schemas/src/internal/generatePyclass.ts
+++ b/typescript/schemas/src/internal/generatePyclass.ts
@@ -283,7 +283,7 @@ function generateMessageClass(schema: FoxgloveMessageSchema): string {
     ...schema.fields.map((field) => rustDoc(pythonParamDoc(field))),
     `///`,
     `/// See https://docs.foxglove.dev/docs/visualization/message-schemas/${constantToKebabCase(className)}`,
-    `#[pyclass(module = "foxglove.messages")]`,
+    `#[pyclass(from_py_object, module = "foxglove.messages")]`,
     `#[derive(Clone)]`,
     `pub(crate) struct ${className}(pub(crate) foxglove::messages::${className});`,
   ];
@@ -390,7 +390,7 @@ function generateEnumClass(schema: FoxgloveEnumSchema): string {
 
   const enumLines = [
     rustDoc(schema.description),
-    `#[pyclass(eq, eq_int, module = "foxglove.messages")]`,
+    `#[pyclass(eq, eq_int, from_py_object, module = "foxglove.messages")]`,
     `#[derive(PartialEq, Clone)]`,
     `pub(crate) enum ${name} {`,
     ...variants.map((v) => `    ${v.rustName} = ${v.value},`),
@@ -761,7 +761,7 @@ impl ${channelClass} {
         let context = context.map(|c| c.0.clone());
         // Release the GIL before calling build(), which may invoke
         // PySinkChannelFilter::should_subscribe() on registered sinks.
-        let base = py.allow_threads(move || {
+        let base = py.detach(move || {
             let builder = ChannelBuilder::new(&topic).metadata(metadata);
             let builder = if let Some(context) = context {
                 builder.context(&context)
@@ -793,7 +793,7 @@ impl ${channelClass} {
     ///
     /// Note that changes made to the returned dictionary will not be applied to
     /// the channel's metadata.
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (key, value) in self.0.metadata() {
             dict.set_item(key, value)?;


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
This change updates pyo3 to the latest version, to address a security
vulnerability. The changes are fairly mechanical:

- `py.allow_threads` -> `py.detach`
- `Python::with_gil` -> `Python::attach`
- `PyObject` -> `Py<PyAny>`
- `Bound::downcast` -> `Bound::cast`
- Explicit `from_py_object` derive for types that impl Clone

See the migration guide for reference: https://pyo3.rs/v0.29.0/migration.html

TypeError messages for argument conversions have also changed slightly
to look more native. The old exceptions had a message like this:

```
TypeError: argument 'metadata': 'int' object cannot be converted to 'PyString'
```

New ones include a "while processing '<field name>'" as a PEP 678 note:

```
TypeError: 'int' object is not an instance of 'str'
while processing 'metadata'
```

Fixes: https://github.com/foxglove/foxglove-sdk/security/dependabot/180