### PR TITLE
foxglove_bridge: broadcast server time unconditionally

### DIFF
--- a/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -164,6 +164,11 @@ private:
 
   void subscribeConnectionGraph(bool subscribe);
 
+  // Broadcasts the given timestamp (nanoseconds since epoch) to WebSocket clients via the Time
+  // capability. Shared by both the sim-time (/clock) and wall-clock (timer) sources in the
+  // constructor.
+  void broadcastTime(int64_t nanoseconds);
+
   void subscribe(ChannelId channelId, const foxglove::ClientMetadata& client);
 
   void unsubscribe(ChannelId channelId, const foxglove::ClientMetadata& client);

--- a/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros/src/foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -151,6 +151,7 @@ private:
   size_t _minQosDepth = DEFAULT_MIN_QOS_DEPTH;
   size_t _maxQosDepth = DEFAULT_MAX_QOS_DEPTH;
   std::shared_ptr<rclcpp::Subscription<rosgraph_msgs::msg::Clock>> _clockSubscription;
+  rclcpp::TimerBase::SharedPtr _timeBroadcastTimer;
   bool _useSimTime = false;
   std::atomic<int> _graphSubscriptionCount = 0;
   bool _includeHidden = false;

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -194,12 +194,6 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   sdkServerOptions.host = address;
   sdkServerOptions.port = port;
   sdkServerOptions.supported_encodings = {"cdr", "json"};
-  sdkServerOptions.capabilities = _capabilities;
-  sdkServerOptions.context = _serverContext;
-
-  sdkServerOptions.server_info = rosServerInfo;
-  sdkServerOptions.message_backlog_size = messageBacklogSize;
-
   // Always advertise Time, not just under sim time. Without it Foxglove falls back to the
   // *client's* wall clock for currentTime (Studio v1.36.0: "Use system time for Foxglove
   // WebSocket connections if the server does not publish time messages"). Anything resolved at
@@ -207,8 +201,11 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   // transform looked up at the viewer's clock rather than the robot's, while message-stamped
   // geometry still renders correctly, producing a scene inconsistent by exactly the client/server
   // clock skew.
-  sdkServerOptions.capabilities =
-    sdkServerOptions.capabilities | foxglove::WebSocketServerCapabilities::Time;
+  sdkServerOptions.capabilities = _capabilities | foxglove::WebSocketServerCapabilities::Time;
+  sdkServerOptions.context = _serverContext;
+
+  sdkServerOptions.server_info = rosServerInfo;
+  sdkServerOptions.message_backlog_size = messageBacklogSize;
 
   // If TLS is enabled, load the certificate and key files from disk
   if (useTls) {
@@ -311,10 +308,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   if (_useSimTime) {
     _clockSubscription = this->create_subscription<rosgraph_msgs::msg::Clock>(
       "/clock", rclcpp::QoS{rclcpp::KeepLast(1)}.best_effort(),
-      [&](std::shared_ptr<const rosgraph_msgs::msg::Clock> msg) {
-        const auto timestamp = rclcpp::Time{msg->clock}.nanoseconds();
-        assert(timestamp >= 0 && "Timestamp is negative");
-        _server->broadcastTime(static_cast<uint64_t>(timestamp));
+      [this](std::shared_ptr<const rosgraph_msgs::msg::Clock> msg) {
+        broadcastTime(rclcpp::Time{msg->clock}.nanoseconds());
       });
   } else {
     // Outside sim there is no /clock, so drive the broadcast from this node's own clock -- the
@@ -325,7 +320,11 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     // must not depend on delivery through the message bus it is itself serving. A stalled topic
     // would freeze the viewer's clock; a stalled hardware clock is not a failure mode.
     _timeBroadcastTimer = this->create_wall_timer(std::chrono::milliseconds(100), [this]() {
-      _server->broadcastTime(static_cast<uint64_t>(this->now().nanoseconds()));
+      // Skip the broadcast (and its internal per-client work) when nobody is listening.
+      if (_server->clientCount() == 0) {
+        return;
+      }
+      broadcastTime(this->now().nanoseconds());
     });
   }
 
@@ -465,6 +464,11 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
 
   _rosgraphPollThread =
     std::make_unique<std::thread>(std::bind(&FoxgloveBridge::rosgraphPollThread, this));
+}
+
+void FoxgloveBridge::broadcastTime(int64_t nanoseconds) {
+  assert(nanoseconds >= 0 && "Timestamp is negative");
+  _server->broadcastTime(static_cast<uint64_t>(nanoseconds));
 }
 
 FoxgloveBridge::~FoxgloveBridge() {

--- a/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -200,10 +200,15 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   sdkServerOptions.server_info = rosServerInfo;
   sdkServerOptions.message_backlog_size = messageBacklogSize;
 
-  if (_useSimTime) {
-    sdkServerOptions.capabilities =
-      sdkServerOptions.capabilities | foxglove::WebSocketServerCapabilities::Time;
-  }
+  // Always advertise Time, not just under sim time. Without it Foxglove falls back to the
+  // *client's* wall clock for currentTime (Studio v1.36.0: "Use system time for Foxglove
+  // WebSocket connections if the server does not publish time messages"). Anything resolved at
+  // current time -- coordinate frame axes, frame_locked scene entities -- is then placed using a
+  // transform looked up at the viewer's clock rather than the robot's, while message-stamped
+  // geometry still renders correctly, producing a scene inconsistent by exactly the client/server
+  // clock skew.
+  sdkServerOptions.capabilities =
+    sdkServerOptions.capabilities | foxglove::WebSocketServerCapabilities::Time;
 
   // If TLS is enabled, load the certificate and key files from disk
   if (useTls) {
@@ -311,6 +316,17 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
         assert(timestamp >= 0 && "Timestamp is negative");
         _server->broadcastTime(static_cast<uint64_t>(timestamp));
       });
+  } else {
+    // Outside sim there is no /clock, so drive the broadcast from this node's own clock -- the
+    // same one that stamps log_time and every header in the graph, so the client's timeline
+    // matches the data exactly.
+    //
+    // Deliberately a wall timer rather than a /clock subscription: the bridge's notion of time
+    // must not depend on delivery through the message bus it is itself serving. A stalled topic
+    // would freeze the viewer's clock; a stalled hardware clock is not a failure mode.
+    _timeBroadcastTimer = this->create_wall_timer(std::chrono::milliseconds(100), [this]() {
+      _server->broadcastTime(static_cast<uint64_t>(this->now().nanoseconds()));
+    });
   }
 
 #ifndef FOXGLOVE_REMOTE_ACCESS

