### PR TITLE
Identify ROS bridge in headers

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -3205,6 +3205,13 @@ extern "C" {
 void foxglove_internal_register_cpp_wrapper(void);
 #endif
 
+#if !defined(__wasm__)
+/**
+ * For use by wrappers built on top of the SDK. Prepends a product token to library identifiers.
+ */
+void foxglove_internal_set_library_identifier_prefix(struct foxglove_string prefix);
+#endif
+
 /**
  * Convert a `FoxgloveError` code to a C string.
  */

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -255,6 +255,15 @@ pub extern "C" fn foxglove_internal_register_cpp_wrapper() {
     }
 }
 
+/// For use by wrappers built on top of the SDK. Prepends a product token to library identifiers.
+#[cfg(not(target_family = "wasm"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn foxglove_internal_set_library_identifier_prefix(prefix: FoxgloveString) {
+    if let Ok(prefix) = unsafe { prefix.as_utf8_str() } {
+        foxglove::library_version::set_library_identifier_prefix(prefix.to_string());
+    }
+}
+
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FoxgloveError {

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -259,9 +259,11 @@ pub extern "C" fn foxglove_internal_register_cpp_wrapper() {
 #[cfg(not(target_family = "wasm"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn foxglove_internal_set_library_identifier_prefix(prefix: FoxgloveString) {
-    if let Ok(prefix) = unsafe { prefix.as_utf8_str() } {
-        foxglove::library_version::set_library_identifier_prefix(prefix.to_string());
-    }
+    let Ok(prefix) = (unsafe { prefix.as_utf8_str() }) else {
+        tracing::warn!("Ignoring invalid UTF-8 library identifier prefix");
+        return;
+    };
+    foxglove::library_version::set_library_identifier_prefix(prefix.to_string());
 }
 
 #[repr(u8)]

--- a/cpp/foxglove/include/foxglove/foxglove.hpp
+++ b/cpp/foxglove/include/foxglove/foxglove.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 namespace foxglove {
 
@@ -41,5 +42,13 @@ enum class LogLevel : uint8_t {
 ///
 /// @note This is thread-safe, but only the first call to this function will have an effect.
 void setLogLevel(LogLevel level);
+
+namespace internal {
+
+/// @cond foxglove_internal
+void setLibraryIdentifierPrefix(std::string_view prefix);
+/// @endcond
+
+}  // namespace internal
 
 }  // namespace foxglove

--- a/cpp/foxglove/src/foxglove.cpp
+++ b/cpp/foxglove/src/foxglove.cpp
@@ -7,4 +7,12 @@ void setLogLevel(LogLevel level) {
   foxglove_set_log_level(static_cast<foxglove_logging_level>(level));
 }
 
+namespace internal {
+
+void setLibraryIdentifierPrefix(std::string_view prefix) {
+  foxglove_internal_set_library_identifier_prefix({prefix.data(), prefix.size()});
+}
+
+}  // namespace internal
+
 }  // namespace foxglove

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <type_traits>
 #include <unordered_set>
 
@@ -17,6 +18,10 @@ inline bool isHiddenTopicOrService(const std::string& name) {
     throw std::invalid_argument("Topic or service name can't be empty");
   }
   return name.front() == '_' || name.find("/_") != std::string::npos;
+}
+
+std::string bridgeLibraryIdentifier() {
+  return std::string("foxglove-bridge/") + foxglove_bridge::FOXGLOVE_BRIDGE_VERSION;
 }
 
 inline foxglove::WebSocketServerCapabilities processCapabilities(
@@ -100,6 +105,8 @@ using namespace std::placeholders;
 
 FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     : Node("foxglove_bridge", options) {
+  foxglove::internal::setLibraryIdentifierPrefix(bridgeLibraryIdentifier());
+
   const char* rosDistro = std::getenv("ROS_DISTRO");
   RCLCPP_INFO(this->get_logger(), "Starting foxglove_bridge (%s, %s@%s)", rosDistro,
               foxglove_bridge::FOXGLOVE_BRIDGE_VERSION, foxglove_bridge::FOXGLOVE_BRIDGE_GIT_HASH);

--- a/ros/src/foxglove_bridge/tests/smoke_test.cpp
+++ b/ros/src/foxglove_bridge/tests/smoke_test.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <filesystem>
 #include <future>
+#include <string>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -187,7 +188,22 @@ std::shared_ptr<T> deserializeMsg(const rcl_serialized_message_t* msg) {
 
 TEST(SmokeTest, testConnection) {
   foxglove::test::Client<websocketpp::config::asio_client> wsClient;
-  EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(DEFAULT_TIMEOUT));
+  auto promise = std::make_shared<std::promise<nlohmann::json>>();
+  auto serverInfoFuture = promise->get_future();
+  wsClient.setTextMessageHandler([promise = std::move(promise)](const std::string& payload) {
+    const auto msg = nlohmann::json::parse(payload);
+    if (msg.value("op", "") == "serverInfo") {
+      promise->set_value(msg);
+    }
+  });
+
+  ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(DEFAULT_TIMEOUT));
+  ASSERT_EQ(std::future_status::ready, serverInfoFuture.wait_for(DEFAULT_TIMEOUT));
+
+  const auto serverInfo = serverInfoFuture.get();
+  const auto library = serverInfo["metadata"]["fg-library"].get<std::string>();
+  EXPECT_EQ(library.rfind("foxglove-bridge/", 0), 0);
+  EXPECT_NE(library.find(" foxglove-sdk-cpp/"), std::string::npos);
 }
 
 TEST(SmokeTest, testConnectionGraphSubscribeUnsubscribe) {

--- a/rust/foxglove/src/library_version.rs
+++ b/rust/foxglove/src/library_version.rs
@@ -8,11 +8,20 @@ static COMPILED_SDK_LANGUAGE: LazyLock<String> = LazyLock::new(|| {
 });
 
 static CELL: OnceLock<&'static str> = OnceLock::new();
+static LIBRARY_IDENTIFIER_PREFIX: OnceLock<String> = OnceLock::new();
 
 /// Sets the language of the SDK. This should be called as soon as possible by an implementation,
 /// otherwise the compiled language will be used when reporting the library version.
 pub fn set_sdk_language(language: &'static str) {
     CELL.get_or_init(|| language);
+}
+
+/// Sets a product token to prepend to this library's identifier.
+///
+/// This should be called as soon as possible by wrappers that identify a product built on top of
+/// the SDK.
+pub fn set_library_identifier_prefix(prefix: impl Into<String>) {
+    LIBRARY_IDENTIFIER_PREFIX.get_or_init(|| prefix.into());
 }
 
 /// Get the language of the SDK.
@@ -30,7 +39,23 @@ pub(crate) fn get_sdk_version() -> &'static str {
 /// and wire-visible metadata.
 /// Note that `set_sdk_language` must be called before this for it to have an effect.
 pub(crate) fn get_library_identifier() -> String {
-    format!("foxglove-sdk-{}/{}", get_sdk_language(), get_sdk_version())
+    format_library_identifier(
+        LIBRARY_IDENTIFIER_PREFIX.get().map(String::as_str),
+        get_sdk_language(),
+        get_sdk_version(),
+    )
+}
+
+fn format_library_identifier(
+    prefix: Option<&str>,
+    sdk_language: &str,
+    sdk_version: &str,
+) -> String {
+    let sdk_identifier = format!("foxglove-sdk-{sdk_language}/{sdk_version}");
+    match prefix {
+        Some(prefix) if !prefix.is_empty() => format!("{prefix} {sdk_identifier}"),
+        _ => sdk_identifier,
+    }
 }
 
 #[cfg(test)]
@@ -49,5 +74,16 @@ mod tests {
         );
         assert!(!library_identifier.contains("/v"));
         assert!(!library_identifier.contains("mcap-rust/"));
+    }
+
+    #[test]
+    fn library_identifier_prefix_is_prepended() {
+        let library_identifier =
+            format_library_identifier(Some("foxglove-bridge/1.2.3"), "cpp", "0.25.2");
+
+        assert_eq!(
+            library_identifier,
+            "foxglove-bridge/1.2.3 foxglove-sdk-cpp/0.25.2"
+        );
     }
 }

