### PR TITLE
ci: Re-enable ROS Rolling builds

### DIFF
--- a/.github/workflows/draft-ros-release.yml
+++ b/.github/workflows/draft-ros-release.yml
@@ -56,8 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
-        # rolling temporarily disabled while upstream changes land; re-enable when stable
-        distro: [humble, jazzy, kilted, lyrical]
+        distro: [humble, jazzy, kilted, lyrical, rolling]
         package: [bridge, msgs]
         include:
           - arch: x86_64

--- a/.github/workflows/publish-ros-bridge.yml
+++ b/.github/workflows/publish-ros-bridge.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # rolling temporarily disabled while upstream changes land; re-enable when stable
-        ros_distribution: [humble, jazzy, kilted, lyrical]
+        ros_distribution: [humble, jazzy, kilted, lyrical, rolling]
     env:
       DOCKER_REPO: us-central1-docker.pkg.dev/foxglove-images/images/foxglove_bridge
 
@@ -72,6 +71,7 @@ jobs:
           push: true
           build-args: |
             ROS_DISTRIBUTION=${{ matrix.ros_distribution }}
+            USE_ROS_TESTING=${{ matrix.ros_distribution == 'rolling' }}
           tags: ${{ steps.compute-tags.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -66,7 +66,7 @@ jobs:
           - jazzy
           - kilted
           - lyrical
-          # rolling temporarily disabled while upstream changes land; re-enable when stable
+          - rolling
     name: "ros (${{ matrix.ros_distribution }})"
     steps:
       - uses: actions/checkout@v7

--- a/ros/src/foxglove_bridge/Dockerfile
+++ b/ros/src/foxglove_bridge/Dockerfile
@@ -5,6 +5,11 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 # See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG USE_ROS_TESTING=false
+RUN if [ "$USE_ROS_TESTING" = "true" ]; then \
+      apt-get update && apt-get install -y ros2-testing-apt-source; \
+    fi
+
 # Keep ROS rolling base packages in sync.
 RUN apt-get update && apt-get -y dist-upgrade
 


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Upstream Rolling has completed its migration to Ubuntu 26.04 (resolute): the official ros:rolling images are now based on resolute and install from the ros2-testing apt repository. Add rolling back to the CI, deb release, and bridge publish matrices.

Tested by running `make docker-build-image-rolling` locally.