### PR TITLE
FLE-628: expose suppress_video_transcode in C/C++/Python bindings

### DIFF
--- a/c/include/foxglove-c/foxglove-c.h
+++ b/c/include/foxglove-c/foxglove-c.h
@@ -2813,6 +2813,19 @@ typedef struct foxglove_gateway_options {
   struct foxglove_qos_profile (*qos_classifier)(const void *context,
                                                 const struct foxglove_channel_descriptor *channel);
   /**
+   * Context provided to the `suppress_video_transcode` callback.
+   */
+  const void *suppress_video_transcode_context;
+  /**
+   * Opts channels out of video transcoding, delivering them as data instead.
+   *
+   * Return true to deliver the given channel as data rather than transcoding it to video. This
+   * is required for compressed depth maps, whose pixel values encode depth and would be
+   * corrupted by lossy video transcoding. If not set, all video-capable channels are transcoded.
+   */
+  bool (*suppress_video_transcode)(const void *context,
+                                   const struct foxglove_channel_descriptor *channel);
+  /**
    * Context provided to the `fetch_asset` callback.
    */
   const void *fetch_asset_context;

--- a/c/src/gateway.rs
+++ b/c/src/gateway.rs
@@ -83,7 +83,7 @@ impl foxglove::remote_access::QosClassifier for QosClassifier {
     }
 }
 
-/// A video-transcode opt-out classifier that wraps a C callback.
+/// A video-transcode opt-out predicate that wraps a C callback.
 #[derive(Clone)]
 struct SuppressVideoTranscode {
     callback_context: *const c_void,

--- a/c/src/gateway.rs
+++ b/c/src/gateway.rs
@@ -83,6 +83,35 @@ impl foxglove::remote_access::QosClassifier for QosClassifier {
     }
 }
 
+/// A video-transcode opt-out classifier that wraps a C callback.
+#[derive(Clone)]
+struct SuppressVideoTranscode {
+    callback_context: *const c_void,
+    callback: unsafe extern "C" fn(*const c_void, *const FoxgloveChannelDescriptor) -> bool,
+}
+
+impl SuppressVideoTranscode {
+    fn new(
+        callback_context: *const c_void,
+        callback: unsafe extern "C" fn(*const c_void, *const FoxgloveChannelDescriptor) -> bool,
+    ) -> Self {
+        Self {
+            callback_context,
+            callback,
+        }
+    }
+}
+
+unsafe impl Send for SuppressVideoTranscode {}
+unsafe impl Sync for SuppressVideoTranscode {}
+
+impl foxglove::remote_access::SuppressVideoTranscode for SuppressVideoTranscode {
+    fn should_suppress(&self, channel: &foxglove::ChannelDescriptor) -> bool {
+        let c_channel_descriptor = FoxgloveChannelDescriptor(channel.clone());
+        unsafe { (self.callback)(self.callback_context, &raw const c_channel_descriptor) }
+    }
+}
+
 /// The status of the remote access gateway connection.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -595,6 +624,21 @@ pub struct FoxgloveGatewayOptions<'a> {
         ) -> FoxgloveQosProfile,
     >,
 
+    /// Context provided to the `suppress_video_transcode` callback.
+    pub suppress_video_transcode_context: *const c_void,
+
+    /// Opts channels out of video transcoding, delivering them as data instead.
+    ///
+    /// Return true to deliver the given channel as data rather than transcoding it to video. This
+    /// is required for compressed depth maps, whose pixel values encode depth and would be
+    /// corrupted by lossy video transcoding. If not set, all video-capable channels are transcoded.
+    pub suppress_video_transcode: Option<
+        unsafe extern "C" fn(
+            context: *const c_void,
+            channel: *const FoxgloveChannelDescriptor,
+        ) -> bool,
+    >,
+
     /// Context provided to the `fetch_asset` callback.
     pub fetch_asset_context: *const c_void,
 
@@ -787,6 +831,14 @@ unsafe fn do_foxglove_gateway_start(
         gateway = gateway.qos_classifier(Arc::new(QosClassifier::new(
             options.qos_classifier_context,
             qos_classifier,
+        )));
+    }
+
+    // Suppress video transcode
+    if let Some(suppress_video_transcode) = options.suppress_video_transcode {
+        gateway = gateway.suppress_video_transcode(Arc::new(SuppressVideoTranscode::new(
+            options.suppress_video_transcode_context,
+            suppress_video_transcode,
         )));
     }
 

