### PR TITLE
ros: Release version 3.4.2

### DIFF
--- a/ros/src/foxglove_bridge/CHANGELOG.rst
+++ b/ros/src/foxglove_bridge/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package foxglove_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.4.2 (2026-06-24)
+------------------
+* Fix a bug where the bridge would not initialize SDK logging unless ``debug:=true``
+* ROS bridge connections now identify themselves as ``foxglove-bridge/<version>`` in library headers
+* Update Foxglove SDK version to 0.25.3
+
 3.4.1 (2026-06-01)
 ------------------
 * Fix an issue with video publication over remote access for certain formats and encoders

--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -9,7 +9,7 @@ if(POLICY CMP0024)
   set(CMAKE_POLICY_DEFAULT_CMP0024 NEW)
 endif()
 
-project(foxglove_bridge LANGUAGES CXX VERSION 3.4.1)
+project(foxglove_bridge LANGUAGES CXX VERSION 3.4.2)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -89,14 +89,14 @@ endif()
 # to point at a `make build-cpp-dist`-produced `cpp/dist` tree — the
 # ros/Makefile's FOXGLOVE_CPP_SDK_DIR variable does this for you (see
 # ros/README.md).
-set(FOXGLOVE_SDK_VERSION "0.25.1")
+set(FOXGLOVE_SDK_VERSION "0.25.3")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   set(FOXGLOVE_SDK_PLATFORM "aarch64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "c70e35c78f0e37f3ba8d0251cd31f353bb10b1fd106200dc6c5f409ed4df1918")
+  set(FOXGLOVE_SDK_SHA "c2223dcb29b0534b31cc9ed1a51fec93863c102de5a0a1fa749f70f21170fcd9")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(FOXGLOVE_SDK_PLATFORM "x86_64-unknown-linux-gnu")
-  set(FOXGLOVE_SDK_SHA "0b9d348df3a8e98d2c2cee2360cc9f52e83bb3445044debd771d1b46dc358be4")
+  set(FOXGLOVE_SDK_SHA "d48b53f142e9d91a497bde63c030b0120f376be569a4315decc034da019e5aa7")
 else()
   message(FATAL_ERROR "Unsupported platform/architecture combination: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
 endif()

--- a/ros/src/foxglove_bridge/package.xml
+++ b/ros/src/foxglove_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>foxglove_bridge</name>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
     <description>ROS Foxglove Bridge</description>
     <license>MIT</license>
     <url type="website">https://github.com/foxglove/foxglove-sdk</url>

--- a/ros/src/foxglove_msgs/CHANGELOG.rst
+++ b/ros/src/foxglove_msgs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package foxglove_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.4.2 (2026-06-24)
+------------------
+* Version bump for foxglove_bridge 3.4.2 release
+
 3.4.1 (2026-06-01)
 ------------------
 * Version bump for foxglove_bridge 3.4.1 release

--- a/ros/src/foxglove_msgs/package.xml
+++ b/ros/src/foxglove_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>foxglove_msgs</name>
-  <version>3.4.1</version>
+  <version>3.4.2</version>
   <description>
     foxglove_msgs provides visualization messages that are supported by Foxglove.
   </description>


### PR DESCRIPTION
### Changelog
foxglove_bridge:
* Fix a bug where the bridge would not initialize SDK logging unless debug:=true
* ROS bridge connections now identify themselves as foxglove-bridge/<version> in library headers
* Updated Foxglove SDK to version 0.25.3

### Docs
None

### Description
Update foxglove_bridge and foxglove_msgs to 3.4.2, and bump the bundled
Foxglove SDK to v0.25.3.