### PR TITLE
pin the sanitizer job's nightly before a rustc ICE

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -261,13 +261,18 @@ jobs:
     env:
       CC: clang
       CXX: clang++
+      # Pinned: the 2026-07-23 nightly ICEs while compiling tokio at opt-level 3
+      # (https://github.com/rust-lang/rust/issues/159815). Unpin back to `nightly`
+      # once that issue is fixed. The Makefile passes this name through to corrosion,
+      # which resolves it against the installed rustup toolchains.
+      SANITIZE_RUST_TOOLCHAIN: nightly-2026-07-22
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env.SANITIZE_RUST_TOOLCHAIN }}
           components: rust-src
       - run: |
           bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" --no-install-recommends \

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -13,6 +13,10 @@ endif
 
 CMAKE_BUILD_TYPE?=RelWithDebInfo
 FOXGLOVE_REMOTE_ACCESS?=ON
+# Sanitizer builds need a nightly Rust toolchain (-Zbuild-std). Corrosion resolves this
+# name against the installed rustup toolchains, so CI can override it with a pinned
+# nightly (e.g. nightly-2026-07-22) when the floating nightly is broken.
+SANITIZE_RUST_TOOLCHAIN?=nightly
 
 .PHONY: lint
 lint:
@@ -37,7 +41,7 @@ build:
 	cmake \
 		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=true \
-		$(if $(SANITIZE),-DSANITIZE=$(SANITIZE) -DRust_TOOLCHAIN=nightly) \
+		$(if $(SANITIZE),-DSANITIZE=$(SANITIZE) -DRust_TOOLCHAIN=$(SANITIZE_RUST_TOOLCHAIN)) \
 		$(if $(STRICT),-DSTRICT=$(STRICT)) \
 		$(if $(CLANG_TIDY),-DCLANG_TIDY=$(CLANG_TIDY)) \
 		$(if $(FOXGLOVE_BUILD_EXAMPLES),-DFOXGLOVE_BUILD_EXAMPLES=$(FOXGLOVE_BUILD_EXAMPLES)) \
@@ -56,7 +60,7 @@ build-integration:
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=true \
 		-DFOXGLOVE_REMOTE_ACCESS=ON \
 		-DFOXGLOVE_BUILD_INTEGRATION_TESTS=ON \
-		$(if $(SANITIZE),-DSANITIZE=$(SANITIZE) -DRust_TOOLCHAIN=nightly) \
+		$(if $(SANITIZE),-DSANITIZE=$(SANITIZE) -DRust_TOOLCHAIN=$(SANITIZE_RUST_TOOLCHAIN)) \
 		$(if $(STRICT),-DSTRICT=$(STRICT)) \
 		$(if $(FOXGLOVE_BUILD_EXAMPLES),-DFOXGLOVE_BUILD_EXAMPLES=$(FOXGLOVE_BUILD_EXAMPLES)) \
 		$(if $(FOXGLOVE_PREBUILT_LIB_DIR),-DFOXGLOVE_PREBUILT_LIB_DIR=$(FOXGLOVE_PREBUILT_LIB_DIR)) \


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The 2026-07-23 nightly (89c61a754) has a codegen regression that ICEs while compiling tokio at opt-level 3 (rust-lang/rust#159815, hit at rustc_codegen_ssa/src/mir/operand.rs:291), which breaks the test-asan-ubsan job for every branch. Pin to the last good nightly; unpin once the upstream fix ships. The rustdoc job's floating nightly is unaffected: it builds dependencies as metadata only, without optimized codegen.