### PR TITLE
python: Use uv publish to release SDK packages

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -533,17 +533,15 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           path: python/foxglove-sdk
+      - uses: astral-sh/setup-uv@v7
       - run: find python/foxglove-sdk/wheels-*
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: "python/foxglove-sdk/wheels-*/*"
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        with:
-          command: upload
-          working-directory: python/foxglove-sdk
-          args: --non-interactive --skip-existing wheels-*/*
+        run: uv publish --check-url https://pypi.org/simple/ wheels-*/*
+        working-directory: python/foxglove-sdk
 
   test-sdk-examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

The Python SDK release job publishes the Rust-backed `foxglove-sdk` wheels to PyPI using `PyO3/maturin-action` (`maturin upload`). This consolidates the publish front-end on `uv`, which the repo already uses for environment management and the sdist build (`uv build --sdist`), so releases are driven by a single tool.

`maturin` is still required as the build backend that compiles the Rust extension, and the wheel-build matrix (`linux`/`musllinux`/`windows`/`macos`) keeps using `PyO3/maturin-action` because `uv` cannot do manylinux/musllinux/cross-compilation. Only the final publish step changes:

- `maturin upload` -> `uv publish`.
- Added an `astral-sh/setup-uv@v7` step to the `release` job (it previously installed only maturin via the action).

Behavior is preserved:

- Trusted publishing (OIDC) still works via uv's default `--trusted-publishing automatic`; `id-token: write` and the absence of an API token are unchanged.
- `--check-url https://pypi.org/simple/` reproduces the previous `--skip-existing` semantics, so re-running a release skips already-published files instead of failing.

The build-provenance attestation, artifact download, and `wheels-*/*` layout are untouched.

### Testing

- [ ] On a real `sdk/v*` tag (or a test fork against TestPyPI), confirm `uv publish` authenticates via OIDC trusted publishing and uploads all wheels + sdist.
- [ ] Re-run the release job on an already-published version and confirm `--check-url` causes existing files to be skipped rather than erroring.

Fixes: FLE-531