### PR TITLE
ci: Split msrv/rustdoc builds out of ci/rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          # The last-specified toolchain is the default.
-          toolchain: 1.88.0,nightly,stable
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Ensure generated protobuf schemas are up to date
@@ -48,13 +47,7 @@ jobs:
       - run: cargo build -p foxglove --no-default-features
       # Validate that the ring-only crypto backend path compiles.
       - run: cargo check -p foxglove --no-default-features --features "remote-access,ring"
-      # Validate that we can build against the MSRV (minimum specified rust version).
-      - run: cargo +1.88.0 build -p foxglove
       - run: cargo clippy --no-deps --all-targets --tests -- -D warnings
-      - run: cargo +nightly rustdoc -p foxglove --features full -- -D warnings --cfg docsrs
-      - run: "[ -d ./target/doc/foxglove ] || exit 1"
-      - name: Check for ws-protocol references in public docs
-        run: '! grep -R "foxglove/ws-protocol" ./target/doc/foxglove'
       - run: cargo test -p foxglove --features full
         timeout-minutes: 5
       - run: cargo test -p foxglove --no-default-features
@@ -64,10 +57,50 @@ jobs:
       - run: cargo test -p foxglove_derive
       - run: cargo test -p foxglove-sdk-python --features remote-access
 
+  rust-msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install common dependencies
+        uses: ./.github/actions/common-deps
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.88.0
+
+      - run: cargo check -p foxglove --features full
+
+  rust-rustdoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install common dependencies
+        uses: ./.github/actions/common-deps
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - run: cargo rustdoc -p foxglove --features full -- -D warnings --cfg docsrs
+      - run: "[ -d ./target/doc/foxglove ] || exit 1"
+      - name: Check for ws-protocol references in public docs
+        run: '! grep -R "foxglove/ws-protocol" ./target/doc/foxglove'
+
+  rust-status:
+    name: rust-status
+    needs: [rust, rust-msrv, rust-rustdoc]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   release-rust:
     if: startsWith(github.ref, 'refs/tags/sdk/v')
     runs-on: ubuntu-latest
-    needs: rust
+    needs: rust-status
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
@@ -90,7 +123,7 @@ jobs:
   release-foxglove-data-loader:
     if: startsWith(github.ref, 'refs/tags/rust/foxglove_data_loader/v')
     runs-on: ubuntu-latest
-    needs: rust
+    needs: rust-status
     timeout-minutes: 10
     env:
       github_ref: ${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,15 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo build
       # Validate that we can build each example individually.
-      - name: Build examples individually
+      - name: Check examples individually
         run: |
           set -euo pipefail
           cargo metadata --no-deps --format-version 1 \
             | jq -r ".packages[].name" \
             | grep example \
             | while read package; do
-            echo "Building $package"
-            cargo build -p "$package"
+            echo "Checking $package"
+            cargo check -p "$package"
           done
       # Validate that we can build without default features.
       - run: cargo build -p foxglove --no-default-features


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Another change to try and speed up ci/rust a bit.

The MSRV & rustdoc builds are easy to separate out, because they use
different rust toolchains, and therefore don't benefit from running in
the same job as the rust checks we run against latest stable.

We follow the same pattern as the C/C++ and Python workflows, and
aggregate the rust build statuses as a single synthetic `rust-status`.
We'll need to manually update the repo settings to treat this as a
required status check after this PR merges.

I also noticed that we weren't building the full feature set against
MSRV, which was a mistake that I'm gonna fix while we're here.