### PR TITLE
chore: Upgrade CI actions and Node.js to 24

### DIFF
--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -9,11 +9,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: astral-sh/setup-uv@v6
+    - uses: astral-sh/setup-uv@v10.1.0
 
     # disable man-db to speed up apt install
     - shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
           registry-url: https://registry.npmjs.org
 
@@ -197,7 +197,7 @@ jobs:
         with:
           python-version: "3.10"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
 
       - name: Ensure generated files are up to date
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ssciwr/doxygen-install@v2
         with:
           version: "1.13.2"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
       - run: make docs
         working-directory: cpp
       - name: Upload artifact
@@ -36,9 +36,9 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
       - run: make -f Container.mk docs-python
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -69,7 +69,7 @@ jobs:
             </ul>
           EOF
       - name: Deploy to CF Pages
-        uses: cloudflare/pages-action@v1.5.0
+        uses: cloudflare/wrangler-action@v4
         # Run preview deploys on PRs (but not for forks or dependabot PRs, since we do not have
         # access to secrets in these environments). Only run production deploys on release tags, not
         # the main branch.
@@ -84,9 +84,9 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: "3"
           # For PRs, use the PR head branch name. Otherwise we are running on a release tag, so use
           # "main" to trigger a "production" deploy in CF pages.
-          branch: ${{ github.head_ref || 'main' }}
-          projectName: foxglove-sdk-api-docs
-          directory: artifacts
+          command: >-
+            pages deploy artifacts
+            --project-name=foxglove-sdk-api-docs
+            --branch=${{ github.head_ref || 'main' }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
 
       - name: Check for existing ${{ env.SDK_TAG }} release

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.10"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
       - run: make -f Container.mk lint-python
 
   lint-and-test-sdk:
@@ -48,7 +48,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
 
       - run: make -f Container.mk test-python
@@ -64,7 +64,7 @@ jobs:
       - name: Unpack sdist
         run: tar xzf foxglove_sdk-*.tar.gz --strip-components 1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: wasm32-unknown-emscripten
@@ -107,7 +107,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - name: Download wheel
         uses: actions/download-artifact@v8
@@ -116,7 +116,7 @@ jobs:
           path: playground/public
       - run: yarn install
       - run: yarn build
-      - uses: cloudflare/pages-action@v1.5.0
+      - uses: cloudflare/wrangler-action@v4
         # Only run if not a fork, and not a dependabot PR, since we do not have
         # access to secrets in these environments.
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
@@ -125,10 +125,13 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           gitHubToken: ${{ secrets.FOXGLOVEBOT_GITHUB_TOKEN }}
-          wranglerVersion: "3"
-          branch: ${{ github.head_ref || github.ref_name }}
-          projectName: foxglove-sdk-playground
-          directory: playground/dist
+          # Without this, wrangler-action infers yarn from the repo's yarn.lock and tries to add
+          # wrangler to the workspace. Install it with npm instead, outside the yarn workspace.
+          packageManager: npm
+          command: >-
+            pages deploy playground/dist
+            --project-name=foxglove-sdk-playground
+            --branch=${{ github.head_ref || github.ref_name }}
 
   schemas:
     runs-on: ubuntu-latest
@@ -154,7 +157,7 @@ jobs:
           rm Linux.flatc.binary.clang++-12.zip
           sudo mv flatc /usr/local/bin
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
 
       - run: make -f Container.mk build-python-schemas
 
@@ -479,11 +482,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
       - run: corepack enable
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - name: Build sdist
         run: uv build --sdist
@@ -529,7 +532,7 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           path: python/foxglove-sdk
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
       - run: find python/foxglove-sdk/wheels-*
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
@@ -550,11 +553,11 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.10"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.1.0
       - run: corepack enable
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install
       - run: yarn run-python-sdk-examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN rustup toolchain install ${MSRV_RUST_VERSION}
 RUN rustup component add rustfmt clippy
 
 # node
-RUN curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh \
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh \
   && bash nodesource_setup.sh \
   && apt-get update \
   && apt-get install -y nodejs \


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Links

1. #1458 ← current
2. #1459
3. #1460
4. #1461
5. #1462
6. #1463

### Description

Several CI and development dependencies are multiple major versions behind. This updates the repository’s build infrastructure without changing SDK APIs or user-facing behavior.

- Move Node-based GitHub Actions workflows from Node 22 to Node 24 and the Docker development environment from Node 23 to Node 24.
- Upgrade `actions/setup-python` from v6 to v7 in the shared dependency setup.
- Standardize `astral-sh/setup-uv` on v10.1.0 across the common dependency setup and workflows.

Jobs that use Yarn continue enabling Corepack before dependency installation.

#### Testing

Automated CI is the relevant validation for this tooling-only change; no separate manual testing is needed.

The main risk is CI compatibility: workflows must continue installing their expected toolchains and dependencies with the updated action and runtime versions.