### PR TITLE
ci: Convert remaining c_cpp.yml apt-get steps to shared apt-retry.sh (FLE-657)

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -181,8 +181,7 @@ jobs:
       - name: Install CUDA build dependencies
         if: matrix.require_cuda && runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y nvidia-cuda-dev
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" nvidia-cuda-dev
           echo "CUDA_HOME=/usr" >> $GITHUB_ENV
       - name: Use Clang
         if: matrix.compiler == 'clang'
@@ -300,7 +299,7 @@ jobs:
 
       - name: Install LiveKit C++ SDK dependencies
         run: |
-          sudo apt-get install -y --no-install-recommends \
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" --no-install-recommends \
             llvm-dev libclang-dev clang \
             libdrm-dev libgbm-dev libx11-dev libgl1-mesa-dev \
             libxext-dev libxcomposite-dev libxdamage-dev libxfixes-dev \

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -42,8 +42,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" --no-install-recommends \
             clang-format-19 clang-tidy-19 \
             gcc g++ libglib2.0-dev libva-dev  \
             libwebsockets-dev nlohmann-json3-dev
@@ -271,8 +270,7 @@ jobs:
           toolchain: nightly
           components: rust-src
       - run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" --no-install-recommends \
             libglib2.0-dev libva-dev \
             libwebsockets-dev nlohmann-json3-dev
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Dependency-install steps in `c_cpp.yml` ran `apt-get` directly, so a transient Ubuntu mirror failure during any of them would fail an otherwise-healthy CI job. This routes every remaining raw `apt-get` step through the shared `.github/scripts/apt-retry.sh` (bounded `apt-get update` + `install` retry) added in FLE-654. After this change, no raw `apt-get` invocation remains in the file.

FLE-657 originally named two steps (CUDA and LiveKit); this converts all four remaining raw steps so the file is fully consistent:
- **`build` job — "Install CUDA build dependencies"** (`CUDA_HOME` export preserved)
- **`integration-test` job — "Install LiveKit C++ SDK dependencies"**
- **`lint` job** (`$GITHUB_PATH` export preserved)
- **`test-asan-ubsan` job**

The LiveKit step previously had no preceding `apt-get update`; the shared script always runs one first, which is harmless and arguably more correct. Otherwise consistency-only — no behavior change beyond retry-on-transient-failure.

Fixes: [FLE-657](https://linear.app/foxglove/issue/FLE-657)
