### PR TITLE
Prepare @foxglove/schemas 2.2.0 for release

### DIFF
--- a/typescript/schemas/package.json
+++ b/typescript/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/schemas",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Foxglove-defined message schemas for ROS, Protobuf, FlatBuffers, OMG IDL, and JSON",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
### Changelog

Release `@foxglove/schemas` 2.2.0 with the new `foxglove.Event` schema, documented G.711 `RawAudio` formats, and clearer `SceneEntity.frame_locked` documentation.

### Docs

None.

### Description

`@foxglove/schemas` is released independently from the rest of the SDK, and the current npm release, 2.1.0, predates several schema updates already merged into `main`.

This PR only updates the package version to 2.2.0. Merging it does not publish the package or change runtime behavior; publication occurs after the release tag is created.

The user-facing schema changes since 2.1.0 are:

- The new `foxglove.Event` TypeScript type and JSON Schema from #1368.
- Documentation for the `g711-alaw` and `g711-ulaw` `RawAudio` formats from #1455.
- Clarified behavior for `SceneEntity.frame_locked` from #1304.

A minor release is appropriate because `Event` is a new export. The other changes clarify existing schema contracts: `RawAudio.format` remains a `string`, and no existing fields or wire representations change. G.711 decoding in consuming applications remains outside the scope of this release.

The workspace entry in `yarn.lock` uses the local version `0.0.0-use.local`, so the package version bump does not require a lockfile update. No manual testing is needed for this metadata-only diff.

After merging, create a GitHub Release from the merged commit using the tag `typescript/schemas/v2.2.0`, then confirm that the tagged CI run publishes `@foxglove/schemas@2.2.0` to npm. The package version, release tag, and tagged commit must remain aligned so npm receives the intended schema contents under the correct version.

Related: [VIZ-3086](https://linear.app/foxglove/issue/VIZ-3086/feature-request-add-g711-audio-to-compressedaudio)