--- a/rust/foxglove/src/library_version.rs
+++ b/rust/foxglove/src/library_version.rs
@@ -1,5 +1,5 @@
 //! Provides an identifier for the library used as a log source.
-use std::sync::{LazyLock, OnceLock};
+use std::sync::{LazyLock, OnceLock, RwLock};
 
 static COMPILED_SDK_LANGUAGE: LazyLock<String> = LazyLock::new(|| {
     option_env!("FOXGLOVE_SDK_LANGUAGE")
@@ -8,7 +8,8 @@ static COMPILED_SDK_LANGUAGE: LazyLock<String> = LazyLock::new(|| {
 });
 
 static CELL: OnceLock<&'static str> = OnceLock::new();
-static LIBRARY_IDENTIFIER_PREFIX: OnceLock<String> = OnceLock::new();
+static LIBRARY_IDENTIFIER_PREFIX: LazyLock<RwLock<Option<String>>> =
+    LazyLock::new(|| RwLock::new(None));
 
 /// Sets the language of the SDK. This should be called as soon as possible by an implementation,
 /// otherwise the compiled language will be used when reporting the library version.
@@ -19,11 +20,13 @@ pub fn set_sdk_language(language: &'static str) {
 /// Sets a product token to prepend to this library's identifier.
 ///
 /// This should be called as soon as possible by wrappers that identify a product built on top of
-/// the SDK.
-///
-/// Only the first call to this function has an effect.
+/// the SDK. Calling this function updates the token used for subsequently generated identifiers.
 pub fn set_library_identifier_prefix(prefix: impl Into<String>) {
-    LIBRARY_IDENTIFIER_PREFIX.get_or_init(|| prefix.into());
+    let prefix = prefix.into();
+    let prefix = (!prefix.is_empty()).then_some(prefix);
+    *LIBRARY_IDENTIFIER_PREFIX
+        .write()
+        .expect("library identifier prefix lock poisoned") = prefix;
 }
 
 /// Get the language of the SDK.
@@ -41,11 +44,10 @@ pub(crate) fn get_sdk_version() -> &'static str {
 /// and wire-visible metadata.
 /// Note that `set_sdk_language` must be called before this for it to have an effect.
 pub(crate) fn get_library_identifier() -> String {
-    format_library_identifier(
-        LIBRARY_IDENTIFIER_PREFIX.get().map(String::as_str),
-        get_sdk_language(),
-        get_sdk_version(),
-    )
+    let prefix = LIBRARY_IDENTIFIER_PREFIX
+        .read()
+        .expect("library identifier prefix lock poisoned");
+    format_library_identifier(prefix.as_deref(), get_sdk_language(), get_sdk_version())
 }
 
 fn format_library_identifier(

--- a/rust/foxglove/src/library_version.rs
+++ b/rust/foxglove/src/library_version.rs
@@ -20,6 +20,8 @@ pub fn set_sdk_language(language: &'static str) {
 ///
 /// This should be called as soon as possible by wrappers that identify a product built on top of
 /// the SDK.
+///
+/// Only the first call to this function has an effect.
 pub fn set_library_identifier_prefix(prefix: impl Into<String>) {
     LIBRARY_IDENTIFIER_PREFIX.get_or_init(|| prefix.into());
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

ROS bridge connections now identify themselves as `foxglove-bridge/<version>` before the underlying C++ SDK token in library headers.

### Docs

None.

### Description

ROS bridge currently reaches the SDK through the C++ wrapper, so `fg-library` metadata and remote-access API `User-Agent` values look identical to vanilla C++ SDK usage. This adds an internal library identifier prefix hook and has `foxglove_bridge` set `foxglove-bridge/<bridge version>` during node startup, preserving the existing SDK token afterward for SDK-version analytics. The prefix is mutable so wrappers can update the product token used by subsequently generated identifiers.

Validation run:
- `cargo fmt --package foxglove --package foxglove_c`
- `cargo build -p foxglove_c`
- `cargo test -p foxglove --features full library_version`
- `cargo test -p foxglove --no-default-features library_version`
- `cargo test -p foxglove_c`
- `cargo check --features full`
- `cargo clippy --no-deps --tests --features full -- -D warnings`
- `cargo test -p foxglove --features full`
- `cargo test -p foxglove --no-default-features`
- `make lint-fix` and `make lint` from `cpp/`
- `make build` and `make test` from `cpp/`
- Review follow-up: `cargo fmt --package foxglove --package foxglove_c && cargo test -p foxglove --features full library_version && cargo test -p foxglove_c`
- Mutable-prefix follow-up: `cargo fmt --package foxglove --package foxglove_c && cargo test -p foxglove --features full library_version && cargo test -p foxglove_c`

Environment-blocked checks:
- Root Docker-backed C++ targets and ROS Docker build could not run because Docker is not installed in this VM.
- Local ROS build could not run because `colcon` and local ROS distro setups are not installed.

Reviewer verification:
- [x] In a ROS build environment, run `make FOXGLOVE_CPP_SDK_DIR=/sdk/cpp/dist docker-build-humble && make docker-test-humble` and confirm the smoke test passes with `serverInfo.metadata["fg-library"]` starting with `foxglove-bridge/` and including `foxglove-sdk-cpp/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6237b28a-9aeb-4c02-aa70-6ca4a7ab1e70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6237b28a-9aeb-4c02-aa70-6ca4a7ab1e70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

