### PR TITLE
chore: Upgrade Clang, Doxygen, and flatc

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -42,11 +42,14 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: |
+          # Ubuntu 24.04 only packages clang up to 20, so pull 21 from apt.llvm.org.
+          curl https://apt.llvm.org/llvm.sh -fsS -o /tmp/llvm.sh
+          sudo bash /tmp/llvm.sh 21
           bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" --no-install-recommends \
-            clang-format-19 clang-tidy-19 \
+            clang-format-21 clang-tidy-21 \
             gcc g++ libglib2.0-dev libva-dev  \
             libwebsockets-dev nlohmann-json3-dev
-          echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
+          echo "/usr/lib/llvm-21/bin" >> $GITHUB_PATH
       - run: clang-format --version
       - run: clang-tidy --version
       - run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,10 @@ jobs:
 
       - name: Install Flatbuffer compiler
         run: |
-          curl -LO https://github.com/google/flatbuffers/releases/download/v23.1.21/Linux.flatc.binary.clang++-12.zip
-          echo "359dbbf56153cc1b022170a228adfde4199f67dc  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
-          unzip Linux.flatc.binary.clang++-12.zip
-          rm Linux.flatc.binary.clang++-12.zip
+          curl -LO https://github.com/google/flatbuffers/releases/download/v25.12.19/Linux.flatc.binary.clang++-18.zip
+          echo "e19243c6824e798dbc4c8b9e426240391ea928f9  Linux.flatc.binary.clang++-18.zip" | shasum -a 1 -c
+          unzip Linux.flatc.binary.clang++-18.zip
+          rm Linux.flatc.binary.clang++-18.zip
           sudo mv flatc /usr/local/bin
 
       - uses: arduino/setup-protoc@v3
@@ -198,6 +198,21 @@ jobs:
           python-version: "3.10"
 
       - uses: astral-sh/setup-uv@v7
+
+      # `yarn generate` runs clang-format over the generated C++, so this job writes the formatting
+      # that the C/C++ lint job then checks. Without an explicit install it would use the runner
+      # image's default (18) and the two jobs would demand different wrapping.
+      #
+      # This installs from apt.llvm.org, the same channel as the other two places clang-format is
+      # resolved (.github/workflows/c_cpp.yml and the Dockerfile). Using one channel is what keeps
+      # the job that writes the formatting and the job that checks it on the same build; two
+      # channels could sit at different 21.x patches at the same time.
+      - name: Install clang-format
+        run: |
+          curl https://apt.llvm.org/llvm.sh -fsS -o /tmp/llvm.sh
+          sudo bash /tmp/llvm.sh 21
+          bash "$GITHUB_WORKSPACE/.github/scripts/apt-retry.sh" --no-install-recommends clang-format-21
+          echo "/usr/lib/llvm-21/bin" >> $GITHUB_PATH
 
       - name: Ensure generated files are up to date
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ssciwr/doxygen-install@v2
         with:
-          version: "1.13.2"
+          version: "1.18.0"
       - uses: astral-sh/setup-uv@v7
       - run: make docs
         working-directory: cpp

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -148,10 +148,10 @@ jobs:
 
       - name: Install Flatbuffer compiler
         run: |
-          curl -LO https://github.com/google/flatbuffers/releases/download/v23.1.21/Linux.flatc.binary.clang++-12.zip
-          echo "359dbbf56153cc1b022170a228adfde4199f67dc  Linux.flatc.binary.clang++-12.zip" | shasum -a 1 -c
-          unzip Linux.flatc.binary.clang++-12.zip
-          rm Linux.flatc.binary.clang++-12.zip
+          curl -LO https://github.com/google/flatbuffers/releases/download/v25.12.19/Linux.flatc.binary.clang++-18.zip
+          echo "e19243c6824e798dbc4c8b9e426240391ea928f9  Linux.flatc.binary.clang++-18.zip" | shasum -a 1 -c
+          unzip Linux.flatc.binary.clang++-18.zip
+          rm Linux.flatc.binary.clang++-18.zip
           sudo mv flatc /usr/local/bin
 
       - uses: astral-sh/setup-uv@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # doxygen — pin to match CI (.github/workflows/docs.yml)
