### PR TITLE
ci: Use cargo check instead of build for examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,15 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo build
       # Validate that we can build each example individually.
-      - name: Build examples individually
+      - name: Check examples individually
         run: |
           set -euo pipefail
           cargo metadata --no-deps --format-version 1 \
             | jq -r ".packages[].name" \
             | grep example \
             | while read package; do
-            echo "Building $package"
-            cargo build -p "$package"
+            echo "Checking $package"
+            cargo check -p "$package"
           done
       # Validate that we can build without default features.
       - run: cargo build -p foxglove --no-default-features


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
The ci/rust job is getting pretty long. We spend several minutes
building each of the examples, when a cargo check would give us the same
assurance without the overhead of codegen and linking. Perhaps more
importantly, this avoids invalidating foxglove/mcap/tokio build artifacts by
building them over and over again with different feature sets.

Looks like this one trick shaves 11 minutes off the build when we have a
warm cache. If we have a cold cache, the build time is no worse than
before.

With cache:
- [Before](https://github.com/foxglove/foxglove-sdk/actions/runs/29784719200/job/88493633169): 15 minutes 
- [After](https://github.com/foxglove/foxglove-sdk/actions/runs/29787380152/job/88501773696?pr=1397): 4 minutes 

Without cache:
- [Before](https://github.com/foxglove/foxglove-sdk/actions/runs/29611358549/job/87986548332): 16 minutes
- [After](https://github.com/foxglove/foxglove-sdk/actions/runs/29788504196/job/88505055096?pr=1397): 15 minutes 