### PR TITLE
bridge: Terminate strings for CDR serialization

### DIFF
--- a/ros/src/foxglove_bridge/CMakeLists.txt
+++ b/ros/src/foxglove_bridge/CMakeLists.txt
@@ -249,6 +249,10 @@ if(BUILD_TESTING)
   target_link_libraries(utils_test foxglove_bridge_component)
   enable_strict_compiler_warnings(utils_test)
 
+  ament_add_gtest(cdr_serializer_test tests/cdr_serializer_test.cpp)
+  target_link_libraries(cdr_serializer_test foxglove_bridge_component)
+  enable_strict_compiler_warnings(cdr_serializer_test)
+
   ament_add_gtest(message_definition_cache_test tests/message_definition_cache_test.cpp)
   target_link_libraries(message_definition_cache_test foxglove_bridge_component)
   enable_strict_compiler_warnings(message_definition_cache_test)

--- a/ros/src/foxglove_bridge/include/foxglove_bridge/cdr_serializer.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/cdr_serializer.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <string>
+
+#include <rosx_introspection/serializer.hpp>
+
+namespace foxglove_bridge {
+
+/// Reports whether the rosx_introspection ROS 2 serializer omits the null terminator when writing
+/// a string.
+///
+/// ROS 2 middlewares expect a string to be encoded as a length of `size() + 1`, followed by the
+/// characters and a trailing null byte. rosx_introspection writes the characters alone, prefixed
+/// by a length that excludes the terminator, which Cyclone DDS rejects outright
+/// (https://github.com/facontidavide/rosx_introspection/issues/40).
+///
+/// This is probed at runtime rather than assumed, so that a fixed rosx_introspection doesn't leave
+/// us writing two terminators. The encoded buffer holds the 4-byte encapsulation header and a
+/// 4-byte length, followed by the characters, so a one-character string occupies 9 bytes without a
+/// terminator and 10 bytes with one.
+inline bool serializerOmitsNullTerminator() {
+  RosMsgParser::ROS2_Serializer probe;
+  probe.reset();
+  probe.serializeString("x");
+  return probe.getBufferSize() == 9;
+}
+
+/// CDR serializer used to convert client-published JSON messages to ROS 2 CDR.
+class CdrSerializer : public RosMsgParser::ROS2_Serializer {
+public:
+  void serializeString(const std::string& str) override {
+    static const bool appendTerminator = serializerOmitsNullTerminator();
+    if (!appendTerminator) {
+      RosMsgParser::ROS2_Serializer::serializeString(str);
+      return;
+    }
+    std::string terminated = str;
+    terminated.push_back('\0');
+    RosMsgParser::ROS2_Serializer::serializeString(terminated);
+  }
+};
+
+}  // namespace foxglove_bridge

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -11,6 +11,7 @@
 #include <rclcpp/version.h>
 #include <resource_retriever/retriever.hpp>
 
+#include <foxglove_bridge/cdr_serializer.hpp>
 #include <foxglove_bridge/ros2_foxglove_bridge.hpp>
 #include <foxglove_bridge/utils.hpp>
 #include <foxglove_bridge/version.hpp>
