### PR TITLE
Add ROS Lyrical badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Visit [Foxglove SDK Docs](https://docs.foxglove.dev/sdk) to get started.
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove-sdk)](https://index.ros.org/p/foxglove_msgs#humble)<br/>
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/foxglove-sdk)](https://index.ros.org/p/foxglove_msgs#jazzy)<br/>
 [![ROS Kilted version](https://img.shields.io/ros/v/kilted/foxglove-sdk)](https://index.ros.org/p/foxglove_msgs#kilted)<br/>
+[![ROS Lyrical version](https://img.shields.io/ros/v/lyrical/foxglove-sdk)](https://index.ros.org/p/foxglove_msgs#lyrical)<br/>
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove-sdk)](https://index.ros.org/p/foxglove_msgs#rolling)
 
 </td>
@@ -92,6 +93,7 @@ Visit [Foxglove SDK Docs](https://docs.foxglove.dev/sdk) to get started.
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove-sdk)](https://index.ros.org/p/foxglove_bridge#humble)<br/>
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/foxglove-sdk)](https://index.ros.org/p/foxglove_bridge#jazzy)<br/>
 [![ROS Kilted version](https://img.shields.io/ros/v/kilted/foxglove-sdk)](https://index.ros.org/p/foxglove_bridge#kilted)<br/>
+[![ROS Lyrical version](https://img.shields.io/ros/v/lyrical/foxglove-sdk)](https://index.ros.org/p/foxglove_bridge#lyrical)<br/>
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove-sdk)](https://index.ros.org/p/foxglove_bridge#rolling)
 
 </td>


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Adds missing badges for ROS Lyrical releases to the README.md.