### PR TITLE
Fix PointCloud transform examples

### DIFF
--- a/cpp/examples/message-filtering/src/main.cpp
+++ b/cpp/examples/message-filtering/src/main.cpp
@@ -30,6 +30,7 @@ using foxglove::messages::PackedElementField;
 using foxglove::messages::PointCloud;
 using foxglove::messages::Pose;
 using foxglove::messages::Quaternion;
+using foxglove::messages::Timestamp;
 using foxglove::messages::Vector3;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -228,17 +229,6 @@ int main() {
 
   const auto start = std::chrono::system_clock::now();
 
-  // Create a static transform for the point cloud
-  foxglove::messages::FrameTransform tf;
-  tf.parent_frame_id = "world";
-  tf.child_frame_id = "points";
-  tf.translation = foxglove::messages::Vector3{
-    -10.0,
-    -10.0,
-    0.0,
-  };
-  foxglove::messages::FrameTransforms point_cloud_tf{{tf}};
-
   while (!done) {
     const auto now = std::chrono::system_clock::now();
     const auto elapsed = now - start;
@@ -255,7 +245,22 @@ int main() {
     // Generate and log point cloud
     const auto point_cloud = makePointCloud(std::chrono::duration<double>(elapsed));
     point_cloud_channel.log(point_cloud, timestamp);
-    point_cloud_tf_channel.log(point_cloud_tf, timestamp);
+
+    // Log transform for the point cloud
+    const auto time_since_epoch = now.time_since_epoch();
+    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(time_since_epoch);
+    const auto nanoseconds =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoch - seconds);
+    foxglove::messages::FrameTransform tf;
+    tf.timestamp = Timestamp{
+      static_cast<uint32_t>(seconds.count()),
+      static_cast<uint32_t>(nanoseconds.count()),
+    };
+    tf.parent_frame_id = "world";
+    tf.child_frame_id = "points";
+    tf.translation = Vector3{-10.0, -10.0, 0.0};
+    tf.rotation = Quaternion{0.0, 0.0, 0.0, 1.0};
+    point_cloud_tf_channel.log(foxglove::messages::FrameTransforms{{tf}}, timestamp);
 
     std::this_thread::sleep_for(33ms);
   }

--- a/python/foxglove-sdk-examples/message-filtering/main.py
+++ b/python/foxglove-sdk-examples/message-filtering/main.py
@@ -13,6 +13,7 @@ from foxglove.messages import (
     PointCloud,
     Pose,
     Quaternion,
+    Timestamp,
     Vector3,
 )
 
@@ -44,23 +45,26 @@ def main() -> None:
         channel_filter=live_viz_filter,
     )
 
-    cloud_tf = FrameTransforms(
-        transforms=[
-            FrameTransform(
-                parent_frame_id="world",
-                child_frame_id="points",
-                translation=Vector3(x=-10, y=-10, z=0),
-            ),
-        ]
-    )
-
     pc_chan = foxglove.channels.PointCloudChannel(topic="/point_cloud")
 
     try:
         while True:
             foxglove.log("/info", {"state": get_state(), "y": cos(time.time())})
 
-            foxglove.log("/point_cloud_tf", cloud_tf)
+            foxglove.log(
+                "/point_cloud_tf",
+                FrameTransforms(
+                    transforms=[
+                        FrameTransform(
+                            timestamp=Timestamp.from_epoch_secs(time.time()),
+                            parent_frame_id="world",
+                            child_frame_id="points",
+                            translation=Vector3(x=-10, y=-10, z=0),
+                            rotation=Quaternion(x=0, y=0, z=0, w=1),
+                        ),
+                    ]
+                ),
+            )
 
             pc_chan.log(
                 # "/point_cloud",

--- a/rust/examples/message_filtering/src/main.rs
+++ b/rust/examples/message_filtering/src/main.rs
@@ -11,9 +11,9 @@
 //!
 //! In this example, we log some point cloud data to one MCAP file, and some minimal metadata to
 //! another.
-use foxglove::messages::{FrameTransform, FrameTransforms};
 use foxglove::messages::{
-    PackedElementField, PointCloud, Pose, Quaternion, Vector3, packed_element_field::NumericType,
+    FrameTransform, FrameTransforms, PackedElementField, PointCloud, Pose, Quaternion, Timestamp,
+    Vector3, packed_element_field::NumericType,
 };
 use foxglove::{Encode, LazyChannel, McapWriter};
 use std::sync::Arc;
@@ -65,18 +65,6 @@ fn main() {
         .expect("Server failed to start");
 
     let start = SystemTime::now();
-    let cloud_tf = FrameTransforms {
-        transforms: vec![FrameTransform {
-            parent_frame_id: "world".to_string(),
-            child_frame_id: "points".to_string(),
-            translation: Some(Vector3 {
-                x: -10.0,
-                y: -10.0,
-                z: 0.0,
-            }),
-            ..Default::default()
-        }],
-    };
 
     while !done.load(Ordering::Relaxed) {
         let elapsed = SystemTime::now()
@@ -88,7 +76,24 @@ fn main() {
 
         let point_cloud = make_point_cloud(elapsed);
         POINT_CLOUD_CHANNEL.log(&point_cloud);
-        POINT_CLOUD_TF_CHANNEL.log(&cloud_tf);
+        POINT_CLOUD_TF_CHANNEL.log(&FrameTransforms {
+            transforms: vec![FrameTransform {
+                timestamp: Some(Timestamp::now()),
+                parent_frame_id: "world".to_string(),
+                child_frame_id: "points".to_string(),
+                translation: Some(Vector3 {
+                    x: -10.0,
+                    y: -10.0,
+                    z: 0.0,
+                }),
+                rotation: Some(Quaternion {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                    w: 1.0,
+                }),
+            }],
+        });
 
         std::thread::sleep(Duration::from_millis(33));
     }


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

The message-filtering examples (Rust / Python / C++) were publishing PointCloud transforms without the required timestamp and rotation fields. Fill those in so the examples produce valid messages.

**This is PR 2/9 in the series — independent of the compression work; can merge anytime.**

**FLE-613 PR series (review in order where noted):**

| # | PR | Base | Depends on |
|---|----|------|------------|
| 1/9 | #1388 Bump MSRV to 1.88 | `main` | — |
| 2/9 | #1389 Fix PointCloud transform examples | `main` | — (independent) |
| 3/9 | #1390 Harden C++ websocket callback tests | `main` | — (independent; land before #1392) |
| 4/9 | #1391 Add RA Draco point cloud compression | #1388 | #1388 |
| 5/9 | #1392 Expose point cloud compression in C/C++ | #1391 | #1391 (+ includes #1390 until rebase) |
| 6/9 | #1393 Expose point cloud compression in Python | #1392 | #1392 |
| 7/9 | #1394 Add RA point cloud compression example | #1391 | #1391 |
| 8/9 | #1395 Add ROS2 PointCloud2 compression input | #1393 | #1393 |
| 9/9 | #1396 Add JSON/FlatBuffer PointCloud inputs | #1395 | #1395 |

Parent: [FLE-613](https://linear.app/foxglove/issue/FLE-613) · Original monolith: #1371

Fixes: [FLE-680](https://linear.app/foxglove/issue/FLE-680)