@@ -1146,7 +1147,7 @@ void FoxgloveBridge::publishClientData(const ClientAdvertisement& ad, const std:
     if (!ad.jsonParser) {
       throw std::runtime_error("no JSON parser found for schema \"" + ad.topicType + "\"");
     }
-    thread_local RosMsgParser::ROS2_Serializer serializer;
+    thread_local CdrSerializer serializer;
     serializer.reset();
     const std::string jsonMessage(reinterpret_cast<const char*>(data), dataLen);
     ad.jsonParser->serializeFromJson(jsonMessage, &serializer);

--- a/ros/src/foxglove_bridge/tests/cdr_serializer_test.cpp
+++ b/ros/src/foxglove_bridge/tests/cdr_serializer_test.cpp
@@ -1,0 +1,105 @@
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <rosx_introspection/ros_parser.hpp>
+
+#include <foxglove_bridge/cdr_serializer.hpp>
+
+namespace {
+
+std::vector<uint8_t> toBytes(const RosMsgParser::Serializer& serializer) {
+  const auto* data = reinterpret_cast<const uint8_t*>(serializer.getBufferData());
+  return std::vector<uint8_t>(data, data + serializer.getBufferSize());
+}
+
+// Converts a JSON message to CDR the same way the bridge does for messages published by a client
+// on a channel advertised with the "json" encoding.
+std::vector<uint8_t> jsonToCdr(const std::string& topicType, const std::string& schema,
+                               const std::string& json) {
+  const RosMsgParser::Parser parser("topic", RosMsgParser::ROSType(topicType), schema);
+  foxglove_bridge::CdrSerializer serializer;
+  serializer.reset();
+  parser.serializeFromJson(json, &serializer);
+  return toBytes(serializer);
+}
+
+// Little-endian, plain CDR encapsulation header.
+constexpr uint8_t H[] = {0x00, 0x01, 0x00, 0x00};
+
+}  // namespace
+
+// CdrSerializer only appends a terminator if the underlying serializer omits it. The probe that
+// decides this recognizes exactly two encodings; any other output means rosx_introspection changed
+// in a way the probe can no longer reason about.
+TEST(CdrSerializerTest, probeMatchesUnderlyingSerializer) {
+  RosMsgParser::ROS2_Serializer serializer;
+  serializer.reset();
+  serializer.serializeString("x");
+
+  const std::vector<uint8_t> unterminated = {H[0], H[1], H[2], H[3], 1, 0, 0, 0, 'x'};
+  const std::vector<uint8_t> terminated = {H[0], H[1], H[2], H[3], 2, 0, 0, 0, 'x', '\0'};
+  if (foxglove_bridge::serializerOmitsNullTerminator()) {
+    EXPECT_EQ(unterminated, toBytes(serializer));
+  } else {
+    EXPECT_EQ(terminated, toBytes(serializer));
+  }
+}
+
+TEST(CdrSerializerTest, serializesString) {
+  const auto cdr = jsonToCdr("std_msgs/msg/String", "string data", R"({"data": "hello world"})");
+
+  // The length prefix (12) includes the trailing null byte.
+  const std::vector<uint8_t> expected = {
+    H[0], H[1], H[2], H[3],                                           //
+    12,   0,    0,    0,                                              //
+    'h',  'e',  'l',  'l',  'o', ' ', 'w', 'o', 'r', 'l', 'd', '\0',  //
+  };
+  EXPECT_EQ(expected, cdr);
+}
+
+TEST(CdrSerializerTest, serializesEmptyString) {
+  const auto cdr = jsonToCdr("std_msgs/msg/String", "string data", R"({"data": ""})");
+
+  const std::vector<uint8_t> expected = {H[0], H[1], H[2], H[3], 1, 0, 0, 0, '\0'};
+  EXPECT_EQ(expected, cdr);
+}
+
+TEST(CdrSerializerTest, serializesOmittedStringAsEmpty) {
+  const auto cdr = jsonToCdr("std_msgs/msg/String", "string data", "{}");
+
+  const std::vector<uint8_t> expected = {H[0], H[1], H[2], H[3], 1, 0, 0, 0, '\0'};
+  EXPECT_EQ(expected, cdr);
+}
+
+TEST(CdrSerializerTest, alignsFieldFollowingString) {
+  const auto cdr = jsonToCdr("test_msgs/msg/StringAndInt", "string data\nint32 value",
+                             R"({"data": "abcd", "value": 42})");
+
+  // "abcd\0" is 5 bytes, so the int32 that follows is preceded by 3 bytes of padding.
+  const std::vector<uint8_t> expected = {
+    H[0], H[1], H[2], H[3],        //
+    5,    0,    0,    0,           //
+    'a',  'b',  'c',  'd',  '\0',  //
+    0,    0,    0,                 // padding
+    42,   0,    0,    0,           //
+  };
+  EXPECT_EQ(expected, cdr);
+}
+
+TEST(CdrSerializerTest, serializesStringArray) {
+  const auto cdr =
+    jsonToCdr("test_msgs/msg/StringArray", "string[] data", R"({"data": ["ab", "cd"]})");
+
+  const std::vector<uint8_t> expected = {
+    H[0], H[1], H[2], H[3],  //
+    2,    0,    0,    0,     // array length
+    3,    0,    0,    0,     //
+    'a',  'b',  '\0',        //
+    0,                       // padding
+    3,    0,    0,    0,     //
+    'c',  'd',  '\0',        //
+  };
+  EXPECT_EQ(expected, cdr);
+}


### PR DESCRIPTION
### Changelog
- bridge: Fixed an issue where JSON-encoded strings were not properly
  nul-terminated when reserialized as CDR.

### Links
Fixes #1428 

### Docs
None

### Description
The upstream rosx_introspection crate's CDR serializer does not properly
nul-terminate strings (facontidavide/rosx_introspection#40). This change
works around that issue by overriding ROS2_Serializer::serializeString()
to append a trailing '\0' byte.

A probe is used to statically determine whether rosx_introspection is
broken.