### PR TITLE
remote_access: Configure max data-track message size from the bridge (FLE-642)

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2854,9 +2854,8 @@ typedef struct foxglove_gateway_options {
    */
   foxglove_video_encoder_backend video_encoder;
   /**
-   * Maximum size, in bytes, of a lossy data-track message. Larger messages are dropped
-   * before publishing so one high-bandwidth channel cannot starve the others. A value of 0
-   * means use the default (102400). Must be at least 1200 (one data-channel packet).
+   * Maximum lossy data-track message size in bytes. A value of 0 means use the default
+   * (102400). Must be at least 1200.
    *
    * New fields are appended last so that adding them preserves the memory offsets of all
    * pre-existing fields.

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2851,11 +2851,17 @@ typedef struct foxglove_gateway_options {
    * Defaults to `FOXGLOVE_VIDEO_ENCODER_BACKEND_AUTO` (0), which lets the SDK choose and
    * honors the `FOXGLOVE_VIDEO_ENCODER` environment variable. Any other value overrides the
    * environment variable.
-   *
-   * This field is last in the struct so that adding it preserves the memory offsets of all
-   * pre-existing fields.
    */
   foxglove_video_encoder_backend video_encoder;
+  /**
+   * Maximum size, in bytes, of a lossy data-track message. Larger messages are dropped
+   * before publishing so one high-bandwidth channel cannot starve the others. A value of 0
+   * means use the default (102400). Must be at least 1200 (one data-channel packet).
+   *
+   * New fields are appended last so that adding them preserves the memory offsets of all
+   * pre-existing fields.
+   */
+  size_t max_data_track_message_size;
 } foxglove_gateway_options;
 #endif
 

--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2856,9 +2856,6 @@ typedef struct foxglove_gateway_options {
   /**
    * Maximum lossy data-track message size in bytes. A value of 0 means use the default
    * (102400). Must be at least 1200.
-   *
-   * New fields are appended last so that adding them preserves the memory offsets of all
-   * pre-existing fields.
    */
   size_t max_data_track_message_size;
 } foxglove_gateway_options;

--- a/c/src/gateway.rs
+++ b/c/src/gateway.rs
@@ -652,9 +652,8 @@ pub struct FoxgloveGatewayOptions<'a> {
     /// environment variable.
     pub video_encoder: FoxgloveVideoEncoderBackend,
 
-    /// Maximum size, in bytes, of a lossy data-track message. Larger messages are dropped
-    /// before publishing so one high-bandwidth channel cannot starve the others. A value of 0
-    /// means use the default (102400). Must be at least 1200 (one data-channel packet).
+    /// Maximum lossy data-track message size in bytes. A value of 0 means use the default
+    /// (102400). Must be at least 1200.
     ///
     /// New fields are appended last so that adding them preserves the memory offsets of all
     /// pre-existing fields.

--- a/c/src/gateway.rs
+++ b/c/src/gateway.rs
@@ -650,10 +650,15 @@ pub struct FoxgloveGatewayOptions<'a> {
     /// Defaults to `FOXGLOVE_VIDEO_ENCODER_BACKEND_AUTO` (0), which lets the SDK choose and
     /// honors the `FOXGLOVE_VIDEO_ENCODER` environment variable. Any other value overrides the
     /// environment variable.
-    ///
-    /// This field is last in the struct so that adding it preserves the memory offsets of all
-    /// pre-existing fields.
     pub video_encoder: FoxgloveVideoEncoderBackend,
+
+    /// Maximum size, in bytes, of a lossy data-track message. Larger messages are dropped
+    /// before publishing so one high-bandwidth channel cannot starve the others. A value of 0
+    /// means use the default (102400). Must be at least 1200 (one data-channel packet).
+    ///
+    /// New fields are appended last so that adding them preserves the memory offsets of all
+    /// pre-existing fields.
+    pub max_data_track_message_size: usize,
 }
 
 // Handle
