### PR TITLE
bridge: Always initialize SDK logging

### DIFF
--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -147,6 +147,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   if (debug) {
     foxglove::setLogLevel(foxglove::LogLevel::Debug);
     this->get_logger().set_level(rclcpp::Logger::Level::Debug);
+  } else {
+    foxglove::setLogLevel(foxglove::LogLevel::Info);
   }
 
   _serverContext = foxglove::Context::create();


### PR DESCRIPTION
### Changelog
- Fixed a bug where the bridge would not initialize SDK logging unless debug:=true

### Docs
None

### Description
The bridge was only initializing SDK logging when debug:=true. It should
always initialize logging at the default level (info).

### Links
Fixes: FLE-625