--- a/cpp/foxglove/include/foxglove/remote_access.hpp
+++ b/cpp/foxglove/include/foxglove/remote_access.hpp
@@ -192,6 +192,13 @@ struct QosProfile {
 /// Accepts any callable with signature `QosProfile(const ChannelDescriptor&)`.
 using QosClassifierFn = std::function<QosProfile(const ChannelDescriptor&)>;
 
+/// @brief A callable that decides, per channel, whether to opt out of video transcoding.
+///
+/// Accepts any callable with signature `bool(const ChannelDescriptor&)`. Return true to deliver
+/// the channel as data rather than transcoding it to video; this is required for compressed depth
+/// maps, whose pixel values encode depth and would be corrupted by lossy video transcoding.
+using SuppressVideoTranscodeFn = std::function<bool(const ChannelDescriptor&)>;
+
 /// @brief Preferred backend for encoding published video tracks.
 ///
 /// This preference applies to every video track the gateway publishes. If the requested
@@ -240,6 +247,12 @@ struct RemoteAccessGatewayOptions {
   /// If set, this callback is invoked for each channel to determine its quality-of-service
   /// profile. If not set, all channels use the default lossy profile.
   QosClassifierFn qos_classifier;
+  /// @brief A video-transcode opt-out callback.
+  ///
+  /// If set, this callback is invoked for each channel; returning true delivers the channel as
+  /// data instead of transcoding it to video. If not set, all video-capable channels are
+  /// transcoded.
+  SuppressVideoTranscodeFn suppress_video_transcode;
   /// @brief A parameter handler.
   ///
   /// When set, this handler takes precedence over the deprecated
@@ -361,6 +374,7 @@ private:
     std::unique_ptr<FetchAssetHandler> fetch_asset,
     std::unique_ptr<SinkChannelFilterFn> sink_channel_filter,
     std::unique_ptr<QosClassifierFn> qos_classifier,
+    std::unique_ptr<SuppressVideoTranscodeFn> suppress_video_transcode,
     std::unique_ptr<ParameterHandler> parameter_handler
   );
 
@@ -368,6 +382,7 @@ private:
   std::unique_ptr<FetchAssetHandler> fetch_asset_;
   std::unique_ptr<SinkChannelFilterFn> sink_channel_filter_;
   std::unique_ptr<QosClassifierFn> qos_classifier_;
+  std::unique_ptr<SuppressVideoTranscodeFn> suppress_video_transcode_;
   std::unique_ptr<ParameterHandler> parameter_handler_;
   std::unique_ptr<foxglove_gateway, foxglove_error (*)(foxglove_gateway*)> impl_;
 };

--- a/cpp/foxglove/src/remote_access.cpp
+++ b/cpp/foxglove/src/remote_access.cpp
@@ -107,7 +107,7 @@ bool forwardSuppressVideoTranscode(
     auto cpp_channel = ChannelDescriptor(channel);
     return (*classifier)(cpp_channel);
   } catch (const std::exception& exc) {
-    warn() << "Video-transcode opt-out classifier failed: " << exc.what();
+    warn() << "Video-transcode opt-out predicate failed: " << exc.what();
     return false;
   }
 }

--- a/cpp/foxglove/src/remote_access.cpp
+++ b/cpp/foxglove/src/remote_access.cpp
@@ -96,6 +96,22 @@ foxglove_qos_profile forwardQosClassifier(
   }
 }
 
+bool forwardSuppressVideoTranscode(
+  const void* context, const foxglove_channel_descriptor* channel
+) {
+  if (context == nullptr) {
+    return false;
+  }
+  try {
+    const auto* classifier = static_cast<const SuppressVideoTranscodeFn*>(context);
+    auto cpp_channel = ChannelDescriptor(channel);
+    return (*classifier)(cpp_channel);
+  } catch (const std::exception& exc) {
+    warn() << "Video-transcode opt-out classifier failed: " << exc.what();
+    return false;
+  }
+}
+
 // Populates `c` with forward function pointers for every callback set on `cb`,
 // and reports whether any callback was set. Callers should leave both the
 // heap-allocated callbacks wrapper unallocated and `c_options.callbacks` null
