### PR TITLE
remote_access: Warn viewers of dropped oversized messages (FLE-645)

### DIFF
--- a/rust/foxglove/src/remote_access/connection.rs
+++ b/rust/foxglove/src/remote_access/connection.rs
@@ -541,6 +541,9 @@ impl RemoteAccessConnection {
         let video_metadata_task = tokio::spawn(RemoteAccessSession::run_video_metadata_watcher(
             session.clone(),
         ));
+        let drop_status_task = tokio::spawn(RemoteAccessSession::run_drop_status_sweeper(
+            session.clone(),
+        ));
 
         // Send ServerInfo and channel advertisements to participants already in the room.
         // ParticipantConnected events only fire for participants joining after us.
@@ -609,6 +612,13 @@ impl RemoteAccessConnection {
                 remote_access_session_id,
                 error = %e,
                 "video metadata watcher failed"
+            );
+        }
+        if let Err(e) = drop_status_task.await {
+            error!(
+                remote_access_session_id,
+                error = %e,
+                "drop status sweeper failed"
             );
         }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -388,7 +388,7 @@ impl Sink for RemoteAccessSession {
         }
 
         if let Some((report, subscriber_sids)) = drop_report {
-            self.emit_drop_status(channel, channel_id, report, subscriber_sids);
+            self.emit_drop_status(channel, report, subscriber_sids);
         }
 
         Ok(())
