### PR TITLE
remote_access: Drop oversized data-track messages (FLE-592)

### DIFF
--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -42,7 +42,7 @@ use crate::{
 
 type Result<T> = std::result::Result<T, Box<RemoteAccessError>>;
 
-use super::session::DEFAULT_MESSAGE_BACKLOG_SIZE;
+use super::session::{DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE, DEFAULT_MESSAGE_BACKLOG_SIZE};
 
 /// The status of the remote access gateway connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -99,6 +99,7 @@ pub(super) struct ConnectionParams {
     pub(super) qos_classifier: Option<Arc<dyn QosClassifier>>,
     pub(super) server_info: Option<HashMap<String, String>>,
     pub(super) message_backlog_size: Option<usize>,
+    pub(super) max_data_track_message_size: Option<usize>,
     pub(super) video_codec_override: Option<VideoCodec>,
     pub(super) context: Weak<Context>,
 }
@@ -136,6 +137,7 @@ pub(super) struct RemoteAccessConnection {
     qos_classifier: Option<Arc<dyn QosClassifier>>,
     server_info: Option<HashMap<String, String>>,
     message_backlog_size: Option<usize>,
+    max_data_track_message_size: Option<usize>,
     video_codec_override: Option<VideoCodec>,
     context: Weak<Context>,
     cancellation_token: CancellationToken,
@@ -167,6 +169,7 @@ impl RemoteAccessConnection {
             qos_classifier: params.qos_classifier,
             server_info: params.server_info,
             message_backlog_size: params.message_backlog_size,
+            max_data_track_message_size: params.max_data_track_message_size,
             video_codec_override: params.video_codec_override,
             context: params.context,
             cancellation_token: CancellationToken::new(),
@@ -321,6 +324,9 @@ impl RemoteAccessConnection {
             message_backlog_size: self
                 .message_backlog_size
                 .unwrap_or(DEFAULT_MESSAGE_BACKLOG_SIZE),
+            max_data_track_message_size: self
+                .max_data_track_message_size
+                .unwrap_or(DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE),
             video_codec_override: self.video_codec_override,
             services: self.services.clone(),
             connection_graph: self.connection_graph.clone(),

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -364,9 +364,9 @@ impl Gateway {
     /// warning, rather than allowed to monopolize the shared data channel and
     /// starve other channels.
     ///
-    /// The limit must be at least one transport packet (16,000 bytes); a smaller
-    /// limit would drop messages that already fit in a single packet, and
-    /// [`start`](Self::start) rejects it. By default, the limit is 100 KiB.
+    /// The limit must be at least 1200 bytes (one WebRTC data-channel packet);
+    /// [`start`](Self::start) rejects anything smaller. By default, the limit is
+    /// 100 KiB.
     pub fn max_data_track_message_size(mut self, size: usize) -> Self {
         self.max_data_track_message_size = Some(size);
         self
@@ -547,7 +547,7 @@ impl Gateway {
             if size < MIN_DATA_TRACK_MESSAGE_SIZE {
                 return Err(FoxgloveError::ConfigurationError(format!(
                     "max_data_track_message_size ({size} bytes) is below the minimum of \
-                     {MIN_DATA_TRACK_MESSAGE_SIZE} bytes (one transport packet)."
+                     {MIN_DATA_TRACK_MESSAGE_SIZE} bytes (one data-channel packet)."
                 )));
             }
         }

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -644,8 +644,8 @@ mod tests {
 
     #[test]
     fn max_data_track_message_size_below_minimum_rejected() {
-        // A limit smaller than one transport packet is a misconfiguration and
-        // must be rejected at startup.
+        // A limit below the minimum is a misconfiguration and must be rejected
+        // at startup.
         let result = Gateway::new()
             .device_token("test-token")
             .max_data_track_message_size(MIN_DATA_TRACK_MESSAGE_SIZE - 1)

--- a/rust/foxglove/src/remote_access/gateway.rs
+++ b/rust/foxglove/src/remote_access/gateway.rs
@@ -19,6 +19,7 @@ use crate::{
 use super::qos::{QosClassifier, QosClassifierFn, QosProfile};
 
 use super::connection::{ConnectionParams, ConnectionStatus, RemoteAccessConnection};
+use super::session::MIN_DATA_TRACK_MESSAGE_SIZE;
 use super::{Capability, Listener};
 use crate::remote_common::parameters::ParameterHandler;
 
@@ -130,6 +131,7 @@ impl GatewayHandle {
             qos_classifier: None,
             server_info: None,
             message_backlog_size: None,
+            max_data_track_message_size: None,
             video_codec_override: None,
             context: std::sync::Weak::new(),
         };
@@ -193,6 +195,7 @@ pub struct Gateway {
     qos_classifier: Option<Arc<dyn QosClassifier>>,
     server_info: Option<HashMap<String, String>>,
     message_backlog_size: Option<usize>,
+    max_data_track_message_size: Option<usize>,
     context: std::sync::Weak<Context>,
 }
 
@@ -214,6 +217,7 @@ impl Default for Gateway {
             qos_classifier: None,
             server_info: None,
             message_backlog_size: None,
+            max_data_track_message_size: None,
             context: Arc::downgrade(&Context::get_default()),
         }
     }
@@ -240,6 +244,10 @@ impl std::fmt::Debug for Gateway {
             .field("has_qos_classifier", &self.qos_classifier.is_some())
             .field("server_info", &self.server_info)
             .field("message_backlog_size", &self.message_backlog_size)
+            .field(
+                "max_data_track_message_size",
+                &self.max_data_track_message_size,
+            )
             .field("has_context", &(self.context.strong_count() > 0));
         dbg.finish()
     }
@@ -348,6 +356,19 @@ impl Gateway {
     /// By default, each participant gets a queue of 1024 messages.
     pub fn message_backlog_size(mut self, size: usize) -> Self {
         self.message_backlog_size = Some(size);
+        self
+    }
+
+    /// Sets the maximum size in bytes of a single message published to a lossy
+    /// channel's data track. Larger messages are dropped, with a throttled
+    /// warning, rather than allowed to monopolize the shared data channel and
+    /// starve other channels.
+    ///
+    /// The limit must be at least one transport packet (16,000 bytes); a smaller
+    /// limit would drop messages that already fit in a single packet, and
+    /// [`start`](Self::start) rejects it. By default, the limit is 100 KiB.
+    pub fn max_data_track_message_size(mut self, size: usize) -> Self {
+        self.max_data_track_message_size = Some(size);
         self
     }
 
@@ -522,6 +543,14 @@ impl Gateway {
                     .to_string(),
             ));
         }
+        if let Some(size) = self.max_data_track_message_size {
+            if size < MIN_DATA_TRACK_MESSAGE_SIZE {
+                return Err(FoxgloveError::ConfigurationError(format!(
+                    "max_data_track_message_size ({size} bytes) is below the minimum of \
+                     {MIN_DATA_TRACK_MESSAGE_SIZE} bytes (one transport packet)."
+                )));
+            }
+        }
         let runtime = self.runtime.unwrap_or_else(get_runtime_handle);
         let services = Arc::new(parking_lot::RwLock::new(ServiceMap::from_iter(
             self.services.into_values(),
@@ -541,6 +570,7 @@ impl Gateway {
             qos_classifier: self.qos_classifier,
             server_info: self.server_info,
             message_backlog_size: self.message_backlog_size,
+            max_data_track_message_size: self.max_data_track_message_size,
             video_codec_override,
             context: self.context,
         };
@@ -595,6 +625,30 @@ mod tests {
         let result = Gateway::new()
             .device_token("test-token")
             .capabilities([Capability::Assets])
+            .start();
+        assert!(matches!(result, Err(FoxgloveError::ConfigurationError(_))));
+    }
+
+    #[test]
+    fn max_data_track_message_size_builder() {
+        // Unset by default; the default value is applied downstream when building
+        // SessionParams (see DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE).
+        assert_eq!(Gateway::new().max_data_track_message_size, None);
+        assert_eq!(
+            Gateway::new()
+                .max_data_track_message_size(64 * 1024)
+                .max_data_track_message_size,
+            Some(64 * 1024)
+        );
+    }
+
+    #[test]
+    fn max_data_track_message_size_below_minimum_rejected() {
+        // A limit smaller than one transport packet is a misconfiguration and
+        // must be rejected at startup.
+        let result = Gateway::new()
+            .device_token("test-token")
+            .max_data_track_message_size(MIN_DATA_TRACK_MESSAGE_SIZE - 1)
             .start();
         assert!(matches!(result, Err(FoxgloveError::ConfigurationError(_))));
     }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -87,11 +87,12 @@ pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 /// cannot monopolize the shared data channel and starve the others (see FLE-592).
 pub(super) const DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE: usize = 100 * 1024;
 
-/// Minimum configurable data-track message limit, in bytes. Below one packet
-/// (livekit-datatrack's 16,000-byte max packet size, its `TRANSPORT_MTU`) the
-/// limit would shed messages that already fit in a single packet, which is never
-/// the intent.
-pub(super) const MIN_DATA_TRACK_MESSAGE_SIZE: usize = 16_000;
+/// Minimum configurable data-track message limit, in bytes. ~1200 bytes fits in
+/// a single WebRTC data-channel packet — LiveKit's recommended maximum frame
+/// size, above which a frame is segmented and, since delivery is unreliable, lost
+/// whole if any segment is lost. A smaller limit only sheds more aggressively
+/// without improving reliability.
+pub(super) const MIN_DATA_TRACK_MESSAGE_SIZE: usize = 1200;
 
 /// The default codec for published video tracks.
 ///

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -87,9 +87,10 @@ pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 /// cannot monopolize the shared data channel and starve the others (see FLE-592).
 pub(super) const DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE: usize = 100 * 1024;
 
-/// Minimum configurable data-track message limit, in bytes. Below one transport
-/// packet (livekit-datatrack's 16,000-byte MTU) the limit would shed messages
-/// that already fit in a single packet, which is never the intent.
+/// Minimum configurable data-track message limit, in bytes. Below one packet
+/// (livekit-datatrack's 16,000-byte max packet size, its `TRANSPORT_MTU`) the
+/// limit would shed messages that already fit in a single packet, which is never
+/// the intent.
 pub(super) const MIN_DATA_TRACK_MESSAGE_SIZE: usize = 16_000;
 
 /// The default codec for published video tracks.

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -87,12 +87,15 @@ pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 /// cannot monopolize the shared data channel and starve the others (see FLE-592).
 pub(super) const DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE: usize = 100 * 1024;
 
-/// Minimum configurable data-track message limit, in bytes. ~1200 bytes fits in
-/// a single WebRTC data-channel packet — LiveKit's recommended maximum frame
-/// size, above which a frame is segmented and, since delivery is unreliable, lost
-/// whole if any segment is lost. A smaller limit only sheds more aggressively
-/// without improving reliability.
+/// Minimum configurable data-track message limit, in bytes. A message of ~1200
+/// bytes fits in a single WebRTC data-channel packet — LiveKit's recommended
+/// maximum frame size, above which a frame is segmented and, since delivery is
+/// unreliable, lost whole if any segment is lost. A smaller limit only sheds
+/// more aggressively without improving reliability.
 pub(super) const MIN_DATA_TRACK_MESSAGE_SIZE: usize = 1200;
+
+// The default must satisfy the configurable minimum.
+const _: () = assert!(DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE >= MIN_DATA_TRACK_MESSAGE_SIZE);
 
 /// The default codec for published video tracks.
 ///

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -82,6 +82,16 @@ const ROOM_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 
+/// Default per-message size limit for lossy data-track channels, in bytes.
+/// Messages larger than this are dropped before publish so one oversized channel
+/// cannot monopolize the shared data channel and starve the others (see FLE-592).
+pub(super) const DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE: usize = 100 * 1024;
+
+/// Minimum configurable data-track message limit, in bytes. Below one transport
+/// packet (livekit-datatrack's 16,000-byte MTU) the limit would shed messages
+/// that already fit in a single packet, which is never the intent.
+pub(super) const MIN_DATA_TRACK_MESSAGE_SIZE: usize = 16_000;
+
 /// The default codec for published video tracks.
 ///
 /// We prefer H.264 so that the libwebrtc nvenc encoder (H.264-only) can be used on Linux
@@ -211,6 +221,8 @@ pub(super) struct RemoteAccessSession {
     /// If set (via the `FOXGLOVE_VIDEO_CODEC` environment variable), overrides the per-OS
     /// default codec for published video tracks.
     video_codec_override: Option<VideoCodec>,
+    /// Per-message size limit for lossy data-track channels; larger messages are dropped.
+    max_data_track_message_size: usize,
 }
 
 impl Sink for RemoteAccessSession {
@@ -388,6 +400,7 @@ pub(super) struct SessionParams {
     pub(super) runtime: Handle,
     pub(super) cancellation_token: CancellationToken,
     pub(super) message_backlog_size: usize,
+    pub(super) max_data_track_message_size: usize,
     pub(super) services: Arc<parking_lot::RwLock<ServiceMap>>,
     pub(super) connection_graph: Arc<parking_lot::Mutex<ConnectionGraph>>,
     pub(super) remote_access_session_id: Option<String>,
@@ -429,6 +442,7 @@ impl RemoteAccessSession {
             participant_registry,
             device_wait_for_viewer: params.device_wait_for_viewer,
             video_codec_override: params.video_codec_override,
+            max_data_track_message_size: params.max_data_track_message_size,
         })
     }
 
@@ -2302,6 +2316,7 @@ impl RemoteAccessSession {
                 self.room.local_participant(),
                 *channel_id,
                 self.cancellation_token.clone(),
+                self.max_data_track_message_size,
             );
             self.channel_registry
                 .write()

--- a/rust/foxglove/src/remote_access/session/data_track.rs
+++ b/rust/foxglove/src/remote_access/session/data_track.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -6,7 +6,7 @@ use livekit::prelude::{DataTrackFrame, LocalDataTrack, LocalParticipant, Publish
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::{ChannelId, Metadata};
 
@@ -26,6 +26,13 @@ pub(crate) struct DataTrack {
     sequence: AtomicU32,
     /// Throttles debug log messages when data track messages are dropped.
     drop_throttler: parking_lot::Mutex<crate::throttler::Throttler>,
+    /// Per-message size limit in bytes; messages larger than this are dropped
+    /// before publish. See `DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE` for the rationale.
+    max_message_size: usize,
+    /// Count of messages dropped for exceeding [`max_message_size`](Self::max_message_size).
+    oversized_dropped: AtomicU64,
+    /// Throttles warnings emitted when oversized messages are dropped.
+    oversized_throttler: parking_lot::Mutex<crate::throttler::Throttler>,
 }
 
 impl DataTrack {
@@ -43,7 +50,12 @@ impl DataTrack {
         local_participant: LocalParticipant,
         channel_id: ChannelId,
         session_cancel: CancellationToken,
+        max_message_size: usize,
     ) -> Self {
+        debug_assert!(
+            max_message_size >= super::MIN_DATA_TRACK_MESSAGE_SIZE,
+            "data-track message size limit must be at least one transport packet"
+        );
         let track = Arc::new(OnceLock::new());
         let track_clone = Arc::clone(&track);
         let close = CancellationToken::new();
@@ -99,12 +111,32 @@ impl DataTrack {
             drop_throttler: parking_lot::Mutex::new(crate::throttler::Throttler::new(
                 Duration::from_secs(30),
             )),
+            max_message_size,
+            oversized_dropped: AtomicU64::new(0),
+            oversized_throttler: parking_lot::Mutex::new(crate::throttler::Throttler::new(
+                Duration::from_secs(30),
+            )),
         }
     }
 
     /// Build a sequenced frame and push it to the data track.
-    /// Drops with a throttled debug log if the track is not ready or full.
+    ///
+    /// Drops the message (with a throttled warning) if it exceeds
+    /// [`max_message_size`](Self::max_message_size), or with a throttled debug
+    /// log if the track is not ready or full.
     pub fn log(&self, channel_id: ChannelId, msg: &[u8], metadata: &Metadata) {
+        if msg.len() > self.max_message_size {
+            let dropped = self.oversized_dropped.fetch_add(1, Ordering::Relaxed) + 1;
+            if self.oversized_throttler.lock().try_acquire() {
+                warn!(
+                    "dropping {}-byte message on channel {channel_id:?}: exceeds \
+                     data-track limit of {} bytes ({dropped} dropped on this channel so far)",
+                    msg.len(),
+                    self.max_message_size
+                );
+            }
+            return;
+        }
         let Some(track) = self.track.get() else {
             if self.drop_throttler.lock().try_acquire() {
                 debug!("data track not ready, dropping message for channel {channel_id:?}");
@@ -128,6 +160,12 @@ impl DataTrack {
         }
     }
 
+    /// Number of messages dropped for exceeding [`max_message_size`](Self::max_message_size).
+    #[cfg(test)]
+    pub fn oversized_dropped(&self) -> u64 {
+        self.oversized_dropped.load(Ordering::Relaxed)
+    }
+
     /// Close the data track: stop retrying, wait for any in-flight publish to
     /// complete, then unpublish the track if it was successfully published.
     pub async fn close(&mut self) {
@@ -145,5 +183,47 @@ impl DataTrack {
 impl Drop for DataTrack {
     fn drop(&mut self) {
         self.close.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl DataTrack {
+        /// Builds a `DataTrack` with no live LiveKit track, so the size gate in
+        /// [`log`](Self::log) can be exercised without a room or participant.
+        fn for_test(max_message_size: usize) -> Self {
+            Self {
+                track: Arc::new(OnceLock::new()),
+                close: CancellationToken::new(),
+                task: None,
+                sequence: AtomicU32::new(0),
+                drop_throttler: parking_lot::Mutex::new(crate::throttler::Throttler::new(
+                    Duration::from_secs(30),
+                )),
+                max_message_size,
+                oversized_dropped: AtomicU64::new(0),
+                oversized_throttler: parking_lot::Mutex::new(crate::throttler::Throttler::new(
+                    Duration::from_secs(30),
+                )),
+            }
+        }
+    }
+
+    #[test]
+    fn drops_oversized_message_and_counts_it() {
+        let track = DataTrack::for_test(16);
+        let channel_id = ChannelId::new(1);
+        let metadata = Metadata::default();
+
+        // An over-limit message is dropped and counted.
+        track.log(channel_id, &[0u8; 17], &metadata);
+        assert_eq!(track.oversized_dropped(), 1);
+
+        // An at-limit message takes the normal path (the track is not ready, so
+        // it is dropped downstream) and does not touch the oversized counter.
+        track.log(channel_id, &[0u8; 16], &metadata);
+        assert_eq!(track.oversized_dropped(), 1);
     }
 }

--- a/rust/foxglove/src/remote_access/session/data_track.rs
+++ b/rust/foxglove/src/remote_access/session/data_track.rs
@@ -52,10 +52,6 @@ impl DataTrack {
         session_cancel: CancellationToken,
         max_message_size: usize,
     ) -> Self {
-        debug_assert!(
-            max_message_size >= super::MIN_DATA_TRACK_MESSAGE_SIZE,
-            "data-track message size limit must be at least one transport packet"
-        );
         let track = Arc::new(OnceLock::new());
         let track_clone = Arc::clone(&track);
         let close = CancellationToken::new();

--- a/rust/foxglove/src/remote_access/session/data_track.rs
+++ b/rust/foxglove/src/remote_access/session/data_track.rs
@@ -29,7 +29,8 @@ pub(crate) struct DataTrack {
     /// Per-message size limit in bytes; messages larger than this are dropped
     /// before publish. See `DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE` for the rationale.
     max_message_size: usize,
-    /// Count of messages dropped for exceeding [`max_message_size`](Self::max_message_size).
+    /// Oversized messages dropped since the last warning was logged; reset to
+    /// zero each time the throttled warning fires.
     oversized_dropped: AtomicU64,
     /// Throttles warnings emitted when oversized messages are dropped.
     oversized_throttler: parking_lot::Mutex<crate::throttler::Throttler>,
@@ -122,14 +123,16 @@ impl DataTrack {
     /// log if the track is not ready or full.
     pub fn log(&self, channel_id: ChannelId, msg: &[u8], metadata: &Metadata) {
         if msg.len() > self.max_message_size {
-            let dropped = self.oversized_dropped.fetch_add(1, Ordering::Relaxed) + 1;
             if self.oversized_throttler.lock().try_acquire() {
+                let dropped = 1 + self.oversized_dropped.swap(0, Ordering::Relaxed);
                 warn!(
                     "dropping {}-byte message on channel {channel_id:?}: exceeds \
-                     data-track limit of {} bytes ({dropped} dropped on this channel so far)",
+                     data-track limit of {} bytes ({dropped} dropped since last warning)",
                     msg.len(),
                     self.max_message_size
                 );
+            } else {
+                self.oversized_dropped.fetch_add(1, Ordering::Relaxed);
             }
             return;
         }
@@ -156,7 +159,7 @@ impl DataTrack {
         }
     }
 
-    /// Number of messages dropped for exceeding [`max_message_size`](Self::max_message_size).
+    /// Oversized messages dropped since the last warning was logged (test-only).
     #[cfg(test)]
     pub fn oversized_dropped(&self) -> u64 {
         self.oversized_dropped.load(Ordering::Relaxed)
@@ -213,12 +216,13 @@ mod tests {
         let channel_id = ChannelId::new(1);
         let metadata = Metadata::default();
 
-        // An over-limit message is dropped and counted.
+        // The first oversized message fires the throttled warning, which resets
+        // the pending counter, so send a second to leave one pending drop.
+        track.log(channel_id, &[0u8; 17], &metadata);
         track.log(channel_id, &[0u8; 17], &metadata);
         assert_eq!(track.oversized_dropped(), 1);
 
-        // An at-limit message takes the normal path (the track is not ready, so
-        // it is dropped downstream) and does not touch the oversized counter.
+        // An at-limit message takes the normal path and is not counted.
         track.log(channel_id, &[0u8; 16], &metadata);
         assert_eq!(track.oversized_dropped(), 1);
     }

--- a/rust/remote_access_tests/src/test_helpers.rs
+++ b/rust/remote_access_tests/src/test_helpers.rs
@@ -867,6 +867,7 @@ pub struct TestGatewayOptions {
     pub capabilities: Vec<foxglove::remote_access::Capability>,
     pub services: Vec<Service>,
     pub qos_classifier: Option<QosClassifierFn>,
+    pub max_data_track_message_size: Option<usize>,
 }
 
 /// A test gateway backed by a mock Foxglove API server and a LiveKit room.
@@ -949,6 +950,9 @@ impl TestGateway {
         }
         if let Some(classifier) = options.qos_classifier {
             gateway = gateway.qos_classifier_fn(classifier);
+        }
+        if let Some(size) = options.max_data_track_message_size {
+            gateway = gateway.max_data_track_message_size(size);
         }
 
         let handle = gateway.start().context("start Gateway")?;

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -138,6 +138,76 @@ async fn livekit_viewer_receives_message_after_subscribe() -> Result<()> {
     Ok(())
 }
 
+/// Test that a message exceeding the configured data-track size limit is dropped
+/// at the gateway, while smaller messages on the same channel are delivered. The
+/// viewer receives the two small payloads and never the oversized one logged
+/// between them, proving the oversized message was shed at publish rather than
+/// merely delayed (FLE-592).
+#[traced_test]
+#[ignore]
+#[tokio::test]
+#[serial(livekit)]
+async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
+    let ctx = foxglove::Context::new();
+    let channel = ctx
+        .channel_builder("/test")
+        .message_encoding("json")
+        .build_raw()
+        .context("create channel")?;
+
+    // Use the minimum allowed limit (one transport packet). Messages larger than
+    // this are dropped before publish; smaller ones flow normally.
+    let limit = 16_000;
+    let gw = TestGateway::start_with_options(
+        &ctx,
+        TestGatewayOptions {
+            max_data_track_message_size: Some(limit),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let mut viewer = ViewerConnection::connect(&gw.room_name, "viewer-1").await?;
+
+    let _server_info = viewer.expect_server_info().await?;
+    let advertise = viewer.expect_advertise().await?;
+    let channel_id = advertise.channels[0].id;
+
+    viewer.subscribe_and_wait(&[channel_id], &channel).await?;
+    let mut ch_reader = viewer.expect_device_channel_data_track(channel_id).await?;
+
+    // Each message is awaited before the next is logged, so LiveKit's own
+    // single-frame send queue never evicts one — any loss is attributable to the
+    // gateway-side size gate.
+
+    // 1. A small message is delivered, proving the channel works.
+    channel.log(b"before");
+    let before = ch_reader.next_message_data().await?;
+    assert_eq!(before.data.as_ref(), b"before");
+
+    // 2. An oversized message logged on its own must be dropped at the gateway
+    //    and never reach the viewer. Nothing else is in flight, so if the gate
+    //    were absent this lone message would be delivered like the others.
+    let oversized = vec![0xAB_u8; limit + 1];
+    channel.log(&oversized);
+    let res = tokio::time::timeout(Duration::from_secs(3), ch_reader.next_message_data()).await;
+    assert!(
+        res.is_err(),
+        "oversized message must be dropped at the gateway, but the viewer \
+         received a frame"
+    );
+
+    // 3. A later small message is delivered, confirming the stream is still
+    //    healthy — the absence above was the drop, not a broken channel.
+    channel.log(b"after");
+    let after = ch_reader.next_message_data().await?;
+    assert_eq!(after.data.as_ref(), b"after");
+    info!("oversized data-track message correctly dropped at the gateway");
+
+    viewer.close().await?;
+    gw.stop().await?;
+    Ok(())
+}
+
 /// Test that messages logged before the viewer subscribes are not delivered.
 #[traced_test]
 #[ignore]

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -155,9 +155,10 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
         .build_raw()
         .context("create channel")?;
 
-    // A representative limit; messages above it are dropped before publish,
-    // smaller ones flow normally.
-    let limit = 16_000;
+    // Use the minimum allowed limit: a message of limit+1 bytes is still small
+    // enough that LiveKit would deliver it if it weren't dropped, so the absence
+    // checked below is attributable to the gateway gate, not LiveKit's own queue.
+    let limit = 1200;
     let gw = TestGateway::start_with_options(
         &ctx,
         TestGatewayOptions {

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -155,8 +155,8 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
         .build_raw()
         .context("create channel")?;
 
-    // Use the minimum allowed limit (one transport packet). Messages larger than
-    // this are dropped before publish; smaller ones flow normally.
+    // A representative limit; messages above it are dropped before publish,
+    // smaller ones flow normally.
     let limit = 16_000;
     let gw = TestGateway::start_with_options(
         &ctx,


### PR DESCRIPTION
### Changelog

Remote access gateways now drop lossy data-track messages larger than a configurable limit (default 100 KiB), with a throttled warning, so one high-bandwidth channel can no longer starve the others; configure via `Gateway::max_data_track_message_size`.

### Docs

None — the new builder method is documented via rustdoc.

### Description

When streaming over remote access, subscribing a single high-bandwidth lossy channel (e.g. point clouds at ~1.25 MiB/message) could starve every other data channel while delivering nothing itself. All of a participant's data tracks multiplex onto one unreliable LiveKit `_data_track` channel fronted by a one-frame, drop-oldest send queue, so a stream of oversized frames monopolizes that single slot. The data-track stack is built for small, frequent messages; a multi-megabyte point cloud violates that assumption (and the same architecture is present in the latest LiveKit, so upgrading the dependency wouldn't help).

This change sheds the problem at the source: a configurable per-message size limit (default 100 KiB) on the lossy data-track publish path. Messages above the limit are dropped before publish, with a throttled warning that reports the running per-channel drop count. The limit is set via `Gateway::max_data_track_message_size` and must be at least 1200 bytes (one WebRTC data-channel packet); `start()` rejects smaller values. Reliable channels (which use the control bytestream) are unaffected.

This is the contained gateway-side fix. A viewer-facing drop signal (a versioned control-plane message so the app can surface lossiness, coordinated with FLE-603) is deferred to a follow-up.

Note: this is a default-behavior change — lossy data-track messages over 100 KiB are now dropped by default.

Manual testing — the gateway-side drop behavior is covered by unit and integration tests in this PR; the browser + netem end-to-end path was verified manually:

- [x] **End-to-end starvation check.** Ran `yarn stream-mcap` with `demo.mcap` (netem egress-shaped). `/velodyne_points` (~1.28 MB/msg) was dropped at the 100 KiB default and no longer held up the rest of the stream, with the gateway logging the throttled `dropping … exceeds data-track limit of 102400 bytes` warning. Verified on an earlier commit of this branch; the drop behavior is unchanged since (only the warning's wording was refined to report drops-since-last-warning), and the automated integration test re-ran green on the final code.

Fixes: [FLE-592](https://linear.app/foxglove/issue/FLE-592)