@@ -227,6 +243,15 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
     c_options.qos_classifier = &forwardQosClassifier;
   }
 
+  // Suppress video transcode
+  std::unique_ptr<SuppressVideoTranscodeFn> suppress_video_transcode;
+  if (options.suppress_video_transcode) {
+    suppress_video_transcode =
+      std::make_unique<SuppressVideoTranscodeFn>(std::move(options.suppress_video_transcode));
+    c_options.suppress_video_transcode_context = suppress_video_transcode.get();
+    c_options.suppress_video_transcode = &forwardSuppressVideoTranscode;
+  }
+
   // Fetch asset handler
   internal::wireFetchAsset(c_options, std::move(options.fetch_asset), fetch_asset);
 
@@ -275,6 +300,7 @@ FoxgloveResult<RemoteAccessGateway> RemoteAccessGateway::create(
     std::move(fetch_asset),
     std::move(sink_channel_filter),
     std::move(qos_classifier),
+    std::move(suppress_video_transcode),
     std::move(parameter_handler)
   );
 }
@@ -284,12 +310,14 @@ RemoteAccessGateway::RemoteAccessGateway(
   std::unique_ptr<FetchAssetHandler> fetch_asset,
   std::unique_ptr<SinkChannelFilterFn> sink_channel_filter,
   std::unique_ptr<QosClassifierFn> qos_classifier,
+  std::unique_ptr<SuppressVideoTranscodeFn> suppress_video_transcode,
   std::unique_ptr<ParameterHandler> parameter_handler
 )
     : callbacks_(std::move(callbacks))
     , fetch_asset_(std::move(fetch_asset))
     , sink_channel_filter_(std::move(sink_channel_filter))
     , qos_classifier_(std::move(qos_classifier))
+    , suppress_video_transcode_(std::move(suppress_video_transcode))
     , parameter_handler_(std::move(parameter_handler))
     , impl_(gateway, foxglove_gateway_stop) {}
 