@@ -817,6 +822,11 @@ unsafe fn do_foxglove_gateway_start(
     // Message backlog size
     if options.message_backlog_size != 0 {
         gateway = gateway.message_backlog_size(options.message_backlog_size);
+    }
+
+    // Max data-track message size
+    if options.max_data_track_message_size != 0 {
+        gateway = gateway.max_data_track_message_size(options.max_data_track_message_size);
     }
 
     // Preferred video encoder backend. Leave `Auto` unset so the

--- a/c/src/gateway.rs
+++ b/c/src/gateway.rs
@@ -654,10 +654,9 @@ pub struct FoxgloveGatewayOptions<'a> {
 
     /// Maximum lossy data-track message size in bytes. A value of 0 means use the default
     /// (102400). Must be at least 1200.
-    ///
-    /// New fields are appended last so that adding them preserves the memory offsets of all
-    /// pre-existing fields.
     pub max_data_track_message_size: usize,
+    // New fields are appended last so that adding them preserves the memory offsets of all
+    // pre-existing fields.
 }
 
 // Handle
@@ -823,7 +822,7 @@ unsafe fn do_foxglove_gateway_start(
         gateway = gateway.message_backlog_size(options.message_backlog_size);
     }
 
-    // Max data-track message size
+    // A value of 0 means "unset" — leave it off so the SDK applies its default.
     if options.max_data_track_message_size != 0 {
         gateway = gateway.max_data_track_message_size(options.max_data_track_message_size);
     }

--- a/cpp/foxglove/include/foxglove/remote_access.hpp
+++ b/cpp/foxglove/include/foxglove/remote_access.hpp
@@ -274,10 +274,17 @@ struct RemoteAccessGatewayOptions {
   ///
   /// Defaults to @ref VideoEncoderBackend::Auto, which lets the SDK choose and honors the
   /// `FOXGLOVE_VIDEO_ENCODER` environment variable.
-  ///
-  /// This field is last in the struct so that adding it preserves the layout of pre-existing
-  /// fields.
   VideoEncoderBackend video_encoder = VideoEncoderBackend::Auto;
+  /// @brief Override the maximum lossy data-track message size.
+  ///
+  /// Lossy data-track messages larger than this many bytes are dropped before publishing, with a
+  /// throttled warning, so one high-bandwidth channel cannot starve the others. Must be at least
+  /// 1200 bytes (one data-channel packet).
+  ///
+  /// By default, the limit is 102400 bytes (100 KiB).
+  ///
+  /// New fields are appended last so that adding them preserves the layout of pre-existing fields.
+  std::optional<size_t> max_data_track_message_size = std::nullopt;
 };
 
 /// @brief A remote access gateway for live visualization and teleop in Foxglove.

--- a/cpp/foxglove/include/foxglove/remote_access.hpp
+++ b/cpp/foxglove/include/foxglove/remote_access.hpp
@@ -282,9 +282,8 @@ struct RemoteAccessGatewayOptions {
   /// 1200 bytes (one data-channel packet).
   ///
   /// By default, the limit is 102400 bytes (100 KiB).
-  ///
-  /// New fields are appended last so that adding them preserves the layout of pre-existing fields.
   std::optional<size_t> max_data_track_message_size = std::nullopt;
+  // New fields are appended last so that adding them preserves the layout of pre-existing fields.
 };
 
 /// @brief A remote access gateway for live visualization and teleop in Foxglove.

--- a/cpp/foxglove/src/remote_access.cpp
+++ b/cpp/foxglove/src/remote_access.cpp
@@ -251,6 +251,7 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
   }
 
   c_options.message_backlog_size = options.message_backlog_size.value_or(0);
