### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Foxglove SDK",
+  "install": ".cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The Foxglove SDK's Rust workspace targets edition 2024 (MSRV 1.88.0, see the root
+# Cargo.toml). The default Cloud Agent image ships an older toolchain, so install and
+# select a current stable toolchain, including the components the canonical fmt/clippy
+# workflow relies on.
+rustup toolchain install stable --profile minimal --no-self-update
+rustup component add --toolchain stable clippy rustfmt
+rustup default stable
+
+# Warm the Cargo dependency cache so agents can build, test, and run examples without a
+# cold download on first use.
+cargo fetch --locked


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

None

### Docs

None

### Description

Adds a Cursor Cloud Agent development environment for this repository so that agents start with a Rust toolchain capable of building and running the SDK.

The Rust workspace targets edition 2024 (MSRV `1.88.0`, per the root `Cargo.toml`), but the default Cloud Agent image ships an older toolchain (1.83), which fails with `feature edition2024 is required`. This adds:

- `.cursor/environment.json` — names the environment and points `install` at the setup script.
- `.cursor/install.sh` — installs and selects a current stable Rust toolchain via the image's `rustup`, adds the `clippy` and `rustfmt` components used by the canonical fmt/lint workflow, and warms the Cargo dependency cache with `cargo fetch --locked`. The script is idempotent.

This scopes the environment to the primary, self-contained Rust surface (core SDK + examples). Python (`uv` + maturin), C/C++ (CMake), and TypeScript schema tooling are not provisioned here and can be layered on later if agents need cross-language work.

Validated on a default Cloud Agent VM:

- `install.sh` runs to completion and is idempotent (second run makes no changes); results in `rustc`/`cargo` 1.97.1 with `clippy` + `rustfmt`.
- `cargo build -p example_mcap` builds the SDK and example.
- Running the `example_mcap` application logs messages and writes a valid MCAP file (correct `MCAP0` magic at head and tail; contains the `/msg` and `/json` topics, the JSON schema, and platform metadata; profile `foxglove-sdk-rust/0.26.0`).
- `cargo test -p foxglove` passes (unit tests + 23 doctests).
- `cargo clippy -p foxglove --no-deps -- -D warnings` passes.

Manual testing steps for reviewers, if desired:

- [ ] Start a fresh Cloud Agent on this branch and confirm `install` completes.
- [ ] Run `cargo run -p example_mcap -- --path /tmp/out.mcap --overwrite` and confirm a valid MCAP file is produced.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a5c319e-4ea9-4b66-b7c1-fa6e1387f190?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a5c319e-4ea9-4b66-b7c1-fa6e1387f190&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

