### PR TITLE
chore: Upgrade C++ FetchContent dependencies

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 
 find_or_fetch(Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.8.0
+  GIT_TAG        v3.16.0
   VERSION 3
 )
 if(catch2_SOURCE_DIR)
@@ -47,8 +47,8 @@ include(Catch)
 if(NOT FOXGLOVE_PREBUILT_LIB_DIR)
   find_or_fetch(Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.5.1
-    VERSION 0.5.1
+    GIT_TAG v0.6.1
+    VERSION 0.6.1
   )
 endif()
 
@@ -91,12 +91,12 @@ if(FOXGLOVE_BUILD_EXAMPLES)
   set(ENABLE_DATE_INSTALL OFF CACHE BOOL "" FORCE)
   find_or_fetch(date
     GIT_REPOSITORY https://github.com/HowardHinnant/date.git
-    GIT_TAG v3.0.4
+    GIT_TAG v3.0.5
   )
 
   find_or_fetch(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG releases/cpp/v2.1.2
+    GIT_TAG releases/cpp/v2.1.3
   )
 
   set(LZ4_BUILD_CLI OFF CACHE BOOL "" FORCE)
@@ -122,7 +122,7 @@ if(FOXGLOVE_BUILD_EXAMPLES OR FOXGLOVE_BUILD_INTEGRATION_TESTS)
   set(HTTPLIB_INSTALL OFF CACHE BOOL "" FORCE)
   find_or_fetch(httplib
     GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-    GIT_TAG v0.32.0
+    GIT_TAG v0.54.1
   )
 endif()
 
@@ -382,7 +382,7 @@ if(FOXGLOVE_BUILD_INTEGRATION_TESTS)
   FetchContent_Declare(
     jwt-cpp
     GIT_REPOSITORY https://github.com/Thalhammer/jwt-cpp.git
-    GIT_TAG v0.7.0
+    GIT_TAG v0.7.2
     EXCLUDE_FROM_ALL
   )
   FetchContent_MakeAvailable(jwt-cpp)


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Links

1. #1458
2. #1459
3. #1460
4. #1461 ← current
5. #1462
6. #1463

### Description

The C++ build's FetchContent fallbacks were pinned to older dependency releases. This updates those fallbacks without changing SDK source code or intended runtime behavior.

- Upgrade Catch2 3.8.0 to 3.16.0 and Corrosion 0.5.1 to 0.6.1.
- Upgrade the example dependencies date 3.0.4 to 3.0.5, MCAP 2.1.2 to 2.1.3, and cpp-httplib 0.32.0 to 0.54.1.
- Upgrade the integration-test dependency jwt-cpp 0.7.0 to 0.7.2.

When `USE_PACKAGE_MANAGER_DEPENDENCIES` is enabled, system packages can satisfy `find_package` before these pins are fetched, so which fallbacks a job exercises depends on what it installs. The `build` job installs `libwebsockets-dev` and masks that pin; the `integration-test` job installs no such package and builds libwebsockets from source. A local macOS build compiled the fetched dependencies and examples and passed CTest.

libwebsockets is held at 4.3.3 rather than moved to 4.5.8. The integration tests began segfaulting on this branch, twice in a row but on a different test each time, while `main` passes that job consistently. libwebsockets is the largest behavioural change among the pins the integration job builds from source, so reverting it is the first bisect step. If it turns out innocent, the bump comes back and cpp-httplib is next.

LiveKit C++ remains at 0.3.4. Moving across its 1.0 stabilization requires a live integration environment and belongs in a dedicated compatibility change.

#### Testing

- [ ] Confirm the `FOXGLOVE_BUILD_INTEGRATION_TESTS` build succeeds with jwt-cpp 0.7.2 and cpp-httplib 0.54.1.

The main risk is platform-specific build compatibility: every updated FetchContent fallback must compile where no system package masks it, while the SDK's behavior remains unchanged.
