### PR TITLE
bump sockjs/uuid 9.0.1 -> 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "esbuild": "0.28.1",
     "minimatch": "^10.2.3",
     "serialize-javascript": "^7.0.5",
-    "sockjs/uuid": "^9.0.1"
+    "sockjs/uuid": "^11.1.1"
   },
   "workspaces": [
     "typescript/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10458,12 +10458,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Bump the override for sockjs/uuid for GHSA-w5hq-g745-h8pq.