### PR TITLE
Teach ros/Makefile to clean deb build dirs before building debs

### DIFF
--- a/ros/Makefile
+++ b/ros/Makefile
@@ -26,8 +26,18 @@ endif
 all: deps build
 
 .PHONY: clean
-clean:
+clean: clean-deb-bridge clean-deb-msgs
 	rm -rf build dist install log
+
+.PHONY: clean-deb-bridge
+clean-deb-bridge:
+	rm -rf src/foxglove_bridge/debian src/foxglove_bridge/.obj-*
+	rm -f src/ros-*-foxglove-bridge*
+
+.PHONY: clean-deb-msgs
+clean-deb-msgs:
+	rm -rf src/foxglove_msgs/debian src/foxglove_msgs/.obj-*
+	rm -f src/ros-*-foxglove-msgs*
 
 .PHONY: deps
 deps:
@@ -56,22 +66,20 @@ BLOOM_BRIDGE_CMAKE_ARGS := \
 	$(if $(FOXGLOVE_CPP_SDK_DIR),-DFETCHCONTENT_SOURCE_DIR_FOXGLOVE_SDK=$(FOXGLOVE_CPP_SDK_DIR))
 
 .PHONY: deb-bridge
-deb-bridge:
+deb-bridge: clean-deb-bridge
 	cd src/foxglove_bridge && bloom-generate rosdebian
 	sed -i 's|dh_auto_configure --|dh_auto_configure -- $(BLOOM_BRIDGE_CMAKE_ARGS)|' \
 		src/foxglove_bridge/debian/rules
 	cd src/foxglove_bridge && fakeroot debian/rules binary
 	mkdir -p dist && mv src/ros-*-foxglove-bridge*.deb dist/
-	rm -rf src/foxglove_bridge/debian src/foxglove_bridge/.obj-*
-	rm -f src/ros-*-foxglove-bridge*
+	$(MAKE) clean-deb-bridge
 
 .PHONY: deb-msgs
-deb-msgs:
+deb-msgs: clean-deb-msgs
 	cd src/foxglove_msgs && bloom-generate rosdebian
 	cd src/foxglove_msgs && fakeroot debian/rules binary
 	mkdir -p dist && mv src/ros-*-foxglove-msgs*.deb dist/
-	rm -rf src/foxglove_msgs/debian src/foxglove_msgs/.obj-*
-	rm -f src/ros-*-foxglove-msgs*
+	$(MAKE) clean-deb-msgs
 
 .PHONY: deb
 deb: deb-bridge deb-msgs

--- a/ros/Makefile
+++ b/ros/Makefile
@@ -25,19 +25,27 @@ endif
 .PHONY: all
 all: deps build
 
+define clean_deb_bridge =
+rm -rf src/foxglove_bridge/debian src/foxglove_bridge/.obj-*
+rm -f src/ros-*-foxglove-bridge*
+endef
+
+define clean_deb_msgs =
+rm -rf src/foxglove_msgs/debian src/foxglove_msgs/.obj-*
+rm -f src/ros-*-foxglove-msgs*
+endef
+
 .PHONY: clean
 clean: clean-deb-bridge clean-deb-msgs
 	rm -rf build dist install log
 
 .PHONY: clean-deb-bridge
 clean-deb-bridge:
-	rm -rf src/foxglove_bridge/debian src/foxglove_bridge/.obj-*
-	rm -f src/ros-*-foxglove-bridge*
+	$(clean_deb_bridge)
 
 .PHONY: clean-deb-msgs
 clean-deb-msgs:
-	rm -rf src/foxglove_msgs/debian src/foxglove_msgs/.obj-*
-	rm -f src/ros-*-foxglove-msgs*
+	$(clean_deb_msgs)
 
 .PHONY: deps
 deps:
@@ -72,14 +80,14 @@ deb-bridge: clean-deb-bridge
 		src/foxglove_bridge/debian/rules
 	cd src/foxglove_bridge && fakeroot debian/rules binary
 	mkdir -p dist && mv src/ros-*-foxglove-bridge*.deb dist/
-	$(MAKE) clean-deb-bridge
+	$(clean_deb_bridge)
 
 .PHONY: deb-msgs
 deb-msgs: clean-deb-msgs
 	cd src/foxglove_msgs && bloom-generate rosdebian
 	cd src/foxglove_msgs && fakeroot debian/rules binary
 	mkdir -p dist && mv src/ros-*-foxglove-msgs*.deb dist/
-	$(MAKE) clean-deb-msgs
+	$(clean_deb_msgs)
 
 .PHONY: deb
 deb: deb-bridge deb-msgs


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
When building debs, the ros/Makefile cleans the build dirs after the
build, but only on success. Which means it should also proactively clean
them before attempting to build, in case the previous build was a
failure. This change also updates the clean target to cover these
directories, for good measure.