--- a/ros/src/foxglove_bridge/tests/client/test_client.hpp
+++ b/ros/src/foxglove_bridge/tests/client/test_client.hpp
@@ -387,6 +387,9 @@ public:
 
     setBinaryMessageHandler([promise = std::move(promise), fulfilled, subscriptionId](
                               const uint8_t* data, size_t dataLength) {
+      if (static_cast<ServerBinaryOpcode>(data[0]) != ServerBinaryOpcode::MESSAGE_DATA) {
+        return;
+      }
       if (ReadUint32LE(data + 1) != subscriptionId) {
         return;
       }

--- a/ros/src/foxglove_bridge/tests/smoke_test.cpp
+++ b/ros/src/foxglove_bridge/tests/smoke_test.cpp
@@ -779,10 +779,17 @@ TEST(SmokeTest, receiveMessagesOfMultipleTransientLocalPublishers) {
   const foxglove::test::Channel channel = channelFuture.get();
   const foxglove::test::SubscriptionId subscriptionId = 1;
 
-  // Set up binary message handler to resolve the promise when all nPub message have been received
+  // Set up binary message handler to resolve the promise when all nPub message have been
+  // received. The bridge also broadcasts periodic Time frames now that Time is advertised
+  // unconditionally, so filter to MESSAGE_DATA frames only -- otherwise those would be
+  // miscounted as received publisher messages.
   std::promise<void> promise;
   std::atomic<size_t> nReceivedMessages = 0;
-  client->setBinaryMessageHandler([&promise, &nReceivedMessages](const uint8_t*, size_t) {
+  client->setBinaryMessageHandler([&promise, &nReceivedMessages](const uint8_t* data, size_t) {
+    if (static_cast<foxglove::test::ServerBinaryOpcode>(data[0]) !=
+        foxglove::test::ServerBinaryOpcode::MESSAGE_DATA) {
+      return;
+    }
     if (++nReceivedMessages == nPubs) {
       promise.set_value();
     }


### PR DESCRIPTION
### Changelog

`foxglove_bridge` now advertises the WebSocket `Time` capability and broadcasts server time unconditionally, not just when `use_sim_time` is set.

### Docs

None.

### Description

`foxglove_bridge` only advertised the `Time` capability and called `broadcastTime(...)` when `use_sim_time` was true. On a real robot that flag is false, so the bridge never told the client what time it was. Per Foxglove Studio (v1.36.0): "Use system time for Foxglove WebSocket connections if the server does not publish time messages" — so the client fell back to its own wall clock.

Anything the 3D panel resolves at current time (coordinate frame axes, `frame_locked` scene entities) was then placed using a transform looked up at the *viewer's* clock instead of the robot's, while message-stamped geometry (which carries its own header stamp) still rendered correctly. The result: a scene internally inconsistent by exactly the client/server clock skew — any robot whose clock isn't synchronized with the client's (different timezone, unsynced NTP, stopped clock) would show axes and frame-locked entities offset by that skew.

Changes:
- Advertise the `Time` capability unconditionally, not gated on `_useSimTime`.
- Keep the existing sim-time path (`/clock` subscription → `broadcastTime`) unchanged.
- Add an `else` branch: when not using sim time, drive `broadcastTime(this->now())` from a 100ms wall timer, skipped when there are no connected clients.

This is deliberately a wall timer, not a `/clock` publisher + `use_sim_time: true`. Setting that flag would make `this->now()` read `/clock` instead of the system clock, and with nothing publishing `/clock` on a real robot the bridge's own clock would freeze at zero, taking every outgoing `log_time` with it. A `/clock`-publisher-based alternative would also make the bridge's notion of time depend on delivery through the same message bus it's serving — the failure mode this avoids.

Ran the full test suite via the repo's docker-based colcon build/test flow for ROS Jazzy. This surfaced a real regression in `smoke_test.cpp`'s `receiveMessagesOfMultipleTransientLocalPublishers`: it counted every binary WebSocket frame as a received publisher message, and the now-periodic Time broadcast frames (`ServerBinaryOpcode::TIME = 2`) were miscounted alongside `MESSAGE_DATA` frames (`= 1`). Fixed by filtering to `MESSAGE_DATA` frames only, matching the opcode-filtering pattern already used elsewhere in the test client (e.g. `waitForServiceResponse`); the same gap existed in the shared `waitForChannelMsg` test helper and was fixed there too.

After those fixes: `foxglove_bridge` and `foxglove_msgs` both build clean, all 3127 tests pass, 0 errors, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