+  c_options.max_data_track_message_size = options.max_data_track_message_size.value_or(0);
 
   std::vector<foxglove_key_value> server_info;
   if (options.server_info) {

--- a/ros/src/foxglove_bridge/README.md
+++ b/ros/src/foxglove_bridge/README.md
@@ -138,6 +138,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
 - **remote_access**: Enable the remote access gateway, allowing the bridge to be reached through Foxglove's platform without exposing a port on the device. Requires the bridge to be built with `FOXGLOVE_BRIDGE_REMOTE_ACCESS=ON` (the default for our published Docker images). Defaults to `false`.
 - **device_token**: Foxglove device token used to authenticate with the Foxglove platform when `remote_access` is enabled. If empty, the bridge falls back to the `FOXGLOVE_DEVICE_TOKEN` environment variable.
 - **video_encoder**: Preferred backend for encoding published video tracks when `remote_access` is enabled: one of `auto`, `software`, `hardware`, `nvenc`, `vaapi`, `videotoolbox`. With `auto` (the default) the SDK chooses the backend and honors the `FOXGLOVE_VIDEO_ENCODER` environment variable. If the requested backend is unavailable on the host, the SDK falls back to another compatible encoder.
+- **max_data_track_message_size**: Maximum size, in bytes, of a lossy data-track message sent by the remote access gateway when `remote_access` is enabled. Larger messages are dropped before publishing, with a throttled warning, so one high-bandwidth channel cannot starve the others. Must be at least `1200` (one data-channel packet). Defaults to `102400` (100 KiB).
 
 #### Capabilities
 

--- a/ros/src/foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -38,6 +38,7 @@ constexpr char PARAM_REMOTE_ACCESS[] = "remote_access";
 constexpr char PARAM_DEVICE_TOKEN[] = "device_token";
 constexpr char PARAM_FOXGLOVE_API_URL[] = "foxglove_api_url";
 constexpr char PARAM_VIDEO_ENCODER[] = "video_encoder";
+constexpr char PARAM_MAX_DATA_TRACK_MESSAGE_SIZE[] = "max_data_track_message_size";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
@@ -47,6 +48,7 @@ constexpr int64_t DEFAULT_MAX_QOS_DEPTH = 25;
 constexpr char DEFAULT_SYSINFO_TOPIC[] = "/foxglove_bridge/sysinfo";
 constexpr int64_t DEFAULT_SYSINFO_REFRESH_INTERVAL_MS = 500;
 constexpr int64_t DEFAULT_MESSAGE_BACKLOG_SIZE = 1024;
+constexpr int64_t DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE = 102400;
 
 void declareParameters(rclcpp::Node* node);
 

--- a/ros/src/foxglove_bridge/launch/foxglove_bridge_launch.xml
+++ b/ros/src/foxglove_bridge/launch/foxglove_bridge_launch.xml
@@ -26,6 +26,7 @@
   <arg name="remote_access"                  default="false" />
   <arg name="device_token"                   default="" />
   <arg name="foxglove_api_url"               default="" />
+  <arg name="max_data_track_message_size"    default="102400" />
 
   <node pkg="foxglove_bridge" exec="foxglove_bridge">
     <param name="port"                            value="$(var port)" />
@@ -55,5 +56,6 @@
     <param name="remote_access"                  value="$(var remote_access)" />
     <param name="device_token"                   value="$(var device_token)" />
     <param name="foxglove_api_url"               value="$(var foxglove_api_url)" />
+    <param name="max_data_track_message_size"    value="$(var max_data_track_message_size)" />
   </node>
 </launch>

--- a/ros/src/foxglove_bridge/src/param_utils.cpp
+++ b/ros/src/foxglove_bridge/src/param_utils.cpp
@@ -295,7 +295,8 @@ void declareParameters(rclcpp::Node* node) {
   maxDataTrackMessageSizeDescription.read_only = true;
   maxDataTrackMessageSizeDescription.integer_range.resize(1);
   maxDataTrackMessageSizeDescription.integer_range[0].from_value = 1200;
-  maxDataTrackMessageSizeDescription.integer_range[0].to_value = std::numeric_limits<int64_t>::max();
+  maxDataTrackMessageSizeDescription.integer_range[0].to_value =
+    std::numeric_limits<int64_t>::max();
   maxDataTrackMessageSizeDescription.integer_range[0].step = 1;
   node->declare_parameter(PARAM_MAX_DATA_TRACK_MESSAGE_SIZE, DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE,
                           maxDataTrackMessageSizeDescription);

--- a/ros/src/foxglove_bridge/src/param_utils.cpp
+++ b/ros/src/foxglove_bridge/src/param_utils.cpp
@@ -283,6 +283,22 @@ void declareParameters(rclcpp::Node* node) {
     "unavailable, the SDK falls back to another compatible encoder.";
   videoEncoderDescription.read_only = true;
   node->declare_parameter(PARAM_VIDEO_ENCODER, "auto", videoEncoderDescription);
+
+  auto maxDataTrackMessageSizeDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  maxDataTrackMessageSizeDescription.name = PARAM_MAX_DATA_TRACK_MESSAGE_SIZE;
+  maxDataTrackMessageSizeDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  maxDataTrackMessageSizeDescription.description =
+    "Maximum size, in bytes, of a lossy data-track message sent by the remote access gateway. "
+    "Larger messages are dropped before publishing, with a throttled warning, so one "
+    "high-bandwidth channel cannot starve the others. Must be at least 1200 (one data-channel "
+    "packet).";
+  maxDataTrackMessageSizeDescription.read_only = true;
+  maxDataTrackMessageSizeDescription.integer_range.resize(1);
+  maxDataTrackMessageSizeDescription.integer_range[0].from_value = 1200;
+  maxDataTrackMessageSizeDescription.integer_range[0].to_value = std::numeric_limits<int64_t>::max();
+  maxDataTrackMessageSizeDescription.integer_range[0].step = 1;
+  node->declare_parameter(PARAM_MAX_DATA_TRACK_MESSAGE_SIZE, DEFAULT_MAX_DATA_TRACK_MESSAGE_SIZE,
+                          maxDataTrackMessageSizeDescription);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -340,6 +340,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     gatewayOptions.supported_encodings = {"cdr", "json"};
     gatewayOptions.server_info = std::move(rosServerInfo);
     gatewayOptions.message_backlog_size = messageBacklogSize;
+    gatewayOptions.max_data_track_message_size =
+      saturatingToSizeT(this->get_parameter(PARAM_MAX_DATA_TRACK_MESSAGE_SIZE).as_int(), 1200);
 
     const auto foxgloveApiUrl = this->get_parameter(PARAM_FOXGLOVE_API_URL).as_string();
     if (!foxgloveApiUrl.empty()) {

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -341,7 +341,7 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     gatewayOptions.server_info = std::move(rosServerInfo);
     gatewayOptions.message_backlog_size = messageBacklogSize;
     gatewayOptions.max_data_track_message_size =
-      saturatingToSizeT(this->get_parameter(PARAM_MAX_DATA_TRACK_MESSAGE_SIZE).as_int(), 1200);
+      saturatingToSizeT(this->get_parameter(PARAM_MAX_DATA_TRACK_MESSAGE_SIZE).as_int());
 
     const auto foxgloveApiUrl = this->get_parameter(PARAM_FOXGLOVE_API_URL).as_string();
     if (!foxgloveApiUrl.empty()) {


### PR DESCRIPTION
### Changelog

The `foxglove_bridge` now exposes a `max_data_track_message_size` parameter (default 100 KiB) to configure the remote access gateway's lossy data-track message size limit.

### Docs

The new parameter is documented in the bridge `README.md` and `foxglove_bridge_launch.xml`.

### Description

The remote access gateway drops lossy data-track messages larger than a configurable limit (default 100 KiB), a limit added SDK-side in #1345 to keep one high-bandwidth channel from starving the others. That limit was only reachable through the Rust `Gateway::max_data_track_message_size` builder, so operators running the ROS 2 `foxglove_bridge` had no way to tune it.

This change plumbs the existing knob out to a bridge ROS parameter, threading it through the layers between: the C-API options struct (`c/src/gateway.rs`, and the cbindgen-generated `foxglove-c.h`), the C++ `RemoteAccessGatewayOptions`, and finally the ROS parameter declaration + wiring. It mirrors the existing `message_backlog_size` option at every layer.

- **C-API / C++**: a new `max_data_track_message_size` field where `0` means "use the SDK default", forwarded to the Rust builder exactly like `message_backlog_size`. The field is appended last in both the `#[repr(C)]` struct and the C++ options struct to preserve the offsets of pre-existing fields.
- **ROS bridge**: a `max_data_track_message_size` integer parameter, default `102400` (100 KiB), minimum `1200` (one WebRTC data-channel packet, matching the SDK's `MIN_DATA_TRACK_MESSAGE_SIZE`). The `integer_range` rejects out-of-range overrides at declare time. The parameter is consumed only when remote access is enabled, like `foxglove_api_url` and `video_encoder`.

No behavior change by default: `102400` equals the SDK's built-in default, so the bridge behaves identically unless an operator overrides the value.

The `CHANGELOG.rst` is intentionally untouched — it is release-managed (generated at release time), consistent with how `message_backlog_size` (#1273) was handled.

Testing: the drop behavior and sub-1200 rejection are already covered by unit tests on the Rust builder and by `rust/remote_access_tests` (from #1345); the int64→size_t conversion helper (`saturatingToSizeT`) has its own tests. The C-API/C++/ROS layers here are pure forwarding. Verified locally: `cargo check`/`clippy`/`fmt`/`test`, the C++ SDK `make build`, and `clang-format` on the changed ROS files.

Fixes: [FLE-642](https://linear.app/foxglove/issue/FLE-642)
