### PR TITLE
Require protobuf 5.29.6 for Python schemas

### DIFF
--- a/python/foxglove-schemas-protobuf/pyproject.toml
+++ b/python/foxglove-schemas-protobuf/pyproject.toml
@@ -10,7 +10,11 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 requires-python = ">=3.10"
-dependencies = ["protobuf (>=3.20)"]
+# This floor must match the protoc version CI pins (the arduino/setup-protoc `version` in
+# .github/workflows/ci.yml and python.yml). The generated code is not committed: it is built at
+# publish time, and protoc emits a runtime assertion for its own version, so a wheel built with
+# protoc 29.6 refuses to import on any protobuf older than 5.29.6. Bump both together.
+dependencies = ["protobuf (>=5.29.6)"]
 
 [project.urls]
 repository = "https://github.com/foxglove/foxglove-sdk"

--- a/python/foxglove-schemas-protobuf/uv.lock
+++ b/python/foxglove-schemas-protobuf/uv.lock
@@ -35,7 +35,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "protobuf", specifier = ">=3.20" }]
+requires-dist = [{ name = "protobuf", specifier = ">=5.29.6" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
### Changelog

`foxglove-schemas-protobuf` now requires protobuf 5.29.6 or newer, so incompatible runtimes are rejected during dependency resolution instead of failing at import.

### Docs

None

### Description

The package currently declares `protobuf>=3.20`, although its generated modules require protobuf 5.29.6 or newer. This allows installation with a runtime that fails when the first generated module is imported. Users already running a compatible protobuf version will see no behavior change.

The schemas job generates these modules at publish time using protoc 29.6. The generated modules validate against version 5.29.6, so the project metadata and lockfile now declare that exact minimum. Runtime 5.29.5 is rejected, while the tested newer runtimes—6.33.0 and 7.36.1—accept the generated code.

`foxglove-schemas-flatbuffer` remains unchanged because its generated code has no equivalent runtime assertion. The package version also remains at 0.4.0 because releases and tags are handled separately.

- [ ] Install protobuf 4.25.8, then install `foxglove-schemas-protobuf`; confirm protobuf is upgraded to at least 5.29.6 and a generated `_pb2` module imports successfully.

The compatibility risk is limited to environments that constrain protobuf below 5.29.6. Those environments already fail at import; after this change, they fail earlier during dependency resolution. Future protoc upgrades must keep this dependency floor synchronized.

Related: #1459
