### PR TITLE
python: Drop unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,15 +1422,11 @@ dependencies = [
  "bytes",
  "foxglove 0.25.1",
  "log",
- "prost-types 0.14.3",
  "pyo3",
  "pyo3-log",
  "thiserror 2.0.14",
  "tokio",
- "tokio-tungstenite 0.28.0",
- "tokio-util",
  "tracing",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,7 @@ dependencies = [
  "bytes",
  "foxglove 0.25.1",
  "log",
- "prost-types 0.13.5",
+ "prost-types 0.14.3",
  "pyo3",
  "pyo3-log",
  "thiserror 2.0.14",

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -34,7 +34,7 @@ workspace = true
 base64 = "0.22.1"
 bytes.workspace = true
 log.workspace = true
-prost-types = "0.13"
+prost-types.workspace = true
 pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 pyo3-log = "0.13.4"
 thiserror.workspace = true

--- a/python/foxglove-sdk/Cargo.toml
+++ b/python/foxglove-sdk/Cargo.toml
@@ -34,7 +34,6 @@ workspace = true
 base64 = "0.22.1"
 bytes.workspace = true
 log.workspace = true
-prost-types.workspace = true
 pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 pyo3-log = "0.13.4"
 thiserror.workspace = true
@@ -44,8 +43,6 @@ tracing.workspace = true
 foxglove = { path = "../../rust/foxglove", default-features = false, features = ["lz4", "zstd"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio-tungstenite.workspace = true
-tokio-util.workspace = true
 tokio.workspace = true
 foxglove = { path = "../../rust/foxglove", default-features = false, features = [
   "lz4",
@@ -53,6 +50,3 @@ foxglove = { path = "../../rust/foxglove", default-features = false, features = 
   "websocket",
   "zstd",
 ] }
-
-[build-dependencies]
-walkdir = "2.5.0"


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
We were pulling in a duplicate prost-types version from the python
crate. Turns out we weren't using it anyway. This change drops the
explicit dependency, along with a few others that were also unused.

Before:
```
❱ cargo tree --duplicates --depth 0 -p foxglove-sdk-python | grep prost
prost v0.13.5
prost v0.14.3
prost-derive v0.13.5 (proc-macro)
prost-derive v0.14.3 (proc-macro)
prost-types v0.13.5
prost-types v0.14.3
```

After:
```
❱ cargo tree --duplicates --depth 0 -p foxglove-sdk-python | grep prost
```