### PR TITLE
ci: Retry apt-get dependency installs to survive transient mirror failures (FLE-654)

### DIFF
--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -19,13 +19,21 @@ runs:
     - shell: bash
       run: sudo rm -f /var/lib/man-db/auto-update
 
-    - shell: bash
-      run: sudo apt-get update
-
-    - shell: bash
+    - name: Install apt packages (with retry)
+      shell: bash
       run: |
-        sudo apt-get install -y --no-install-recommends \
-          libprotobuf-dev \
-          protobuf-compiler \
-          libglib2.0-dev \
-          libva-dev
+        for attempt in 1 2 3; do
+          if sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+            libprotobuf-dev \
+            protobuf-compiler \
+            libglib2.0-dev \
+            libva-dev; then
+            exit 0
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::apt-get failed after 3 attempts"
+            exit 1
+          fi
+          echo "::warning::apt-get failed (attempt $attempt/3); retrying in 15s"
+          sleep 15
+        done

--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -22,18 +22,9 @@ runs:
     - name: Install apt packages (with retry)
       shell: bash
       run: |
-        for attempt in 1 2 3; do
-          if sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libglib2.0-dev \
-            libva-dev; then
-            exit 0
-          fi
-          if [ "$attempt" -eq 3 ]; then
-            echo "::error::apt-get failed after 3 attempts"
-            exit 1
-          fi
-          echo "::warning::apt-get failed (attempt $attempt/3); retrying in 15s"
-          sleep 15
-        done
+        "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" \
+          --no-install-recommends \
+          libprotobuf-dev \
+          protobuf-compiler \
+          libglib2.0-dev \
+          libva-dev

--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Install apt packages (with retry)
       shell: bash
       run: |
-        "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" \
+        bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" \
           --no-install-recommends \
           libprotobuf-dev \
           protobuf-compiler \

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,9 @@
+# CI helper scripts
+
+Shell helpers invoked by the workflows and composite actions under
+`.github/`. Scripts here may use GitHub Actions workflow commands (e.g.
+`::error::`, `::warning::`) and assume they run on a GitHub-hosted runner
+with the repository checked out at `$GITHUB_WORKSPACE`.
+
+- `apt-retry.sh` — `apt-get update` + `install` wrapped in a bounded retry, so
+  transient Ubuntu mirror failures don't fail an otherwise-healthy job.

--- a/.github/scripts/apt-retry.sh
+++ b/.github/scripts/apt-retry.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Runs `apt-get update` followed by `apt-get install` with bounded retries, to
+# survive transient Ubuntu mirror failures (Failed to fetch, hash-sum mismatch,
+# 5xx) that would otherwise fail an entire CI job. All arguments are forwarded
+# verbatim to `apt-get install -y`, so callers pass any flags (e.g.
+# --no-install-recommends) and the package list. Exits non-zero after 3 failed
+# attempts so a genuine breakage is not masked.
+set -euo pipefail
+
+for attempt in 1 2 3; do
+  if sudo apt-get update && sudo apt-get install -y "$@"; then
+    exit 0
+  fi
+  if [ "$attempt" -eq 3 ]; then
+    echo "::error::apt-get failed after 3 attempts"
+    exit 1
+  fi
+  echo "::warning::apt-get failed (attempt $attempt/3); retrying in 15s"
+  sleep 15
+done

--- a/.github/scripts/apt-retry.sh
+++ b/.github/scripts/apt-retry.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
-# Runs `apt-get update` followed by `apt-get install` with bounded retries, to
-# survive transient Ubuntu mirror failures (Failed to fetch, hash-sum mismatch,
-# 5xx) that would otherwise fail an entire CI job. All arguments are forwarded
-# verbatim to `apt-get install -y`, so callers pass any flags (e.g.
-# --no-install-recommends) and the package list. Exits non-zero after 3 failed
-# attempts so a genuine breakage is not masked.
+# Runs `apt-get update` + `apt-get install` with bounded retries so transient
+# Ubuntu mirror failures don't fail an otherwise-healthy CI job. All arguments
+# are forwarded verbatim to `apt-get install -y` (flags plus the package list).
+# Exits non-zero after 3 failed attempts so a genuine breakage is not masked.
 set -euo pipefail
 
 for attempt in 1 2 3; do

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -174,17 +174,7 @@ jobs:
       - name: Install remote access build dependencies (Linux)
         if: matrix.remote_access && runner.os == 'Linux'
         run: |
-          for attempt in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y libglib2.0-dev libva-dev libwebsockets-dev; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::apt-get failed after 3 attempts"
-              exit 1
-            fi
-            echo "::warning::apt-get failed (attempt $attempt/3); retrying in 15s"
-            sleep 15
-          done
+          "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" libglib2.0-dev libva-dev libwebsockets-dev
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -174,8 +174,17 @@ jobs:
       - name: Install remote access build dependencies (Linux)
         if: matrix.remote_access && runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libglib2.0-dev libva-dev libwebsockets-dev
+          for attempt in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y libglib2.0-dev libva-dev libwebsockets-dev; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::apt-get failed after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::apt-get failed (attempt $attempt/3); retrying in 15s"
+            sleep 15
+          done
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install remote access build dependencies (Linux)
         if: matrix.remote_access && runner.os == 'Linux'
         run: |
-          "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" libglib2.0-dev libva-dev libwebsockets-dev
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" libglib2.0-dev libva-dev libwebsockets-dev
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 


### PR DESCRIPTION
### Changelog

None — CI-only change.

### Docs

None.

### Description

CI dependency-install steps run `apt-get update` / `apt-get install` against Ubuntu package mirrors with no retry, so a transient mirror hiccup ("Failed to fetch", hash-sum mismatch, 5xx) fails the whole job even when nothing is wrong with the change under review. This was observed on PR #1353, where `build (aarch64-unknown-linux-gnu, remote-access)`, `build-python-docs`, `test`, and `integration-test` each failed at their apt-install step within ~30s while the identical steps passed on other jobs — the signature of transient mirror flakiness.

This adds a shared `.github/scripts/apt-retry.sh` that wraps `apt-get update` + `install` in a bounded retry (3 attempts, 15s backoff) and forwards its arguments verbatim to `apt-get install -y`. On persistent failure the script exits non-zero after 3 attempts, so a genuine breakage is not masked. Both mirror-hitting steps now call it:

- `.github/actions/common-deps/action.yml` — the shared "Install common dependencies" composite action used by `test`, `build-python-docs`, `rust`, `python`, docs, and remote-access-tests (and by `integration-test`).
- `.github/workflows/c_cpp.yml` — the "Install remote access build dependencies (Linux)" step.

A self-contained bash script is used rather than a third-party retry action, since the repo has no retry-action precedent (only `timeout-minutes` and one `actions/cache@v6`). It lives under `.github/scripts/` because it emits GitHub Actions workflow commands (`::warning::`, `::error::`) and assumes a checked-out runner; every caller already runs `actions/checkout` before it, and a local composite action reference guarantees the repo is present.

Not included: the `Install CUDA build dependencies` and `Install LiveKit C++ SDK dependencies` steps in `c_cpp.yml` use the same unguarded `apt-get` pattern; converting them to the shared script is tracked in [FLE-657](https://linear.app/foxglove/issue/FLE-657/convert-remaining-c-cppyml-apt-get-steps-to-the-shared-apt-retrysh). This change targets the steps observed failing.

Fixes: [FLE-654](https://linear.app/foxglove/issue/FLE-654)