@@ -621,10 +621,11 @@ impl RemoteAccessSession {
     fn emit_drop_status(
         &self,
         channel: &RawChannel,
-        channel_id: ChannelId,
         report: OversizedDropReport,
         subscriber_sids: SmallVec<[ParticipantSid; 4]>,
     ) {
+        let channel_id = channel.id();
+
         // The registry read lock is released before we get here, so a
         // concurrent `remove_channel` may have unadvertised the channel and run
         // its eager clear in the meantime. Skip emitting in that case so we

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -606,8 +606,8 @@ impl RemoteAccessSession {
 
         // Don't take `subscription_lock` here: listeners can synchronously log
         // from subscribe/unsubscribe callbacks while that lock is held. The
-        // subscriber snapshot may be slightly stale, but unsubscribe/remove and
-        // the quiet-period sweeper all clear the stable status id.
+        // subscriber snapshot may be stale, but the status will be eventually
+        // cleared by the sweeper.
         if !self.channel_registry.read().has_channel(&channel_id) {
             return;
         }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -212,17 +212,27 @@ fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropRe
     .with_id(drop_status_id(channel_id))
 }
 
+/// A channel's most recent oversized-drop report and when it was emitted.
+///
+/// `last_report` feeds the quiet-period sweeper; `report` lets the warning be
+/// rebuilt and replayed to viewers who subscribe while drops are ongoing.
+#[derive(Debug, Clone, Copy)]
+struct ActiveDropStatus {
+    last_report: std::time::Instant,
+    report: OversizedDropReport,
+}
+
 /// Drains and returns the channels whose most recent drop report is at least
 /// `quiet_period` old, leaving fresher entries in place. Pure and timer-free so
 /// the sweeper's expiry logic can be unit-tested with a synthetic `now`.
 fn drain_expired_drop_statuses(
-    statuses: &mut HashMap<ChannelId, std::time::Instant>,
+    statuses: &mut HashMap<ChannelId, ActiveDropStatus>,
     now: std::time::Instant,
     quiet_period: Duration,
 ) -> Vec<ChannelId> {
     let mut expired = Vec::new();
-    statuses.retain(|channel_id, last_report| {
-        if now.duration_since(*last_report) >= quiet_period {
+    statuses.retain(|channel_id, status| {
+        if now.duration_since(status.last_report) >= quiet_period {
             expired.push(*channel_id);
             false
         } else {
@@ -307,10 +317,11 @@ pub(super) struct RemoteAccessSession {
     video_codec_override: Option<VideoCodec>,
     /// Per-message size limit for lossy data-track channels; larger messages are dropped.
     max_data_track_message_size: usize,
-    /// Per-channel time of the most recent oversized-drop `Status` warning
+    /// Per-channel record of the most recent oversized-drop `Status` warning
     /// emitted to viewers. Feeds the quiet-period sweeper, which sends
-    /// `RemoveStatus` once a channel stops dropping. See [`DROP_STATUS_QUIET_PERIOD`].
-    active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, std::time::Instant>>,
+    /// `RemoveStatus` once a channel stops dropping, and lets the warning be
+    /// replayed to late subscribers. See [`DROP_STATUS_QUIET_PERIOD`].
+    active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, ActiveDropStatus>>,
     /// The preferred encoder backend applied to published video tracks.
     /// [`VideoEncoderBackend::Auto`](super::gateway::VideoEncoderBackend::Auto) leaves the
     /// choice to libwebrtc.
@@ -627,9 +638,13 @@ impl RemoteAccessSession {
             return;
         }
 
-        self.active_drop_statuses
-            .lock()
-            .insert(channel_id, std::time::Instant::now());
+        self.active_drop_statuses.lock().insert(
+            channel_id,
+            ActiveDropStatus {
+                last_report: std::time::Instant::now(),
+                report,
+            },
+        );
 
         let status = build_drop_status(channel_id, channel.topic(), report);
         let encoded = encode_json_message(&status);
@@ -980,6 +995,31 @@ impl RemoteAccessSession {
                 );
                 for descriptor in &subscribe_result.newly_subscribed_descriptors {
                     listener.on_subscribe(&client, descriptor);
+                }
+            }
+        }
+
+        // Replay any active oversized-drop warning to the new data subscribers,
+        // so a viewer subscribing mid-drop-storm sees the warning immediately
+        // instead of waiting up to a throttle window for the next report. Video
+        // subscribers are excluded to match the original warning's audience
+        // (they bypass the data plane). The sends are queued while holding the
+        // map lock: the sweeper drains entries under this lock strictly before
+        // broadcasting `RemoveStatus`, so a replayed `Status` can never arrive
+        // after the `RemoveStatus` that clears it. `subscription_lock` (held
+        // above) serializes this against `remove_channel`'s eager clear.
+        {
+            let statuses = self.active_drop_statuses.lock();
+            if !statuses.is_empty() {
+                for descriptor in &subscribe_result.newly_subscribed_descriptors {
+                    if !data_channel_ids.contains(&descriptor.id()) {
+                        continue;
+                    }
+                    if let Some(active) = statuses.get(&descriptor.id()) {
+                        let status =
+                            build_drop_status(descriptor.id(), descriptor.topic(), active.report);
+                        participant.send_control(encode_json_message(&status));
+                    }
                 }
             }
         }
@@ -3091,6 +3131,16 @@ mod tests {
         assert_eq!(format_byte_size(2 * 1024 * 1024), "2 MiB");
     }
 
+    fn active_drop_status(last_report: std::time::Instant) -> ActiveDropStatus {
+        ActiveDropStatus {
+            last_report,
+            report: OversizedDropReport {
+                dropped_since_last: 1,
+                size_limit: 1200,
+            },
+        }
+    }
+
     #[test]
     fn drain_expired_drop_statuses_removes_only_stale_entries() {
         let quiet = Duration::from_secs(60);
@@ -3100,9 +3150,9 @@ mod tests {
         let fresh = ChannelId::new(2);
         let mut statuses = HashMap::from([
             // Idle exactly the quiet period → expired (boundary is inclusive).
-            (stale, now - quiet),
+            (stale, active_drop_status(now - quiet)),
             // Idle less than the quiet period → retained.
-            (fresh, now - Duration::from_secs(30)),
+            (fresh, active_drop_status(now - Duration::from_secs(30))),
         ]);
 
         let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
@@ -3123,7 +3173,7 @@ mod tests {
         let quiet = Duration::from_secs(60);
         let now = std::time::Instant::now();
         let fresh = ChannelId::new(9);
-        let mut statuses = HashMap::from([(fresh, now)]);
+        let mut statuses = HashMap::from([(fresh, active_drop_status(now))]);
 
         let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -330,7 +330,7 @@ impl Sink for RemoteAccessSession {
         let channel_id = channel.id();
 
         // Captured under the read lock and handled after the lock is released.
-        let mut drop_report: Option<OversizedDropReport> = None;
+        let mut drop_report: Option<(OversizedDropReport, SmallVec<[ParticipantSid; 4]>)> = None;
 
         // Snapshot subscriber SIDs under the channel-registry read lock and
         // release it before resolving against the participant registry. A
@@ -355,7 +355,7 @@ impl Sink for RemoteAccessSession {
                 // inline, while we still hold the state read lock.
                 if let Some(track) = state.get_subscribed_data_track(&channel_id) {
                     if let Err(report) = track.log(channel_id, msg, metadata) {
-                        drop_report = Some(report);
+                        drop_report = Some((report, state.data_subscriber_sids(&channel_id)));
                     }
                 }
                 SmallVec::new()
@@ -373,8 +373,8 @@ impl Sink for RemoteAccessSession {
             }
         }
 
-        if let Some(report) = drop_report {
-            self.emit_drop_status(channel, report);
+        if let Some((report, subscriber_sids)) = drop_report {
+            self.emit_drop_status(channel, report, subscriber_sids);
         }
 
         Ok(())
@@ -596,18 +596,21 @@ impl RemoteAccessSession {
     }
 
     /// Warn current data subscribers about a throttled oversized data-track drop.
-    fn emit_drop_status(&self, channel: &RawChannel, report: OversizedDropReport) {
+    fn emit_drop_status(
+        &self,
+        channel: &RawChannel,
+        report: OversizedDropReport,
+        subscriber_sids: SmallVec<[ParticipantSid; 4]>,
+    ) {
         let channel_id = channel.id();
 
-        let _guard = self.subscription_lock.lock();
-        let subscriber_sids = {
-            let state = self.channel_registry.read();
-            if !state.has_channel(&channel_id) {
-                return;
-            }
-            state.data_subscriber_sids(&channel_id)
-        };
-
+        // Don't take `subscription_lock` here: listeners can synchronously log
+        // from subscribe/unsubscribe callbacks while that lock is held. The
+        // subscriber snapshot may be slightly stale, but unsubscribe/remove and
+        // the quiet-period sweeper all clear the stable status id.
+        if !self.channel_registry.read().has_channel(&channel_id) {
+            return;
+        }
         self.active_drop_statuses.lock().insert(
             channel_id,
             ActiveDropStatus {

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -368,7 +368,7 @@ impl Sink for RemoteAccessSession {
                 // throttled oversized drop, capture the report and the current
                 // data subscribers so we can warn them after the lock.
                 if let Some(track) = state.get_subscribed_data_track(&channel_id) {
-                    if let Some(report) = track.log(channel_id, msg, metadata) {
+                    if let Err(report) = track.log(channel_id, msg, metadata) {
                         drop_report = Some((report, state.data_subscriber_sids(&channel_id)));
                     }
                 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -212,27 +212,17 @@ fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropRe
     .with_id(drop_status_id(channel_id))
 }
 
-/// A channel's most recent oversized-drop report and when it was emitted.
-///
-/// `last_report` feeds the quiet-period sweeper; `report` lets the warning be
-/// rebuilt and replayed to viewers who subscribe while drops are ongoing.
-#[derive(Debug, Clone, Copy)]
-struct ActiveDropStatus {
-    last_report: std::time::Instant,
-    report: OversizedDropReport,
-}
-
 /// Drains and returns the channels whose most recent drop report is at least
 /// `quiet_period` old, leaving fresher entries in place. Pure and timer-free so
 /// the sweeper's expiry logic can be unit-tested with a synthetic `now`.
 fn drain_expired_drop_statuses(
-    statuses: &mut HashMap<ChannelId, ActiveDropStatus>,
+    statuses: &mut HashMap<ChannelId, std::time::Instant>,
     now: std::time::Instant,
     quiet_period: Duration,
 ) -> Vec<ChannelId> {
     let mut expired = Vec::new();
-    statuses.retain(|channel_id, status| {
-        if now.duration_since(status.last_report) >= quiet_period {
+    statuses.retain(|channel_id, last_report| {
+        if now.duration_since(*last_report) >= quiet_period {
             expired.push(*channel_id);
             false
         } else {
@@ -317,11 +307,10 @@ pub(super) struct RemoteAccessSession {
     video_codec_override: Option<VideoCodec>,
     /// Per-message size limit for lossy data-track channels; larger messages are dropped.
     max_data_track_message_size: usize,
-    /// Per-channel record of the most recent oversized-drop `Status` warning
+    /// Per-channel time of the most recent oversized-drop `Status` warning
     /// emitted to viewers. Feeds the quiet-period sweeper, which sends
-    /// `RemoveStatus` once a channel stops dropping, and lets the warning be
-    /// replayed to late subscribers. See [`DROP_STATUS_QUIET_PERIOD`].
-    active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, ActiveDropStatus>>,
+    /// `RemoveStatus` once a channel stops dropping. See [`DROP_STATUS_QUIET_PERIOD`].
+    active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, std::time::Instant>>,
     /// The preferred encoder backend applied to published video tracks.
     /// [`VideoEncoderBackend::Auto`](super::gateway::VideoEncoderBackend::Auto) leaves the
     /// choice to libwebrtc.
@@ -638,13 +627,9 @@ impl RemoteAccessSession {
             return;
         }
 
-        self.active_drop_statuses.lock().insert(
-            channel_id,
-            ActiveDropStatus {
-                last_report: std::time::Instant::now(),
-                report,
-            },
-        );
+        self.active_drop_statuses
+            .lock()
+            .insert(channel_id, std::time::Instant::now());
 
         let status = build_drop_status(channel_id, channel.topic(), report);
         let encoded = encode_json_message(&status);
@@ -995,31 +980,6 @@ impl RemoteAccessSession {
                 );
                 for descriptor in &subscribe_result.newly_subscribed_descriptors {
                     listener.on_subscribe(&client, descriptor);
-                }
-            }
-        }
-
-        // Replay any active oversized-drop warning to the new data subscribers,
-        // so a viewer subscribing mid-drop-storm sees the warning immediately
-        // instead of waiting up to a throttle window for the next report. Video
-        // subscribers are excluded to match the original warning's audience
-        // (they bypass the data plane). The sends are queued while holding the
-        // map lock: the sweeper drains entries under this lock strictly before
-        // broadcasting `RemoveStatus`, so a replayed `Status` can never arrive
-        // after the `RemoveStatus` that clears it. `subscription_lock` (held
-        // above) serializes this against `remove_channel`'s eager clear.
-        {
-            let statuses = self.active_drop_statuses.lock();
-            if !statuses.is_empty() {
-                for descriptor in &subscribe_result.newly_subscribed_descriptors {
-                    if !data_channel_ids.contains(&descriptor.id()) {
-                        continue;
-                    }
-                    if let Some(active) = statuses.get(&descriptor.id()) {
-                        let status =
-                            build_drop_status(descriptor.id(), descriptor.topic(), active.report);
-                        participant.send_control(encode_json_message(&status));
-                    }
                 }
             }
         }
@@ -3112,16 +3072,6 @@ mod tests {
         assert_eq!(format_byte_size(2 * 1024 * 1024), "2 MiB");
     }
 
-    fn active_drop_status(last_report: std::time::Instant) -> ActiveDropStatus {
-        ActiveDropStatus {
-            last_report,
-            report: OversizedDropReport {
-                dropped_since_last: 1,
-                size_limit: 1200,
-            },
-        }
-    }
-
     #[test]
     fn drain_expired_drop_statuses_removes_only_stale_entries() {
         let quiet = Duration::from_secs(60);
@@ -3131,9 +3081,9 @@ mod tests {
         let fresh = ChannelId::new(2);
         let mut statuses = HashMap::from([
             // Idle exactly the quiet period → expired (boundary is inclusive).
-            (stale, active_drop_status(now - quiet)),
+            (stale, now - quiet),
             // Idle less than the quiet period → retained.
-            (fresh, active_drop_status(now - Duration::from_secs(30))),
+            (fresh, now - Duration::from_secs(30)),
         ]);
 
         let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
@@ -3154,7 +3104,7 @@ mod tests {
         let quiet = Duration::from_secs(60);
         let now = std::time::Instant::now();
         let fresh = ChannelId::new(9);
-        let mut statuses = HashMap::from([(fresh, active_drop_status(now))]);
+        let mut statuses = HashMap::from([(fresh, now)]);
 
         let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -169,11 +169,44 @@ fn drop_status_id(channel_id: ChannelId) -> String {
     format!("channel-drops-{}", u64::from(channel_id))
 }
 
+/// Formats a byte count human-readably (bytes / KiB / MiB) so viewers don't
+/// have to divide by 1024. Uses the largest binary unit that keeps the value
+/// at least 1, with up to two decimal places and trailing zeros trimmed
+/// (e.g. `102400` → `100 KiB`, `1200` → `1.17 KiB`, `512` → `512 bytes`).
+fn format_byte_size(bytes: usize) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    let bytes_f = bytes as f64;
+    if bytes_f >= MIB {
+        format!("{} MiB", trim_trailing_zeros(bytes_f / MIB))
+    } else if bytes_f >= KIB {
+        format!("{} KiB", trim_trailing_zeros(bytes_f / KIB))
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+/// Renders `value` with up to two decimal places, dropping any trailing zeros
+/// and a bare trailing decimal point (`100.00` → `100`, `1.50` → `1.5`).
+fn trim_trailing_zeros(value: f64) -> String {
+    let formatted = format!("{value:.2}");
+    formatted
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_string()
+}
+
 /// Builds the viewer-facing warning for a throttled oversized data-track drop.
 fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropReport) -> Status {
+    let messages = if report.dropped_since_last == 1 {
+        "message"
+    } else {
+        "messages"
+    };
     Status::warning(format!(
-        "Dropped {} message(s) on topic {topic}: exceeds the data-track size limit of {} bytes",
-        report.dropped_since_last, report.size_limit,
+        "Dropped {} {messages} on topic {topic}: exceeds {} per-message size limit",
+        report.dropped_since_last,
+        format_byte_size(report.size_limit),
     ))
     .with_id(drop_status_id(channel_id))
 }
@@ -582,6 +615,17 @@ impl RemoteAccessSession {
         report: OversizedDropReport,
         subscriber_sids: SmallVec<[ParticipantSid; 4]>,
     ) {
+        // The registry read lock is released before we get here, so a
+        // concurrent `remove_channel` may have unadvertised the channel and run
+        // its eager clear in the meantime. Skip emitting in that case so we
+        // don't resurrect a `Status` for a topic that's already gone. A much
+        // narrower window remains (removal's `RemoveStatus` racing ahead of the
+        // `Status` we're about to send); the quiet-period sweeper is the
+        // backstop that clears any such straggler.
+        if !self.channel_registry.read().has_channel(&channel_id) {
+            return;
+        }
+
         self.active_drop_statuses
             .lock()
             .insert(channel_id, std::time::Instant::now());
@@ -2993,7 +3037,7 @@ mod tests {
         let channel_id = ChannelId::new(7);
         let report = OversizedDropReport {
             dropped_since_last: 3,
-            size_limit: 1200,
+            size_limit: 100 * 1024,
         };
         let status = build_drop_status(channel_id, "/points", report);
 
@@ -3001,8 +3045,30 @@ mod tests {
         assert_eq!(status.id.as_deref(), Some("channel-drops-7"));
         assert_eq!(
             status.message,
-            "Dropped 3 message(s) on topic /points: exceeds the data-track size limit of 1200 bytes"
+            "Dropped 3 messages on topic /points: exceeds 100 KiB per-message size limit"
         );
+    }
+
+    #[test]
+    fn build_drop_status_uses_singular_for_one_dropped_message() {
+        let report = OversizedDropReport {
+            dropped_since_last: 1,
+            size_limit: 1200,
+        };
+        let status = build_drop_status(ChannelId::new(1), "/points", report);
+        assert_eq!(
+            status.message,
+            "Dropped 1 message on topic /points: exceeds 1.17 KiB per-message size limit"
+        );
+    }
+
+    #[test]
+    fn format_byte_size_renders_human_readable_units() {
+        assert_eq!(format_byte_size(512), "512 bytes");
+        assert_eq!(format_byte_size(1200), "1.17 KiB");
+        assert_eq!(format_byte_size(1536), "1.5 KiB");
+        assert_eq!(format_byte_size(100 * 1024), "100 KiB");
+        assert_eq!(format_byte_size(2 * 1024 * 1024), "2 MiB");
     }
 
     #[test]

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -1015,11 +1015,30 @@ impl RemoteAccessSession {
 
         self.stop_video_tracks(&last_video_unsubscribed);
 
-        if let Some(listener) = &self.listener {
-            if !unsubscribe_result
+        if !unsubscribe_result
+            .actually_unsubscribed_descriptors
+            .is_empty()
+        {
+            // Eagerly clear any oversized-drop warning this participant was shown
+            // for a channel they just unsubscribed from, so it doesn't linger in
+            // their Problems panel until the sweeper's quiet period elapses.
+            // Other subscribers of the same channel are unaffected: the shared
+            // `active_drop_statuses` entry, and their own view of the warning,
+            // are left in place.
+            let statuses = self.active_drop_statuses.lock();
+            let ids_to_clear: SmallVec<[ChannelId; 4]> = unsubscribe_result
                 .actually_unsubscribed_descriptors
-                .is_empty()
-            {
+                .iter()
+                .map(|descriptor| descriptor.id())
+                .filter(|id| statuses.contains_key(id))
+                .collect();
+            drop(statuses);
+            if !ids_to_clear.is_empty() {
+                let remove = RemoveStatus::new(ids_to_clear.iter().map(|id| drop_status_id(*id)));
+                participant.send_control(encode_json_message(&remove));
+            }
+
+            if let Some(listener) = &self.listener {
                 let client = Client::new(
                     participant.client_id(),
                     participant.participant_id().clone(),

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -970,8 +970,11 @@ impl RemoteAccessSession {
             }
         }
 
-        // Replay active drop warnings to new data subscribers. Hold the map
-        // lock while queueing so the sweeper cannot clear first.
+        // Replay active drop warnings to new data subscribers. This is important to ensure that
+        // users are notified of drops in a timely fashion. Otherwise, they have to wait up to the
+        // throttle period, which is deliberately quite long.
+        //
+        // Hold the map lock while queueing so the sweeper cannot clear first.
         {
             let statuses = self.active_drop_statuses.lock();
             if !statuses.is_empty() {

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -54,7 +54,7 @@ use crate::{
 };
 
 mod data_track;
-pub(super) use data_track::DataTrack;
+pub(super) use data_track::{DataTrack, OversizedDropReport};
 mod video_track;
 pub(super) use video_track::{
     VideoInputSchema, VideoMetadata, VideoPublisher, get_video_input_schema,
@@ -81,6 +81,15 @@ const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 const ROOM_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
+
+/// Quiet period after a channel's last oversized-drop report before its
+/// viewer-facing `Status` warning is auto-cleared via `RemoveStatus`. Set to
+/// 2× the 30s drop-warning throttle window so a channel under continuous drops
+/// (reported at most every 30s) never flaps between warned and cleared.
+const DROP_STATUS_QUIET_PERIOD: Duration = Duration::from_secs(60);
+
+/// How often the drop-status sweeper checks for expired drop statuses.
+const DROP_STATUS_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Default per-message size limit for lossy data-track channels, in bytes.
 /// Messages larger than this are dropped before publish so one oversized channel
@@ -151,6 +160,42 @@ pub(super) fn encode_binary_message<'a>(message: &impl BinaryMessage<'a>) -> Byt
     );
     message.encode(&mut buf);
     Bytes::from(buf)
+}
+
+/// Stable per-channel id for the oversized-drop `Status`, so each throttled
+/// report replaces the previous Problems-panel entry rather than accumulating,
+/// and a later `RemoveStatus` clears exactly that entry.
+fn drop_status_id(channel_id: ChannelId) -> String {
+    format!("channel-drops-{}", u64::from(channel_id))
+}
+
+/// Builds the viewer-facing warning for a throttled oversized data-track drop.
+fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropReport) -> Status {
+    Status::warning(format!(
+        "Dropped {} message(s) on topic {topic}: exceeds the data-track size limit of {} bytes",
+        report.dropped_since_last, report.size_limit,
+    ))
+    .with_id(drop_status_id(channel_id))
+}
+
+/// Drains and returns the channels whose most recent drop report is at least
+/// `quiet_period` old, leaving fresher entries in place. Pure and timer-free so
+/// the sweeper's expiry logic can be unit-tested with a synthetic `now`.
+fn drain_expired_drop_statuses(
+    statuses: &mut HashMap<ChannelId, std::time::Instant>,
+    now: std::time::Instant,
+    quiet_period: Duration,
+) -> Vec<ChannelId> {
+    let mut expired = Vec::new();
+    statuses.retain(|channel_id, last_report| {
+        if now.duration_since(*last_report) >= quiet_period {
+            expired.push(*channel_id);
+            false
+        } else {
+            true
+        }
+    });
+    expired
 }
 
 fn build_advertise_services_msg(services: &[Arc<Service>]) -> Option<AdvertiseServices<'_>> {
@@ -228,6 +273,11 @@ pub(super) struct RemoteAccessSession {
     video_codec_override: Option<VideoCodec>,
     /// Per-message size limit for lossy data-track channels; larger messages are dropped.
     max_data_track_message_size: usize,
+    /// Per-channel timestamp of the most recent oversized-drop `Status` warning
+    /// emitted to viewers. Feeds the quiet-period sweeper, which sends
+    /// `RemoveStatus` once a channel stops dropping. See
+    /// [`DROP_STATUS_QUIET_PERIOD`].
+    active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, std::time::Instant>>,
     /// The preferred encoder backend applied to published video tracks.
     /// [`VideoEncoderBackend::Auto`](super::gateway::VideoEncoderBackend::Auto) leaves the
     /// choice to libwebrtc.
@@ -246,6 +296,10 @@ impl Sink for RemoteAccessSession {
         metadata: &Metadata,
     ) -> std::result::Result<(), FoxgloveError> {
         let channel_id = channel.id();
+
+        // Captured under the read lock on the lossy oversized-drop path and
+        // handled after the lock is released (like the reliable branch below).
+        let mut drop_report: Option<(OversizedDropReport, SmallVec<[ParticipantSid; 4]>)> = None;
 
         // Snapshot subscriber SIDs under the channel-registry read lock and
         // release it before resolving against the participant registry. A
@@ -267,9 +321,13 @@ impl Sink for RemoteAccessSession {
                 state.data_subscriber_sids(&channel_id)
             } else {
                 // Lossy channels: send via the eagerly-published data track
-                // inline, while we still hold the state read lock.
+                // inline, while we still hold the state read lock. On a
+                // throttled oversized drop, capture the report and the current
+                // data subscribers so we can warn them after the lock.
                 if let Some(track) = state.get_subscribed_data_track(&channel_id) {
-                    track.log(channel_id, msg, metadata);
+                    if let Some(report) = track.log(channel_id, msg, metadata) {
+                        drop_report = Some((report, state.data_subscriber_sids(&channel_id)));
+                    }
                 }
                 SmallVec::new()
             }
@@ -284,6 +342,10 @@ impl Sink for RemoteAccessSession {
             for participant in self.participant_registry.resolve_sids(reliable_sids) {
                 participant.send_control(encoded.clone());
             }
+        }
+
+        if let Some((report, subscriber_sids)) = drop_report {
+            self.emit_drop_status(channel, channel_id, report, subscriber_sids);
         }
 
         Ok(())
@@ -380,6 +442,15 @@ impl Sink for RemoteAccessSession {
         let unadvertise = Unadvertise::new([u64::from(channel_id)]);
         self.broadcast_control(encode_json_message(&unadvertise));
 
+        // Eagerly clear any viewer-facing oversized-drop status for the removed
+        // channel so it doesn't linger in the app's Problems panel until the
+        // sweeper's quiet period elapses. Removing an unknown status id is a
+        // client-side no-op.
+        self.active_drop_statuses.lock().remove(&channel_id);
+        self.broadcast_control(encode_json_message(&RemoveStatus::new([drop_status_id(
+            channel_id,
+        )])));
+
         // Fire on_unsubscribe callbacks for subscribers of the removed channel.
         if let Some(listener) = &self.listener {
             let descriptor = channel.descriptor();
@@ -453,6 +524,7 @@ impl RemoteAccessSession {
             device_wait_for_viewer: params.device_wait_for_viewer,
             video_codec_override: params.video_codec_override,
             max_data_track_message_size: params.max_data_track_message_size,
+            active_drop_statuses: parking_lot::Mutex::new(HashMap::new()),
             video_encoder: params.video_encoder,
         })
     }
@@ -497,6 +569,30 @@ impl RemoteAccessSession {
         participant.send_control(encode_json_message(&status));
     }
 
+    /// Warn subscribers about a throttled oversized data-track drop and record
+    /// the drop time so the quiet-period sweeper can later clear the status.
+    ///
+    /// The status uses a stable per-channel id (`channel-drops-{id}`) so each
+    /// throttled report replaces the previous Problems-panel entry rather than
+    /// accumulating.
+    fn emit_drop_status(
+        &self,
+        channel: &RawChannel,
+        channel_id: ChannelId,
+        report: OversizedDropReport,
+        subscriber_sids: SmallVec<[ParticipantSid; 4]>,
+    ) {
+        self.active_drop_statuses
+            .lock()
+            .insert(channel_id, std::time::Instant::now());
+
+        let status = build_drop_status(channel_id, channel.topic(), report);
+        let encoded = encode_json_message(&status);
+        for participant in self.participant_registry.resolve_sids(subscriber_sids) {
+            participant.send_control(encoded.clone());
+        }
+    }
+
     /// Enqueue a control plane message for all currently connected participants.
     /// If a participant's queue is full, a reset is requested for that participant.
     fn broadcast_control(&self, data: Bytes) {
@@ -520,6 +616,44 @@ impl RemoteAccessSession {
                 }
             }
         }
+    }
+
+    /// Auto-clears viewer-facing oversized-drop statuses once a channel has had
+    /// no drop reports for [`DROP_STATUS_QUIET_PERIOD`].
+    ///
+    /// Runs until the cancellation token fires.
+    pub(super) async fn run_drop_status_sweeper(session: Arc<Self>) {
+        let mut interval = tokio::time::interval(DROP_STATUS_SWEEP_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                biased;
+                () = session.cancellation_token.cancelled() => break,
+                _ = interval.tick() => {
+                    session.sweep_expired_drop_statuses(std::time::Instant::now());
+                }
+            }
+        }
+    }
+
+    /// Removes drop-status entries idle for at least [`DROP_STATUS_QUIET_PERIOD`]
+    /// and broadcasts a single `RemoveStatus` clearing them. Synchronous and
+    /// timer-free so it can be unit-tested with a synthetic `now`.
+    ///
+    /// `RemoveStatus` is broadcast to all participants; removing an unknown
+    /// status id is a client-side no-op, so we needn't track exactly who
+    /// received each warning.
+    fn sweep_expired_drop_statuses(&self, now: std::time::Instant) {
+        let expired = drain_expired_drop_statuses(
+            &mut self.active_drop_statuses.lock(),
+            now,
+            DROP_STATUS_QUIET_PERIOD,
+        );
+        if expired.is_empty() {
+            return;
+        }
+        let remove = RemoveStatus::new(expired.iter().map(|id| drop_status_id(*id)));
+        self.broadcast_control(encode_json_message(&remove));
     }
 
     /// Cancel the session's `CancellationToken`, signaling all session-scoped
@@ -2850,5 +2984,64 @@ mod tests {
         assert_eq!(status.level, StatusLevel::Error);
         assert!(status.message.contains("failed to send a response"));
         assert!(rx.try_recv().is_err());
+    }
+
+    // ---- oversized data-track drop status tests ----
+
+    #[test]
+    fn build_drop_status_has_warning_level_stable_id_and_message() {
+        let channel_id = ChannelId::new(7);
+        let report = OversizedDropReport {
+            dropped_since_last: 3,
+            size_limit: 1200,
+        };
+        let status = build_drop_status(channel_id, "/points", report);
+
+        assert_eq!(status.level, StatusLevel::Warning);
+        assert_eq!(status.id.as_deref(), Some("channel-drops-7"));
+        assert_eq!(
+            status.message,
+            "Dropped 3 message(s) on topic /points: exceeds the data-track size limit of 1200 bytes"
+        );
+    }
+
+    #[test]
+    fn drain_expired_drop_statuses_removes_only_stale_entries() {
+        let quiet = Duration::from_secs(60);
+        let now = std::time::Instant::now();
+
+        let stale = ChannelId::new(1);
+        let fresh = ChannelId::new(2);
+        let mut statuses = HashMap::from([
+            // Idle exactly the quiet period → expired (boundary is inclusive).
+            (stale, now - quiet),
+            // Idle less than the quiet period → retained.
+            (fresh, now - Duration::from_secs(30)),
+        ]);
+
+        let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
+
+        assert_eq!(expired, vec![stale]);
+        assert!(
+            !statuses.contains_key(&stale),
+            "stale entry should be drained"
+        );
+        assert!(
+            statuses.contains_key(&fresh),
+            "fresh entry should be left alone"
+        );
+    }
+
+    #[test]
+    fn drain_expired_drop_statuses_noop_when_all_fresh() {
+        let quiet = Duration::from_secs(60);
+        let now = std::time::Instant::now();
+        let fresh = ChannelId::new(9);
+        let mut statuses = HashMap::from([(fresh, now)]);
+
+        let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
+
+        assert!(expired.is_empty());
+        assert_eq!(statuses.len(), 1);
     }
 }

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -84,9 +84,10 @@ pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 
 /// Quiet period after a channel's last oversized-drop report before its
 /// viewer-facing `Status` warning is auto-cleared via `RemoveStatus`. Set to
-/// 2× the 30s drop-warning throttle window so a channel under continuous drops
-/// (reported at most every 30s) never flaps between warned and cleared.
-const DROP_STATUS_QUIET_PERIOD: Duration = Duration::from_secs(60);
+/// 2× the drop-warning throttle window so a channel under continuous drops
+/// (reported at most once per window) never flaps between warned and cleared.
+const DROP_STATUS_QUIET_PERIOD: Duration =
+    Duration::from_secs(2 * data_track::OVERSIZED_WARN_INTERVAL.as_secs());
 
 /// How often the drop-status sweeper checks for expired drop statuses.
 const DROP_STATUS_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
@@ -197,6 +198,10 @@ fn trim_trailing_zeros(value: f64) -> String {
 }
 
 /// Builds the viewer-facing warning for a throttled oversized data-track drop.
+///
+/// Quoting the throttle window ("in the last 30 seconds") makes it clear the
+/// count is a rolling per-window tally that updates in place, not a cumulative
+/// total — statuses carry no timestamp, so the message must say so itself.
 fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropReport) -> Status {
     let messages = if report.dropped_since_last == 1 {
         "message"
@@ -204,8 +209,10 @@ fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropRe
         "messages"
     };
     Status::warning(format!(
-        "Dropped {} {messages} on topic {topic}: exceeds {} per-message size limit",
+        "Dropped {} {messages} on topic {topic} in the last {} seconds: \
+         exceeds {} per-message size limit",
         report.dropped_since_last,
+        data_track::OVERSIZED_WARN_INTERVAL.as_secs(),
         format_byte_size(report.size_limit),
     ))
     .with_id(drop_status_id(channel_id))
@@ -3085,7 +3092,8 @@ mod tests {
         assert_eq!(status.id.as_deref(), Some("channel-drops-7"));
         assert_eq!(
             status.message,
-            "Dropped 3 messages on topic /points: exceeds 100 KiB per-message size limit"
+            "Dropped 3 messages on topic /points in the last 30 seconds: \
+             exceeds 100 KiB per-message size limit"
         );
     }
 
@@ -3098,7 +3106,8 @@ mod tests {
         let status = build_drop_status(ChannelId::new(1), "/points", report);
         assert_eq!(
             status.message,
-            "Dropped 1 message on topic /points: exceeds 1.17 KiB per-message size limit"
+            "Dropped 1 message on topic /points in the last 30 seconds: \
+             exceeds 1.17 KiB per-message size limit"
         );
     }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -198,10 +198,6 @@ fn trim_trailing_zeros(value: f64) -> String {
 }
 
 /// Builds the viewer-facing warning for a throttled oversized data-track drop.
-///
-/// Quoting the throttle window ("in the last 30 seconds") makes it clear the
-/// count is a rolling per-window tally that updates in place, not a cumulative
-/// total — statuses carry no timestamp, so the message must say so itself.
 fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropReport) -> Status {
     let messages = if report.dropped_since_last == 1 {
         "message"
@@ -209,10 +205,8 @@ fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropRe
         "messages"
     };
     Status::warning(format!(
-        "Dropped {} {messages} on topic {topic} in the last {} seconds: \
-         exceeds {} per-message size limit",
+        "Dropped {} {messages} on topic {topic}: exceeds {} per-message size limit",
         report.dropped_since_last,
-        data_track::OVERSIZED_WARN_INTERVAL.as_secs(),
         format_byte_size(report.size_limit),
     ))
     .with_id(drop_status_id(channel_id))
@@ -3092,8 +3086,7 @@ mod tests {
         assert_eq!(status.id.as_deref(), Some("channel-drops-7"));
         assert_eq!(
             status.message,
-            "Dropped 3 messages on topic /points in the last 30 seconds: \
-             exceeds 100 KiB per-message size limit"
+            "Dropped 3 messages on topic /points: exceeds 100 KiB per-message size limit"
         );
     }
 
@@ -3106,8 +3099,7 @@ mod tests {
         let status = build_drop_status(ChannelId::new(1), "/points", report);
         assert_eq!(
             status.message,
-            "Dropped 1 message on topic /points in the last 30 seconds: \
-             exceeds 1.17 KiB per-message size limit"
+            "Dropped 1 message on topic /points: exceeds 1.17 KiB per-message size limit"
         );
     }
 

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -82,10 +82,10 @@ const ROOM_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(super) const DEFAULT_MESSAGE_BACKLOG_SIZE: usize = 1024;
 
-/// Quiet period after a channel's last oversized-drop report before its
-/// viewer-facing `Status` warning is auto-cleared via `RemoveStatus`. Set to
-/// 2× the drop-warning throttle window so a channel under continuous drops
-/// (reported at most once per window) never flaps between warned and cleared.
+/// Idle period before clearing a channel's oversized-drop warning.
+///
+/// This is longer than the report throttle window, so a channel under
+/// continuous drops does not flap between warning and cleared states.
 const DROP_STATUS_QUIET_PERIOD: Duration =
     Duration::from_secs(2 * data_track::OVERSIZED_WARN_INTERVAL.as_secs());
 
@@ -163,17 +163,12 @@ pub(super) fn encode_binary_message<'a>(message: &impl BinaryMessage<'a>) -> Byt
     Bytes::from(buf)
 }
 
-/// Stable per-channel id for the oversized-drop `Status`, so each throttled
-/// report replaces the previous Problems-panel entry rather than accumulating,
-/// and a later `RemoveStatus` clears exactly that entry.
+/// Stable per-channel id for the oversized-drop warning.
 fn drop_status_id(channel_id: ChannelId) -> String {
     format!("channel-drops-{}", u64::from(channel_id))
 }
 
-/// Formats a byte count human-readably (bytes / KiB / MiB) so viewers don't
-/// have to divide by 1024. Uses the largest binary unit that keeps the value
-/// at least 1, with up to two decimal places and trailing zeros trimmed
-/// (e.g. `102400` → `100 KiB`, `1200` → `1.17 KiB`, `512` → `512 bytes`).
+/// Formats a byte count with binary units and trimmed decimal zeros.
 fn format_byte_size(bytes: usize) -> String {
     const KIB: f64 = 1024.0;
     const MIB: f64 = 1024.0 * 1024.0;
@@ -212,10 +207,7 @@ fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropRe
     .with_id(drop_status_id(channel_id))
 }
 
-/// A channel's most recent oversized-drop report and when it was emitted.
-///
-/// `last_report` feeds the quiet-period sweeper; `report` lets the warning be
-/// rebuilt and replayed to viewers who subscribe while drops are ongoing.
+/// Latest oversized-drop warning state for a channel.
 #[derive(Debug, Clone, Copy)]
 struct ActiveDropStatus {
     last_report: std::time::Instant,
@@ -223,8 +215,7 @@ struct ActiveDropStatus {
 }
 
 /// Drains and returns the channels whose most recent drop report is at least
-/// `quiet_period` old, leaving fresher entries in place. Pure and timer-free so
-/// the sweeper's expiry logic can be unit-tested with a synthetic `now`.
+/// `quiet_period` old, leaving fresher entries in place.
 fn drain_expired_drop_statuses(
     statuses: &mut HashMap<ChannelId, ActiveDropStatus>,
     now: std::time::Instant,
@@ -317,10 +308,7 @@ pub(super) struct RemoteAccessSession {
     video_codec_override: Option<VideoCodec>,
     /// Per-message size limit for lossy data-track channels; larger messages are dropped.
     max_data_track_message_size: usize,
-    /// Per-channel record of the most recent oversized-drop `Status` warning
-    /// emitted to viewers. Feeds the quiet-period sweeper, which sends
-    /// `RemoveStatus` once a channel stops dropping, and lets the warning be
-    /// replayed to late subscribers. See [`DROP_STATUS_QUIET_PERIOD`].
+    /// Active oversized-drop warnings, keyed by channel.
     active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, ActiveDropStatus>>,
     /// The preferred encoder backend applied to published video tracks.
     /// [`VideoEncoderBackend::Auto`](super::gateway::VideoEncoderBackend::Auto) leaves the
@@ -341,9 +329,8 @@ impl Sink for RemoteAccessSession {
     ) -> std::result::Result<(), FoxgloveError> {
         let channel_id = channel.id();
 
-        // Captured under the read lock on the lossy oversized-drop path and
-        // handled after the lock is released (like the reliable branch below).
-        let mut drop_report: Option<(OversizedDropReport, SmallVec<[ParticipantSid; 4]>)> = None;
+        // Captured under the read lock and handled after the lock is released.
+        let mut drop_report: Option<OversizedDropReport> = None;
 
         // Snapshot subscriber SIDs under the channel-registry read lock and
         // release it before resolving against the participant registry. A
@@ -365,12 +352,10 @@ impl Sink for RemoteAccessSession {
                 state.data_subscriber_sids(&channel_id)
             } else {
                 // Lossy channels: send via the eagerly-published data track
-                // inline, while we still hold the state read lock. On a
-                // throttled oversized drop, capture the report and the current
-                // data subscribers so we can warn them after the lock.
+                // inline, while we still hold the state read lock.
                 if let Some(track) = state.get_subscribed_data_track(&channel_id) {
                     if let Err(report) = track.log(channel_id, msg, metadata) {
-                        drop_report = Some((report, state.data_subscriber_sids(&channel_id)));
+                        drop_report = Some(report);
                     }
                 }
                 SmallVec::new()
@@ -388,8 +373,8 @@ impl Sink for RemoteAccessSession {
             }
         }
 
-        if let Some((report, subscriber_sids)) = drop_report {
-            self.emit_drop_status(channel, report, subscriber_sids);
+        if let Some(report) = drop_report {
+            self.emit_drop_status(channel, report);
         }
 
         Ok(())
@@ -486,10 +471,7 @@ impl Sink for RemoteAccessSession {
         let unadvertise = Unadvertise::new([u64::from(channel_id)]);
         self.broadcast_control(encode_json_message(&unadvertise));
 
-        // Eagerly clear any viewer-facing oversized-drop status for the removed
-        // channel so it doesn't linger in the app's Problems panel until the
-        // sweeper's quiet period elapses. Removing an unknown status id is a
-        // client-side no-op.
+        // Clear any oversized-drop warning for the removed channel.
         self.active_drop_statuses.lock().remove(&channel_id);
         self.broadcast_control(encode_json_message(&RemoveStatus::new([drop_status_id(
             channel_id,
@@ -613,30 +595,18 @@ impl RemoteAccessSession {
         participant.send_control(encode_json_message(&status));
     }
 
-    /// Warn subscribers about a throttled oversized data-track drop and record
-    /// the drop time so the quiet-period sweeper can later clear the status.
-    ///
-    /// The status uses a stable per-channel id (`channel-drops-{id}`) so each
-    /// throttled report replaces the previous Problems-panel entry rather than
-    /// accumulating.
-    fn emit_drop_status(
-        &self,
-        channel: &RawChannel,
-        report: OversizedDropReport,
-        subscriber_sids: SmallVec<[ParticipantSid; 4]>,
-    ) {
+    /// Warn current data subscribers about a throttled oversized data-track drop.
+    fn emit_drop_status(&self, channel: &RawChannel, report: OversizedDropReport) {
         let channel_id = channel.id();
 
-        // The registry read lock is released before we get here, so a
-        // concurrent `remove_channel` may have unadvertised the channel and run
-        // its eager clear in the meantime. Skip emitting in that case so we
-        // don't resurrect a `Status` for a topic that's already gone. A much
-        // narrower window remains (removal's `RemoveStatus` racing ahead of the
-        // `Status` we're about to send); the quiet-period sweeper is the
-        // backstop that clears any such straggler.
-        if !self.channel_registry.read().has_channel(&channel_id) {
-            return;
-        }
+        let _guard = self.subscription_lock.lock();
+        let subscriber_sids = {
+            let state = self.channel_registry.read();
+            if !state.has_channel(&channel_id) {
+                return;
+            }
+            state.data_subscriber_sids(&channel_id)
+        };
 
         self.active_drop_statuses.lock().insert(
             channel_id,
@@ -645,6 +615,10 @@ impl RemoteAccessSession {
                 report,
             },
         );
+
+        if subscriber_sids.is_empty() {
+            return;
+        }
 
         let status = build_drop_status(channel_id, channel.topic(), report);
         let encoded = encode_json_message(&status);
@@ -696,13 +670,7 @@ impl RemoteAccessSession {
         }
     }
 
-    /// Removes drop-status entries idle for at least [`DROP_STATUS_QUIET_PERIOD`]
-    /// and broadcasts a single `RemoveStatus` clearing them. Synchronous and
-    /// timer-free so it can be unit-tested with a synthetic `now`.
-    ///
-    /// `RemoveStatus` is broadcast to all participants; removing an unknown
-    /// status id is a client-side no-op, so we needn't track exactly who
-    /// received each warning.
+    /// Clears drop-status entries idle for at least [`DROP_STATUS_QUIET_PERIOD`].
     fn sweep_expired_drop_statuses(&self, now: std::time::Instant) {
         let expired = drain_expired_drop_statuses(
             &mut self.active_drop_statuses.lock(),
@@ -999,15 +967,8 @@ impl RemoteAccessSession {
             }
         }
 
-        // Replay any active oversized-drop warning to the new data subscribers,
-        // so a viewer subscribing mid-drop-storm sees the warning immediately
-        // instead of waiting up to a throttle window for the next report. Video
-        // subscribers are excluded to match the original warning's audience
-        // (they bypass the data plane). The sends are queued while holding the
-        // map lock: the sweeper drains entries under this lock strictly before
-        // broadcasting `RemoveStatus`, so a replayed `Status` can never arrive
-        // after the `RemoveStatus` that clears it. `subscription_lock` (held
-        // above) serializes this against `remove_channel`'s eager clear.
+        // Replay active drop warnings to new data subscribers. Hold the map
+        // lock while queueing so the sweeper cannot clear first.
         {
             let statuses = self.active_drop_statuses.lock();
             if !statuses.is_empty() {
@@ -1059,12 +1020,7 @@ impl RemoteAccessSession {
             .actually_unsubscribed_descriptors
             .is_empty()
         {
-            // Eagerly clear any oversized-drop warning this participant was shown
-            // for a channel they just unsubscribed from, so it doesn't linger in
-            // their Problems panel until the sweeper's quiet period elapses.
-            // Other subscribers of the same channel are unaffected: the shared
-            // `active_drop_statuses` entry, and their own view of the warning,
-            // are left in place.
+            // Clear warnings for channels this participant just stopped watching.
             let statuses = self.active_drop_statuses.lock();
             let ids_to_clear: SmallVec<[ChannelId; 4]> = unsubscribe_result
                 .actually_unsubscribed_descriptors
@@ -3089,8 +3045,6 @@ mod tests {
         assert!(status.message.contains("failed to send a response"));
         assert!(rx.try_recv().is_err());
     }
-
-    // ---- oversized data-track drop status tests ----
 
     #[test]
     fn build_drop_status_has_warning_level_stable_id_and_message() {

--- a/rust/foxglove/src/remote_access/session.rs
+++ b/rust/foxglove/src/remote_access/session.rs
@@ -211,17 +211,27 @@ fn build_drop_status(channel_id: ChannelId, topic: &str, report: OversizedDropRe
     .with_id(drop_status_id(channel_id))
 }
 
+/// A channel's most recent oversized-drop report and when it was emitted.
+///
+/// `last_report` feeds the quiet-period sweeper; `report` lets the warning be
+/// rebuilt and replayed to viewers who subscribe while drops are ongoing.
+#[derive(Debug, Clone, Copy)]
+struct ActiveDropStatus {
+    last_report: std::time::Instant,
+    report: OversizedDropReport,
+}
+
 /// Drains and returns the channels whose most recent drop report is at least
 /// `quiet_period` old, leaving fresher entries in place. Pure and timer-free so
 /// the sweeper's expiry logic can be unit-tested with a synthetic `now`.
 fn drain_expired_drop_statuses(
-    statuses: &mut HashMap<ChannelId, std::time::Instant>,
+    statuses: &mut HashMap<ChannelId, ActiveDropStatus>,
     now: std::time::Instant,
     quiet_period: Duration,
 ) -> Vec<ChannelId> {
     let mut expired = Vec::new();
-    statuses.retain(|channel_id, last_report| {
-        if now.duration_since(*last_report) >= quiet_period {
+    statuses.retain(|channel_id, status| {
+        if now.duration_since(status.last_report) >= quiet_period {
             expired.push(*channel_id);
             false
         } else {
@@ -306,11 +316,11 @@ pub(super) struct RemoteAccessSession {
     video_codec_override: Option<VideoCodec>,
     /// Per-message size limit for lossy data-track channels; larger messages are dropped.
     max_data_track_message_size: usize,
-    /// Per-channel timestamp of the most recent oversized-drop `Status` warning
+    /// Per-channel record of the most recent oversized-drop `Status` warning
     /// emitted to viewers. Feeds the quiet-period sweeper, which sends
-    /// `RemoveStatus` once a channel stops dropping. See
-    /// [`DROP_STATUS_QUIET_PERIOD`].
-    active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, std::time::Instant>>,
+    /// `RemoveStatus` once a channel stops dropping, and lets the warning be
+    /// replayed to late subscribers. See [`DROP_STATUS_QUIET_PERIOD`].
+    active_drop_statuses: parking_lot::Mutex<HashMap<ChannelId, ActiveDropStatus>>,
     /// The preferred encoder backend applied to published video tracks.
     /// [`VideoEncoderBackend::Auto`](super::gateway::VideoEncoderBackend::Auto) leaves the
     /// choice to libwebrtc.
@@ -626,9 +636,13 @@ impl RemoteAccessSession {
             return;
         }
 
-        self.active_drop_statuses
-            .lock()
-            .insert(channel_id, std::time::Instant::now());
+        self.active_drop_statuses.lock().insert(
+            channel_id,
+            ActiveDropStatus {
+                last_report: std::time::Instant::now(),
+                report,
+            },
+        );
 
         let status = build_drop_status(channel_id, channel.topic(), report);
         let encoded = encode_json_message(&status);
@@ -979,6 +993,31 @@ impl RemoteAccessSession {
                 );
                 for descriptor in &subscribe_result.newly_subscribed_descriptors {
                     listener.on_subscribe(&client, descriptor);
+                }
+            }
+        }
+
+        // Replay any active oversized-drop warning to the new data subscribers,
+        // so a viewer subscribing mid-drop-storm sees the warning immediately
+        // instead of waiting up to a throttle window for the next report. Video
+        // subscribers are excluded to match the original warning's audience
+        // (they bypass the data plane). The sends are queued while holding the
+        // map lock: the sweeper drains entries under this lock strictly before
+        // broadcasting `RemoveStatus`, so a replayed `Status` can never arrive
+        // after the `RemoveStatus` that clears it. `subscription_lock` (held
+        // above) serializes this against `remove_channel`'s eager clear.
+        {
+            let statuses = self.active_drop_statuses.lock();
+            if !statuses.is_empty() {
+                for descriptor in &subscribe_result.newly_subscribed_descriptors {
+                    if !data_channel_ids.contains(&descriptor.id()) {
+                        continue;
+                    }
+                    if let Some(active) = statuses.get(&descriptor.id()) {
+                        let status =
+                            build_drop_status(descriptor.id(), descriptor.topic(), active.report);
+                        participant.send_control(encode_json_message(&status));
+                    }
                 }
             }
         }
@@ -3071,6 +3110,16 @@ mod tests {
         assert_eq!(format_byte_size(2 * 1024 * 1024), "2 MiB");
     }
 
+    fn active_drop_status(last_report: std::time::Instant) -> ActiveDropStatus {
+        ActiveDropStatus {
+            last_report,
+            report: OversizedDropReport {
+                dropped_since_last: 1,
+                size_limit: 1200,
+            },
+        }
+    }
+
     #[test]
     fn drain_expired_drop_statuses_removes_only_stale_entries() {
         let quiet = Duration::from_secs(60);
@@ -3080,9 +3129,9 @@ mod tests {
         let fresh = ChannelId::new(2);
         let mut statuses = HashMap::from([
             // Idle exactly the quiet period → expired (boundary is inclusive).
-            (stale, now - quiet),
+            (stale, active_drop_status(now - quiet)),
             // Idle less than the quiet period → retained.
-            (fresh, now - Duration::from_secs(30)),
+            (fresh, active_drop_status(now - Duration::from_secs(30))),
         ]);
 
         let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
@@ -3103,7 +3152,7 @@ mod tests {
         let quiet = Duration::from_secs(60);
         let now = std::time::Instant::now();
         let fresh = ChannelId::new(9);
-        let mut statuses = HashMap::from([(fresh, now)]);
+        let mut statuses = HashMap::from([(fresh, active_drop_status(now))]);
 
         let expired = drain_expired_drop_statuses(&mut statuses, now, quiet);
 

--- a/rust/foxglove/src/remote_access/session/data_track.rs
+++ b/rust/foxglove/src/remote_access/session/data_track.rs
@@ -15,9 +15,9 @@ const FRAME_HEADER_SIZE: usize = 8; // u16 LE flags + u16 LE data_offset + u32 L
 /// Details of a throttled oversized-message drop, surfaced to viewers as a
 /// `Status` warning.
 ///
-/// Returned by [`DataTrack::log`] only at the moment the throttled gateway-side
-/// warning fires, so the viewer-facing signal reuses the same throttle window
-/// and aggregated count without a second throttle.
+/// Returned as the `Err` variant of [`DataTrack::log`] only at the moment the
+/// throttled gateway-side warning fires, so the viewer-facing signal reuses the
+/// same throttle window and aggregated count without a second throttle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct OversizedDropReport {
     /// Oversized messages dropped since the last report, including this one.
@@ -136,16 +136,16 @@ impl DataTrack {
     /// [`max_message_size`](Self::max_message_size), or with a throttled debug
     /// log if the track is not ready or full.
     ///
-    /// Returns `Some(OversizedDropReport)` only on the throttled oversized-drop
+    /// Returns `Err(OversizedDropReport)` only on the throttled oversized-drop
     /// path — the same moment the gateway-side warning fires — so the caller can
-    /// surface a matching viewer signal. Returns `None` on all other paths
+    /// surface a matching viewer signal. Returns `Ok(())` on all other paths
     /// (delivered, throttled, not-ready, queue-full).
     pub fn log(
         &self,
         channel_id: ChannelId,
         msg: &[u8],
         metadata: &Metadata,
-    ) -> Option<OversizedDropReport> {
+    ) -> Result<(), OversizedDropReport> {
         if msg.len() > self.max_message_size {
             if self.oversized_throttler.lock().try_acquire() {
                 let dropped = 1 + self.oversized_dropped.swap(0, Ordering::Relaxed);
@@ -155,19 +155,19 @@ impl DataTrack {
                     msg.len(),
                     self.max_message_size
                 );
-                return Some(OversizedDropReport {
+                return Err(OversizedDropReport {
                     dropped_since_last: dropped,
                     size_limit: self.max_message_size,
                 });
             }
             self.oversized_dropped.fetch_add(1, Ordering::Relaxed);
-            return None;
+            return Ok(());
         }
         let Some(track) = self.track.get() else {
             if self.drop_throttler.lock().try_acquire() {
                 debug!("data track not ready, dropping message for channel {channel_id:?}");
             }
-            return None;
+            return Ok(());
         };
         let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
         let mut payload = Vec::with_capacity(FRAME_HEADER_SIZE + msg.len());
@@ -184,7 +184,7 @@ impl DataTrack {
                 debug!("data track message dropped for channel {channel_id:?}: {e:?}");
             }
         }
-        None
+        Ok(())
     }
 
     /// Oversized messages dropped since the last warning was logged (test-only).
@@ -249,18 +249,18 @@ mod tests {
         let report = track.log(channel_id, &[0u8; 17], &metadata);
         assert_eq!(
             report,
-            Some(OversizedDropReport {
+            Err(OversizedDropReport {
                 dropped_since_last: 1,
                 size_limit: 16,
             })
         );
 
         // A second oversized message is throttled: no report, one pending drop.
-        assert_eq!(track.log(channel_id, &[0u8; 17], &metadata), None);
+        assert_eq!(track.log(channel_id, &[0u8; 17], &metadata), Ok(()));
         assert_eq!(track.oversized_dropped(), 1);
 
         // An at-limit message takes the normal path: no report, not counted.
-        assert_eq!(track.log(channel_id, &[0u8; 16], &metadata), None);
+        assert_eq!(track.log(channel_id, &[0u8; 16], &metadata), Ok(()));
         assert_eq!(track.oversized_dropped(), 1);
     }
 }

--- a/rust/foxglove/src/remote_access/session/data_track.rs
+++ b/rust/foxglove/src/remote_access/session/data_track.rs
@@ -12,18 +12,15 @@ use crate::{ChannelId, Metadata};
 
 const FRAME_HEADER_SIZE: usize = 8; // u16 LE flags + u16 LE data_offset + u32 LE sequence
 
-/// Minimum interval between oversized-drop warnings for a track. Drops between
-/// firings are counted and aggregated into the next warning's report. The
-/// viewer-facing status message quotes this window ("in the last 30 seconds"),
-/// and the session's drop-status quiet period is derived from it.
+/// Minimum interval between oversized-drop warnings for a track.
+///
+/// Drops between warnings are counted and folded into the next report.
 pub(super) const OVERSIZED_WARN_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Details of a throttled oversized-message drop, surfaced to viewers as a
 /// `Status` warning.
 ///
-/// Returned as the `Err` variant of [`DataTrack::log`] only at the moment the
-/// throttled gateway-side warning fires, so the viewer-facing signal reuses the
-/// same throttle window and aggregated count without a second throttle.
+/// Returned by [`DataTrack::log`] only when the gateway-side warning fires.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct OversizedDropReport {
     /// Oversized messages dropped since the last report, including this one.
@@ -142,10 +139,8 @@ impl DataTrack {
     /// [`max_message_size`](Self::max_message_size), or with a throttled debug
     /// log if the track is not ready or full.
     ///
-    /// Returns `Err(OversizedDropReport)` only on the throttled oversized-drop
-    /// path — the same moment the gateway-side warning fires — so the caller can
-    /// surface a matching viewer signal. Returns `Ok(())` on all other paths
-    /// (delivered, throttled, not-ready, queue-full).
+    /// Returns `Err(OversizedDropReport)` only when an oversized-drop warning
+    /// fires. All other delivered or dropped messages return `Ok(())`.
     pub fn log(
         &self,
         channel_id: ChannelId,

--- a/rust/foxglove/src/remote_access/session/data_track.rs
+++ b/rust/foxglove/src/remote_access/session/data_track.rs
@@ -12,6 +12,20 @@ use crate::{ChannelId, Metadata};
 
 const FRAME_HEADER_SIZE: usize = 8; // u16 LE flags + u16 LE data_offset + u32 LE sequence
 
+/// Details of a throttled oversized-message drop, surfaced to viewers as a
+/// `Status` warning.
+///
+/// Returned by [`DataTrack::log`] only at the moment the throttled gateway-side
+/// warning fires, so the viewer-facing signal reuses the same throttle window
+/// and aggregated count without a second throttle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OversizedDropReport {
+    /// Oversized messages dropped since the last report, including this one.
+    pub dropped_since_last: u64,
+    /// The configured per-message size limit, in bytes.
+    pub size_limit: usize,
+}
+
 /// Manages the lifecycle of a single published data track.
 pub(crate) struct DataTrack {
     /// Shared cell where the publish task deposits the track on success.
@@ -121,7 +135,17 @@ impl DataTrack {
     /// Drops the message (with a throttled warning) if it exceeds
     /// [`max_message_size`](Self::max_message_size), or with a throttled debug
     /// log if the track is not ready or full.
-    pub fn log(&self, channel_id: ChannelId, msg: &[u8], metadata: &Metadata) {
+    ///
+    /// Returns `Some(OversizedDropReport)` only on the throttled oversized-drop
+    /// path — the same moment the gateway-side warning fires — so the caller can
+    /// surface a matching viewer signal. Returns `None` on all other paths
+    /// (delivered, throttled, not-ready, queue-full).
+    pub fn log(
+        &self,
+        channel_id: ChannelId,
+        msg: &[u8],
+        metadata: &Metadata,
+    ) -> Option<OversizedDropReport> {
         if msg.len() > self.max_message_size {
             if self.oversized_throttler.lock().try_acquire() {
                 let dropped = 1 + self.oversized_dropped.swap(0, Ordering::Relaxed);
@@ -131,16 +155,19 @@ impl DataTrack {
                     msg.len(),
                     self.max_message_size
                 );
-            } else {
-                self.oversized_dropped.fetch_add(1, Ordering::Relaxed);
+                return Some(OversizedDropReport {
+                    dropped_since_last: dropped,
+                    size_limit: self.max_message_size,
+                });
             }
-            return;
+            self.oversized_dropped.fetch_add(1, Ordering::Relaxed);
+            return None;
         }
         let Some(track) = self.track.get() else {
             if self.drop_throttler.lock().try_acquire() {
                 debug!("data track not ready, dropping message for channel {channel_id:?}");
             }
-            return;
+            return None;
         };
         let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
         let mut payload = Vec::with_capacity(FRAME_HEADER_SIZE + msg.len());
@@ -157,6 +184,7 @@ impl DataTrack {
                 debug!("data track message dropped for channel {channel_id:?}: {e:?}");
             }
         }
+        None
     }
 
     /// Oversized messages dropped since the last warning was logged (test-only).
@@ -217,13 +245,22 @@ mod tests {
         let metadata = Metadata::default();
 
         // The first oversized message fires the throttled warning, which resets
-        // the pending counter, so send a second to leave one pending drop.
-        track.log(channel_id, &[0u8; 17], &metadata);
-        track.log(channel_id, &[0u8; 17], &metadata);
+        // the pending counter and returns a report for the viewer signal.
+        let report = track.log(channel_id, &[0u8; 17], &metadata);
+        assert_eq!(
+            report,
+            Some(OversizedDropReport {
+                dropped_since_last: 1,
+                size_limit: 16,
+            })
+        );
+
+        // A second oversized message is throttled: no report, one pending drop.
+        assert_eq!(track.log(channel_id, &[0u8; 17], &metadata), None);
         assert_eq!(track.oversized_dropped(), 1);
 
-        // An at-limit message takes the normal path and is not counted.
-        track.log(channel_id, &[0u8; 16], &metadata);
+        // An at-limit message takes the normal path: no report, not counted.
+        assert_eq!(track.log(channel_id, &[0u8; 16], &metadata), None);
         assert_eq!(track.oversized_dropped(), 1);
     }
 }

--- a/rust/foxglove/src/remote_access/session/data_track.rs
+++ b/rust/foxglove/src/remote_access/session/data_track.rs
@@ -12,6 +12,12 @@ use crate::{ChannelId, Metadata};
 
 const FRAME_HEADER_SIZE: usize = 8; // u16 LE flags + u16 LE data_offset + u32 LE sequence
 
+/// Minimum interval between oversized-drop warnings for a track. Drops between
+/// firings are counted and aggregated into the next warning's report. The
+/// viewer-facing status message quotes this window ("in the last 30 seconds"),
+/// and the session's drop-status quiet period is derived from it.
+pub(super) const OVERSIZED_WARN_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Details of a throttled oversized-message drop, surfaced to viewers as a
 /// `Status` warning.
 ///
@@ -125,7 +131,7 @@ impl DataTrack {
             max_message_size,
             oversized_dropped: AtomicU64::new(0),
             oversized_throttler: parking_lot::Mutex::new(crate::throttler::Throttler::new(
-                Duration::from_secs(30),
+                OVERSIZED_WARN_INTERVAL,
             )),
         }
     }
@@ -232,7 +238,7 @@ mod tests {
                 max_message_size,
                 oversized_dropped: AtomicU64::new(0),
                 oversized_throttler: parking_lot::Mutex::new(crate::throttler::Throttler::new(
-                    Duration::from_secs(30),
+                    OVERSIZED_WARN_INTERVAL,
                 )),
             }
         }

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -210,7 +210,7 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
         Some(format!("channel-drops-{channel_id}").as_str())
     );
     assert!(
-        status.message.contains("data-track size limit"),
+        status.message.contains("per-message size limit"),
         "unexpected status message: {}",
         status.message
     );

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -197,6 +197,25 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
          received a frame"
     );
 
+    // The drop is surfaced to the subscribed viewer as a throttled Status
+    // warning on the control channel, with a stable per-channel id so repeated
+    // reports replace rather than accumulate in the Problems panel.
+    let status = viewer.expect_status().await?;
+    assert_eq!(
+        status.level,
+        foxglove::protocol::v2::server::status::Level::Warning
+    );
+    assert_eq!(
+        status.id.as_deref(),
+        Some(format!("channel-drops-{channel_id}").as_str())
+    );
+    assert!(
+        status.message.contains("data-track size limit"),
+        "unexpected status message: {}",
+        status.message
+    );
+    info!("viewer received oversized-drop status warning");
+
     // 3. A later small message is delivered, confirming the stream is still
     //    healthy — the absence above was the drop, not a broken channel.
     channel.log(b"after");

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -141,10 +141,9 @@ async fn livekit_viewer_receives_message_after_subscribe() -> Result<()> {
 /// Test the full oversized data-track drop story: a message exceeding the
 /// configured size limit is dropped at the gateway while smaller messages on
 /// the same channel are delivered (FLE-592), the subscribed viewer is warned
-/// via a `Status` with a stable per-channel id, a viewer subscribing later —
-/// while the warning is still active — receives it replayed immediately at
-/// subscribe time, and removing the channel eagerly clears the warning for
-/// every viewer via a broadcast `RemoveStatus` (FLE-645).
+/// via a `Status` with a stable per-channel id, and removing the channel
+/// eagerly clears the warning for every subscribed viewer via a broadcast
+/// `RemoveStatus` (FLE-645).
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -225,30 +224,14 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     assert_eq!(after.data.as_ref(), b"after");
     info!("oversized data-track message correctly dropped at the gateway");
 
-    // 4. A viewer subscribing while the warning is active receives it replayed
-    //    at subscribe time. No oversized message is logged after this subscribe
-    //    and the 30s report throttle makes a fresh report impossible this soon,
-    //    so the status below is provably the replay, not a new report.
+    // 4. A second viewer subscribes after the warning has already been sent to
+    //    viewer-1. It does not receive the warning itself (no replay to late
+    //    subscribers), but it is still subscribed when the channel is removed
+    //    below, so the eager clear below must reach it too.
     let mut viewer2 = ViewerConnection::connect(&gw.room_name, "viewer-2").await?;
     let _server_info = viewer2.expect_server_info().await?;
     let _advertise = viewer2.expect_advertise().await?;
     viewer2.subscribe_and_wait(&[channel_id], &channel).await?;
-
-    let replayed = viewer2.expect_status().await?;
-    assert_eq!(
-        replayed.level,
-        foxglove::protocol::v2::server::status::Level::Warning
-    );
-    assert_eq!(
-        replayed.id.as_deref(),
-        Some(format!("channel-drops-{channel_id}").as_str())
-    );
-    assert!(
-        replayed.message.contains("per-message size limit"),
-        "unexpected replayed status message: {}",
-        replayed.message
-    );
-    info!("late subscriber received replayed oversized-drop status warning");
 
     // 5. Removing the channel eagerly clears the warning: every viewer gets an
     //    Unadvertise followed by a RemoveStatus for the channel's status id,

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -141,8 +141,9 @@ async fn livekit_viewer_receives_message_after_subscribe() -> Result<()> {
 /// Test the full oversized data-track drop story: a message exceeding the
 /// configured size limit is dropped at the gateway while smaller messages on
 /// the same channel are delivered (FLE-592), the subscribed viewer is warned
-/// via a `Status` with a stable per-channel id, and removing the channel
-/// eagerly clears the warning for every subscribed viewer via a broadcast
+/// via a `Status` with a stable per-channel id, unsubscribing eagerly clears
+/// the warning for just the departing viewer, and removing the channel
+/// eagerly clears the warning for every remaining viewer via a broadcast
 /// `RemoveStatus` (FLE-645).
 #[traced_test]
 #[ignore]
@@ -224,7 +225,22 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     assert_eq!(after.data.as_ref(), b"after");
     info!("oversized data-track message correctly dropped at the gateway");
 
-    // 4. A second viewer subscribes after the warning has already been sent to
+    let expected_status_id = format!("channel-drops-{channel_id}");
+
+    // 4. viewer-1 unsubscribes from the channel while its warning is still
+    //    active. Since it's no longer watching that channel, it gets a
+    //    targeted RemoveStatus clearing the warning immediately, without
+    //    waiting for the sweeper's quiet period.
+    viewer.send_unsubscribe(&[channel_id]).await?;
+    let unsub_clear = viewer.expect_remove_status().await?;
+    assert_eq!(
+        unsub_clear.status_ids,
+        vec![expected_status_id.clone()],
+        "unsubscribing viewer-1 should have its drop status cleared"
+    );
+    info!("unsubscribe eagerly cleared the drop status for the departing viewer");
+
+    // 5. A second viewer subscribes after the warning has already been sent to
     //    viewer-1. It does not receive the warning itself (no replay to late
     //    subscribers), but it is still subscribed when the channel is removed
     //    below, so the eager clear below must reach it too.
@@ -233,11 +249,13 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     let _advertise = viewer2.expect_advertise().await?;
     viewer2.subscribe_and_wait(&[channel_id], &channel).await?;
 
-    // 5. Removing the channel eagerly clears the warning: every viewer gets an
-    //    Unadvertise followed by a RemoveStatus for the channel's status id,
-    //    without waiting for the sweeper's quiet period.
+    // 6. Removing the channel eagerly clears the warning for every remaining
+    //    connected participant: each gets an Unadvertise followed by a
+    //    RemoveStatus for the channel's status id, without waiting for the
+    //    sweeper's quiet period. viewer-1 receives this too even though it
+    //    already unsubscribed, since the removal broadcast doesn't depend on
+    //    subscription state.
     channel.close();
-    let expected_status_id = format!("channel-drops-{channel_id}");
     for (name, v) in [("viewer-1", &mut viewer), ("viewer-2", &mut viewer2)] {
         let unadvertise = v.expect_unadvertise().await?;
         assert_eq!(unadvertise.channel_ids, vec![channel_id]);

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -142,9 +142,10 @@ async fn livekit_viewer_receives_message_after_subscribe() -> Result<()> {
 /// configured size limit is dropped at the gateway while smaller messages on
 /// the same channel are delivered (FLE-592), the subscribed viewer is warned
 /// via a `Status` with a stable per-channel id, unsubscribing eagerly clears
-/// the warning for just the departing viewer, and removing the channel
-/// eagerly clears the warning for every remaining viewer via a broadcast
-/// `RemoveStatus` (FLE-645).
+/// the warning for just the departing viewer, a viewer subscribing later —
+/// while the warning is still active — receives it replayed immediately at
+/// subscribe time, and removing the channel eagerly clears the warning for
+/// every remaining viewer via a broadcast `RemoveStatus` (FLE-645).
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -240,14 +241,28 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     );
     info!("unsubscribe eagerly cleared the drop status for the departing viewer");
 
-    // 5. A second viewer subscribes after the warning has already been sent to
-    //    viewer-1. It does not receive the warning itself (no replay to late
-    //    subscribers), but it is still subscribed when the channel is removed
-    //    below, so the eager clear below must reach it too.
+    // 5. A second viewer subscribing while the warning is still active
+    //    receives it replayed at subscribe time. No oversized message is
+    //    logged after this subscribe and the 30s report throttle makes a
+    //    fresh report impossible this soon, so the status below is provably
+    //    the replay, not a new report.
     let mut viewer2 = ViewerConnection::connect(&gw.room_name, "viewer-2").await?;
     let _server_info = viewer2.expect_server_info().await?;
     let _advertise = viewer2.expect_advertise().await?;
     viewer2.subscribe_and_wait(&[channel_id], &channel).await?;
+
+    let replayed = viewer2.expect_status().await?;
+    assert_eq!(
+        replayed.level,
+        foxglove::protocol::v2::server::status::Level::Warning
+    );
+    assert_eq!(replayed.id.as_deref(), Some(expected_status_id.as_str()));
+    assert!(
+        replayed.message.contains("per-message size limit"),
+        "unexpected replayed status message: {}",
+        replayed.message
+    );
+    info!("late subscriber received replayed oversized-drop status warning");
 
     // 6. Removing the channel eagerly clears the warning for every remaining
     //    connected participant: each gets an Unadvertise followed by a

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -138,14 +138,8 @@ async fn livekit_viewer_receives_message_after_subscribe() -> Result<()> {
     Ok(())
 }
 
-/// Test the full oversized data-track drop story: a message exceeding the
-/// configured size limit is dropped at the gateway while smaller messages on
-/// the same channel are delivered (FLE-592), the subscribed viewer is warned
-/// via a `Status` with a stable per-channel id, unsubscribing eagerly clears
-/// the warning for just the departing viewer, a viewer subscribing later —
-/// while the warning is still active — receives it replayed immediately at
-/// subscribe time, and removing the channel eagerly clears the warning for
-/// every remaining viewer via a broadcast `RemoveStatus` (FLE-645).
+/// Oversized data-track messages are dropped, surfaced as channel-scoped
+/// warnings, replayed to late subscribers, and cleared on unsubscribe/removal.
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -200,9 +194,7 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
          received a frame"
     );
 
-    // The drop is surfaced to the subscribed viewer as a throttled Status
-    // warning on the control channel, with a stable per-channel id so repeated
-    // reports replace rather than accumulate in the Problems panel.
+    // The subscribed viewer is warned with a stable per-channel status id.
     let status = viewer.expect_status().await?;
     assert_eq!(
         status.level,
@@ -219,8 +211,7 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     );
     info!("viewer received oversized-drop status warning");
 
-    // 3. A later small message is delivered, confirming the stream is still
-    //    healthy — the absence above was the drop, not a broken channel.
+    // 3. A later small message is delivered, confirming the stream is healthy.
     channel.log(b"after");
     let after = ch_reader.next_message_data().await?;
     assert_eq!(after.data.as_ref(), b"after");
@@ -228,10 +219,7 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
 
     let expected_status_id = format!("channel-drops-{channel_id}");
 
-    // 4. viewer-1 unsubscribes from the channel while its warning is still
-    //    active. Since it's no longer watching that channel, it gets a
-    //    targeted RemoveStatus clearing the warning immediately, without
-    //    waiting for the sweeper's quiet period.
+    // 4. Unsubscribe clears the warning for the departing viewer.
     viewer.send_unsubscribe(&[channel_id]).await?;
     let unsub_clear = viewer.expect_remove_status().await?;
     assert_eq!(
@@ -241,11 +229,7 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     );
     info!("unsubscribe eagerly cleared the drop status for the departing viewer");
 
-    // 5. A second viewer subscribing while the warning is still active
-    //    receives it replayed at subscribe time. No oversized message is
-    //    logged after this subscribe and the 30s report throttle makes a
-    //    fresh report impossible this soon, so the status below is provably
-    //    the replay, not a new report.
+    // 5. A late subscriber receives the active warning immediately.
     let mut viewer2 = ViewerConnection::connect(&gw.room_name, "viewer-2").await?;
     let _server_info = viewer2.expect_server_info().await?;
     let _advertise = viewer2.expect_advertise().await?;
@@ -264,12 +248,7 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     );
     info!("late subscriber received replayed oversized-drop status warning");
 
-    // 6. Removing the channel eagerly clears the warning for every remaining
-    //    connected participant: each gets an Unadvertise followed by a
-    //    RemoveStatus for the channel's status id, without waiting for the
-    //    sweeper's quiet period. viewer-1 receives this too even though it
-    //    already unsubscribed, since the removal broadcast doesn't depend on
-    //    subscription state.
+    // 6. Removing the channel clears the warning for connected participants.
     channel.close();
     for (name, v) in [("viewer-1", &mut viewer), ("viewer-2", &mut viewer2)] {
         let unadvertise = v.expect_unadvertise().await?;

--- a/rust/remote_access_tests/tests/livekit_test.rs
+++ b/rust/remote_access_tests/tests/livekit_test.rs
@@ -138,11 +138,13 @@ async fn livekit_viewer_receives_message_after_subscribe() -> Result<()> {
     Ok(())
 }
 
-/// Test that a message exceeding the configured data-track size limit is dropped
-/// at the gateway, while smaller messages on the same channel are delivered. The
-/// viewer receives the two small payloads and never the oversized one logged
-/// between them, proving the oversized message was shed at publish rather than
-/// merely delayed (FLE-592).
+/// Test the full oversized data-track drop story: a message exceeding the
+/// configured size limit is dropped at the gateway while smaller messages on
+/// the same channel are delivered (FLE-592), the subscribed viewer is warned
+/// via a `Status` with a stable per-channel id, a viewer subscribing later —
+/// while the warning is still active — receives it replayed immediately at
+/// subscribe time, and removing the channel eagerly clears the warning for
+/// every viewer via a broadcast `RemoveStatus` (FLE-645).
 #[traced_test]
 #[ignore]
 #[tokio::test]
@@ -223,7 +225,50 @@ async fn livekit_oversized_data_track_message_is_dropped() -> Result<()> {
     assert_eq!(after.data.as_ref(), b"after");
     info!("oversized data-track message correctly dropped at the gateway");
 
+    // 4. A viewer subscribing while the warning is active receives it replayed
+    //    at subscribe time. No oversized message is logged after this subscribe
+    //    and the 30s report throttle makes a fresh report impossible this soon,
+    //    so the status below is provably the replay, not a new report.
+    let mut viewer2 = ViewerConnection::connect(&gw.room_name, "viewer-2").await?;
+    let _server_info = viewer2.expect_server_info().await?;
+    let _advertise = viewer2.expect_advertise().await?;
+    viewer2.subscribe_and_wait(&[channel_id], &channel).await?;
+
+    let replayed = viewer2.expect_status().await?;
+    assert_eq!(
+        replayed.level,
+        foxglove::protocol::v2::server::status::Level::Warning
+    );
+    assert_eq!(
+        replayed.id.as_deref(),
+        Some(format!("channel-drops-{channel_id}").as_str())
+    );
+    assert!(
+        replayed.message.contains("per-message size limit"),
+        "unexpected replayed status message: {}",
+        replayed.message
+    );
+    info!("late subscriber received replayed oversized-drop status warning");
+
+    // 5. Removing the channel eagerly clears the warning: every viewer gets an
+    //    Unadvertise followed by a RemoveStatus for the channel's status id,
+    //    without waiting for the sweeper's quiet period.
+    channel.close();
+    let expected_status_id = format!("channel-drops-{channel_id}");
+    for (name, v) in [("viewer-1", &mut viewer), ("viewer-2", &mut viewer2)] {
+        let unadvertise = v.expect_unadvertise().await?;
+        assert_eq!(unadvertise.channel_ids, vec![channel_id]);
+        let removed = v.expect_remove_status().await?;
+        assert_eq!(
+            removed.status_ids,
+            vec![expected_status_id.clone()],
+            "{name} should have the drop status cleared on channel removal"
+        );
+    }
+    info!("channel removal eagerly cleared the drop status for all viewers");
+
     viewer.close().await?;
+    viewer2.close().await?;
     gw.stop().await?;
     Ok(())
 }


### PR DESCRIPTION
### Changelog
Remote access viewers now see a warning in the app when the gateway drops oversized messages on a subscribed topic.

### Docs
None

### Description
FLE-592 made the remote access gateway drop lossy data-track messages that exceed the per-message size limit (default 100 KiB), but the only signal was a throttled warning in the gateway's logs. From the viewer's side, messages on an oversized topic just silently never arrive — and the person watching the stream usually can't see the device's logs, so the topic looks broken with no explanation.

This PR surfaces that same drop report to viewers using the existing `Status`/`RemoveStatus` control-plane messages, which the app already renders in the Problems panel:

- When the gateway's throttled drop warning fires, a `Status` warning is also sent to that channel's current data subscribers.
- The status uses a stable id (`channel-drops-{id}`), so there's only one such problem report per channel.
- The drop warning is latched so it can be replayed to new subscribers immediately. This is useful, because otherwise the 30s throttle period is a very long time to wait.
- The status is cleared via `RemoveStatus`:
  - For all participants, once a channel has had no drops for 60s.
  - For all participants when the channel is removed.
  - For a particular participant that unsubscribes from the channel.

Manual testing:

- [x] Verified end-to-end in the Foxglove app: streaming a topic with oversized messages over remote access shows the warning in the Problems panel (naming the topic, drop count, and size limit), repeated reports replace the entry rather than stacking, and the warning clears automatically ~60–75s after the oversized traffic stops (this manual check is the coverage for the sweeper's timed clear, which has no end-to-end test).

<!-- Use the Before/After table below for screenshots or other visual demonstrations of user-facing changes. Do NOT use this section to re-state code changes that are already visible in the diff. Delete this table if there are no visual changes to show. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>



</td><td>

<img width="901" height="262" alt="Screenshot 2026-07-07 at 12 26 55 PM" src="https://github.com/user-attachments/assets/9e9b46e0-e02e-447c-ba74-175940a03259" />

</td></tr></table>

<!-- Link relevant GitHub or Linear issues. Use `Fixes: https://github.com/<orgname>/<reponame>/issues/123` for GitHub issues or `Fixes: [ABC-123](https://linear.app/foxglove/issue/ABC-123)` for Linear issues. Put each issue on a separate line. -->

Fixes: [FLE-645](https://linear.app/foxglove/issue/FLE-645)