-ARG DOXYGEN_VERSION=1.13.2
+ARG DOXYGEN_VERSION=1.18.0
 RUN curl -fsSL https://github.com/doxygen/doxygen/releases/download/Release_$(echo ${DOXYGEN_VERSION} | tr '.' '_')/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz \
         -o /tmp/doxygen.tar.gz \
     && tar -xzf /tmp/doxygen.tar.gz -C /tmp \
@@ -41,9 +41,9 @@ RUN ARCH=$(uname -m | sed 's/aarch64/aarch_64/') \
     && rm /tmp/protoc.zip
 
 # flatc — pin to match CI (Install Flatbuffer compiler steps in .github/workflows/{ci,python}.yml)
-ARG FLATC_VERSION=23.1.21
-ARG FLATC_SHA1=359dbbf56153cc1b022170a228adfde4199f67dc
-RUN curl -fsSL https://github.com/google/flatbuffers/releases/download/v${FLATC_VERSION}/Linux.flatc.binary.clang++-12.zip \
+ARG FLATC_VERSION=25.12.19
+ARG FLATC_SHA1=e19243c6824e798dbc4c8b9e426240391ea928f9
+RUN curl -fsSL https://github.com/google/flatbuffers/releases/download/v${FLATC_VERSION}/Linux.flatc.binary.clang++-18.zip \
         -o /tmp/flatc.zip \
     && echo "${FLATC_SHA1}  /tmp/flatc.zip" | sha1sum -c \
     && unzip /tmp/flatc.zip -d /tmp \
@@ -52,10 +52,10 @@ RUN curl -fsSL https://github.com/google/flatbuffers/releases/download/v${FLATC_
 
 # clang
 RUN curl https://apt.llvm.org/llvm.sh -fsS -o llvm.sh \
