### PR TITLE
remote_access example: forward channel metadata on replay

### DIFF
--- a/rust/examples/remote_access_stream_mcap/src/main.rs
+++ b/rust/examples/remote_access_stream_mcap/src/main.rs
@@ -125,7 +125,13 @@ fn load_summary<R: Read + Seek>(file: &mut R) -> Result<Option<Summary>> {
     Ok(reader.finish())
 }
 
-/// Creates foxglove channels from the MCAP summary.
+/// Creates foxglove channels from the MCAP summary, forwarding each channel's
+/// metadata verbatim.
+///
+/// Preserving channel metadata keeps replay faithful to the original producer: a
+/// recording that declared channel-level metadata (e.g. remote-access delivery
+/// hints such as `foxglove.suppressVideoTranscode`) is replayed with that
+/// metadata intact, with no per-channel logic in the example.
 fn create_channels(summary: &Summary) -> Result<HashMap<u16, Arc<RawChannel>>> {
     let mut channels = HashMap::new();
     for (&id, mcap_channel) in &summary.channels {
@@ -133,10 +139,13 @@ fn create_channels(summary: &Summary) -> Result<HashMap<u16, Arc<RawChannel>>> {
             .schema
             .as_ref()
             .map(|s| Schema::new(s.name.as_str(), s.encoding.as_str(), s.data.to_vec()));
-        let channel = ChannelBuilder::new(&mcap_channel.topic)
+        let mut builder = ChannelBuilder::new(&mcap_channel.topic)
             .message_encoding(&mcap_channel.message_encoding)
-            .schema(schema)
-            .build_raw()?;
+            .schema(schema);
+        for (key, value) in &mcap_channel.metadata {
+            builder = builder.add_metadata(key, value);
+        }
+        let channel = builder.build_raw()?;
         channels.insert(id, channel);
     }
     Ok(channels)

--- a/rust/examples/remote_access_stream_mcap/src/main.rs
+++ b/rust/examples/remote_access_stream_mcap/src/main.rs
@@ -139,13 +139,11 @@ fn create_channels(summary: &Summary) -> Result<HashMap<u16, Arc<RawChannel>>> {
             .schema
             .as_ref()
             .map(|s| Schema::new(s.name.as_str(), s.encoding.as_str(), s.data.to_vec()));
-        let mut builder = ChannelBuilder::new(&mcap_channel.topic)
+        let channel = ChannelBuilder::new(&mcap_channel.topic)
             .message_encoding(&mcap_channel.message_encoding)
-            .schema(schema);
-        for (key, value) in &mcap_channel.metadata {
-            builder = builder.add_metadata(key, value);
-        }
-        let channel = builder.build_raw()?;
+            .schema(schema)
+            .metadata(mcap_channel.metadata.clone())
+            .build_raw()?;
         channels.insert(id, channel);
     }
     Ok(channels)

--- a/rust/examples/remote_access_stream_mcap/src/main.rs
+++ b/rust/examples/remote_access_stream_mcap/src/main.rs
@@ -125,8 +125,7 @@ fn load_summary<R: Read + Seek>(file: &mut R) -> Result<Option<Summary>> {
     Ok(reader.finish())
 }
 
-/// Creates foxglove channels from the MCAP summary, forwarding each channel's
-/// metadata verbatim.
+/// Creates foxglove channels from the MCAP summary.
 fn create_channels(summary: &Summary) -> Result<HashMap<u16, Arc<RawChannel>>> {
     let mut channels = HashMap::new();
     for (&id, mcap_channel) in &summary.channels {

--- a/rust/examples/remote_access_stream_mcap/src/main.rs
+++ b/rust/examples/remote_access_stream_mcap/src/main.rs
@@ -127,11 +127,6 @@ fn load_summary<R: Read + Seek>(file: &mut R) -> Result<Option<Summary>> {
 
 /// Creates foxglove channels from the MCAP summary, forwarding each channel's
 /// metadata verbatim.
-///
-/// Preserving channel metadata keeps replay faithful to the original producer: a
-/// recording that declared channel-level metadata (e.g. remote-access delivery
-/// hints such as `foxglove.suppressVideoTranscode`) is replayed with that
-/// metadata intact, with no per-channel logic in the example.
 fn create_channels(summary: &Summary) -> Result<HashMap<u16, Arc<RawChannel>>> {
     let mut channels = HashMap::new();
     for (&id, mcap_channel) in &summary.channels {


### PR DESCRIPTION
### Changelog

None (example only).

### Docs

None.

### Description

The `example_remote_access_stream_mcap` replayer rebuilt foxglove channels from the MCAP summary (topic, message encoding, schema) but dropped each channel's `metadata`. This makes replay lossy: any channel-level metadata the original producer declared is silently discarded.

This forwards `mcap_channel.metadata` verbatim onto the `ChannelBuilder`, so a recording that declared channel metadata is replayed with it intact and that metadata round-trips onto the advertised channels — with no per-channel logic in the example.

Manual testing:
- [x] Replayed an MCAP whose channels declare metadata; confirmed the forwarded metadata appears on the advertised channels.
- [ ] Reviewer: replay any recording with channel metadata and confirm it round-trips onto the advertised channels.