--- a/cpp/foxglove/src/remote_access.cpp
+++ b/cpp/foxglove/src/remote_access.cpp
@@ -103,9 +103,9 @@ bool forwardSuppressVideoTranscode(
     return false;
   }
   try {
-    const auto* classifier = static_cast<const SuppressVideoTranscodeFn*>(context);
+    const auto* predicate = static_cast<const SuppressVideoTranscodeFn*>(context);
     auto cpp_channel = ChannelDescriptor(channel);
-    return (*classifier)(cpp_channel);
+    return (*predicate)(cpp_channel);
   } catch (const std::exception& exc) {
     warn() << "Video-transcode opt-out predicate failed: " << exc.what();
     return false;

--- a/cpp/foxglove/tests/integration/test_gateway.hpp
+++ b/cpp/foxglove/tests/integration/test_gateway.hpp
@@ -25,6 +25,7 @@ struct TestGatewayOptions {
     foxglove::RemoteAccessGatewayCapabilities::None;
   foxglove::SinkChannelFilterFn channel_filter;
   foxglove::QosClassifierFn qos_classifier;
+  foxglove::SuppressVideoTranscodeFn suppress_video_transcode;
   std::vector<std::string> supported_encodings = {"json"};
 };
 
@@ -72,6 +73,7 @@ public:
     gw_opts.capabilities = opts.capabilities;
     gw_opts.sink_channel_filter = std::move(opts.channel_filter);
     gw_opts.qos_classifier = std::move(opts.qos_classifier);
+    gw_opts.suppress_video_transcode = std::move(opts.suppress_video_transcode);
 
     auto result = foxglove::RemoteAccessGateway::create(std::move(gw_opts));
     if (!result.has_value()) {

--- a/cpp/foxglove/tests/integration/test_livekit.cpp
+++ b/cpp/foxglove/tests/integration/test_livekit.cpp
@@ -1317,3 +1317,33 @@ TEST_CASE("livekit: video channel forces lossy over reliable classifier", "[inte
 
   gw.stop();
 }
+
+TEST_CASE("livekit: suppress_video_transcode opts channel out of video track", "[integration]") {
+  auto ctx = foxglove::Context::create();
+
+  TestGatewayOptions opts;
+  opts.suppress_video_transcode = [](const foxglove::ChannelDescriptor& ch) {
+    return std::string(ch.topic()) == "/depth";
+  };
+  auto gw = TestGateway::start_with_options(ctx, std::move(opts));
+
+  auto viewer = ViewerConnection::connect(gw.room_name, "viewer-1");
+  viewer.expect_server_info();
+
+  // A video-capable schema that would normally be transcoded; the classifier opts it out by
+  // topic, so it is advertised as data (no video track).
+  auto depth_channel = foxglove::RawChannel::create(
+    "/depth", "protobuf", foxglove::Schema{"foxglove.CompressedImage", "protobuf", nullptr, 0}, ctx
+  );
+  REQUIRE(depth_channel.has_value());
+
+  auto advertise = viewer.expect_advertise();
+  REQUIRE(advertise["channels"].size() == 1);
+  auto& ch = advertise["channels"][0];
+  CHECK(ch["id"].get<uint64_t>() == depth_channel->id());
+
+  auto meta = ch.value("metadata", nlohmann::json::object());
+  CHECK(!meta.contains("foxglove.hasVideoTrack"));
+
+  gw.stop();
+}

--- a/cpp/foxglove/tests/integration/test_livekit.cpp
+++ b/cpp/foxglove/tests/integration/test_livekit.cpp
@@ -1321,6 +1321,18 @@ TEST_CASE("livekit: video channel forces lossy over reliable classifier", "[inte
 TEST_CASE("livekit: suppress_video_transcode opts channel out of video track", "[integration]") {
   auto ctx = foxglove::Context::create();
 
+  // Same video-capable schema for both channels. The gateway opts /depth out by topic (advertised
+  // as data, no video track), while /camera is still transcoded to video — so the test verifies
+  // the callback's per-topic selectivity, not just that it fires.
+  auto depth_channel = foxglove::RawChannel::create(
+    "/depth", "protobuf", foxglove::Schema{"foxglove.CompressedImage", "protobuf", nullptr, 0}, ctx
+  );
+  REQUIRE(depth_channel.has_value());
+  auto camera_channel = foxglove::RawChannel::create(
+    "/camera", "protobuf", foxglove::Schema{"foxglove.CompressedImage", "protobuf", nullptr, 0}, ctx
+  );
+  REQUIRE(camera_channel.has_value());
+
   TestGatewayOptions opts;
   opts.suppress_video_transcode = [](const foxglove::ChannelDescriptor& ch) {
     return std::string(ch.topic()) == "/depth";
@@ -1330,20 +1342,17 @@ TEST_CASE("livekit: suppress_video_transcode opts channel out of video track", "
   auto viewer = ViewerConnection::connect(gw.room_name, "viewer-1");
   viewer.expect_server_info();
 
-  // A video-capable schema that would normally be transcoded; the classifier opts it out by
-  // topic, so it is advertised as data (no video track).
-  auto depth_channel = foxglove::RawChannel::create(
-    "/depth", "protobuf", foxglove::Schema{"foxglove.CompressedImage", "protobuf", nullptr, 0}, ctx
-  );
-  REQUIRE(depth_channel.has_value());
-
   auto advertise = viewer.expect_advertise();
-  REQUIRE(advertise["channels"].size() == 1);
-  auto& ch = advertise["channels"][0];
-  CHECK(ch["id"].get<uint64_t>() == depth_channel->id());
-
-  auto meta = ch.value("metadata", nlohmann::json::object());
-  CHECK(!meta.contains("foxglove.hasVideoTrack"));
+  REQUIRE(advertise["channels"].size() == 2);
+  for (const auto& ch : advertise["channels"]) {
+    auto meta = ch.value("metadata", nlohmann::json::object());
+    if (ch["id"].get<uint64_t>() == depth_channel->id()) {
+      CHECK(!meta.contains("foxglove.hasVideoTrack"));
+    } else {
+      CHECK(ch["id"].get<uint64_t>() == camera_channel->id());
+      CHECK(meta.value("foxglove.hasVideoTrack", "") == "true");
+    }
+  }
 
   gw.stop();
 }

--- a/python/foxglove-sdk/python/foxglove/__init__.py
+++ b/python/foxglove-sdk/python/foxglove/__init__.py
@@ -272,6 +272,7 @@ try:
         context: Context | None = None,
         channel_filter: SinkChannelFilter | None = None,
         qos_classifier: Callable[[ChannelDescriptor], QosProfile] | None = None,
+        suppress_video_transcode: Callable[[ChannelDescriptor], bool] | None = None,
         message_backlog_size: int | None = None,
         foxglove_api_url: str | None = None,
         foxglove_api_timeout: float | None = None,
@@ -296,6 +297,9 @@ try:
         :param qos_classifier: A ``Callable`` that returns the
             :py:class:`foxglove.remote_access.QosProfile` to use for a given channel. If not set,
             all channels use the default lossy profile.
+        :param suppress_video_transcode: A ``Callable`` that returns ``True`` to deliver a given
+            channel as data rather than transcoding it to video. Required for compressed depth
+            maps. If not set, all video-capable channels are transcoded.
         :param message_backlog_size: The maximum number of messages to buffer before disconnecting
             the slow client. Defaults to 1024.
         :param foxglove_api_url: Override the Foxglove API base URL.
@@ -315,6 +319,7 @@ try:
             context=context,
             channel_filter=channel_filter,
             qos_classifier=qos_classifier,
+            suppress_video_transcode=suppress_video_transcode,
             message_backlog_size=message_backlog_size,
             foxglove_api_url=foxglove_api_url,
             foxglove_api_timeout=foxglove_api_timeout,

--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -376,6 +376,7 @@ def start_gateway(
     context: Context | None = None,
     channel_filter: SinkChannelFilter | None = None,
     qos_classifier: Callable[[ChannelDescriptor], QosProfile] | None = None,
+    suppress_video_transcode: Callable[[ChannelDescriptor], bool] | None = None,
     message_backlog_size: int | None = None,
     foxglove_api_url: str | None = None,
     foxglove_api_timeout: float | None = None,

--- a/python/foxglove-sdk/src/remote_access.rs
+++ b/python/foxglove-sdk/src/remote_access.rs
@@ -608,7 +608,7 @@ impl foxglove::remote_access::QosClassifier for PyQosClassifier {
     }
 }
 
-/// A video-transcode opt-out classifier wrapping a Python callable.
+/// A video-transcode opt-out predicate wrapping a Python callable.
 ///
 /// The callable should accept a `ChannelDescriptor` and return a `bool`; returning `True` delivers
 /// the channel as data rather than transcoding it to video.
@@ -628,7 +628,7 @@ impl foxglove::remote_access::SuppressVideoTranscode for PySuppressVideoTranscod
                 Ok(suppress) => suppress,
                 Err(err) => {
                     tracing::error!(
-                        "Error in video-transcode opt-out classifier: {}",
+                        "Error in video-transcode opt-out predicate: {}",
                         err.to_string()
                     );
                     false

--- a/python/foxglove-sdk/src/remote_access.rs
+++ b/python/foxglove-sdk/src/remote_access.rs
@@ -608,9 +608,39 @@ impl foxglove::remote_access::QosClassifier for PyQosClassifier {
     }
 }
 
+/// A video-transcode opt-out classifier wrapping a Python callable.
+///
+/// The callable should accept a `ChannelDescriptor` and return a `bool`; returning `True` delivers
+/// the channel as data rather than transcoding it to video.
+pub struct PySuppressVideoTranscode(pub Py<PyAny>);
+
+impl foxglove::remote_access::SuppressVideoTranscode for PySuppressVideoTranscode {
+    fn should_suppress(&self, channel: &foxglove::ChannelDescriptor) -> bool {
+        Python::attach(|py| {
+            let handler = self.0.clone_ref(py);
+            let descriptor = PyChannelDescriptor(channel.clone());
+            let result = handler
+                .bind(py)
+                .call((descriptor,), None)
+                .and_then(|f| f.extract::<bool>());
+
+            match result {
+                Ok(suppress) => suppress,
+                Err(err) => {
+                    tracing::error!(
+                        "Error in video-transcode opt-out classifier: {}",
+                        err.to_string()
+                    );
+                    false
+                }
+            }
+        })
+    }
+}
+
 /// Start a remote access gateway for live visualization and teleop in Foxglove.
 #[pyfunction]
-#[pyo3(signature = (*, name=None, device_token=None, capabilities=None, listener=None, supported_encodings=None, services=None, context=None, channel_filter=None, qos_classifier=None, message_backlog_size=None, foxglove_api_url=None, foxglove_api_timeout=None, video_encoder=None))]
+#[pyo3(signature = (*, name=None, device_token=None, capabilities=None, listener=None, supported_encodings=None, services=None, context=None, channel_filter=None, qos_classifier=None, suppress_video_transcode=None, message_backlog_size=None, foxglove_api_url=None, foxglove_api_timeout=None, video_encoder=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn start_gateway(
     py: Python<'_>,
@@ -623,6 +653,7 @@ pub fn start_gateway(
     context: Option<PyRef<PyContext>>,
     channel_filter: Option<Py<PyAny>>,
     qos_classifier: Option<Py<PyAny>>,
+    suppress_video_transcode: Option<Py<PyAny>>,
     message_backlog_size: Option<usize>,
     foxglove_api_url: Option<String>,
     foxglove_api_timeout: Option<f64>,
@@ -667,6 +698,11 @@ pub fn start_gateway(
 
     if let Some(qos_classifier) = qos_classifier {
         gateway = gateway.qos_classifier(Arc::new(PyQosClassifier(qos_classifier)));
+    }
+
+    if let Some(suppress_video_transcode) = suppress_video_transcode {
+        gateway = gateway
+            .suppress_video_transcode(Arc::new(PySuppressVideoTranscode(suppress_video_transcode)));
     }
 
     if let Some(size) = message_backlog_size {


### PR DESCRIPTION
### Changelog

The C, C++, and Python remote-access gateway APIs now expose the `suppress_video_transcode` opt-out, so a channel can be delivered as data instead of transcoded to video (required for compressed depth maps).

### Docs

Rustdoc/Doxygen/type-stub coverage for the new option in each binding. User-facing docs.foxglove.dev coverage is tracked in [FLE-648](https://linear.app/foxglove/issue/FLE-648).

### Description

Stacked on #1350, which added the Rust `SuppressVideoTranscode` trait and the `Gateway::suppress_video_transcode` / `suppress_video_transcode_fn` builder methods. This PR bridges that opt-out through the language bindings, following the existing `qos_classifier` pattern at every layer:

- **C** (`c/src/gateway.rs`): a bridge struct that implements the `SuppressVideoTranscode` trait over a C callback + context (`unsafe impl Send/Sync`), two `foxglove_gateway_options` fields (`suppress_video_transcode` + `_context`), and the wiring. The `foxglove-c.h` header is regenerated by cbindgen. `suppress_video_transcode` returns `bool`, so it is simpler than `qos_classifier` (no profile-struct conversion).
- **C++** (`remote_access.hpp` / `.cpp`): a `SuppressVideoTranscodeFn` option (`std::function<bool(const ChannelDescriptor&)>`), a `forwardSuppressVideoTranscode` forwarder, and constructor plumbing.
- **Python** (`src/remote_access.rs`, `__init__.py`, `__init__.pyi`): a `PySuppressVideoTranscode` wrapper implementing the trait over a Python callable, a `start_gateway(suppress_video_transcode=...)` keyword argument, and the type stub.

This is the seam the ROS bridge (#1351) consumes to mark compressed depth topics as data.

### Testing

- C++: a gated LiveKit integration test (`livekit: suppress_video_transcode opts channel out of video track`) advertises two `foxglove.CompressedImage` channels and opts one out by topic, asserting the opted-out channel lacks `foxglove.hasVideoTrack` while the other retains it — verifying the callback's per-topic selectivity, not just that it fires. Mirrors the Rust sibling test.
- Verified locally: C crate builds (cbindgen regenerates the header), `cd cpp && make build && make test` (76/76) and `make build-integration` pass, `cargo check`/`clippy`/`test` for the Python crate pass, `black`/`rustfmt`/`clang-format` clean.

Part of: [FLE-628](https://linear.app/foxglove/issue/FLE-628)