-    && bash llvm.sh 19 \
-    && apt-get install -y clang-tidy-19 clang-format-19 \
+    && bash llvm.sh 21 \
+    && apt-get install -y clang-tidy-21 clang-format-21 \
     && rm -rf /var/lib/apt/lists/*
-ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+ENV PATH="/usr/lib/llvm-21/bin:${PATH}"
 
 # rust
 ARG MSRV_RUST_VERSION=1.88.0

--- a/cpp/examples/message-filtering/src/main.cpp
+++ b/cpp/examples/message-filtering/src/main.cpp
@@ -182,8 +182,7 @@ int main() {
 
   // In one MCAP, drop all of our point_cloud (and related tf) messages
   auto small_writer = createMcapWriter(
-    "example-topic-splitting-small.mcap",
-    [](const foxglove::ChannelDescriptor& channel) -> bool {
+    "example-topic-splitting-small.mcap", [](const foxglove::ChannelDescriptor& channel) -> bool {
       return channel.topic().find("/point_cloud") == std::string::npos;
     }
   );
@@ -193,8 +192,7 @@ int main() {
 
   // In the other, log only the point_cloud (and related tf) messages
   auto large_writer = createMcapWriter(
-    "example-topic-splitting-large.mcap",
-    [](const foxglove::ChannelDescriptor& channel) -> bool {
+    "example-topic-splitting-large.mcap", [](const foxglove::ChannelDescriptor& channel) -> bool {
       return channel.topic().find("/point_cloud") != std::string::npos;
     }
   );

--- a/cpp/examples/param-server/src/main.cpp
+++ b/cpp/examples/param-server/src/main.cpp
@@ -63,7 +63,7 @@ class OpQueue {
 public:
   void push(ParameterOp&& op) {
     {
-      std::lock_guard<std::mutex> lock(mu_);
+      std::scoped_lock<std::mutex> lock(mu_);
       queue_.push(std::move(op));
     }
     cv_.notify_one();

--- a/cpp/examples/remote-data-loader-backend/src/main.cpp
+++ b/cpp/examples/remote-data-loader-backend/src/main.cpp
@@ -283,7 +283,8 @@ void dataHandler(const httplib::Request& req, httplib::Response& res) {
         // major implementations).
         channel.log(
           msg,
-          static_cast<uint64_t>(date::floor<std::chrono::nanoseconds>(ts).time_since_epoch().count()
+          static_cast<uint64_t>(
+            date::floor<std::chrono::nanoseconds>(ts).time_since_epoch().count()
           )
         );
 

--- a/cpp/examples/ws-stream-mcap/src/main.cpp
+++ b/cpp/examples/ws-stream-mcap/src/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[]) {
   options.callbacks.onPlaybackControlRequest = [mtx, player_ref](
                                                  const foxglove::PlaybackControlRequest& request
                                                ) -> std::optional<foxglove::PlaybackState> {
-    std::lock_guard<std::mutex> lock(*mtx);
+    std::scoped_lock<std::mutex> lock(*mtx);
 
     bool did_seek = request.seek_time.has_value();
 
@@ -149,18 +149,20 @@ int main(int argc, char* argv[]) {
 
   while (!done) {
     {
-      std::lock_guard<std::mutex> lock(*mtx);
+      std::scoped_lock<std::mutex> lock(*mtx);
       current_status = player_ptr->status();
 
       if (current_status == foxglove::PlaybackStatus::Ended &&
           last_status != foxglove::PlaybackStatus::Ended) {
-        server.broadcastPlaybackState(foxglove::PlaybackState{
-          foxglove::PlaybackStatus::Ended,
-          player_ptr->currentTime(),
-          player_ptr->playbackSpeed(),
-          false,
-          std::nullopt,
-        });
+        server.broadcastPlaybackState(
+          foxglove::PlaybackState{
+            foxglove::PlaybackStatus::Ended,
+            player_ptr->currentTime(),
+            player_ptr->playbackSpeed(),
+            false,
+            std::nullopt,
+          }
+        );
       }
     }
     last_status = current_status;
@@ -172,7 +174,7 @@ int main(int argc, char* argv[]) {
 
     std::optional<std::chrono::nanoseconds> sleep_duration;
     {
-      std::lock_guard<std::mutex> lock(*mtx);
+      std::scoped_lock<std::mutex> lock(*mtx);
       sleep_duration = player_ptr->logNextMessage(server);
     }
 

--- a/cpp/examples/ws-stream-mcap/src/mcap_player.hpp
+++ b/cpp/examples/ws-stream-mcap/src/mcap_player.hpp
@@ -35,7 +35,8 @@ public:
   [[nodiscard]] foxglove::PlaybackStatus status() const override;
   [[nodiscard]] uint64_t currentTime() const override;
   [[nodiscard]] float playbackSpeed() const override;
-  std::optional<std::chrono::nanoseconds> logNextMessage(const foxglove::WebSocketServer& server
+  std::optional<std::chrono::nanoseconds> logNextMessage(
+    const foxglove::WebSocketServer& server
   ) override;
 
 private:

--- a/cpp/foxglove/include/foxglove/channel.hpp
+++ b/cpp/foxglove/include/foxglove/channel.hpp
@@ -38,11 +38,12 @@ public:
   [[nodiscard]] std::string_view messageEncoding() const noexcept;
 
   /// @deprecated Use messageEncoding() instead.
-  // NOLINTNEXTLINE(readability-identifier-naming)
-  [[deprecated("Use messageEncoding() instead")]] [[nodiscard]] std::string_view message_encoding(
-  ) const noexcept {
+  // NOLINTBEGIN(readability-identifier-naming)
+  [[deprecated("Use messageEncoding() instead")]] [[nodiscard]] std::string_view
+  message_encoding() const noexcept {
     return messageEncoding();
   }
+  // NOLINTEND(readability-identifier-naming)
 
   /// @brief Get the metadata for the channel descriptor.
   [[nodiscard]] std::optional<std::map<std::string, std::string>> metadata() const noexcept;
@@ -174,11 +175,12 @@ public:
   [[nodiscard]] std::string_view messageEncoding() const noexcept;
 
   /// @deprecated Use messageEncoding() instead.
-  // NOLINTNEXTLINE(readability-identifier-naming)
-  [[deprecated("Use messageEncoding() instead")]] [[nodiscard]] std::string_view message_encoding(
-  ) const noexcept {
+  // NOLINTBEGIN(readability-identifier-naming)
+  [[deprecated("Use messageEncoding() instead")]] [[nodiscard]] std::string_view
+  message_encoding() const noexcept {
     return messageEncoding();
   }
+  // NOLINTEND(readability-identifier-naming)
 
   /// @brief Find out if any sinks have been added to the channel.
   ///

--- a/cpp/foxglove/include/foxglove/messages.hpp
+++ b/cpp/foxglove/include/foxglove/messages.hpp
@@ -2637,8 +2637,8 @@ public:
   }
 
   CompressedPointCloudChannel(const CompressedPointCloudChannel& other) noexcept = delete;
-  CompressedPointCloudChannel& operator=(const CompressedPointCloudChannel& other
-  ) noexcept = delete;
+  CompressedPointCloudChannel& operator=(const CompressedPointCloudChannel& other) noexcept =
+    delete;
   /// @brief Default move constructor.
   CompressedPointCloudChannel(CompressedPointCloudChannel&& other) noexcept = default;
   /// @brief Default move assignment.
@@ -5251,8 +5251,8 @@ public:
   }
 
   TriangleListPrimitiveChannel(const TriangleListPrimitiveChannel& other) noexcept = delete;
-  TriangleListPrimitiveChannel& operator=(const TriangleListPrimitiveChannel& other
-  ) noexcept = delete;
+  TriangleListPrimitiveChannel& operator=(const TriangleListPrimitiveChannel& other) noexcept =
+    delete;
   /// @brief Default move constructor.
   TriangleListPrimitiveChannel(TriangleListPrimitiveChannel&& other) noexcept = default;
   /// @brief Default move assignment.

--- a/cpp/foxglove/include/foxglove/remote_access.hpp
+++ b/cpp/foxglove/include/foxglove/remote_access.hpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+// The C API declares this as an unscoped enum, so it cannot be an enum class here.
+// NOLINTNEXTLINE(cppcoreguidelines-use-enum-class)
 enum foxglove_error : uint8_t;
 struct foxglove_gateway;
 

--- a/cpp/foxglove/include/foxglove/remote_data_loader_backend.hpp
+++ b/cpp/foxglove/include/foxglove/remote_data_loader_backend.hpp
@@ -243,12 +243,14 @@ private:
     }
     uint16_t id = next_schema_id_++;  // wraps to 0 after 65535
 
-    schemas.push_back(Schema{
-      id,
-      schema.name,
-      schema.encoding,
-      std::move(encoded_data),
-    });
+    schemas.push_back(
+      Schema{
+        id,
+        schema.name,
+        schema.encoding,
+        std::move(encoded_data),
+      }
+    );
     return id;
   }
 };

--- a/cpp/foxglove/include/foxglove/websocket.hpp
+++ b/cpp/foxglove/include/foxglove/websocket.hpp
@@ -18,6 +18,8 @@
 #include <optional>
 #include <string>
 
+// The C API declares this as an unscoped enum, so it cannot be an enum class here.
+// NOLINTNEXTLINE(cppcoreguidelines-use-enum-class)
 enum foxglove_error : uint8_t;
 struct foxglove_websocket_server;
 struct foxglove_connection_graph;
@@ -240,8 +242,8 @@ struct WebSocketServerCallbacks {
   /// @note Since this playback state is in response to a specific request from the client, the
   /// `request_id` field in the returned `PlaybackState` will be overwritten to match the request_id
   /// in `playback_control_request`.
-  std::function<std::optional<PlaybackState>(const PlaybackControlRequest& playback_control_request
-  )>
+  std::function<
+    std::optional<PlaybackState>(const PlaybackControlRequest& playback_control_request)>
     onPlaybackControlRequest;
 };
 #if defined(__GNUC__) || defined(__clang__)

--- a/cpp/foxglove/src/parameter_handler.cpp
+++ b/cpp/foxglove/src/parameter_handler.cpp
@@ -3,7 +3,8 @@
 
 namespace foxglove {
 
-void GetParametersResponder::Deleter::operator()(foxglove_get_parameters_responder* ptr
+void GetParametersResponder::Deleter::operator()(
+  foxglove_get_parameters_responder* ptr
 ) const noexcept {
   foxglove_get_parameters_responder_drop(ptr);
 }
@@ -13,7 +14,8 @@ void GetParametersResponder::respond(std::vector<Parameter>&& params) && {
   foxglove_get_parameters_responder_respond(impl_.release(), array.release());
 }
 
-void SetParametersResponder::Deleter::operator()(foxglove_set_parameters_responder* ptr
+void SetParametersResponder::Deleter::operator()(
+  foxglove_set_parameters_responder* ptr
 ) const noexcept {
   foxglove_set_parameters_responder_drop(ptr);
 }

--- a/cpp/foxglove/src/websocket.cpp
+++ b/cpp/foxglove/src/websocket.cpp
@@ -340,7 +340,8 @@ void WebSocketServer::broadcastPlaybackState(const PlaybackState& playback_state
 }
 /// @endcond
 
-FoxgloveError WebSocketServer::clearSession(std::optional<std::string_view> session_id
+FoxgloveError WebSocketServer::clearSession(
+  std::optional<std::string_view> session_id
 ) const noexcept {
   auto c_session_id = session_id
                         ? std::optional<foxglove_string>{{session_id->data(), session_id->size()}}

--- a/cpp/foxglove/tests/integration/livekit_token.cpp
+++ b/cpp/foxglove/tests/integration/livekit_token.cpp
@@ -27,10 +27,14 @@ std::string generate_token(const std::string& room_name, const std::string& iden
                  .set_expires_at(now + std::chrono::hours(1))
                  .set_payload_claim(
                    "video",
-                   jwt::claim(picojson::value(picojson::object{
-                     {"roomJoin", picojson::value(true)},
-                     {"room", picojson::value(room_name)},
-                   }))
+                   jwt::claim(
+                     picojson::value(
+                       picojson::object{
+                         {"roomJoin", picojson::value(true)},
+                         {"room", picojson::value(room_name)},
+                       }
+                     )
+                   )
                  )
                  .sign(jwt::algorithm::hs256{DEV_API_SECRET});
   return token;

--- a/cpp/foxglove/tests/integration/mock_server.cpp
+++ b/cpp/foxglove/tests/integration/mock_server.cpp
@@ -35,8 +35,7 @@ MockServerHandle::MockServerHandle(const std::string& room_name)
   auto stop_flag = stop_flag_;
 
   server_->Get(
-    "/internal/platform/v1/device-info",
-    [](const httplib::Request& req, httplib::Response& res) {
+    "/internal/platform/v1/device-info", [](const httplib::Request& req, httplib::Response& res) {
       if (!validate_device_token(req)) {
         res.status = 401;
         return;

--- a/cpp/foxglove/tests/integration/viewer_connection.hpp
+++ b/cpp/foxglove/tests/integration/viewer_connection.hpp
@@ -76,13 +76,15 @@ struct ViewerEvent {
 class TestRoomDelegate : public livekit::RoomDelegate {
 public:
   void onTrackSubscribed(livekit::Room& room, const livekit::TrackSubscribedEvent& event) override;
-  void onTrackUnsubscribed(livekit::Room& room, const livekit::TrackUnsubscribedEvent& event)
-    override;
+  void onTrackUnsubscribed(
+    livekit::Room& room, const livekit::TrackUnsubscribedEvent& event
+  ) override;
   void onParticipantDisconnected(
     livekit::Room& room, const livekit::ParticipantDisconnectedEvent& event
   ) override;
-  void onDataTrackPublished(livekit::Room& room, const livekit::DataTrackPublishedEvent& event)
-    override;
+  void onDataTrackPublished(
+    livekit::Room& room, const livekit::DataTrackPublishedEvent& event
+  ) override;
 
   /// Wait for an event matching the predicate, up to the given timeout.
   std::optional<ViewerEvent> wait_for_event(

--- a/cpp/foxglove/tests/test_websocket.cpp
+++ b/cpp/foxglove/tests/test_websocket.cpp
@@ -2157,9 +2157,11 @@ std::vector<std::byte> playbackControlRequestToBinary(
   msg.reserve(message_size);
 
   msg.emplace_back(std::byte{0x03});
-  msg.emplace_back(std::byte{static_cast<std::underlying_type_t<foxglove::PlaybackCommand>>(
-    playback_control_request.playback_command
-  )});
+  msg.emplace_back(
+    std::byte{static_cast<std::underlying_type_t<foxglove::PlaybackCommand>>(
+      playback_control_request.playback_command
+    )}
+  );
 
   writeFloatLE(msg, playback_control_request.playback_speed);
   msg.emplace_back(
@@ -2227,7 +2229,8 @@ TEST_CASE("Playback control request callback") {
   ws_options.capabilities = foxglove::WebSocketServerCapabilities::PlaybackControl;
   ws_options.playback_time_range = std::make_pair(0, 1000);
   ws_options.callbacks.onPlaybackControlRequest =
-    [&]([[maybe_unused]] const foxglove::PlaybackControlRequest& playback_control_request
+    [&](
+      [[maybe_unused]] const foxglove::PlaybackControlRequest& playback_control_request
     ) -> foxglove::PlaybackState {
     {
       std::unique_lock lock(mutex);

--- a/cpp/foxglove_data_loader/examples/data_loader.cpp
+++ b/cpp/foxglove_data_loader/examples/data_loader.cpp
@@ -61,7 +61,8 @@ public:
 
   Result<Initialization> initialize() override;
 
-  Result<std::unique_ptr<AbstractMessageIterator>> create_iterator(const MessageIteratorArgs& args
+  Result<std::unique_ptr<AbstractMessageIterator>> create_iterator(
+    const MessageIteratorArgs& args
   ) override;
 };
 
@@ -117,35 +118,35 @@ Result<Initialization> TextDataLoader::initialize() {
     }
     this->files.emplace_back(buf);
     uint16_t channel_id = file_index;
-    channels.push_back(Channel{
-      .id = channel_id,
-      .schema_id = 1,
-      .topic_name = "/log",
-      .message_encoding = "protobuf",
-      .message_count = line_count,
-    });
+    channels.push_back(
+      Channel{
+        .id = channel_id,
+        .schema_id = 1,
+        .topic_name = "/log",
+        .message_encoding = "protobuf",
+        .message_count = line_count,
+      }
+    );
   }
   foxglove::Schema log_schema = foxglove::messages::Log::schema();
   return Result<Initialization>{
-    .value =
-      Initialization{
-        .channels = channels,
-        .schemas = {Schema{
-          .id = 1,
-          .name = log_schema.name,
-          .encoding = log_schema.encoding,
-          .data =
-            BytesView{
-              .ptr = reinterpret_cast<const uint8_t*>(log_schema.data),
-              .len = log_schema.data_len,
-            }
-        }},
-        .time_range =
-          TimeRange{
-            .start_time = 0,
-            .end_time = this->line_indexes.size(),
+    .value = Initialization{
+      .channels = channels,
+      .schemas = {Schema{
+        .id = 1,
+        .name = log_schema.name,
+        .encoding = log_schema.encoding,
+        .data =
+          BytesView{
+            .ptr = reinterpret_cast<const uint8_t*>(log_schema.data),
+            .len = log_schema.data_len,
           }
+      }},
+      .time_range = TimeRange{
+        .start_time = 0,
+        .end_time = this->line_indexes.size(),
       }
+    }
   };
 }
 /** returns an AbstractMessageIterator for the set of requested args.
@@ -209,17 +210,15 @@ std::optional<Result<Message>> TextMessageIterator::next() {
         }
         index++;
         return Result<Message>{
-          .value =
-            Message{
-              .channel_id = channel_id,
-              .log_time = time,
-              .publish_time = time,
-              .data =
-                BytesView{
-                  .ptr = last_encoded_message.data(),
-                  .len = encoded_len,
-                }
+          .value = Message{
+            .channel_id = channel_id,
+            .log_time = time,
+            .publish_time = time,
+            .data = BytesView{
+              .ptr = last_encoded_message.data(),
+              .len = encoded_len,
             }
+          }
         };
       }
     }

--- a/cpp/foxglove_data_loader/include/foxglove_data_loader/host_internal.inl
+++ b/cpp/foxglove_data_loader/include/foxglove_data_loader/host_internal.inl
@@ -6,16 +6,19 @@
 
 // Imported Functions from `foxglove:loader/console@0.1.0`
 
-__attribute__((__import_module__("foxglove:loader/console@0.1.0"), __import_name__("log"))
-) extern void
+__attribute__((
+  __import_module__("foxglove:loader/console@0.1.0"), __import_name__("log")
+)) extern void
 __wasm_import_foxglove_loader_console_log(uint8_t*, size_t);
 
-__attribute__((__import_module__("foxglove:loader/console@0.1.0"), __import_name__("error"))
-) extern void
+__attribute__((
+  __import_module__("foxglove:loader/console@0.1.0"), __import_name__("error")
+)) extern void
 __wasm_import_foxglove_loader_console_error(uint8_t*, size_t);
 
-__attribute__((__import_module__("foxglove:loader/console@0.1.0"), __import_name__("warn"))
-) extern void
+__attribute__((
+  __import_module__("foxglove:loader/console@0.1.0"), __import_name__("warn")
+)) extern void
 __wasm_import_foxglove_loader_console_warn(uint8_t*, size_t);
 
 // Imported Functions from `foxglove:loader/reader@0.1.0`
@@ -40,8 +43,9 @@ __attribute__((
 )) extern int64_t
 __wasm_import_foxglove_loader_reader_method_reader_size(int32_t);
 
-__attribute__((__import_module__("foxglove:loader/reader@0.1.0"), __import_name__("open"))
-) extern int32_t
+__attribute__((
+  __import_module__("foxglove:loader/reader@0.1.0"), __import_name__("open")
+)) extern int32_t
 __wasm_import_foxglove_loader_reader_open(uint8_t*, size_t);
 
 // Exported Functions from `foxglove:loader/loader@0.1.0`
@@ -49,7 +53,8 @@ __wasm_import_foxglove_loader_reader_open(uint8_t*, size_t);
 __attribute__((
   __weak__, __export_name__("cabi_post_foxglove:loader/loader@0.1.0#[method]message-iterator.next")
 )) void
-__wasm_export_exports_foxglove_loader_loader_method_message_iterator_next_post_return(uint8_t* arg0
+__wasm_export_exports_foxglove_loader_loader_method_message_iterator_next_post_return(
+  uint8_t* arg0
 ) {
   switch ((int32_t)(int32_t)*((uint8_t*)(arg0 + 0))) {
     case 0: {
@@ -90,7 +95,8 @@ __wasm_export_exports_foxglove_loader_loader_method_message_iterator_next_post_r
 __attribute__((
   __weak__, __export_name__("cabi_post_foxglove:loader/loader@0.1.0#[method]data-loader.initialize")
 )) void
-__wasm_export_exports_foxglove_loader_loader_method_data_loader_initialize_post_return(uint8_t* arg0
+__wasm_export_exports_foxglove_loader_loader_method_data_loader_initialize_post_return(
+  uint8_t* arg0
 ) {
   switch ((int32_t)(int32_t)*((uint8_t*)(arg0 + 0))) {
     case 0: {
@@ -434,16 +440,18 @@ exports_foxglove_loader_loader_own_message_iterator_t
 exports_foxglove_loader_loader_message_iterator_new(
   exports_foxglove_loader_loader_message_iterator_t* rep
 ) {
-  return (exports_foxglove_loader_loader_own_message_iterator_t
-  ){__wasm_import_exports_foxglove_loader_loader_message_iterator_new((int32_t)rep)};
+  return (exports_foxglove_loader_loader_own_message_iterator_t){
+    __wasm_import_exports_foxglove_loader_loader_message_iterator_new((int32_t)rep)
+  };
 }
 
 exports_foxglove_loader_loader_message_iterator_t*
 exports_foxglove_loader_loader_message_iterator_rep(
   exports_foxglove_loader_loader_own_message_iterator_t handle
 ) {
-  return (exports_foxglove_loader_loader_message_iterator_t*)
-    __wasm_import_exports_foxglove_loader_loader_message_iterator_rep(handle.__handle);
+  return (
+    exports_foxglove_loader_loader_message_iterator_t*
+  )__wasm_import_exports_foxglove_loader_loader_message_iterator_rep(handle.__handle);
 }
 
 // NOTE: wit-bindgen v0.43.0 has a bug that uses snake_case for the exported destructor name,
@@ -482,15 +490,17 @@ __wasm_import_exports_foxglove_loader_loader_data_loader_rep(int32_t);
 exports_foxglove_loader_loader_own_data_loader_t exports_foxglove_loader_loader_data_loader_new(
   exports_foxglove_loader_loader_data_loader_t* rep
 ) {
-  return (exports_foxglove_loader_loader_own_data_loader_t
-  ){__wasm_import_exports_foxglove_loader_loader_data_loader_new((int32_t)rep)};
+  return (exports_foxglove_loader_loader_own_data_loader_t){
+    __wasm_import_exports_foxglove_loader_loader_data_loader_new((int32_t)rep)
+  };
 }
 
 exports_foxglove_loader_loader_data_loader_t* exports_foxglove_loader_loader_data_loader_rep(
   exports_foxglove_loader_loader_own_data_loader_t handle
 ) {
-  return (exports_foxglove_loader_loader_data_loader_t*)
-    __wasm_import_exports_foxglove_loader_loader_data_loader_rep(handle.__handle);
+  return (
+    exports_foxglove_loader_loader_data_loader_t*
+  )__wasm_import_exports_foxglove_loader_loader_data_loader_rep(handle.__handle);
 }
 
 // NOTE: wit-bindgen v0.43.0 has a bug that uses snake_case for the exported destructor name,
@@ -607,7 +617,8 @@ uint64_t foxglove_loader_reader_method_reader_seek(
   return (uint64_t)(ret);
 }
 
-uint64_t foxglove_loader_reader_method_reader_position(foxglove_loader_reader_borrow_reader_t self
+uint64_t foxglove_loader_reader_method_reader_position(
+  foxglove_loader_reader_borrow_reader_t self
 ) {
   int64_t ret = __wasm_import_foxglove_loader_reader_method_reader_position((self).__handle);
   return (uint64_t)(ret);
@@ -747,8 +758,9 @@ __wasm_export_exports_foxglove_loader_loader_method_data_loader_create_iterator(
     (exports_foxglove_loader_loader_message_iterator_args_t){
       (host_option_time_nanos_t)option,
       (host_option_time_nanos_t)option6,
-      (host_list_channel_id_t)(host_list_channel_id_t
-      ){(exports_foxglove_loader_loader_channel_id_t*)(arg4), (arg5)},
+      (host_list_channel_id_t)(host_list_channel_id_t){
+        (exports_foxglove_loader_loader_channel_id_t*)(arg4), (arg5)
+      },
     };
   exports_foxglove_loader_loader_result_own_message_iterator_error_t ret;
   exports_foxglove_loader_loader_own_message_iterator_t ok;
@@ -784,8 +796,9 @@ __wasm_export_exports_foxglove_loader_loader_method_data_loader_get_backfill(
   exports_foxglove_loader_loader_backfill_args_t arg3 =
     (exports_foxglove_loader_loader_backfill_args_t){
       (exports_foxglove_loader_loader_time_nanos_t)(uint64_t)(arg0),
-      (host_list_channel_id_t)(host_list_channel_id_t
-      ){(exports_foxglove_loader_loader_channel_id_t*)(arg1), (arg2)},
+      (host_list_channel_id_t)(host_list_channel_id_t){
+        (exports_foxglove_loader_loader_channel_id_t*)(arg1), (arg2)
+      },
     };
   exports_foxglove_loader_loader_result_list_message_error_t ret;
   exports_foxglove_loader_loader_list_message_t ok;


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Links

1. #1458
2. #1459 ← current
3. #1460
4. #1461
5. #1462
6. #1463

### Description

CI and the Docker development image pin native compilers and generators separately, so outdated or mismatched versions can make generated sources disagree with lint and build jobs. This brings those pins current and keeps the environments aligned; no SDK API is intentionally changed.

- Upgrade Clang tooling from 19 to 21, Doxygen from 1.13.2 to 1.18.0, and flatc from 23.1.21 to 25.12.19.
- Install Clang 21 from apt.llvm.org in the C++ lint job, the generated-files job, and the Docker image. The generated-files job writes clang-formatted C++, so using the same distribution in all three places prevents patch-level formatter drift from making generation and lint disagree.
- Update the FlatBuffers release asset and checksum for the clang++-18 build shipped by 25.12.19.

Clang 21 changes C++ formatting but not behavior. Its new formatting also requires block-scoped suppression around the deprecated `message_encoding` methods, and its new `cppcoreguidelines-use-enum-class` check requires a targeted exemption for `foxglove_error`, which mirrors an unscoped C API enum.

The protoc upgrade was removed from this change because newer gencode would require raising the published Python protobuf runtime floor. Updating that package contract belongs in a separate compatibility change.

#### Testing

- [ ] Confirm the Docs workflow's `build-cpp-docs` job succeeds with Doxygen 1.18.0.

The main risk is cross-environment compatibility: generation and lint must resolve the same Clang build, the new flatc binary must continue running in CI and the development image, and the C++ documentation must build with Doxygen 1.18.0.