### PR TITLE
api_client: Log more error details

### DIFF
--- a/rust/foxglove/src/api_client/client.rs
+++ b/rust/foxglove/src/api_client/client.rs
@@ -12,6 +12,22 @@ const DEFAULT_API_URL: &str = "https://api.foxglove.dev";
 
 const MAX_ERROR_RESPONSE_LEN: u64 = 16_384;
 
+/// Renders an error followed by its `source()` chain, joined with ": ".
+///
+/// `reqwest::Error`'s own `Display` omits the underlying cause (the transport/IO error), so
+/// logging it directly hides why a request failed. Walking the chain surfaces the root cause
+/// (e.g. DNS resolution or socket creation failures).
+fn format_source_chain(err: &dyn std::error::Error) -> String {
+    let mut out = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        out.push_str(": ");
+        out.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    out
+}
+
 #[derive(Clone)]
 pub(crate) struct DeviceToken(String);
 
@@ -28,10 +44,10 @@ impl DeviceToken {
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub(crate) enum RequestError {
-    #[error("failed to send request: {0}")]
+    #[error("failed to send request: {}", format_source_chain(.0))]
     SendRequest(#[source] reqwest::Error),
 
-    #[error("failed to load response bytes: {0}")]
+    #[error("failed to load response bytes: {}", format_source_chain(.0))]
     LoadResponseBytes(#[source] reqwest::Error),
 
     #[error("received error response {status}: {error:?}")]
@@ -64,7 +80,7 @@ pub(crate) enum FoxgloveApiClientError {
     #[error(transparent)]
     Request(#[from] RequestError),
 
-    #[error("failed to build client: {0}")]
+    #[error("failed to build client: {}", format_source_chain(.0))]
     BuildClient(#[from] reqwest::Error),
 }
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Today we just log `reqwest::Error` with its `Display` impl, which doesn't
give us enough information to troubleshoot failures. It looks like
"error sending request for url (…)", with no further information.

This change updates the API client to log the source chain, using
`std::error::Error::source()`.

Before:
```
[2026-06-24T19:33:35Z WARN  foxglove::remote_access::connection] failed to initialize device context; retrying error=API error: failed to send request: error sending request for url (https://api.foxglove.pretty/internal/platform/v1/device-info)
```

After:
```
[2026-06-24T19:29:11Z WARN  foxglove::remote_access::connection] failed to initialize device context; retrying error=API error: failed to send request: error sending request for url (https://api.foxglove.pretty/internal/platform/v1/device-info): client error (Connect): dns error: failed to lookup address information: Name or service not known
```

### Links:
Fixes: FLE-626