### PR TITLE
build(deps): bump aws-lc-rs from 1.17.0 to 1.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -192,14 +192,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]


### PR DESCRIPTION
### Changelog

Bumped `aws-lc-rs` from 1.17.0 to 1.17.1 (and `aws-lc-sys` from 0.41.0
to 0.42.0) to fix a missing `poly_Rq_mul` symbol in x86_64 static
archives that caused linker failures for consumers of `libfoxglove.a`.

### Docs

None

### Description

Every x86_64 `libfoxglove.a` release since sdk/v0.24.0 has an undefined
reference to `aws_lc_<ver>_poly_Rq_mul` in `hrss.o`, with no
corresponding definition anywhere in the archive. This causes linker
failures for consumers:

```
ld: error: undefined symbol: aws_lc_0_41_0_poly_Rq_mul
>>> referenced by hrss.c
>>>               hrss.o in archive libfoxglove.a
```

Shared libraries and aarch64 archives are unaffected.

The root cause was an incomplete source file list in `aws-lc-sys`'s
`cc_builder` — the AVX2 assembly file `crypto/hrss/asm/poly_rq_mul.S`
was present in the cmake build path but missing from the cc_builder
path. Foxglove hit this because commit 199710bc switched from carrying
`aws-lc-rs` with the `bindgen` feature (which selects the cmake builder)
to obtaining it through rustls without `bindgen` (which selects the
cc_builder).

This was fixed upstream in https://github.com/aws/aws-lc-rs/pull/1130,
shipped in `aws-lc-sys` 0.42.0 / `aws-lc-rs` 1.17.1.

**Repro (before fix):**

```bash
curl -LO https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.25.3/foxglove-v0.25.3-cpp-x86_64-unknown-linux-gnu.zip
unzip -q foxglove-v0.25.3-cpp-x86_64-unknown-linux-gnu.zip
nm -A foxglove/lib/libfoxglove.a | grep poly_Rq_mul
# hrss.o: U aws_lc_0_41_0_poly_Rq_mul  (undefined, defined nowhere in archive)
```

### Testing

- `cargo check -p foxglove_c --no-default-features --features aws-lc-rs` passes
- Lockfile-only change; no source code modified