### PR TITLE
python: Plumb metadata to context._create_channel()

### DIFF
--- a/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
+++ b/python/foxglove-sdk/python/foxglove/_foxglove_py/__init__.pyi
@@ -134,9 +134,10 @@ class Context:
     def _create_channel(
         self,
         topic: str,
+        *,
         message_encoding: str,
         schema: Schema | None = None,
-        metadata: list[tuple[str, str]] | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> "BaseChannel":
         """
         Instead of calling this method, pass a context to a channel constructor.

--- a/python/foxglove-sdk/python/foxglove/channel.py
+++ b/python/foxglove-sdk/python/foxglove/channel.py
@@ -49,7 +49,10 @@ class Channel:
 
         if context is not None:
             self.base = context._create_channel(
-                topic, message_encoding=message_encoding, schema=schema
+                topic,
+                message_encoding=message_encoding,
+                schema=schema,
+                metadata=metadata,
             )
         else:
             self.base = _foxglove.BaseChannel(

--- a/python/foxglove-sdk/python/foxglove/tests/test_channel.py
+++ b/python/foxglove-sdk/python/foxglove/tests/test_channel.py
@@ -155,6 +155,8 @@ def test_typed_channel_attributes(new_topic: str) -> None:
 def test_channel_metadata(new_topic: str) -> None:
     channel = Channel(new_topic, metadata={"foo": "bar"})
     assert channel.metadata() == {"foo": "bar"}
+    channel = Channel(new_topic, context=Context(), metadata={"foo": "baz"})
+    assert channel.metadata() == {"foo": "baz"}
 
 
 def test_channel_metadata_mistyped(new_topic: str) -> None:


### PR DESCRIPTION
### Changelog
- Fixed a bug where the `foxglove.Channel` constructor ignored
  `metadata` when `context` was also provided.

### Docs
None

### Description
Straightforward fix to plumb a metadata properly in the `Channel`
constructor.